### PR TITLE
chore: GitHub workflow — issue/PR templates, discussions, subagent installer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+name: Bug Report
+description: Something is not working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! Please provide enough detail to
+        reproduce the issue. Fill in all fields below.
+
+  - type: input
+    id: kiwidesk_version
+    attributes:
+      label: KiwiDesk version or commit
+      description: |
+        For a source build, run `git rev-parse --short HEAD`
+        in the repo. For a release, the version you installed.
+      placeholder: "abc1234 or 1.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: macos_version
+    attributes:
+      label: macOS version
+      description: "Run `sw_vers` or check System Settings."
+      placeholder: "macOS 15.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mac_model
+    attributes:
+      label: Mac model type
+      options:
+        - Apple Silicon (M1, M2, M3, etc.)
+        - Intel
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Clear, numbered steps. Include key presses, commands,
+        or conditions needed to trigger the bug.
+      placeholder: |
+        1. Open Terminal
+        2. Run `KiwiDesk set_mode bsp`
+        3. (etc.)
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_vs_actual
+    attributes:
+      label: Expected vs. actual behavior
+      description: |
+        What should happen? What actually happened instead?
+      placeholder: |
+        Expected: windows tile in binary-space-partition
+        Actual: windows stack vertically
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs_and_state
+    attributes:
+      label: Relevant output and logs
+      description: |
+        Paste the output of these commands (one per block):
+        - `KiwiDesk get_state` (print as JSON)
+        - `KiwiDesk get_layout_info` (current layout details)
+        - `log show --predicate 'eventMessage contains[c] "KiwiDesk"'`
+        (copy lines mentioning KiwiDesk)
+      placeholder: |
+        ## KiwiDesk get_state
+        { "spaces": {...}, ... }
+
+        ## KiwiDesk get_layout_info
+        { "layout": "bsp", ... }
+
+        ## System log (KiwiDesk filter)
+        [timestamp] ...
+
+  - type: checkboxes
+    id: other_tools
+    attributes:
+      label: Other window managers or AX tools running?
+      description: |
+        Some tools interact. Is anything else managing windows,
+        tracking focus, or controlling accessibility?
+      options:
+        - label: Other window managers (e.g., Rectangle, yabai)
+        - label: Accessibility tools (e.g., Keyboard Maestro)
+        - label: None that I know of
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra_context
+    attributes:
+      label: Extra context
+      description: "Any other relevant details?"
+      placeholder: |
+        Happens only with a specific app?
+        Only on external monitor?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/hajiboy95/KiwiDesk/security/advisories/new
+    about: |
+      Report privately via GitHub's Security tab.
+      See SECURITY.md for details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,10 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Questions & ideas
+    url: https://github.com/hajiboy95/KiwiDesk/discussions
+    about: |
+      Ask a question, share a setup, or float a feature idea
+      in Discussions before opening an issue.
   - name: Security vulnerability
     url: https://github.com/hajiboy95/KiwiDesk/security/advisories/new
     about: |

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,9 +9,8 @@ body:
         solves**, not just the feature itself.
 
         Check the **Status** note at the top of the
-        [README](https://github.com/hajiboy95/KiwiDesk) first —
-        the SwiftUI GUI, per-native-space profiles, and
-        drag-and-drop are already planned.
+        [README](https://github.com/hajiboy95/KiwiDesk) first to
+        see what already ships and what's still in progress.
 
   - type: textarea
     id: use_case

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature Request
+description: Suggest an enhancement or new behavior
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the **use case** and the **problem it
+        solves**, not just the feature itself.
+
+        Check the **Status** note at the top of the
+        [README](https://github.com/hajiboy95/KiwiDesk) first —
+        the SwiftUI GUI, per-native-space profiles, and
+        drag-and-drop are already planned.
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: |
+        What are you trying to do? What workflow or problem
+        does this enable?
+      placeholder: |
+        I manage windows across many spaces and need to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: |
+        How would you like KiwiDesk to behave? Be as specific
+        or exploratory as you like.
+      placeholder: |
+        - A new command or setting like...
+        - A change to existing behavior (e.g., ...)
+        - Integration with (e.g., ...)
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: |
+        Any other approaches or workarounds you've tried?
+      placeholder: "I've tried using..., but it doesn't..."
+
+  - type: textarea
+    id: extra_context
+    attributes:
+      label: Extra context
+      placeholder: "Screenshots, examples, or related projects?"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description
+
+Brief summary of the change(s).
+
+## Related Issue(s)
+
+Closes #... (if applicable)
+
+## Checklist
+
+- [ ] Commits follow Conventional Commits format
+  (see AGENTS.md §3)
+- [ ] New behavior is tested (pure logic / layout code
+  required)
+- [ ] User-facing changes are documented in `docs/`
+- [ ] No contradictions between code and docs
+- [ ] `swift build && swift test && ./scripts/lint.sh`
+  passes
+- [ ] Release build passes: `swift build -c release`
+- [ ] PR is focused; refactors separated from features
+
+## Notes for Reviewer
+
+(Any context that makes review easier, or open questions.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,20 @@ and (later) the Lua VM.
    their findings before opening a PR. (See §4 subagent
    delegation.)
 
+### Branching & Pull Requests
+
+Branch from `main` with a name that matches the Conventional
+Commit type: `feat/`, `fix/`, `refactor/`, `docs/`, `test/`,
+`chore/`, `ci/`, `perf/`, etc., followed by a short kebab-case
+description (e.g., `feat/scrolling-snap-mode`). One focused
+change per branch; separate refactors from features.
+
+When opening an issue or pull request, use the GitHub
+[issue templates](.github/ISSUE_TEMPLATE/) and
+[PR template](.github/pull_request_template.md). Reference
+related issues in commit messages or PR descriptions using
+`fixes #123` syntax.
+
 ### Commit messages (Angular / Conventional Commits)
 
 Format: `type(scope): subject` — imperative, lower-case subject,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,33 +33,46 @@ The binding style and workflow rules live in
 - Run `swift build && swift test && ./scripts/lint.sh` before
   pushing — CI enforces all three and blocks merging on red.
 
-## Pull Requests
+## Branching & Pull Requests
 
-1. Fork and branch from `main`.
-2. Keep PRs focused; separate refactors from features.
-3. Include tests for new behavior and update the docs
-   (`docs/`, README) when you change user-facing behavior.
-4. Make sure CI is green.
+**Branch naming:** follow Conventional Commit types with kebab-case
+descriptions. Examples:
+- `feat/scrolling-snap-mode` — new feature
+- `fix/z-order-on-monitor-change` — bug fix
+- `refactor/layout-math` — code restructure (no behavior change)
+- `docs/update-cli-guide` — documentation
+- `test/animation-timing` — new tests
+- `chore/upgrade-lua` — build/maintenance
 
-## Bug Reports
+Branch from `main` and keep one focused change per branch. Separate
+refactors from features (review them independently).
 
-Please include:
+**Pull request process:**
+1. Fill in the PR template (checklist of tests, docs,
+   linting).
+2. Commit messages follow Conventional Commits format
+   (see [AGENTS.md](AGENTS.md) §3).
+3. CI (build, lint, test) must pass before merging.
+4. Address feedback from code-reviewer and
+   architect-reviewer agents (see [AGENTS.md](AGENTS.md) §4)
+   before opening a PR.
 
-- macOS version and Mac model (Apple Silicon / Intel).
-- KiwiDesk version or commit hash.
-- Steps to reproduce, expected vs. actual behavior.
-- Relevant output: `KiwiDesk get_state`,
-  `KiwiDesk get_layout_info`, and log lines (KiwiDesk logs to
-  the system log; filter for "KiwiDesk").
-- Whether other window managers / AX tools were running —
-  they often interact.
+## Reporting Issues
 
-## Feature Requests
+Use the [issue templates](.github/ISSUE_TEMPLATE/) when opening
+an issue. GitHub will prompt you to choose a template.
 
-Open an issue describing the use case (not just the feature).
-Check the roadmap in the README status note first — the GUI,
-per-native-space profiles, and drag-and-drop are already
-planned.
+**Bug reports** capture macOS version, KiwiDesk version/commit,
+repro steps, expected vs. actual behavior, and relevant logs
+(`KiwiDesk get_state`, `get_layout_info`, and system log lines).
+The template walks you through the details.
+
+**Feature requests** should describe the **use case** and
+**problem it solves** (not just the feature itself). Check the
+**Status** note at the top of the
+[README](https://github.com/hajiboy95/KiwiDesk) first — the
+SwiftUI GUI, per-native-space profiles, and drag-and-drop are
+already planned.
 
 ## Vulnerability Reports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,8 @@ The template walks you through the details.
 **Feature requests** should describe the **use case** and
 **problem it solves** (not just the feature itself). Check the
 **Status** note at the top of the
-[README](https://github.com/hajiboy95/KiwiDesk) first — the
-SwiftUI GUI, per-native-space profiles, and drag-and-drop are
-already planned.
+[README](https://github.com/hajiboy95/KiwiDesk) first to see
+what already ships and what's still in progress.
 
 ## Vulnerability Reports
 

--- a/scripts/install-subagents.sh
+++ b/scripts/install-subagents.sh
@@ -17,6 +17,7 @@ AGENTS=(
     "03-infrastructure/devops-engineer"
     "04-quality-security/code-reviewer"
     "04-quality-security/architect-reviewer"
+    "06-developer-experience/git-workflow-manager"
     "09-meta-orchestration/codebase-orchestrator"
 )
 


### PR DESCRIPTION
## Summary

Sets up the repository's contribution workflow surface: issue/PR
templates, branch-naming guidance, GitHub Discussions, and the
git-workflow-manager subagent in the installer.

## Changes

- **Issue & PR templates** — bug report + feature request forms, a
  PR template, and branch-naming guidance in AGENTS.md /
  CONTRIBUTING.md.
- **Discussions** — enabled on the repo, with a "Questions & ideas"
  contact link in the issue-template chooser.
- **Subagent installer** — adds `git-workflow-manager` to
  `scripts/install-subagents.sh`.

## Notes

- Feature-request guidance now points at the README **Status** note
  rather than a hand-listed roadmap, which had gone stale
  (per-native-space profiles already ships; drag-and-drop was never
  in the status). Keeps the guidance from drifting.
- `KiwiDesk --version` was intentionally left out of the bug
  template — that command doesn't exist yet (tracked as a follow-up
  to add the command, then wire it back into the template + docs).

## Test plan

- Docs/templates only; no code paths touched.
- Template YAML renders in GitHub's issue chooser; contact links
  resolve (Discussions tab now live, security advisories page
  exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)