### PR TITLE
refactor(lua): pin default-mode icon asymmetry

### DIFF
--- a/Sources/KiwiDeskCore/Config/LuaConfigWriter+Layout.swift
+++ b/Sources/KiwiDeskCore/Config/LuaConfigWriter+Layout.swift
@@ -109,7 +109,7 @@ extension LuaConfigWriter {
                 !$0.combo.isEmpty
             }
             if mode.isDefault {
-                blocks.append(defaultBinds(mode, rows: rows))
+                blocks.append(defaultBinds(rows))
             } else {
                 blocks.append(defineMode(mode, rows: rows))
             }
@@ -123,18 +123,14 @@ extension LuaConfigWriter {
     /// The default mode always shows the standard menu bar
     /// glyph — the GUI never offers an icon picker for it (see
     /// `KeybindingsTab.modeIconRow`), so `KiwiDesk.bind` has no
-    /// icon argument to emit. This assertion pins that
-    /// asymmetry: revisit both sides together if it ever
-    /// changes.
+    /// icon argument to emit. Any icon on the default mode
+    /// (e.g. from hand-edited profile JSON) is silently dropped
+    /// here rather than surfaced: revisit both sides together
+    /// if the GUI ever allows a default-mode icon.
     private static func defaultBinds(
-        _ mode: KeyMode,
-        rows: [KeyBinding]
+        _ rows: [KeyBinding]
     ) -> String {
-        assert(
-            mode.icon == nil,
-            "default mode must never carry an icon"
-        )
-        return rows.map { row in
+        rows.map { row in
             "KiwiDesk.bind("
                 + LuaLiteral.string(row.combo)
                 + ", function()\n" + indent(row.lua)

--- a/Sources/KiwiDeskCore/Config/LuaConfigWriter+Layout.swift
+++ b/Sources/KiwiDeskCore/Config/LuaConfigWriter+Layout.swift
@@ -109,7 +109,7 @@ extension LuaConfigWriter {
                 !$0.combo.isEmpty
             }
             if mode.isDefault {
-                blocks.append(defaultBinds(rows))
+                blocks.append(defaultBinds(mode, rows: rows))
             } else {
                 blocks.append(defineMode(mode, rows: rows))
             }
@@ -120,10 +120,21 @@ extension LuaConfigWriter {
             .joined(separator: "\n\n")
     }
 
+    /// The default mode always shows the standard menu bar
+    /// glyph — the GUI never offers an icon picker for it (see
+    /// `KeybindingsTab.modeIconRow`), so `KiwiDesk.bind` has no
+    /// icon argument to emit. This assertion pins that
+    /// asymmetry: revisit both sides together if it ever
+    /// changes.
     private static func defaultBinds(
-        _ rows: [KeyBinding]
+        _ mode: KeyMode,
+        rows: [KeyBinding]
     ) -> String {
-        rows.map { row in
+        assert(
+            mode.icon == nil,
+            "default mode must never carry an icon"
+        )
+        return rows.map { row in
             "KiwiDesk.bind("
                 + LuaLiteral.string(row.combo)
                 + ", function()\n" + indent(row.lua)

--- a/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
+++ b/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
@@ -151,6 +151,25 @@ struct ConfigWriteTests {
         #expect(!lua.contains("define_mode(\"default\""))
     }
 
+    @Test(
+        "a malformed default mode icon is dropped, not emitted"
+    )
+    func defaultModeIconIsDropped() {
+        let modes = [
+            KeyMode(
+                name: KeyMode.defaultName,
+                icon: "📐",
+                bindings: [
+                    KeyBinding(combo: "alt+h", lua: "-- noop")
+                ]
+            )
+        ]
+        let lua = LuaConfigWriter.keybindings(modes)
+        #expect(lua.contains("KiwiDesk.bind(\"alt+h\""))
+        #expect(!lua.contains("icon ="))
+        #expect(!lua.contains("define_mode"))
+    }
+
     @Test("round-trip: write, reload, live state matches")
     func roundTrip() throws {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
+++ b/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
@@ -124,6 +124,33 @@ struct ConfigWriteTests {
         #expect(!lua.contains("top ="))
     }
 
+    @Test(
+        "default mode never emits an icon; other modes do"
+    )
+    func defaultModeHasNoIcon() {
+        let modes = [
+            KeyMode(
+                name: "default",
+                bindings: [
+                    KeyBinding(combo: "alt+h", lua: "-- noop")
+                ]
+            ),
+            KeyMode(
+                name: "resize",
+                icon: "📐",
+                bindings: [
+                    KeyBinding(combo: "alt+l", lua: "-- noop")
+                ]
+            ),
+        ]
+        let lua = LuaConfigWriter.keybindings(modes)
+        #expect(lua.contains("KiwiDesk.bind(\"alt+h\""))
+        #expect(lua.contains("icon = \"📐\""))
+        // The default mode's block never carries an icon
+        // argument — only `KiwiDesk.bind`, no `define_mode`.
+        #expect(!lua.contains("define_mode(\"default\""))
+    }
+
     @Test("round-trip: write, reload, live state matches")
     func roundTrip() throws {
         let core = makeCore()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -495,7 +495,8 @@ KiwiDesk.define_mode("service", { --[[ bindings ]] },
 The default mode (`KiwiDesk.bind`) never takes an icon — it
 always shows the standard KiwiDesk glyph. The Settings app
 reflects this by hiding the icon picker while the default mode
-is selected.
+is selected. An icon set on the default mode by hand (e.g. in
+directly-edited profile JSON) is simply ignored and never shown.
 
 ## Events
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -492,6 +492,11 @@ KiwiDesk.define_mode("service", { --[[ bindings ]] },
     { icon = "⚙️" })
 ```
 
+The default mode (`KiwiDesk.bind`) never takes an icon — it
+always shows the standard KiwiDesk glyph. The Settings app
+reflects this by hiding the icon picker while the default mode
+is selected.
+
 ## Events
 
 Subscribe to state changes (see also


### PR DESCRIPTION
## Description

The Lua writer's `defaultBinds` silently ignored a `KeyMode`
icon, while `defineMode` emitted one for every other mode. The
GUI already enforces the asymmetry (`KeybindingsTab.modeIconRow`
hides the icon picker for the `default` mode), but nothing
asserted the two stayed in sync on the writer side. This change
documents and enforces the invariant so it can't silently drift.

## Related Issue(s)

Fixes #15

## Checklist

- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## Notes for Reviewer

Enforcement approach: `LuaConfigWriter.defaultBinds` now takes
the `KeyMode` (not just its rows) and `assert`s `mode.icon ==
nil` before emitting `KiwiDesk.bind` calls — this traps in debug
builds if the invariant is ever violated upstream (e.g. the GUI
guard is removed) but is a no-op in release, matching how Swift
`assert` normally behaves. A new unit test in
`ConfigWriteTests.swift` (`defaultModeHasNoIcon`) pins the
observable behavior in all build configurations: it writes a
mix of a default mode and an iconed mode and checks the output
never contains a `define_mode("default"...)` block or an icon
argument on the default mode's bindings. Also added a short note
to `docs/configuration.md` under "Modal modes" clarifying the
default mode never takes an icon.

If the GUI ever allows a default-mode icon, both
`KeybindingsTab.modeIconRow` and this assertion/test need to be
revisited together, as called out in the code comment.