### PR TITLE
fix(lua): non-blocking external commands (KiwiDesk.exec, async os.execute)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,16 @@ Keep this list updated whenever a recurring mistake is found.
   while a failed lookup returns nil and the caller falls back to
   the public Accessibility API (`AXUIElement`). Every private
   fast path must have such a fallback.
+- **The Lua watchdog cannot interrupt blocking C calls.** The
+  runaway-script guard is an instruction-count hook; code that
+  blocks inside C (`system()`, pipe reads) executes zero VM
+  instructions and freezes the main thread forever. Never add
+  an API that blocks in C on the main thread — external
+  commands always go through `ExecLauncher`. Lua registry refs
+  (`luaL_ref`) are VM-specific and their slots are reused:
+  never deliver a ref into a different interpreter than the
+  one that minted it (capture the owning `LuaInterpreter`
+  weakly, as `KiwiCore+ExecAPI` does).
 - **AX calls are slow and can block.** Never call AX APIs inside
   tight loops or layout math; snapshot state first.
 - **Electron/WebKit apps answer AX queries lazily** (100–300 ms).

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -101,6 +101,9 @@ public final class KiwiCore {
         keys.onLog = { [weak self] message in
             self?.onLog(message)
         }
+        exec.onLog = { [weak self] message in
+            self?.onLog(message)
+        }
         wireDrag()
         appBar.onSelect = { [weak self] id in
             self?.focusWindow(id)

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -19,6 +19,7 @@ public final class KiwiCore {
     public let profiles: ProfileManager
     public let crash: CrashRecovery
     public internal(set) var lua: LuaInterpreter?
+    public let exec = ExecLauncher()
 
     /// A stack z-order restore is waiting for the current
     /// animations to settle (see restoreStackZOrder).

--- a/Sources/KiwiDeskCore/Lua/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/Lua/ExecLauncher.swift
@@ -1,0 +1,185 @@
+import Foundation
+import os
+
+/// Launches external commands without ever blocking the main
+/// thread (issue #5): `KiwiDesk.exec` and the async `os.execute`
+/// replacement both funnel through here.
+///
+/// Each command runs as `/bin/sh -c <command>`. The launcher
+/// never waits for the child; an optional Lua callback is
+/// invoked back on the main actor once the child exits, with
+/// `(exit_code, stdout, stderr)`. Output pipes are only created
+/// when a callback exists, and they are drained on a background
+/// queue — the main thread never touches a pipe, so even a
+/// child that leaves grandchildren holding the descriptors open
+/// can only delay its own callback, never stall the app.
+@MainActor
+public final class ExecLauncher {
+    /// Delivers callbacks into the VM. Weak on purpose: a
+    /// config reload replaces the interpreter, and pending
+    /// callbacks into the torn-down VM must silently drop.
+    public weak var lua: LuaInterpreter?
+
+    public var onLog: @MainActor (String) -> Void = { message in
+        NSLog("KiwiDesk: %@", message)
+    }
+
+    /// Children we have launched and not yet reaped. Process
+    /// objects must stay alive until termination or their
+    /// handlers never fire.
+    private var running: [Int32: Process] = [:]
+
+    public init() {}
+
+    public var runningCount: Int { running.count }
+
+    /// Starts `command` and returns its pid, or nil when the
+    /// child could not be spawned. `callbackRef` is a Lua
+    /// registry reference; ownership transfers to the launcher,
+    /// which releases it after delivery.
+    @discardableResult
+    public func launch(
+        _ command: String,
+        callbackRef: Int32? = nil
+    ) -> Int32? {
+        let process = Process()
+        process.executableURL = URL(
+            fileURLWithPath: "/bin/sh"
+        )
+        process.arguments = ["-c", command]
+
+        let capture: OutputCapture?
+        if callbackRef != nil {
+            let pipes = (out: Pipe(), err: Pipe())
+            process.standardOutput = pipes.out
+            process.standardError = pipes.err
+            capture = OutputCapture(pipes.out, pipes.err)
+        } else {
+            capture = nil
+        }
+
+        // Install before run(): a fast child may exit before
+        // launch() returns, and a handler set after the fact
+        // would never fire. The main-actor reap cannot race
+        // the bookkeeping below — it only runs once launch()
+        // has returned control to the main actor.
+        process.terminationHandler = { [weak self] child in
+            let pid = child.processIdentifier
+            let code = child.terminationStatus
+            let deliver: @Sendable (String, String) -> Void = {
+                out,
+                err in
+                Task { @MainActor in
+                    self?.reap(
+                        pid: pid,
+                        code: code,
+                        callbackRef: callbackRef,
+                        stdout: out,
+                        stderr: err
+                    )
+                }
+            }
+            if let capture {
+                capture.onComplete(deliver)
+            } else {
+                deliver("", "")
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            onLog(
+                "exec: failed to start '\(command)': \(error)"
+            )
+            if let ref = callbackRef {
+                lua?.release(ref: ref)
+            }
+            return nil
+        }
+
+        running[process.processIdentifier] = process
+        capture?.drain()
+        return process.processIdentifier
+    }
+
+    private func reap(
+        pid: Int32,
+        code: Int32,
+        callbackRef: Int32?,
+        stdout: String,
+        stderr: String
+    ) {
+        running[pid] = nil
+        guard let ref = callbackRef else { return }
+        guard let lua else { return }
+        defer { lua.release(ref: ref) }
+        let result = lua.call(
+            ref: ref,
+            args: [
+                .number(Double(code)),
+                .string(stdout),
+                .string(stderr),
+            ]
+        )
+        if case .failure(let error) = result {
+            onLog("exec callback error: \(error)")
+        }
+    }
+}
+
+/// Drains a child's stdout/stderr to end on a background
+/// queue and reports both, off the main thread, once both
+/// reads hit EOF.
+private final class OutputCapture: Sendable {
+    private let out: Pipe
+    private let err: Pipe
+    private let group = DispatchGroup()
+    private let collected = OSAllocatedUnfairLock(
+        initialState: (out: Data(), err: Data())
+    )
+
+    init(_ out: Pipe, _ err: Pipe) {
+        self.out = out
+        self.err = err
+    }
+
+    /// Starts both reads; must be called exactly once.
+    func drain() {
+        read(out.fileHandleForReading) { [collected] data in
+            collected.withLock { $0.out = data }
+        }
+        read(err.fileHandleForReading) { [collected] data in
+            collected.withLock { $0.err = data }
+        }
+    }
+
+    private func read(
+        _ handle: FileHandle,
+        _ store: @escaping @Sendable (Data) -> Void
+    ) {
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            [group] in
+            let data = handle.readDataToEndOfFile()
+            store(data)
+            group.leave()
+        }
+    }
+
+    /// Calls `handler` (on a background queue) once both
+    /// streams are fully read.
+    func onComplete(
+        _ handler: @escaping @Sendable (String, String) -> Void
+    ) {
+        group.notify(
+            queue: .global(qos: .utility)
+        ) { [collected] in
+            let (outData, errData) = collected.withLock { $0 }
+            handler(
+                String(decoding: outData, as: UTF8.self),
+                String(decoding: errData, as: UTF8.self)
+            )
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/Lua/KiwiCore+ExecAPI.swift
+++ b/Sources/KiwiDeskCore/Lua/KiwiCore+ExecAPI.swift
@@ -9,34 +9,75 @@ import Foundation
 /// executes zero VM instructions, so the hook can never fire
 /// and the whole app freezes. External commands therefore must
 /// always go through `ExecLauncher`, which backgrounds them.
+///
+/// `exec` is deliberately Lua-only, like `bind` and `on`: its
+/// callback cannot cross the JSON socket, and exposing shell
+/// execution on the IPC socket would let any client with file
+/// access to it run commands under KiwiDesk's identity (and
+/// its Accessibility grant). Do not add it to the dispatcher.
 extension KiwiCore {
     func registerExecAPI(on lua: LuaInterpreter) {
-        exec.lua = lua
-        exec.onLog = { [weak self] message in
-            self?.onLog(message)
-        }
-        lua.register("exec") { [weak self] args in
+        lua.register("exec") { [weak self, weak lua] args in
+            let callbackRef: Int32?
+            if case .functionRef(let ref) =
+                args.dropFirst().first ?? .none
+            {
+                callbackRef = ref
+            } else {
+                callbackRef = nil
+            }
             guard let self,
                 let command = args.first?.stringValue,
                 !command.isEmpty
             else {
+                // The trampoline already took registry refs
+                // on any function arguments; don't leak them.
+                for case .functionRef(let ref) in args {
+                    lua?.release(ref: ref)
+                }
                 self?.onLog(
                     "exec(): expected a command string"
                 )
                 return .none
             }
-            var ref: Int32?
-            if case .functionRef(let found) =
-                args.dropFirst().first ?? .none
-            {
-                ref = found
+            var onExit: ExecLauncher.ExitHandler?
+            if let ref = callbackRef {
+                // Bind the ref to the VM that minted it: on a
+                // config reload the weak capture goes nil and
+                // the callback drops silently. A ref must
+                // never reach a different VM's registry —
+                // its slot may already belong to an unrelated
+                // function there.
+                onExit = {
+                    [weak self, weak lua] code, out, err in
+                    guard let lua else { return }
+                    defer { lua.release(ref: ref) }
+                    let result = lua.call(
+                        ref: ref,
+                        args: [
+                            .number(Double(code)),
+                            .string(out),
+                            .string(err),
+                        ]
+                    )
+                    if case .failure(let error) = result {
+                        self?.onLog(
+                            "exec callback error: \(error)"
+                        )
+                    }
+                }
             }
             guard
                 let pid = self.exec.launch(
                     command,
-                    callbackRef: ref
+                    onExit: onExit
                 )
-            else { return .none }
+            else {
+                if let ref = callbackRef {
+                    lua?.release(ref: ref)
+                }
+                return .none
+            }
             return .number(Double(pid))
         }
         neutralizeBlockingOSCalls(on: lua)

--- a/Sources/KiwiDeskCore/Lua/KiwiCore+ExecAPI.swift
+++ b/Sources/KiwiDeskCore/Lua/KiwiCore+ExecAPI.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// `KiwiDesk.exec` and the non-blocking `os.execute` bridge
+/// (issue #5).
+///
+/// The Lua VM runs synchronously on the main thread, and the
+/// runaway-script guard is an instruction-count hook — a
+/// callback blocking inside a C call (`system()`, pipe reads)
+/// executes zero VM instructions, so the hook can never fire
+/// and the whole app freezes. External commands therefore must
+/// always go through `ExecLauncher`, which backgrounds them.
+extension KiwiCore {
+    func registerExecAPI(on lua: LuaInterpreter) {
+        exec.lua = lua
+        exec.onLog = { [weak self] message in
+            self?.onLog(message)
+        }
+        lua.register("exec") { [weak self] args in
+            guard let self,
+                let command = args.first?.stringValue,
+                !command.isEmpty
+            else {
+                self?.onLog(
+                    "exec(): expected a command string"
+                )
+                return .none
+            }
+            var ref: Int32?
+            if case .functionRef(let found) =
+                args.dropFirst().first ?? .none
+            {
+                ref = found
+            }
+            guard
+                let pid = self.exec.launch(
+                    command,
+                    callbackRef: ref
+                )
+            else { return .none }
+            return .number(Double(pid))
+        }
+        neutralizeBlockingOSCalls(on: lua)
+    }
+
+    /// Rewrites the stdlib entry points that block in C where
+    /// the instruction-count watchdog cannot interrupt them:
+    /// `os.execute` becomes fire-and-forget via `exec`, and
+    /// `io.popen` is disabled outright (its synchronous
+    /// read-the-output contract cannot be honored without
+    /// blocking).
+    private func neutralizeBlockingOSCalls(
+        on lua: LuaInterpreter
+    ) {
+        lua.run(
+            """
+            local launch = KiwiDesk.exec
+            local warned = false
+            os.execute = function(command)
+                if command == nil then return true end
+                if not warned then
+                    warned = true
+                    KiwiDesk.debug_log(
+                        "os.execute runs asynchronously in "
+                        .. "KiwiDesk; use KiwiDesk.exec(cmd, "
+                        .. "callback) for exit codes")
+                end
+                launch(command)
+                return true
+            end
+            io.popen = function()
+                return nil, "io.popen is disabled (it "
+                    .. "blocks the app); use KiwiDesk.exec("
+                    .. "cmd, callback) instead"
+            end
+            """
+        )
+    }
+}

--- a/Sources/KiwiDeskCore/Lua/KiwiCore+LuaAPI.swift
+++ b/Sources/KiwiDeskCore/Lua/KiwiCore+LuaAPI.swift
@@ -47,6 +47,7 @@ extension KiwiCore {
         }
         registerEventAPI(on: lua)
         registerKeybindingAPI(on: lua)
+        registerExecAPI(on: lua)
         installTypoGuard(on: lua)
     }
 

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -6,50 +6,53 @@ import os
 /// replacement both funnel through here.
 ///
 /// Each command runs as `/bin/sh -c <command>`. The launcher
-/// never waits for the child; an optional Lua callback is
+/// never waits for the child; the optional `onExit` closure is
 /// invoked back on the main actor once the child exits, with
 /// `(exit_code, stdout, stderr)`. Output pipes are only created
-/// when a callback exists, and they are drained on a background
+/// when a closure exists, and they are drained on a background
 /// queue — the main thread never touches a pipe, so even a
 /// child that leaves grandchildren holding the descriptors open
 /// can only delay its own callback, never stall the app.
+///
+/// The launcher knows nothing about Lua: callers bind their own
+/// callback lifetime into `onExit` (see `KiwiCore+ExecAPI`,
+/// which captures the owning interpreter weakly so a config
+/// reload drops pending callbacks).
 @MainActor
 public final class ExecLauncher {
-    /// Delivers callbacks into the VM. Weak on purpose: a
-    /// config reload replaces the interpreter, and pending
-    /// callbacks into the torn-down VM must silently drop.
-    public weak var lua: LuaInterpreter?
+    public typealias ExitHandler =
+        @MainActor @Sendable (Int32, String, String) -> Void
 
     public var onLog: @MainActor (String) -> Void = { message in
         NSLog("KiwiDesk: %@", message)
     }
 
-    /// Children we have launched and not yet reaped. Process
-    /// objects must stay alive until termination or their
-    /// handlers never fire.
-    private var running: [Int32: Process] = [:]
+    /// Children we have launched and not yet reaped, keyed by
+    /// object identity (pids can be recycled). Process objects
+    /// must stay alive until termination or their handlers
+    /// never fire.
+    private var running: [ObjectIdentifier: Process] = [:]
 
     public init() {}
 
     public var runningCount: Int { running.count }
 
     /// Starts `command` and returns its pid, or nil when the
-    /// child could not be spawned. `callbackRef` is a Lua
-    /// registry reference; ownership transfers to the launcher,
-    /// which releases it after delivery.
+    /// child could not be spawned.
     @discardableResult
     public func launch(
         _ command: String,
-        callbackRef: Int32? = nil
+        onExit: ExitHandler? = nil
     ) -> Int32? {
         let process = Process()
         process.executableURL = URL(
             fileURLWithPath: "/bin/sh"
         )
         process.arguments = ["-c", command]
+        process.environment = Self.childEnvironment()
 
         let capture: OutputCapture?
-        if callbackRef != nil {
+        if onExit != nil {
             let pipes = (out: Pipe(), err: Pipe())
             process.standardOutput = pipes.out
             process.standardError = pipes.err
@@ -64,16 +67,16 @@ public final class ExecLauncher {
         // the bookkeeping below — it only runs once launch()
         // has returned control to the main actor.
         process.terminationHandler = { [weak self] child in
-            let pid = child.processIdentifier
+            let key = ObjectIdentifier(child)
             let code = child.terminationStatus
             let deliver: @Sendable (String, String) -> Void = {
                 out,
                 err in
                 Task { @MainActor in
                     self?.reap(
-                        pid: pid,
+                        key: key,
                         code: code,
-                        callbackRef: callbackRef,
+                        onExit: onExit,
                         stdout: out,
                         stderr: err
                     )
@@ -92,39 +95,40 @@ public final class ExecLauncher {
             onLog(
                 "exec: failed to start '\(command)': \(error)"
             )
-            if let ref = callbackRef {
-                lua?.release(ref: ref)
-            }
             return nil
         }
 
-        running[process.processIdentifier] = process
+        running[ObjectIdentifier(process)] = process
         capture?.drain()
         return process.processIdentifier
     }
 
     private func reap(
-        pid: Int32,
+        key: ObjectIdentifier,
         code: Int32,
-        callbackRef: Int32?,
+        onExit: ExitHandler?,
         stdout: String,
         stderr: String
     ) {
-        running[pid] = nil
-        guard let ref = callbackRef else { return }
-        guard let lua else { return }
-        defer { lua.release(ref: ref) }
-        let result = lua.call(
-            ref: ref,
-            args: [
-                .number(Double(code)),
-                .string(stdout),
-                .string(stderr),
-            ]
-        )
-        if case .failure(let error) = result {
-            onLog("exec callback error: \(error)")
+        running[key] = nil
+        onExit?(code, stdout, stderr)
+    }
+
+    /// GUI apps inherit launchd's minimal PATH, not the user's
+    /// shell PATH — `sketchybar`, `borders`, etc. live in the
+    /// Homebrew prefix and would be "command not found" in
+    /// production while working in terminal-launched dev runs.
+    private static func childEnvironment() -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        var parts = (env["PATH"] ?? "")
+            .split(separator: ":")
+            .map(String.init)
+        for extra in ["/opt/homebrew/bin", "/usr/local/bin"]
+        where !parts.contains(extra) {
+            parts.append(extra)
         }
+        env["PATH"] = parts.joined(separator: ":")
+        return env
     }
 }
 
@@ -142,6 +146,12 @@ private final class OutputCapture: Sendable {
     init(_ out: Pipe, _ err: Pipe) {
         self.out = out
         self.err = err
+        // Enter for both streams up front: the termination
+        // handler can fire before drain() runs on the main
+        // actor, and an empty group would notify immediately
+        // with empty output.
+        group.enter()
+        group.enter()
     }
 
     /// Starts both reads; must be called exactly once.
@@ -158,11 +168,12 @@ private final class OutputCapture: Sendable {
         _ handle: FileHandle,
         _ store: @escaping @Sendable (Data) -> Void
     ) {
-        group.enter()
         DispatchQueue.global(qos: .utility).async {
             [group] in
-            let data = handle.readDataToEndOfFile()
-            store(data)
+            // readToEnd throws on I/O errors; the legacy
+            // readDataToEndOfFile raises an ObjC exception
+            // Swift cannot catch.
+            store((try? handle.readToEnd()) ?? Data())
             group.leave()
         }
     }

--- a/Tests/KiwiDeskCoreTests/ExecTests.swift
+++ b/Tests/KiwiDeskCoreTests/ExecTests.swift
@@ -109,6 +109,36 @@ struct ExecTests {
         #expect(core.exec.runningCount == 0)
     }
 
+    @Test("config reload drops pending exec callbacks")
+    func reloadDropsPendingCallbacks() async throws {
+        let core = makeCore()
+        let lua1 = try #require(core.lua)
+        #expect(
+            lua1.run(
+                """
+                KiwiDesk.exec("sleep 0.2", function()
+                    hit = true
+                end)
+                """
+            ).succeeded
+        )
+        // Reload swaps in a fresh VM; the pending ref was
+        // minted in the old one and must never cross over.
+        core.loadConfig()
+        let lua2 = try #require(core.lua)
+        let deadline = Date().addingTimeInterval(5)
+        while core.exec.runningCount > 0, Date() < deadline {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        // Child was reaped, but the callback went nowhere:
+        // neither VM saw it.
+        #expect(core.exec.runningCount == 0)
+        #expect(lua2.global("hit") == .none)
+        // The fresh VM is fully functional afterwards.
+        #expect(lua2.run("sane = 1").succeeded)
+        #expect(lua2.global("sane") == .number(1))
+    }
+
     @Test("io.popen is disabled with a pointer to exec")
     func popenDisabled() throws {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/ExecTests.swift
+++ b/Tests/KiwiDeskCoreTests/ExecTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+extension Result {
+    fileprivate var succeeded: Bool {
+        if case .success = self { return true }
+        return false
+    }
+}
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+            "kiwidesk-exec-tests-\(UUID().uuidString)"
+        )
+    let core = KiwiCore(configDirectory: directory)
+    core.loadConfig()
+    return core
+}
+
+/// Polls the Lua global until it is non-nil or the timeout
+/// elapses (exec callbacks arrive via the main-actor queue).
+@MainActor
+private func awaitGlobal(
+    _ lua: LuaInterpreter,
+    _ name: String,
+    timeout: TimeInterval = 5
+) async throws -> LuaValue {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        let value = lua.global(name)
+        if value != .none { return value }
+        try await Task.sleep(nanoseconds: 20_000_000)
+    }
+    return .none
+}
+
+@Suite("External command execution", .serialized)
+@MainActor
+struct ExecTests {
+    @Test("os.execute returns immediately, never blocking")
+    func osExecuteIsNonBlocking() throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        let started = Date()
+        let result = lua.run("ok = os.execute('sleep 2')")
+        let elapsed = Date().timeIntervalSince(started)
+        #expect(result.succeeded)
+        // system() would sit in a kernel wait for 2s; the
+        // async replacement returns right away.
+        #expect(elapsed < 1.0)
+        #expect(lua.global("ok") == .bool(true))
+    }
+
+    @Test("os.execute() without a command reports a shell")
+    func osExecuteShellQuery() throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        #expect(
+            lua.run("has_shell = os.execute()").succeeded
+        )
+        #expect(lua.global("has_shell") == .bool(true))
+    }
+
+    @Test("exec delivers exit code, stdout, and stderr")
+    func execCallback() async throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        let result = lua.run(
+            """
+            KiwiDesk.exec(
+                "printf hello; printf oops 1>&2; exit 3",
+                function(code, out, err)
+                    got_code = code
+                    got_out = out
+                    got_err = err
+                end)
+            """
+        )
+        #expect(result.succeeded)
+        let code = try await awaitGlobal(lua, "got_code")
+        #expect(code == .number(3))
+        #expect(lua.global("got_out") == .string("hello"))
+        #expect(lua.global("got_err") == .string("oops"))
+    }
+
+    @Test("exec without callback returns a pid and reaps")
+    func execFireAndForget() async throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        #expect(
+            lua.run("pid = KiwiDesk.exec('true')").succeeded
+        )
+        guard
+            case .number(let pid) = lua.global("pid")
+        else {
+            Issue.record("expected a pid")
+            return
+        }
+        #expect(pid > 0)
+        // The launcher lets go of the Process once reaped.
+        let deadline = Date().addingTimeInterval(5)
+        while core.exec.runningCount > 0, Date() < deadline {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(core.exec.runningCount == 0)
+    }
+
+    @Test("io.popen is disabled with a pointer to exec")
+    func popenDisabled() throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        #expect(
+            lua.run(
+                "h, msg = io.popen('ls')"
+            ).succeeded
+        )
+        #expect(lua.global("h") == .none)
+        guard
+            case .string(let message) = lua.global("msg")
+        else {
+            Issue.record("expected an error message")
+            return
+        }
+        #expect(message.contains("KiwiDesk.exec"))
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -537,7 +537,11 @@ it is called once the command has exited, with:
 immediately — KiwiDesk never waits for it. Returns the
 child's pid (a number), or `nil` when the command could not
 be started. If the config reloads before the command
-finishes, the callback is dropped silently.
+finishes, the callback is dropped silently. The child's
+`PATH` gets `/opt/homebrew/bin` and `/usr/local/bin`
+appended, so Homebrew tools (`sketchybar`, `borders`, …)
+resolve even when KiwiDesk was launched from Finder — GUI
+apps inherit launchd's minimal `PATH`, not your shell's.
 
 **Example:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -499,7 +499,7 @@ Subscribe to state changes (see also
 
 ```lua
 KiwiDesk.on("space_change", function(space_id, mode)
-    os.execute(
+    KiwiDesk.exec(
         "sketchybar --trigger space_change SPACE="
         .. space_id)
 end)
@@ -512,6 +512,86 @@ end)
 | `focus_change` | `window_id`, `app` |
 | `monitor_change` | `monitor_count` |
 | `native_space_change` | `native_space` (desktop number) |
+
+## External Commands
+
+Config callbacks run on KiwiDesk's main thread — a shell
+command that waits synchronously there would freeze window
+management, animations, and the menu bar. External commands
+therefore always run in the background.
+
+### `KiwiDesk.exec(command [, callback])`
+
+**Expects:** `command` — a string, run via `/bin/sh -c`, so
+pipes, quoting, `&&`, and `$PATH` lookups work exactly as in
+a terminal. `callback` — an optional Lua function; if given,
+it is called once the command has exited, with:
+
+| Callback argument | Type | Meaning |
+|---|---|---|
+| `code` | number | exit code (`0` = success) |
+| `stdout` | string | everything written to stdout |
+| `stderr` | string | everything written to stderr |
+
+**Does:** starts the command in the background and returns
+immediately — KiwiDesk never waits for it. Returns the
+child's pid (a number), or `nil` when the command could not
+be started. If the config reloads before the command
+finishes, the callback is dropped silently.
+
+**Example:**
+
+```lua
+-- Fire and forget:
+KiwiDesk.exec("sketchybar --reload")
+
+-- Read a command's output via the callback:
+KiwiDesk.exec("defaults read -g AppleInterfaceStyle",
+    function(code, out, err)
+        dark = (code == 0 and out:match("Dark") ~= nil)
+    end)
+```
+
+### `os.execute(command)` — asynchronous in KiwiDesk
+
+**Expects:** a command string, like standard Lua. Calling it
+with no argument keeps its stdlib meaning ("is a shell
+available?") and returns `true`.
+
+**Does:** forwards the command to `KiwiDesk.exec` and returns
+`true` **immediately** — it does *not* wait, and the return
+value says nothing about whether the command succeeded. When
+you need the exit code or output, use `KiwiDesk.exec` with a
+callback instead.
+
+**Example:**
+
+```lua
+-- Fine: fire-and-forget side effect.
+os.execute("open -a Spotify")
+
+-- Wrong: the file is NOT guaranteed to exist yet here.
+os.execute("touch /tmp/marker")
+-- do_something("/tmp/marker")
+```
+
+### `io.popen(command)` — disabled
+
+**Expects:** n/a — any call is rejected.
+
+**Does:** returns `nil` plus an explanatory message instead
+of a file handle. Reading a child's output synchronously
+cannot be done without blocking the app; `KiwiDesk.exec`
+with a callback delivers the same output asynchronously.
+
+**Example:**
+
+```lua
+-- Instead of: local h = io.popen("pmset -g batt")
+KiwiDesk.exec("pmset -g batt", function(code, out)
+    battery_info = out
+end)
+```
 
 ## Profiles & Monitors
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -10,20 +10,20 @@ Space indicator + layout mode display. In `init.lua`:
 
 ```lua
 KiwiDesk.on("space_change", function(space_id, mode)
-    os.execute(
+    KiwiDesk.exec(
         "sketchybar --trigger kiwi_space_change "
         .. "SPACE=" .. space_id .. " MODE=" .. mode)
 end)
 
 KiwiDesk.on("focus_change", function(window_id, app)
-    os.execute(
+    KiwiDesk.exec(
         "sketchybar --trigger kiwi_focus APP='"
         .. app .. "'")
 end)
 
 -- Native macOS desktop indicator (Mission Control number):
 KiwiDesk.on("native_space_change", function(desktop)
-    os.execute(
+    KiwiDesk.exec(
         "sketchybar --trigger kiwi_desktop DESKTOP="
         .. desktop)
 end)
@@ -56,7 +56,7 @@ KiwiDesk.on("layout_change", function(space_id, mode)
         floating  = "0x00000000",  -- transparent
     }
     local c = colors[mode] or "0xFFFFFFFF"
-    os.execute("borders active_color=" .. c)
+    KiwiDesk.exec("borders active_color=" .. c)
 end)
 ```
 


### PR DESCRIPTION
## Description

External commands can no longer freeze the app (issue #5): the
Lua VM is `@MainActor` and its runaway-script guard is an
instruction-count hook, so a callback blocking inside C
(`os.execute` → `system()`) executed zero VM instructions and
hung the main thread — menu bar, DisplayLink animations, event
handling — until the child unblocked.

- **`ExecLauncher`** (`Sources/KiwiDeskCore/OS/`): Lua-free
  process launcher. Runs `/bin/sh -c <cmd>`, never waits;
  optional `onExit` closure delivered on the main actor with
  `(exit_code, stdout, stderr)`. Pipes exist only when a
  callback does, drained on background queues (no >64 KB pipe
  deadlock; grandchildren holding FDs can only delay their own
  callback). Child `PATH` gets Homebrew paths appended so
  `sketchybar`/`borders` resolve under launchd's minimal PATH.
- **`KiwiDesk.exec(cmd [, callback])`**: Lua-only API (like
  `bind`/`on` — deliberately not on the dispatcher/socket; see
  the docblock for the security rationale). Callback refs are
  bound to the VM that minted them via per-launch weak capture:
  a config reload drops pending callbacks instead of letting a
  stale `luaL_ref` index fire into the fresh VM's registry.
- **`os.execute`** forwards to `exec` and returns `true`
  immediately (one-time log hint); **`io.popen`** is disabled
  with a pointer to `exec` — its synchronous contract cannot be
  honored without blocking.
- New guardrails entry in AGENTS.md; docs rewritten in
  *expects → does → example* form; integration recipes switched
  to `KiwiDesk.exec`.

Both `code-reviewer` and `architect-reviewer` ran on the branch;
their merge blocker (stale refs crossing VMs on reload) and all
mechanical findings are fixed in the third commit. Deferred
hardening items are tracked in #37.

## Related Issue(s)

Closes #5. Follow-up hardening: #37.

## Checklist

- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## Notes for Reviewer

- The regression test "config reload drops pending exec
  callbacks" pins the ref-lifetime semantics; the launcher
  keys running children by object identity because pids can
  be recycled.
- `os.execute`'s single-`true` return diverges from stdlib's
  `(ok, "exit", code)` triple — documented as intentional in
  configuration.md.
- Watchdog for stalled callbacks (issue #5 "consider") was
  deliberately left out: blocking C calls are now removed at
  the source and the instruction-count hook covers pure-Lua
  runaways; a child watchdog is tracked in #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
