### PR TITLE
feat(events): window_created / window_destroyed / window_minimized

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Emitters.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Emitters.swift
@@ -102,6 +102,34 @@ extension KiwiCore {
         emitWindowGone(.windowMinimized, id, app, space)
     }
 
+    /// Fires on an explicit single-window move
+    /// (`move_to_virtual_space`); bulk reassignments
+    /// (snapshot restore, profile load) stay silent.
+    func emitWindowMovedToSpace(
+        _ id: WindowID,
+        app: String,
+        from: SpaceID?,
+        to: SpaceID
+    ) {
+        bus.emit(
+            .windowMovedToSpace,
+            data: .object([
+                "window_id": .number(Double(id.raw)),
+                "app": .string(app),
+                "from_space_id": from.map {
+                    .string($0.raw)
+                } ?? .null,
+                "to_space_id": .string(to.raw),
+            ]),
+            luaArgs: [
+                .number(Double(id.raw)),
+                .string(app),
+                .string(from?.raw ?? ""),
+                .string(to.raw),
+            ]
+        )
+    }
+
     /// `app` and `space` are captured by handle() before
     /// state.apply removes the window — the payload reports
     /// the space the window actually disappeared from, not

--- a/Sources/KiwiDeskCore/App/KiwiCore+Emitters.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Emitters.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Event emission helpers: bridge state changes onto the
+/// EventBus for Lua callbacks and the CLI event stream.
+extension KiwiCore {
+    func emitSpaceChange() {
+        guard let id = state.workspaces.activeSpace,
+            let space = state.workspaces[id]
+        else { return }
+        bus.emit(
+            .spaceChange,
+            data: .object([
+                "space_id": .string(id.raw),
+                "layout_mode": .string(space.mode.rawValue),
+                "window_count": .number(
+                    Double(space.windows.count)
+                ),
+            ]),
+            luaArgs: [
+                .string(id.raw),
+                .string(space.mode.rawValue),
+            ]
+        )
+    }
+
+    func emitLayoutChange(space: Space) {
+        bus.emit(
+            .layoutChange,
+            data: .object([
+                "space_id": .string(space.id.raw),
+                "layout_mode": .string(space.mode.rawValue),
+            ]),
+            luaArgs: [
+                .string(space.id.raw),
+                .string(space.mode.rawValue),
+            ]
+        )
+    }
+
+    func emitFocusChange(_ id: WindowID) {
+        let window = state.windows[id]
+        bus.emit(
+            .focusChange,
+            data: .object([
+                "window_id": .number(Double(id.raw)),
+                "app": .string(window?.appName ?? ""),
+                "title": .string(window?.title ?? ""),
+            ]),
+            luaArgs: [
+                .number(Double(id.raw)),
+                .string(window?.appName ?? ""),
+            ]
+        )
+    }
+
+    func emitMonitorChange() {
+        let displays = state.workspaces.allDisplays
+        bus.emit(
+            .monitorChange,
+            data: .object([
+                "count": .number(Double(displays.count))
+            ]),
+            luaArgs: [.number(Double(displays.count))]
+        )
+    }
+
+    // MARK: - Window lifecycle (issue #20)
+
+    /// Fires after state placed the new window, so `space`
+    /// reflects app_rules / spawn placement.
+    func emitWindowCreated(_ window: ManagedWindow) {
+        let space = state.workspaces.space(of: window.id)
+        bus.emit(
+            .windowCreated,
+            data: .object([
+                "window_id": .number(Double(window.id.raw)),
+                "app": .string(window.appName),
+                "space": space.map { .string($0.raw) }
+                    ?? .null,
+            ]),
+            luaArgs: [
+                .number(Double(window.id.raw)),
+                .string(window.appName),
+                .string(space?.raw ?? ""),
+            ]
+        )
+    }
+
+    func emitWindowDestroyed(_ id: WindowID) {
+        emitWindowGone(.windowDestroyed, id)
+    }
+
+    func emitWindowMinimized(_ id: WindowID) {
+        emitWindowGone(.windowMinimized, id)
+    }
+
+    /// The window already left the layout, so `space` is the
+    /// active space it disappeared from (05_GUI issue #20).
+    private func emitWindowGone(
+        _ event: KiwiNotification,
+        _ id: WindowID
+    ) {
+        let space = state.workspaces.activeSpace
+        bus.emit(
+            event,
+            data: .object([
+                "window_id": .number(Double(id.raw)),
+                "space": space.map { .string($0.raw) }
+                    ?? .null,
+            ]),
+            luaArgs: [
+                .number(Double(id.raw)),
+                .string(space?.raw ?? ""),
+            ]
+        )
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore+Emitters.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Emitters.swift
@@ -75,7 +75,7 @@ extension KiwiCore {
             data: .object([
                 "window_id": .number(Double(window.id.raw)),
                 "app": .string(window.appName),
-                "space": space.map { .string($0.raw) }
+                "space_id": space.map { .string($0.raw) }
                     ?? .null,
             ]),
             luaArgs: [
@@ -86,30 +86,43 @@ extension KiwiCore {
         )
     }
 
-    func emitWindowDestroyed(_ id: WindowID) {
-        emitWindowGone(.windowDestroyed, id)
+    func emitWindowDestroyed(
+        _ id: WindowID,
+        app: String?,
+        space: SpaceID?
+    ) {
+        emitWindowGone(.windowDestroyed, id, app, space)
     }
 
-    func emitWindowMinimized(_ id: WindowID) {
-        emitWindowGone(.windowMinimized, id)
+    func emitWindowMinimized(
+        _ id: WindowID,
+        app: String?,
+        space: SpaceID?
+    ) {
+        emitWindowGone(.windowMinimized, id, app, space)
     }
 
-    /// The window already left the layout, so `space` is the
-    /// active space it disappeared from (05_GUI issue #20).
+    /// `app` and `space` are captured by handle() before
+    /// state.apply removes the window — the payload reports
+    /// the space the window actually disappeared from, not
+    /// whichever space happens to be active.
     private func emitWindowGone(
         _ event: KiwiNotification,
-        _ id: WindowID
+        _ id: WindowID,
+        _ app: String?,
+        _ space: SpaceID?
     ) {
-        let space = state.workspaces.activeSpace
         bus.emit(
             event,
             data: .object([
                 "window_id": .number(Double(id.raw)),
-                "space": space.map { .string($0.raw) }
+                "app": .string(app ?? ""),
+                "space_id": space.map { .string($0.raw) }
                     ?? .null,
             ]),
             luaArgs: [
                 .number(Double(id.raw)),
+                .string(app ?? ""),
                 .string(space?.raw ?? ""),
             ]
         )

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -229,6 +229,7 @@ public final class KiwiCore {
             // of a hidden window (see above).
             pendingFocusFollow?.cancel()
             newlyCreatedWindow = window.id
+            emitWindowCreated(window)
         case .windowMoved(let id, let frame):
             drag.windowMoved(id, frame: frame)
         case .windowResized(let id, let frame):
@@ -239,9 +240,14 @@ public final class KiwiCore {
             if isResizeGesture(id) {
                 drag.windowMoved(id, frame: frame)
             }
-        case .windowDestroyed(let id, _):
+        case .windowDestroyed(let id, let wasMinimized):
             drag.cancel(id)
             dragOverlay.hideAll()
+            if wasMinimized {
+                emitWindowMinimized(id)
+            } else {
+                emitWindowDestroyed(id)
+            }
         case .nativeSpaceChanged:
             handleNativeSpaceChange()
         default:
@@ -270,69 +276,6 @@ public final class KiwiCore {
         for record in snapshot.windows {
             tiler.setFrame(record.windowID, record.frame)
         }
-    }
-
-    // MARK: - Event emission helpers
-
-    func emitSpaceChange() {
-        guard let id = state.workspaces.activeSpace,
-            let space = state.workspaces[id]
-        else { return }
-        bus.emit(
-            .spaceChange,
-            data: .object([
-                "space_id": .string(id.raw),
-                "layout_mode": .string(space.mode.rawValue),
-                "window_count": .number(
-                    Double(space.windows.count)
-                ),
-            ]),
-            luaArgs: [
-                .string(id.raw),
-                .string(space.mode.rawValue),
-            ]
-        )
-    }
-
-    func emitLayoutChange(space: Space) {
-        bus.emit(
-            .layoutChange,
-            data: .object([
-                "space_id": .string(space.id.raw),
-                "layout_mode": .string(space.mode.rawValue),
-            ]),
-            luaArgs: [
-                .string(space.id.raw),
-                .string(space.mode.rawValue),
-            ]
-        )
-    }
-
-    private func emitFocusChange(_ id: WindowID) {
-        let window = state.windows[id]
-        bus.emit(
-            .focusChange,
-            data: .object([
-                "window_id": .number(Double(id.raw)),
-                "app": .string(window?.appName ?? ""),
-                "title": .string(window?.title ?? ""),
-            ]),
-            luaArgs: [
-                .number(Double(id.raw)),
-                .string(window?.appName ?? ""),
-            ]
-        )
-    }
-
-    private func emitMonitorChange() {
-        let displays = state.workspaces.allDisplays
-        bus.emit(
-            .monitorChange,
-            data: .object([
-                "count": .number(Double(displays.count))
-            ]),
-            luaArgs: [.number(Double(displays.count))]
-        )
     }
 
     // MARK: - Accessors

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -189,10 +189,16 @@ public final class KiwiCore {
     private func handle(_ event: KiwiEvent) {
         // Closing or minimizing the focused window must hand
         // focus to the space's fallback window (state already
-        // picks one; the AX raise below makes it real).
+        // picks one; the AX raise below makes it real). The
+        // gone-event payload needs the window's app and space
+        // captured here too — state.apply removes both.
         var focusLost = false
+        var goneApp: String? = nil
+        var goneSpace: SpaceID? = nil
         if case .windowDestroyed(let id, _) = event {
             focusLost = activeSpace?.focused == id
+            goneApp = state.windows[id]?.appName
+            goneSpace = state.workspaces.space(of: id)
         }
         state.spawnPlacements = [
             .bsp: tiler.settings.bsp.newWindowPlacement,
@@ -244,9 +250,17 @@ public final class KiwiCore {
             drag.cancel(id)
             dragOverlay.hideAll()
             if wasMinimized {
-                emitWindowMinimized(id)
+                emitWindowMinimized(
+                    id,
+                    app: goneApp,
+                    space: goneSpace
+                )
             } else {
-                emitWindowDestroyed(id)
+                emitWindowDestroyed(
+                    id,
+                    app: goneApp,
+                    space: goneSpace
+                )
             }
         case .nativeSpaceChanged:
             handleNativeSpaceChange()

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -75,7 +75,16 @@ extension KiwiCore {
             return .fail("no focused window")
         }
         let target = SpaceID(raw)
+        let from = state.workspaces.space(of: focused)
         state.workspaces.add(focused, to: target)
+        if from != target {
+            emitWindowMovedToSpace(
+                focused,
+                app: state.windows[focused]?.appName ?? "",
+                from: from,
+                to: target
+            )
+        }
         if follow {
             state.workspaces.activate(target)
             focusWindow(focused)

--- a/Sources/KiwiDeskCore/Events/EventBus.swift
+++ b/Sources/KiwiDeskCore/Events/EventBus.swift
@@ -10,6 +10,9 @@ public enum KiwiNotification: String, CaseIterable, Sendable,
     case focusChange = "focus_change"
     case monitorChange = "monitor_change"
     case nativeSpaceChange = "native_space_change"
+    case windowCreated = "window_created"
+    case windowDestroyed = "window_destroyed"
+    case windowMinimized = "window_minimized"
 }
 
 /// Fans events out to Lua callbacks and generic sinks (the

--- a/Sources/KiwiDeskCore/Events/EventBus.swift
+++ b/Sources/KiwiDeskCore/Events/EventBus.swift
@@ -13,6 +13,7 @@ public enum KiwiNotification: String, CaseIterable, Sendable,
     case windowCreated = "window_created"
     case windowDestroyed = "window_destroyed"
     case windowMinimized = "window_minimized"
+    case windowMovedToSpace = "window_moved_to_space"
 }
 
 /// Fans events out to Lua callbacks and generic sinks (the

--- a/Tests/KiwiDeskCoreTests/LifecycleEventTests.swift
+++ b/Tests/KiwiDeskCoreTests/LifecycleEventTests.swift
@@ -46,8 +46,8 @@ struct LifecycleEventTests {
         #expect(payload["window_id"] == .number(42))
         #expect(payload["app"] == .string("TestApp"))
         // The window was placed in the active space.
-        #expect(payload["space"] != nil)
-        #expect(payload["space"] != .null)
+        #expect(payload["space_id"] != nil)
+        #expect(payload["space_id"] != .null)
     }
 
     @Test("closing fires window_destroyed, not minimized")
@@ -89,6 +89,42 @@ struct LifecycleEventTests {
             return
         }
         #expect(payload["window_id"] == .number(9))
+    }
+
+    @Test("gone-events report the window's former space")
+    func formerSpace() {
+        let core = makeCore()
+        // Window lands in the active space "1"...
+        core.eventLoop.onEvent(
+            .windowCreated(window(21, app: "Zen"))
+        )
+        // ...then the user switches away.
+        _ = core.execute(
+            "focus_virtual_space",
+            args: [.string("2")]
+        )
+        var events: [(KiwiNotification, JSONValue)] = []
+        core.bus.addSink { event, data in
+            events.append((event, data))
+        }
+        core.eventLoop.onEvent(
+            .windowDestroyed(
+                WindowID(21),
+                wasMinimized: false
+            )
+        )
+        guard
+            let (_, data) = events.first(where: {
+                $0.0 == .windowDestroyed
+            }),
+            case .object(let payload) = data
+        else {
+            Issue.record("expected destroyed payload")
+            return
+        }
+        // The space it disappeared FROM, not the active one.
+        #expect(payload["space_id"] == .string("1"))
+        #expect(payload["app"] == .string("Zen"))
     }
 
     @Test("lifecycle events reach Lua callbacks")

--- a/Tests/KiwiDeskCoreTests/LifecycleEventTests.swift
+++ b/Tests/KiwiDeskCoreTests/LifecycleEventTests.swift
@@ -127,6 +127,45 @@ struct LifecycleEventTests {
         #expect(payload["app"] == .string("Zen"))
     }
 
+    @Test("moving a window across spaces reports from and to")
+    func movedToSpace() {
+        let core = makeCore()
+        core.eventLoop.onEvent(
+            .windowCreated(window(31, app: "Spotify"))
+        )
+        var events: [(KiwiNotification, JSONValue)] = []
+        core.bus.addSink { event, data in
+            events.append((event, data))
+        }
+        let response = core.execute(
+            "move_to_virtual_space",
+            args: [.string("3")]
+        )
+        #expect(response.isSuccess)
+        guard
+            let (_, data) = events.first(where: {
+                $0.0 == .windowMovedToSpace
+            }),
+            case .object(let payload) = data
+        else {
+            Issue.record("expected moved-to-space payload")
+            return
+        }
+        #expect(payload["window_id"] == .number(31))
+        #expect(payload["app"] == .string("Spotify"))
+        #expect(payload["from_space_id"] == .string("1"))
+        #expect(payload["to_space_id"] == .string("3"))
+        // Moving to the space it is already on stays silent.
+        events.removeAll()
+        _ = core.execute(
+            "move_to_virtual_space",
+            args: [.string("3")]
+        )
+        #expect(
+            !events.contains { $0.0 == .windowMovedToSpace }
+        )
+    }
+
     @Test("lifecycle events reach Lua callbacks")
     func luaCallback() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/LifecycleEventTests.swift
+++ b/Tests/KiwiDeskCoreTests/LifecycleEventTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+            "kiwidesk-lifecycle-tests-\(UUID().uuidString)"
+        )
+    return KiwiCore(configDirectory: directory)
+}
+
+@MainActor
+private func window(
+    _ id: UInt32,
+    app: String = "TestApp"
+) -> ManagedWindow {
+    ManagedWindow(id: WindowID(id), pid: 99, appName: app)
+}
+
+@Suite("Window lifecycle events", .serialized)
+@MainActor
+struct LifecycleEventTests {
+    @Test("window_created fires with id, app, and space")
+    func created() {
+        let core = makeCore()
+        var events: [(KiwiNotification, JSONValue)] = []
+        core.bus.addSink { event, data in
+            events.append((event, data))
+        }
+        core.eventLoop.onEvent(.windowCreated(window(42)))
+        guard
+            let (_, data) = events.first(where: {
+                $0.0 == .windowCreated
+            })
+        else {
+            Issue.record("expected window_created")
+            return
+        }
+        guard case .object(let payload) = data else {
+            Issue.record("expected object payload")
+            return
+        }
+        #expect(payload["window_id"] == .number(42))
+        #expect(payload["app"] == .string("TestApp"))
+        // The window was placed in the active space.
+        #expect(payload["space"] != nil)
+        #expect(payload["space"] != .null)
+    }
+
+    @Test("closing fires window_destroyed, not minimized")
+    func destroyed() {
+        let core = makeCore()
+        core.eventLoop.onEvent(.windowCreated(window(7)))
+        var events: [KiwiNotification] = []
+        core.bus.addSink { event, _ in
+            events.append(event)
+        }
+        core.eventLoop.onEvent(
+            .windowDestroyed(WindowID(7), wasMinimized: false)
+        )
+        #expect(events.contains(.windowDestroyed))
+        #expect(!events.contains(.windowMinimized))
+    }
+
+    @Test("minimizing fires window_minimized, not destroyed")
+    func minimized() {
+        let core = makeCore()
+        core.eventLoop.onEvent(.windowCreated(window(9)))
+        var events: [(KiwiNotification, JSONValue)] = []
+        core.bus.addSink { event, data in
+            events.append((event, data))
+        }
+        core.eventLoop.onEvent(
+            .windowDestroyed(WindowID(9), wasMinimized: true)
+        )
+        let names = events.map(\.0)
+        #expect(names.contains(.windowMinimized))
+        #expect(!names.contains(.windowDestroyed))
+        guard
+            let (_, data) = events.first(where: {
+                $0.0 == .windowMinimized
+            }),
+            case .object(let payload) = data
+        else {
+            Issue.record("expected minimized payload")
+            return
+        }
+        #expect(payload["window_id"] == .number(9))
+    }
+
+    @Test("lifecycle events reach Lua callbacks")
+    func luaCallback() {
+        let core = makeCore()
+        core.loadConfig()
+        guard let lua = core.lua else {
+            Issue.record("no VM")
+            return
+        }
+        lua.run(
+            """
+            KiwiDesk.on("window_created",
+                function(id, app, space)
+                    created_id = id
+                    created_app = app
+                end)
+            """
+        )
+        core.eventLoop.onEvent(
+            .windowCreated(window(11, app: "Ghostty"))
+        )
+        #expect(lua.global("created_id") == .number(11))
+        #expect(
+            lua.global("created_app") == .string("Ghostty")
+        )
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -122,7 +122,25 @@ Each event is one JSON line:
 ```
 
 Events: `space_change`, `layout_change`, `focus_change`,
-`monitor_change`, `native_space_change`.
+`monitor_change`, `native_space_change`, `window_created`,
+`window_destroyed`, `window_minimized`.
+
+The window lifecycle events fire even when focus does not
+change, so bars can drop stale icons immediately:
+
+```json
+{"event": "window_created",
+ "data": {"window_id": 4711, "app": "Ghostty",
+          "space": "2"}}
+{"event": "window_destroyed",
+ "data": {"window_id": 4711, "space": "2"}}
+```
+
+`window_created` carries the space the window was placed in
+(`app_rules` included); `window_destroyed` and
+`window_minimized` carry the active space the window
+disappeared from. A minimize fires only `window_minimized`,
+never `window_destroyed`.
 
 `native_space_change` fires when the user switches native
 macOS Spaces (Mission Control desktops); its data carries the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -123,7 +123,8 @@ Each event is one JSON line:
 
 Events: `space_change`, `layout_change`, `focus_change`,
 `monitor_change`, `native_space_change`, `window_created`,
-`window_destroyed`, `window_minimized`.
+`window_destroyed`, `window_minimized`,
+`window_moved_to_space`.
 
 The window lifecycle events fire even when focus does not
 change, so bars can drop stale icons immediately:
@@ -149,6 +150,17 @@ lifecycle. Deminiaturize surfaces as `window_created`, and a
 native macOS Space switch fires a burst of `window_destroyed`
 for the old desktop's windows and `window_created` when they
 return.
+
+`window_moved_to_space` fires when a window is explicitly
+moved to another virtual space (`move_to_virtual_space`,
+with or without follow); bulk reassignments (profile load,
+session restore) stay silent:
+
+```json
+{"event": "window_moved_to_space",
+ "data": {"window_id": 4711, "app": "Spotify",
+          "from_space_id": "1", "to_space_id": "3"}}
+```
 
 `native_space_change` fires when the user switches native
 macOS Spaces (Mission Control desktops); its data carries the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -131,16 +131,24 @@ change, so bars can drop stale icons immediately:
 ```json
 {"event": "window_created",
  "data": {"window_id": 4711, "app": "Ghostty",
-          "space": "2"}}
+          "space_id": "2"}}
 {"event": "window_destroyed",
- "data": {"window_id": 4711, "space": "2"}}
+ "data": {"window_id": 4711, "app": "Ghostty",
+          "space_id": "2"}}
 ```
 
 `window_created` carries the space the window was placed in
 (`app_rules` included); `window_destroyed` and
-`window_minimized` carry the active space the window
-disappeared from. A minimize fires only `window_minimized`,
-never `window_destroyed`.
+`window_minimized` carry the space the window disappeared
+from — its own space, even when that space is not active. A
+minimize fires only `window_minimized`, never
+`window_destroyed`.
+
+Caveat: these events track the *visible window set*, not app
+lifecycle. Deminiaturize surfaces as `window_created`, and a
+native macOS Space switch fires a burst of `window_destroyed`
+for the old desktop's windows and `window_created` when they
+return.
 
 `native_space_change` fires when the user switches native
 macOS Spaces (Mission Control desktops); its data carries the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -557,6 +557,7 @@ end)
 | `window_created` | `window_id`, `app`, `space` |
 | `window_destroyed` | `window_id`, `app`, `space` |
 | `window_minimized` | `window_id`, `app`, `space` |
+| `window_moved_to_space` | `window_id`, `app`, `from`, `to` |
 
 The window lifecycle events fire even when focus does not
 change (a background window opening or closing), so status
@@ -568,6 +569,13 @@ minimize fires only `window_minimized`, never
 `space_id` (matching `space_change`) and an unknown space is
 JSON `null`; the Lua callback receives `""` instead, since a
 positional `nil` would truncate the argument list.
+
+`window_moved_to_space` fires on an explicit
+`move_to_virtual_space` (with or without follow) when the
+target differs from the window's current space. Bulk
+reassignments — profile loads, session restore — stay
+silent. JSON keys: `from_space_id` (null if unknown) and
+`to_space_id`.
 
 Two caveats: `window_created` / `window_destroyed` also fire
 when windows *appear to* come and go — deminiaturizing a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -554,6 +554,14 @@ end)
 | `focus_change` | `window_id`, `app` |
 | `monitor_change` | `monitor_count` |
 | `native_space_change` | `native_space` (desktop number) |
+| `window_created` | `window_id`, `app`, `space` |
+| `window_destroyed` | `window_id`, `space` |
+| `window_minimized` | `window_id`, `space` |
+
+The window lifecycle events fire even when focus does not
+change (a background window opening or closing), so status
+bars stay current without polling. A minimize fires only
+`window_minimized`, never `window_destroyed`.
 
 ## External Commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -555,13 +555,28 @@ end)
 | `monitor_change` | `monitor_count` |
 | `native_space_change` | `native_space` (desktop number) |
 | `window_created` | `window_id`, `app`, `space` |
-| `window_destroyed` | `window_id`, `space` |
-| `window_minimized` | `window_id`, `space` |
+| `window_destroyed` | `window_id`, `app`, `space` |
+| `window_minimized` | `window_id`, `app`, `space` |
 
 The window lifecycle events fire even when focus does not
 change (a background window opening or closing), so status
-bars stay current without polling. A minimize fires only
-`window_minimized`, never `window_destroyed`.
+bars stay current without polling. `space` is always the
+space the window lives in — for the gone-events, the one it
+disappeared from, even when that space is not active. A
+minimize fires only `window_minimized`, never
+`window_destroyed`. In the CLI event stream the key is
+`space_id` (matching `space_change`) and an unknown space is
+JSON `null`; the Lua callback receives `""` instead, since a
+positional `nil` would truncate the argument list.
+
+Two caveats: `window_created` / `window_destroyed` also fire
+when windows *appear to* come and go — deminiaturizing a
+window surfaces as `window_created`, and switching native
+macOS Spaces makes every managed window on the old desktop
+vanish from the accessibility tree (a burst of
+`window_destroyed`) and reappear on return (a burst of
+`window_created`). Treat the events as "the visible window
+set changed", not as app lifecycle.
 
 ## External Commands
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -32,6 +32,7 @@ end)
 -- (background window opens, closes, or minimizes):
 for _, event in ipairs({
     "window_created", "window_destroyed", "window_minimized",
+    "window_moved_to_space",
 }) do
     KiwiDesk.on(event, function()
         KiwiDesk.exec(

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -27,6 +27,17 @@ KiwiDesk.on("native_space_change", function(desktop)
         "sketchybar --trigger kiwi_desktop DESKTOP="
         .. desktop)
 end)
+
+-- Window icons stay fresh even when focus doesn't change
+-- (background window opens, closes, or minimizes):
+for _, event in ipairs({
+    "window_created", "window_destroyed", "window_minimized",
+}) do
+    KiwiDesk.on(event, function()
+        KiwiDesk.exec(
+            "sketchybar --trigger kiwi_space_change")
+    end)
+end
 ```
 
 In your `sketchybarrc`:


### PR DESCRIPTION
## Description

Adds the window lifecycle events from #20 — plus a fourth,
`window_moved_to_space`, added during review — so bars react
to background windows opening, closing, minimizing, or moving
between spaces without a focus change:

- `window_created` — fired after state placement, so the
  payload space reflects `app_rules` / spawn placement.
- `window_destroyed` / `window_minimized` — split by the
  existing `wasMinimized` flag on the internal event; the
  payload carries the window's **former** space and app,
  captured in `handle()` before `state.apply` removes them
  (a background window closing on a hidden space is
  attributed to the right space).
- Payload keys follow the shipped vocabulary: `window_id`
  (like `focus_change`) and `space_id` (like `space_change`)
  — deliberate deviations from the issue text's `id`/`space`.
- `window_moved_to_space` — fired by `move_to_virtual_space`
  (with or without follow) when the target differs from the
  window's current space; payload `from_space_id` /
  `to_space_id` + `app`. Bulk reassignments (profile load,
  session restore) stay silent. Named as the past-tense form
  of the `move_to_space` command alias; #42 tracks making the
  bare-`space` command names canonical.
- The existing emit helpers moved to `KiwiCore+Emitters.swift`
  (KiwiCore.swift was one line under the 350 ceiling).
- Docs: events tables, stream examples, sketchybar recipe,
  and the visibility-churn caveat (native-Space switches and
  deminiaturize produce created/destroyed bursts — see #40
  for the classification/coalescing follow-up, to be decided
  before #21).

Both `code-reviewer` and `architect-reviewer` ran; their
shared blocker (gone-events reported the active space instead
of the former space) is fixed and pinned by a test. Dismissed
as reviewed: the `monitor_change` "doc mismatch" (the table
documents Lua argument labels, not JSON keys).

Live-tested against the sketchybar setup: icons update on
open/close/minimize without focus changes.

## Related Issue(s)

Closes #20. Follow-up: #40 (burst semantics, gate for #21).

## Checklist

- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## Notes for Reviewer

- The former-space capture reuses the pre-`state.apply`
  pattern `handle()` already had for `focusLost`.
- Lua callbacks receive `""` for an unknown space while the
  JSON stream sends `null` — documented; a positional Lua
  `nil` would truncate the argument list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

