### PR TITLE
fix(spaces): never manage Ghostty's quick terminal, land on the focused window's space

### DIFF
--- a/Sources/KiwiDeskCore/AX/FloatDetection.swift
+++ b/Sources/KiwiDeskCore/AX/FloatDetection.swift
@@ -96,6 +96,14 @@ public enum FloatDetection {
         appName == "Ghostty" && layer != 0
     }
 
+    /// Whether any ignore rule exists for this app at all —
+    /// the cheap gate before every window-list lookup.
+    public static func hasIgnoreRule(
+        appName: String
+    ) -> Bool {
+        appName == "Ghostty"
+    }
+
     /// Window-id variant: skips the CGWindowList lookup for
     /// apps that have no ignore rule at all (the common case
     /// on every reconcile).
@@ -103,7 +111,7 @@ public enum FloatDetection {
         appName: String,
         id: WindowID
     ) -> Bool {
-        guard shouldIgnore(appName: appName, layer: 1) else {
+        guard hasIgnoreRule(appName: appName) else {
             return false
         }
         return shouldIgnore(
@@ -112,19 +120,50 @@ public enum FloatDetection {
         )
     }
 
+    /// CGWindow layers of all of an app's windows in ONE
+    /// window-server round trip. Reconcile uses this instead
+    /// of one lookup per window (AGENTS.md: never query the
+    /// window server in a loop).
+    public static func windowLayers(
+        pid: pid_t
+    ) -> [WindowID: Int] {
+        let list =
+            CGWindowListCopyWindowInfo(
+                [.optionAll],
+                kCGNullWindowID
+            ) as? [[String: Any]] ?? []
+        var layers: [WindowID: Int] = [:]
+        for info in list
+        where info[kCGWindowOwnerPID as String] as? pid_t
+            == pid
+        {
+            guard
+                let number = info[kCGWindowNumber as String]
+                    as? Int,
+                let raw = UInt32(exactly: number)
+            else { continue }
+            layers[WindowID(raw)] =
+                info[kCGWindowLayer as String] as? Int ?? 0
+        }
+        return layers
+    }
+
     /// True while the app currently shows an ignored panel on
     /// screen. While Ghostty's quick terminal is open, AX
     /// reports the app's *main* window as focused — trusting
     /// that report would focus-follow to the main window's
     /// space even though the user is typing into the panel
-    /// (issue #21).
+    /// (issue #21). Known limit: visibility is a proxy for
+    /// focus — with panel autohide disabled, a genuine main-
+    /// window focus is also distrusted while the panel shows.
+    /// Deliberate: suppressing a follow beats hijacking one.
     public static func hasVisibleIgnoredPanel(
         pid: pid_t,
         appName: String
     ) -> Bool {
         // Cheap out before the window-list scan: only apps
         // with an ignore rule can have ignored panels.
-        guard shouldIgnore(appName: appName, layer: 1) else {
+        guard hasIgnoreRule(appName: appName) else {
             return false
         }
         let list =

--- a/Sources/KiwiDeskCore/AX/FloatDetection.swift
+++ b/Sources/KiwiDeskCore/AX/FloatDetection.swift
@@ -43,7 +43,8 @@ public struct FloatRules: Sendable, Equatable {
     }
 }
 
-/// Decides whether a window should float instead of tile.
+/// Classifies windows from AX and CGWindow signals: float
+/// instead of tile, or ignore entirely (never managed).
 public enum FloatDetection {
     /// Subroles that identify auxiliary windows (dialogs,
     /// panels, PIP overlays). Everything that is not a
@@ -95,18 +96,50 @@ public enum FloatDetection {
         appName == "Ghostty" && layer != 0
     }
 
-    /// Live-element variant of `shouldIgnore(appName:layer:)`.
-    @MainActor
+    /// Window-id variant: skips the CGWindowList lookup for
+    /// apps that have no ignore rule at all (the common case
+    /// on every reconcile).
     public static func shouldIgnore(
-        element: AXUIElement,
-        appName: String
+        appName: String,
+        id: WindowID
     ) -> Bool {
-        let layer = AXHelper.windowID(of: element)
-            .flatMap { windowLayer(of: $0) }
+        guard shouldIgnore(appName: appName, layer: 1) else {
+            return false
+        }
         return shouldIgnore(
             appName: appName,
-            layer: layer ?? 0
+            layer: windowLayer(of: id) ?? 0
         )
+    }
+
+    /// True while the app currently shows an ignored panel on
+    /// screen. While Ghostty's quick terminal is open, AX
+    /// reports the app's *main* window as focused — trusting
+    /// that report would focus-follow to the main window's
+    /// space even though the user is typing into the panel
+    /// (issue #21).
+    public static func hasVisibleIgnoredPanel(
+        pid: pid_t,
+        appName: String
+    ) -> Bool {
+        // Cheap out before the window-list scan: only apps
+        // with an ignore rule can have ignored panels.
+        guard shouldIgnore(appName: appName, layer: 1) else {
+            return false
+        }
+        let list =
+            CGWindowListCopyWindowInfo(
+                [.optionOnScreenOnly],
+                kCGNullWindowID
+            ) as? [[String: Any]] ?? []
+        return list.contains { info in
+            info[kCGWindowOwnerPID as String] as? pid_t == pid
+                && shouldIgnore(
+                    appName: appName,
+                    layer: info[kCGWindowLayer as String]
+                        as? Int ?? 0
+                )
+        }
     }
 
     /// Full decision for a live AX element, including user

--- a/Sources/KiwiDeskCore/AX/FloatDetection.swift
+++ b/Sources/KiwiDeskCore/AX/FloatDetection.swift
@@ -80,6 +80,35 @@ public enum FloatDetection {
         return list?.first?[kCGWindowLayer as String] as? Int
     }
 
+    /// Windows KiwiDesk must not manage at all — no tracking,
+    /// no state entry, no events. Ghostty's quick terminal is
+    /// a slide-down panel (non-zero CGWindow layer) that macOS
+    /// shows over every space; merely *floating* it still
+    /// assigns it a space, and focusing it then drags the user
+    /// to that space (issue #21). Hardcoded on purpose: no
+    /// general ignore-rule machinery until a second case
+    /// exists.
+    public static func shouldIgnore(
+        appName: String,
+        layer: Int
+    ) -> Bool {
+        appName == "Ghostty" && layer != 0
+    }
+
+    /// Live-element variant of `shouldIgnore(appName:layer:)`.
+    @MainActor
+    public static func shouldIgnore(
+        element: AXUIElement,
+        appName: String
+    ) -> Bool {
+        let layer = AXHelper.windowID(of: element)
+            .flatMap { windowLayer(of: $0) }
+        return shouldIgnore(
+            appName: appName,
+            layer: layer ?? 0
+        )
+    }
+
     /// Full decision for a live AX element, including user
     /// rules. PIP windows (subrole AXFloatingWindow) float
     /// automatically via the subrole check.

--- a/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
@@ -1,0 +1,78 @@
+import AppKit
+import Foundation
+
+/// Start/stop lifecycle: config load, event loop, session
+/// restore, and the delayed startup sweep.
+extension KiwiCore {
+    /// Loads the config and starts window management.
+    public func start() {
+        lastNativeSpace = NativeSpaces.activeSpaceNumber()
+        loadConfig()
+        sleepWake.start()
+        eventLoop.start()
+        mouse.start()
+        // The event loop discovered windows in AX order; put
+        // back the arrangement of the previous session.
+        if let session = crash.consumeSession() {
+            restore(session)
+            activateSpaceOfFocusedWindow()
+            // Same contract as every other space switch:
+            // force past the tolerance check, respect the
+            // space-switch animation setting, and tell bus
+            // subscribers (the bar) where we landed.
+            retile(
+                animated: tiler.animateSpaceSwitch,
+                force: true
+            )
+            emitSpaceChange()
+            onLog("restored previous session arrangement")
+        }
+        crash.start()
+        do {
+            try socket.start()
+        } catch {
+            onLog("socket server failed: \(error)")
+        }
+        scheduleStartupSweep()
+    }
+
+    /// The startup scan ran against cold AX trees; slow
+    /// responders list windows late or mis-report subroles
+    /// (see AGENTS.md). One delayed sweep re-tracks what the
+    /// scan missed — session restore has remembered their
+    /// spaces. If the user has not switched away meanwhile,
+    /// the landing choice is re-run: the focused window may
+    /// only now be resolvable to its space.
+    private func scheduleStartupSweep() {
+        let landed = state.workspaces.activeSpace
+        pendingStartupSweep?.cancel()
+        pendingStartupSweep = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled, let self,
+                self.eventLoop.isRunning
+            else { return }
+            self.eventLoop.reconcileAll()
+            guard
+                self.state.workspaces.activeSpace == landed
+            else { return }
+            self.activateSpaceOfFocusedWindow()
+            if self.state.workspaces.activeSpace != landed {
+                self.retile(
+                    animated: self.tiler.animateSpaceSwitch,
+                    force: true
+                )
+                self.emitSpaceChange()
+            }
+        }
+    }
+
+    public func stop() {
+        pendingFocusFollow?.cancel()
+        pendingStartupSweep?.cancel()
+        mouse.stop()
+        eventLoop.stop()
+        sleepWake.stop()
+        socket.stop()
+        crash.shutdownCleanly()
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -29,6 +29,10 @@ public final class KiwiCore {
     /// (see scheduleFocusFollow).
     var pendingFocusFollow: Task<Void, Never>?
 
+    /// One-shot startup sweep re-tracking windows the cold
+    /// AX scan missed (see start()).
+    var pendingStartupSweep: Task<Void, Never>?
+
     /// Native desktop we are currently on (Mission Control
     /// number), and the virtual space each desktop showed
     /// last, restored when the user returns to it.
@@ -135,51 +139,6 @@ public final class KiwiCore {
         bus.onLog = { [weak self] message in
             self?.onLog(message)
         }
-    }
-
-    // MARK: - Lifecycle
-
-    /// Loads the config and starts window management.
-    public func start() {
-        lastNativeSpace = NativeSpaces.activeSpaceNumber()
-        loadConfig()
-        sleepWake.start()
-        eventLoop.start()
-        mouse.start()
-        // The event loop discovered windows in AX order; put
-        // back the arrangement of the previous session.
-        if let session = crash.consumeSession() {
-            restore(session)
-            activateSpaceOfFocusedWindow()
-            retile()
-            onLog("restored previous session arrangement")
-        }
-        crash.start()
-        do {
-            try socket.start()
-        } catch {
-            onLog("socket server failed: \(error)")
-        }
-        // The startup scan ran against cold AX trees; slow
-        // responders list windows late or mis-report subroles
-        // (see AGENTS.md). One delayed sweep re-tracks what
-        // the scan missed — session restore has remembered
-        // their spaces — before the first space switch.
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(1))
-            guard let self, self.eventLoop.isRunning
-            else { return }
-            self.eventLoop.reconcileAll()
-        }
-    }
-
-    public func stop() {
-        pendingFocusFollow?.cancel()
-        mouse.stop()
-        eventLoop.stop()
-        sleepWake.stop()
-        socket.stop()
-        crash.shutdownCleanly()
     }
 
     public func retile(
@@ -297,7 +256,7 @@ public final class KiwiCore {
     /// order is the layout order), then the raw frames. Frames
     /// go through the tiler's frame pipeline so the resulting
     /// AX echoes are not mistaken for user drags.
-    private func restore(_ snapshot: StateSnapshot) {
+    func restore(_ snapshot: StateSnapshot) {
         state.adopt(snapshot)
         for record in snapshot.windows {
             tiler.setFrame(record.windowID, record.frame)

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -150,6 +150,7 @@ public final class KiwiCore {
         // back the arrangement of the previous session.
         if let session = crash.consumeSession() {
             restore(session)
+            activateSpaceOfFocusedWindow()
             retile()
             onLog("restored previous session arrangement")
         }
@@ -158,6 +159,17 @@ public final class KiwiCore {
             try socket.start()
         } catch {
             onLog("socket server failed: \(error)")
+        }
+        // The startup scan ran against cold AX trees; slow
+        // responders list windows late or mis-report subroles
+        // (see AGENTS.md). One delayed sweep re-tracks what
+        // the scan missed — session restore has remembered
+        // their spaces — before the first space switch.
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(1))
+            guard let self, self.eventLoop.isRunning
+            else { return }
+            self.eventLoop.reconcileAll()
         }
     }
 
@@ -289,6 +301,18 @@ public final class KiwiCore {
         state.adopt(snapshot)
         for record in snapshot.windows {
             tiler.setFrame(record.windowID, record.frame)
+        }
+        // Diagnostic: snapshot windows that are not tracked
+        // yet stay out of their space until a reconcile finds
+        // them (cold-AX startup scan, issue #21 follow-up).
+        let missing = snapshot.windows.filter {
+            state.windows[$0.windowID] == nil
+        }.count
+        if missing > 0 {
+            onLog(
+                "restore: \(missing) snapshot windows not "
+                    + "tracked yet"
+            )
         }
     }
 

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Diagnostics.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Diagnostics.swift
@@ -3,6 +3,21 @@ import Foundation
 /// Diagnostic commands: `get_state`, `get_layout_info`,
 /// `list_monitors`.
 extension KiwiCore {
+    /// One diagnostic line per space switch: how many windows
+    /// the space holds and how many actually tile. "0
+    /// windows" right after a restart means the startup scan
+    /// missed them; "0 tiled" means wrong float verdicts.
+    func logSpaceContents(_ id: SpaceID) {
+        let members = state.workspaces[id]?.windows ?? []
+        let tiled = members.filter {
+            state.windows[$0]?.isFloating == false
+        }
+        onLog(
+            "space \(id.raw): \(members.count) windows, "
+                + "\(tiled.count) tiled"
+        )
+    }
+
     func layoutInfo() -> CommandResponse {
         guard let space = activeSpace else {
             return .fail("no active space")

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -70,7 +70,11 @@ extension KiwiCore {
                 pid: app.processIdentifier
             ),
             let id = AXHelper.windowID(of: element),
+            // The cold startup scan may not have tracked the
+            // focused window yet — the session snapshot still
+            // remembers where it belongs.
             let space = state.workspaces.space(of: id)
+                ?? state.rememberedSpace(of: id)
         else { return }
         state.workspaces.activate(space)
     }
@@ -133,20 +137,5 @@ extension KiwiCore {
             force: follow
         )
         return .ok()
-    }
-
-    /// One diagnostic line per switch: how many windows the
-    /// space holds and how many actually tile. "0 windows"
-    /// right after a restart means the startup scan missed
-    /// them; "0 tiled" means wrong float verdicts.
-    private func logSpaceContents(_ id: SpaceID) {
-        let members = state.workspaces[id]?.windows ?? []
-        let tiled = members.filter {
-            state.windows[$0]?.isFloating == false
-        }
-        onLog(
-            "space \(id.raw): \(members.count) windows, "
-                + "\(tiled.count) tiled"
-        )
     }
 }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -25,6 +25,15 @@ extension KiwiCore {
             guard let window = self.state.windows[id],
                 NSWorkspace.shared.frontmostApplication?
                     .processIdentifier == window.pid,
+                // An open quick-terminal-style panel makes AX
+                // report the app's main window as focused;
+                // following that report would enforce the main
+                // window's space under the panel the user is
+                // actually typing into (issue #21).
+                !FloatDetection.hasVisibleIgnoredPanel(
+                    pid: window.pid,
+                    appName: window.appName
+                ),
                 let element = AXHelper.focusedWindow(
                     pid: window.pid
                 ),
@@ -43,6 +52,29 @@ extension KiwiCore {
         }
     }
 
+    /// After a restart, land on the virtual space of the
+    /// window the user is focused on right now — the
+    /// snapshot's active space is where they were at
+    /// shutdown, not where they are. Apps currently showing
+    /// an ignored panel are distrusted: while Ghostty's quick
+    /// terminal has focus, AX reports the app's *main*
+    /// window, which may live on another space (issue #21).
+    func activateSpaceOfFocusedWindow() {
+        guard
+            let app = NSWorkspace.shared.frontmostApplication,
+            !FloatDetection.hasVisibleIgnoredPanel(
+                pid: app.processIdentifier,
+                appName: app.localizedName ?? "?"
+            ),
+            let element = AXHelper.focusedWindow(
+                pid: app.processIdentifier
+            ),
+            let id = AXHelper.windowID(of: element),
+            let space = state.workspaces.space(of: id)
+        else { return }
+        state.workspaces.activate(space)
+    }
+
     func focusSpace(
         _ args: [JSONValue]
     ) -> CommandResponse {
@@ -50,6 +82,7 @@ extension KiwiCore {
             return .fail("expected space id")
         }
         state.workspaces.activate(SpaceID(raw))
+        logSpaceContents(SpaceID(raw))
         retile(
             animated: tiler.animateSpaceSwitch,
             force: true
@@ -100,5 +133,20 @@ extension KiwiCore {
             force: follow
         )
         return .ok()
+    }
+
+    /// One diagnostic line per switch: how many windows the
+    /// space holds and how many actually tile. "0 windows"
+    /// right after a restart means the startup scan missed
+    /// them; "0 tiled" means wrong float verdicts.
+    private func logSpaceContents(_ id: SpaceID) {
+        let members = state.workspaces[id]?.windows ?? []
+        let tiled = members.filter {
+            state.windows[$0]?.isFloating == false
+        }
+        onLog(
+            "space \(id.raw): \(members.count) windows, "
+                + "\(tiled.count) tiled"
+        )
     }
 }

--- a/Sources/KiwiDeskCore/Events/EventLoop+Apps.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop+Apps.swift
@@ -109,7 +109,11 @@ extension EventLoop {
         // window, no kAXFocusedWindowChanged fires. Report the
         // cross-app focus change ourselves.
         if let element = AXHelper.focusedWindow(pid: pid),
-            let id = AXHelper.windowID(of: element)
+            let id = AXHelper.windowID(of: element),
+            // Only managed windows: an ignored panel (issue
+            // #21) or a not-yet-tracked window must not leak
+            // a focus event with no state behind it.
+            elements[pid]?[id] != nil
         {
             onEvent(.windowFocused(id))
         }
@@ -123,6 +127,15 @@ extension EventLoop {
     /// space's windows are tiled.
     private func nativeSpaceChanged() {
         onEvent(.nativeSpaceChanged)
+        reconcileAll()
+    }
+
+    /// Re-syncs every attached app against its live AX window
+    /// list. Used after native space switches and once shortly
+    /// after startup: the startup scan runs against cold AX
+    /// trees, and slow responders (Electron/WebKit, see
+    /// AGENTS.md) list windows late or mis-report subroles.
+    public func reconcileAll() {
         for pid in observers.keys {
             let name =
                 NSRunningApplication(

--- a/Sources/KiwiDeskCore/Events/EventLoop+Apps.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop+Apps.swift
@@ -104,6 +104,14 @@ extension EventLoop {
             reconcile(pid: previous, appName: name)
         }
         lastActivePid = pid
+        // Mirror the focused-changed path: reconcile the
+        // activated app first, so a window tracked late (cold
+        // Electron tree, other native Space) is known before
+        // the managed-window guard below.
+        reconcile(
+            pid: pid,
+            appName: app.localizedName ?? "?"
+        )
         // Clicking a window of another app only activates the
         // app: if that window was already its app's focused
         // window, no kAXFocusedWindowChanged fires. Report the

--- a/Sources/KiwiDeskCore/Events/EventLoop.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop.swift
@@ -108,8 +108,8 @@ public final class EventLoop {
         // floating them still pins them to a space (issue #21).
         guard
             !FloatDetection.shouldIgnore(
-                element: element,
-                appName: appName
+                appName: appName,
+                id: window.id
             )
         else { return }
         window.isFloating = FloatDetection.shouldFloat(
@@ -148,8 +148,8 @@ public final class EventLoop {
             // wrong mid-launch), the sweep below untracks it.
             guard
                 !FloatDetection.shouldIgnore(
-                    element: element,
-                    appName: appName
+                    appName: appName,
+                    id: id
                 )
             else { continue }
             live.insert(id)
@@ -243,6 +243,12 @@ public final class EventLoop {
             guard let id = AXHelper.windowID(of: element) else {
                 return
             }
+            // Focus events carry only managed windows: the
+            // reconcile above just settled tracking, so an
+            // absent id is an ignored panel (issue #21) —
+            // reporting it would emit a focus_change with an
+            // empty app and retile focus-driven layouts.
+            guard elements[pid]?[id] != nil else { return }
             onEvent(.windowFocused(id))
         case kAXWindowMovedNotification:
             guard let id = AXHelper.windowID(of: element) else {

--- a/Sources/KiwiDeskCore/Events/EventLoop.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop.swift
@@ -21,6 +21,10 @@ public final class EventLoop {
     /// reconcile can re-check and emit only actual changes
     /// (manual make_floating overrides stay untouched).
     var detectedFloating: [WindowID: Bool] = [:]
+    /// Tracked windows whose CGWindow layer read as ignored
+    /// once; untracked only if the reading persists (layers
+    /// flicker during fullscreen transitions).
+    var ignorePending: Set<WindowID> = []
     var workspaceTokens: [NSObjectProtocol] = []
     var screenToken: NSObjectProtocol?
     var lastActivePid: pid_t?
@@ -61,6 +65,7 @@ public final class EventLoop {
         observers = [:]
         elements = [:]
         detectedFloating = [:]
+        ignorePending = []
     }
 
     /// AX element of a tracked window, if still known. Used to
@@ -130,6 +135,11 @@ public final class EventLoop {
     /// without it, closed windows keep occupying layout slots.
     func reconcile(pid: pid_t, appName: String) {
         guard observers[pid] != nil else { return }
+        // One window-server snapshot for the whole pass; only
+        // apps with an ignore rule need layers at all.
+        let layers =
+            FloatDetection.hasIgnoreRule(appName: appName)
+            ? FloatDetection.windowLayers(pid: pid) : [:]
         var live: Set<WindowID> = []
         var minimized: Set<WindowID> = []
         for element in AXHelper.windows(pid: pid) {
@@ -146,12 +156,23 @@ public final class EventLoop {
             // An ignored panel stays out of `live`: if the
             // startup scan mistracked it (its layer reads
             // wrong mid-launch), the sweep below untracks it.
-            guard
-                !FloatDetection.shouldIgnore(
-                    appName: appName,
-                    id: id
-                )
-            else { continue }
+            // A tracked window gets one reading of grace —
+            // layers flicker during fullscreen transitions,
+            // and untracking on a glitch leaks a spurious
+            // destroy/create pair to subscribers.
+            if FloatDetection.shouldIgnore(
+                appName: appName,
+                layer: layers[id] ?? 0
+            ) {
+                if elements[pid]?[id] != nil,
+                    !ignorePending.contains(id)
+                {
+                    ignorePending.insert(id)
+                    live.insert(id)
+                }
+                continue
+            }
+            ignorePending.remove(id)
             live.insert(id)
             if elements[pid]?[id] == nil {
                 track(element, pid: pid, appName: appName)
@@ -163,6 +184,7 @@ public final class EventLoop {
         where !live.contains(id) {
             elements[pid]?[id] = nil
             detectedFloating[id] = nil
+            ignorePending.remove(id)
             onEvent(
                 .windowDestroyed(
                     id,

--- a/Sources/KiwiDeskCore/Events/EventLoop.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop.swift
@@ -104,6 +104,14 @@ public final class EventLoop {
             )
         else { return }
         guard elements[pid]?[window.id] == nil else { return }
+        // Some panels must never be managed at all — merely
+        // floating them still pins them to a space (issue #21).
+        guard
+            !FloatDetection.shouldIgnore(
+                element: element,
+                appName: appName
+            )
+        else { return }
         window.isFloating = FloatDetection.shouldFloat(
             element: element,
             appName: appName,
@@ -135,6 +143,15 @@ public final class EventLoop {
                 minimized.insert(id)
                 continue
             }
+            // An ignored panel stays out of `live`: if the
+            // startup scan mistracked it (its layer reads
+            // wrong mid-launch), the sweep below untracks it.
+            guard
+                !FloatDetection.shouldIgnore(
+                    element: element,
+                    appName: appName
+                )
+            else { continue }
             live.insert(id)
             if elements[pid]?[id] == nil {
                 track(element, pid: pid, appName: appName)

--- a/Sources/KiwiDeskCore/State/StateCoordinator.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator.swift
@@ -49,6 +49,14 @@ public struct StateCoordinator: Sendable {
         rememberedSpaces[id] = space
     }
 
+    /// Where an untracked window will be filed once tracked.
+    /// Session restore fills this before slow-AX apps list
+    /// their windows, so startup can land on the right space
+    /// even when the window itself is not tracked yet.
+    func rememberedSpace(of id: WindowID) -> SpaceID? {
+        rememberedSpaces[id]
+    }
+
     /// Marks a window floating/tiled (`make_floating`).
     public mutating func setFloating(
         _ id: WindowID,

--- a/Tests/KiwiDeskCoreTests/GridLayoutTests.swift
+++ b/Tests/KiwiDeskCoreTests/GridLayoutTests.swift
@@ -330,6 +330,32 @@ struct FloatRuleTests {
         )
     }
 
+    @Test("Ghostty's quick terminal panel is never managed")
+    func ignoreDetection() throws {
+        // The quick terminal: Ghostty + non-zero layer.
+        #expect(
+            FloatDetection.shouldIgnore(
+                appName: "Ghostty",
+                layer: 3
+            )
+        )
+        // Ghostty's normal windows tile as usual.
+        #expect(
+            !FloatDetection.shouldIgnore(
+                appName: "Ghostty",
+                layer: 0
+            )
+        )
+        // Other apps' panels merely float; only Ghostty's
+        // quick terminal is ignored outright (issue #21).
+        #expect(
+            !FloatDetection.shouldIgnore(
+                appName: "Finder",
+                layer: 3
+            )
+        )
+    }
+
     @Test("Only structural events trigger a retile")
     func retileFilter() throws {
         #expect(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -419,12 +419,19 @@ float_rules = { "Calculator", "Finder:Get Info" }
 ```
 
 Panels and overlays that live above the normal window layer
-(e.g. Ghostty's quick terminal) also float automatically, no
-rule needed. Detection is re-checked as windows come and go,
-so a window that reported wrong metadata while its app was
-still launching corrects itself instead of staying tiled. A
-manual `make_floating` override is never reverted by these
-re-checks.
+also float automatically, no rule needed. Detection is
+re-checked as windows come and go, so a window that reported
+wrong metadata while its app was still launching corrects
+itself instead of staying tiled. A manual `make_floating`
+override is never reverted by these re-checks.
+
+**Ghostty's quick terminal** goes one step further: it is
+not managed at all — no space assignment, no window events.
+Even a floating window belongs to a space, and since macOS
+shows the quick terminal over *every* space, focusing it
+would drag you to whichever space it was first seen on. It
+can take focus freely; KiwiDesk simply pretends it does not
+exist.
 
 ```lua
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -807,10 +807,13 @@ KiwiDesk.set_wake_restore_delay(1500) -- ms after wake
 Quitting KiwiDesk saves the current arrangement — window
 order per virtual space, focus, and the active space — and
 restores it on the next launch, so tiles do not shuffle
-across restarts. This works within one login session (macOS
-window ids reset on logout/reboot; after that, windows are
-re-tiled fresh). Crashes restore from the last autosave (30 s
-interval) instead.
+across restarts. After the restore, KiwiDesk lands on the
+virtual space of the window that has focus *right now*,
+falling back to the space that was active at quit. This
+works within one login session (macOS window ids reset on
+logout/reboot; after that, windows are re-tiled fresh).
+Crashes restore from the last autosave (30 s interval)
+instead.
 
 ## Extras
 


### PR DESCRIPTION
## Description

Ghostty's quick terminal (a layer-3 overlay panel) is now never
managed: no tracking, no state entry, no events. While such a
panel is visible, AX focus reports from its app are distrusted,
so focus-follow no longer yanks the user to the main window's
space while they type into the panel.

Startup is also healed: the initial window scan runs against
cold AX trees, so slow responders (Electron/WebKit, Zen) list
windows late — previously the first switch to their space showed
nothing until a second attempt. A one-shot reconcile sweep 1 s
after start re-tracks what the scan missed. After a session
restore, KiwiDesk now lands on the virtual space of the window
that has focus *right now* (remembered-space fallback + post-
sweep re-landing), instead of the shutdown-time snapshot space.

Review follow-ups from `code-reviewer` and `architect-reviewer`
are included: single CGWindowList snapshot per reconcile pass,
one reading of grace before untracking on a flickering layer,
`appActivated` reconciles the activated app, explicit
`hasIgnoreRule`, sweep task lifecycle, and a lifecycle file
split to respect the size ceiling.

## Related Issue(s)

Closes #21

## Checklist

- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## Notes for Reviewer

Verified manually on the reporter's setup: start KiwiDesk from
the quick terminal while focusing a space-2/space-4 window —
lands on the right space, first switch to space 1 shows its
windows, sketchybar state matches reality. Known accepted
limitation (documented in code): with quick-terminal autohide
disabled, focus-follow is suppressed while the panel is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)