### PR TITLE
fix(spaces): make a moved window visible on first focus (#22)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
@@ -69,6 +69,7 @@ extension KiwiCore {
     public func stop() {
         pendingFocusFollow?.cancel()
         pendingStartupSweep?.cancel()
+        pendingSpaceSettle?.cancel()
         mouse.stop()
         eventLoop.stop()
         sleepWake.stop()

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -29,6 +29,11 @@ public final class KiwiCore {
     /// (see scheduleFocusFollow).
     var pendingFocusFollow: Task<Void, Never>?
 
+    /// One-shot re-assertion of a virtual space's layout shortly
+    /// after a switch, catching windows whose single frame-set a
+    /// slow/background app dropped (see scheduleSpaceSettle).
+    var pendingSpaceSettle: Task<Void, Never>?
+
     /// One-shot startup sweep re-tracking windows the cold
     /// AX scan missed (see start()).
     var pendingStartupSweep: Task<Void, Never>?

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -98,7 +98,42 @@ extension KiwiCore {
             focusWindow(next)
         }
         emitSpaceChange()
+        scheduleSpaceSettle(SpaceID(raw))
         return .ok()
+    }
+
+    /// A virtual-space switch applies each window's target frame
+    /// exactly once. Slow-AX apps (Electron/WebKit answer lazily)
+    /// and deprioritized background windows occasionally drop
+    /// that single position update and stay parked offscreen, so
+    /// the space comes up missing windows until another switch
+    /// re-issues the frames. Re-assert the layout once, shortly
+    /// after the switch, so the stragglers land without a manual
+    /// second focus. Mirrors `settleAfterNativeSwitch` (#22).
+    ///
+    /// Layout only — no focus re-assert (unlike the native
+    /// settle): a virtual switch already handed real focus to the
+    /// space's window, so only dropped *frames* need recovery,
+    /// not focus. Single-shot: an app that drops the frame again
+    /// on the retry still needs another switch — if that recurs,
+    /// re-issue only the windows still at the stash corner rather
+    /// than lengthening or repeating this timer.
+    func scheduleSpaceSettle(_ target: SpaceID) {
+        pendingSpaceSettle?.cancel()
+        pendingSpaceSettle = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled, let self,
+                self.state.workspaces.activeSpace == target,
+                // A native desktop switch in this window runs its
+                // own retile + settle and is still re-tracking
+                // windows; don't collide (cf. scheduleFocusFollow).
+                Date().timeIntervalSince(self.lastNativeSwitch) > 1
+            else { return }
+            self.retile(
+                animated: self.tiler.animateSpaceSwitch,
+                force: true
+            )
+        }
     }
 
     func moveToSpace(
@@ -133,6 +168,9 @@ extension KiwiCore {
             state.workspaces.activate(target)
             focusWindow(focused)
             emitSpaceChange()
+            // Following is a space switch too: re-assert so the
+            // target's other windows survive a dropped frame.
+            scheduleSpaceSettle(target)
         } else if let next = activeSpace?.focused {
             // The moved window would keep macOS focus while
             // stashed offscreen; refocus the current space.

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -114,6 +114,13 @@ extension KiwiCore {
         let target = SpaceID(raw)
         let from = state.workspaces.space(of: focused)
         state.workspaces.add(focused, to: target)
+        // The moved window becomes the target space's focus, so
+        // the FIRST focus of that space raises it. Without this,
+        // `focusSpace` finds no focus to hand over and the window
+        // is un-stashed frame-wise but never brought forward —
+        // the space renders empty until a later focus event
+        // stamps the focus and a second switch surfaces it (#22).
+        state.workspaces.focus(focused, in: target)
         if from != target {
             emitWindowMovedToSpace(
                 focused,

--- a/Tests/KiwiDeskCoreTests/MoveToSpaceTests.swift
+++ b/Tests/KiwiDeskCoreTests/MoveToSpaceTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import CoreGraphics
 import Foundation
 import Testing
 
@@ -36,6 +38,19 @@ struct MoveToSpaceTests {
                 )
             )
         )
+    }
+
+    /// Polls `condition` up to a deadline so a settle that fires
+    /// a little late under load does not flake the test.
+    private func pollUntil(
+        deadlineMS: Int,
+        _ condition: () -> Bool
+    ) async {
+        var waited = 0
+        while !condition(), waited < deadlineMS {
+            try? await Task.sleep(for: .milliseconds(20))
+            waited += 20
+        }
     }
 
     @Test("Moved window becomes the target space's focus")
@@ -99,5 +114,81 @@ struct MoveToSpaceTests {
             core.state.workspaces[SpaceID(1)]?.windows
                 == [WindowID(1)]
         )
+    }
+
+    @Test("A space switch re-asserts the layout after settling")
+    func spaceSwitchReassertsLayout() async throws {
+        // Slot geometry needs a real screen (headless CI skips).
+        guard NSScreen.main != nil else { return }
+        let core = makeCore()
+        // Drive the observable animated apply path and let the
+        // settle re-run use it too.
+        core.tiler.animateSpaceSwitch = true
+        core.tiler.animation.isEnabled = false
+        var applies: [WindowID: Int] = [:]
+        core.tiler.animation.apply = { id, _, _ in
+            applies[id, default: 0] += 1
+        }
+        addWindow(core, 1)
+        core.execute(
+            "move_to_virtual_space",
+            args: [.string("2")]
+        )
+        // Count only what the focus + settle apply.
+        applies = [:]
+        core.execute(
+            "focus_virtual_space",
+            args: [.string("2")]
+        )
+        let onFocus = applies[WindowID(1)] ?? 0
+        #expect(onFocus >= 1)
+        // The settle (~300ms later) re-issues the whole layout, so
+        // the apply count grows past the on-focus count without a
+        // manual second focus — how a dropped frame is recovered.
+        await pollUntil(deadlineMS: 2000) {
+            (applies[WindowID(1)] ?? 0) > onFocus
+        }
+        #expect((applies[WindowID(1)] ?? 0) > onFocus)
+    }
+
+    @Test("Switching away cancels and replaces the settle")
+    func settleCancelsOnReswitch() {
+        let core = makeCore()
+        addWindow(core, 1)
+        core.execute(
+            "focus_virtual_space",
+            args: [.string("2")]
+        )
+        let first = core.pendingSpaceSettle
+        #expect(first != nil)
+        core.execute(
+            "focus_virtual_space",
+            args: [.string("1")]
+        )
+        // The prior settle is cancelled AND a fresh one scheduled
+        // for the new target — not merely cancelled.
+        #expect(first?.isCancelled == true)
+        #expect(core.pendingSpaceSettle != nil)
+        #expect(core.pendingSpaceSettle != first)
+    }
+
+    @Test("Moving to the current space re-stamps focus safely")
+    func moveToSameSpaceIsSafe() {
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        // Window 2 is space 1's focus; move it into space 1 again.
+        #expect(core.activeSpace?.focused == WindowID(2))
+        let response = core.execute(
+            "move_to_virtual_space",
+            args: [.string("1")]
+        )
+        #expect(response.isSuccess)
+        // Both windows survive (nothing dropped) and 2 stays focus.
+        #expect(
+            core.state.workspaces[SpaceID(1)]?.windows
+                == [WindowID(1), WindowID(2)]
+        )
+        #expect(core.activeSpace?.focused == WindowID(2))
     }
 }

--- a/Tests/KiwiDeskCoreTests/MoveToSpaceTests.swift
+++ b/Tests/KiwiDeskCoreTests/MoveToSpaceTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Issue #22: a window moved to another virtual space must
+/// become that space's focused window at move time, so the
+/// FIRST focus of the space raises (surfaces) it. Before the
+/// fix the target space kept no focus, so `focus_virtual_space`
+/// un-stashed the window frame-wise but never brought it
+/// forward — the space rendered empty until a second focus.
+@Suite("Move to virtual space (issue #22)", .serialized)
+@MainActor
+struct MoveToSpaceTests {
+    private func makeCore() -> KiwiCore {
+        KiwiCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-move-\(UUID().uuidString)"
+                )
+        )
+    }
+
+    private func addWindow(
+        _ core: KiwiCore,
+        _ raw: UInt32,
+        app: String = "App"
+    ) {
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(
+                    id: WindowID(raw),
+                    pid: 1,
+                    appName: app
+                )
+            )
+        )
+    }
+
+    @Test("Moved window becomes the target space's focus")
+    func movedWindowFocusesTarget() {
+        let core = makeCore()
+        addWindow(core, 1)
+        // A freshly created window is its space's focus.
+        #expect(core.activeSpace?.id == SpaceID(1))
+        #expect(core.activeSpace?.focused == WindowID(1))
+
+        let response = core.execute(
+            "move_to_virtual_space",
+            args: [.string("2")]
+        )
+        #expect(response.isSuccess)
+        // No follow: we stay on space 1 ...
+        #expect(core.state.workspaces.activeSpace == SpaceID(1))
+        // ... but the window now lives in space 2, as its focus.
+        #expect(
+            core.state.workspaces[SpaceID(2)]?.windows
+                == [WindowID(1)]
+        )
+        #expect(
+            core.state.workspaces[SpaceID(2)]?.focused
+                == WindowID(1)
+        )
+    }
+
+    @Test("First focus of the target lands on the moved window")
+    func firstFocusSurfacesMovedWindow() {
+        let core = makeCore()
+        addWindow(core, 1)
+        core.execute(
+            "move_to_virtual_space",
+            args: [.string("2")]
+        )
+        // A single focus is enough — no second switch (#22).
+        core.execute(
+            "focus_virtual_space",
+            args: [.string("2")]
+        )
+        #expect(core.state.workspaces.activeSpace == SpaceID(2))
+        #expect(core.activeSpace?.focused == WindowID(1))
+    }
+
+    @Test("Follow keeps focus on the moved window")
+    func followFocusesMovedWindow() {
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        // Window 2 is the active-space focus; move+follow it.
+        #expect(core.activeSpace?.focused == WindowID(2))
+        core.execute(
+            "move_to_virtual_space_and_follow",
+            args: [.string("3")]
+        )
+        #expect(core.state.workspaces.activeSpace == SpaceID(3))
+        #expect(core.activeSpace?.focused == WindowID(2))
+        // Space 1 retains its other window and re-picks a focus.
+        #expect(
+            core.state.workspaces[SpaceID(1)]?.windows
+                == [WindowID(1)]
+        )
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,10 @@ window (cmd+tab) pulls its space forward automatically. Floating windows —
 including picture-in-picture — are never stashed and stay
 visible across all virtual spaces.
 
+Sending a window elsewhere with `move_to_virtual_space` makes
+it that space's focused window, so the first time you switch
+there it is the window you land on — even without `_and_follow`.
+
 **Minimizing** a window removes it from its space entirely.
 Restoring it from the Dock opens it in the virtual space you
 are on at that moment (an `app_rules` entry for its app still


### PR DESCRIPTION
## Description

Fixes issue #22 — a window moved to another virtual space did not
appear until the space was focused a **second** time. Two distinct
causes, one per commit:

1. **State (`fix(spaces): focus the moved window in its target space`).**
   `move_to_virtual_space` wrote the window into the target space's
   array but never set that space's `focused`. `focus_virtual_space`
   then had no focus to hand over, so the window was un-stashed
   frame-wise but never raised — the space rendered empty until a
   later focus event stamped the focus and a second switch surfaced
   it. Now the moved window becomes its new space's focus at move
   time, so the first focus raises it.

2. **AX reliability (`fix(spaces): re-assert layout after a virtual space switch`).**
   A virtual switch applies each window's target frame exactly once;
   slow-AX apps (Electron/WebKit) and deprioritized background
   windows occasionally drop that single position update and stay
   parked offscreen. A one-shot `scheduleSpaceSettle` re-asserts the
   layout ~300 ms after a switch (mirroring `settleAfterNativeSwitch`),
   cancelled on re-switch / `stop()`, and skipped during an in-flight
   native-desktop transition.

## Related Issue(s)

Closes #22

## Checklist

- [x] Commits follow Conventional Commits format (see AGENTS.md §3)
- [x] New behavior is tested (`Tests/KiwiDeskCoreTests/MoveToSpaceTests.swift`, 6 tests)
- [x] User-facing changes are documented in `docs/` (`docs/configuration.md`)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes (295 tests)
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## Notes for Reviewer

Reviewed by `code-reviewer` + `architect-reviewer` before opening.
Addressed: `pendingSpaceSettle` cancellation in `stop()`, a
native-switch race guard, and test de-flaking (poll vs. fixed
sleep) + added edge/replacement assertions.

**Conscious scope decisions:** the settle re-asserts layout only
(not focus) — a virtual switch already handed real focus, so only
dropped *frames* need recovery — and it is single-shot.

**Follow-up (tracked separately, out of scope here):** the deferred
`Task` fields on `KiwiCore` (`pendingFocusFollow`,
`pendingStartupSweep`, `pendingSpaceSettle`) and the three
near-identical "settle" helpers are trending toward a small owning
abstraction (a keyed `schedule` + `cancelAll()` that `stop()` calls).
Both reviewers flagged it as "not yet" — do it when a 5th deferred
task appears.