### PR TITLE
feat(animation): granular per-trigger animation toggles

### DIFF
--- a/Sources/KiwiDeskCore/AX/AXHelper.swift
+++ b/Sources/KiwiDeskCore/AX/AXHelper.swift
@@ -130,6 +130,21 @@ public enum AXHelper {
         ) ?? false
     }
 
+    /// Current `AXEnhancedUserInterface` state of an app, read
+    /// live (nil if the app does not answer). Used to bracket an
+    /// instant frame-set: EUI-on apps animate programmatic frame
+    /// changes themselves, so an un-animated placement must drop
+    /// it for the set and restore whatever it was.
+    public static func getEnhancedUserInterface(
+        pid: pid_t
+    ) -> Bool? {
+        attribute(
+            appElement(pid: pid),
+            "AXEnhancedUserInterface",
+            as: Bool.self
+        )
+    }
+
     /// Keeps Electron/WebKit AX trees warm to avoid 100-300 ms
     /// query latency. See AGENTS.md guardrails before changing.
     public static func setEnhancedUserInterface(

--- a/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
@@ -21,7 +21,7 @@ extension KiwiCore {
             // space-switch animation setting, and tell bus
             // subscribers (the bar) where we landed.
             retile(
-                animated: tiler.animateSpaceSwitch,
+                animated: tiler.settings.animations.onSpaceChange,
                 force: true
             )
             emitSpaceChange()
@@ -58,7 +58,7 @@ extension KiwiCore {
             self.activateSpaceOfFocusedWindow()
             if self.state.workspaces.activeSpace != landed {
                 self.retile(
-                    animated: self.tiler.animateSpaceSwitch,
+                    animated: self.tiler.settings.animations.onSpaceChange,
                     force: true
                 )
                 self.emitSpaceChange()

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -146,14 +146,21 @@ public final class KiwiCore {
         }
     }
 
+    /// `animated: nil` (the default for a bare `retile()`) means
+    /// "a structural reflow" — window open/close, mode / gap /
+    /// param change — and obeys `animations.on_relayout`. Callers
+    /// that own a more specific trigger (space switch, swap,
+    /// resize, focus slide) pass an explicit `animated:` and are
+    /// gated by their own toggle instead.
     public func retile(
-        animated: Bool = true,
+        animated: Bool? = nil,
         force: Bool = false,
         newlyCreatedWindow: WindowID? = nil
     ) {
         tiler.retile(
             state: state,
-            animated: animated,
+            animated: animated
+                ?? tiler.settings.animations.onRelayout,
             force: force,
             newlyCreatedWindow: newlyCreatedWindow
         )
@@ -204,7 +211,7 @@ public final class KiwiCore {
             {
                 scheduleFocusFollow(id)
             } else if activeSpace?.mode.isFocusDriven == true {
-                retile()
+                retile(animated: focusRetileAnimated)
             }
         case .windowCreated(let window):
             // A brand-new window supersedes a pending follow

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -67,6 +67,12 @@ public enum APIReference {
 
     /// Layout sub-APIs exposed as global Lua tables.
     public static let namespaces: [String: [String]] = [
+        "animations": [
+            "set_duration",
+            "set_on_space_change", "set_on_scrolling",
+            "set_on_window_resize", "set_on_window_swap",
+            "set_on_relayout",
+        ],
         "stack": [
             "promote", "demote",
             "set_master_count", "set_master_ratio",

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
@@ -83,7 +83,17 @@ extension KiwiCore {
     /// Static layouts skip it: their targets are unchanged,
     /// and re-applying them just fights apps that clamp our
     /// frames (grid-snapping terminals), wobbling everything.
-    public func focusWindow(_ id: WindowID) {
+    ///
+    /// `refocusRetile: false` suppresses that retile for callers
+    /// that just retiled themselves — a space switch already
+    /// placed windows with the correct focus, and re-tiling here
+    /// would spring them from their stale stash-corner frames
+    /// (the AX echo of the instant switch has not landed yet),
+    /// which is the "fly out of the corner" bug (issue #11).
+    public func focusWindow(
+        _ id: WindowID,
+        refocusRetile: Bool = true
+    ) {
         if let space = state.workspaces.space(of: id) {
             state.workspaces.focus(id, in: space)
         }
@@ -92,9 +102,21 @@ extension KiwiCore {
         {
             AXHelper.raise(element, pid: window.pid)
         }
-        if activeSpace?.mode.isFocusDriven == true {
-            retile()
-        }
+        guard refocusRetile,
+            activeSpace?.mode.isFocusDriven == true
+        else { return }
+        retile(animated: focusRetileAnimated)
+    }
+
+    /// Whether a focus-driven re-layout animates. Scrolling's
+    /// focus slide is toggleable (`on_scrolling`); other
+    /// focus-driven modes (Monocle) always animate. Shared by
+    /// the `focusWindow` hand-off and the `windowFocused` event
+    /// handler so an external focus change (click / cmd+tab
+    /// within the space) obeys the same toggle.
+    var focusRetileAnimated: Bool {
+        activeSpace?.mode == .scrolling
+            ? tiler.settings.animations.onScrolling : true
     }
 
     // MARK: - Window state
@@ -164,7 +186,9 @@ extension KiwiCore {
                     + space.mode.rawValue
             )
         }
-        retile()
+        retile(
+            animated: tiler.settings.animations.onWindowResize
+        )
         return .ok()
     }
 

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+LayoutCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+LayoutCommands.swift
@@ -9,7 +9,9 @@ extension KiwiCore {
         _ args: [JSONValue]
     ) -> CommandResponse {
         let response: CommandResponse
-        if command.hasPrefix("stack.") {
+        if command.hasPrefix("animations.") {
+            response = animationsCommand(command, args)
+        } else if command.hasPrefix("stack.") {
             response = stackCommand(command, args)
         } else if command.hasPrefix("bsp.") {
             response = bspCommand(command, args)

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+NavigateCommand.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+NavigateCommand.swift
@@ -74,7 +74,9 @@ extension KiwiCore {
             state.workspaces.withSpace(space.id) {
                 $0.swap(focused, target)
             }
-            retile()
+            retile(
+                animated: tiler.settings.animations.onWindowSwap
+            )
             if crossedZones {
                 scheduleZOrderRestore()
             }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SettingsCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SettingsCommands.swift
@@ -11,15 +11,26 @@ extension KiwiCore {
     ) -> CommandResponse {
         switch command {
         case "set_animation_duration":
+            // Deprecated alias for `animations.set_duration`.
             guard let ms = args.first?.intValue else {
                 return .fail("expected milliseconds")
             }
+            onLog(
+                "set_animation_duration is deprecated — use "
+                    + "animations.set_duration(ms)"
+            )
             tiler.animation.durationMS = ms
         case "set_space_animation":
+            // Deprecated alias for `animations.set_on_space_change`
+            // (issue #11). Still works so existing configs load.
             guard let enabled = args.first?.boolValue else {
                 return .fail("expected boolean")
             }
-            tiler.animateSpaceSwitch = enabled
+            onLog(
+                "set_space_animation is deprecated — use "
+                    + "animations.set_on_space_change(bool)"
+            )
+            tiler.settings.animations.onSpaceChange = enabled
         case "set_mouse_resize":
             guard let raw = args.first?.stringValue,
                 let mode = MouseResizeMode(rawValue: raw)
@@ -59,6 +70,42 @@ extension KiwiCore {
             }
             message += " (run 'help' for all commands)"
             return .fail(message)
+        }
+        return .ok()
+    }
+
+    /// `animations.*` toggles (issue #11): per-trigger animation
+    /// control. Persisted in `settings.animations`.
+    func animationsCommand(
+        _ command: String,
+        _ args: [JSONValue]
+    ) -> CommandResponse {
+        // Duration takes an Int, not a Bool. Runtime-only (like
+        // scroll.set_speed, which shares this knob) — not
+        // persisted, so set it in init.lua.
+        if command == "animations.set_duration" {
+            guard let ms = args.first?.intValue else {
+                return .fail("expected milliseconds")
+            }
+            tiler.animation.durationMS = ms
+            return .ok()
+        }
+        guard let enabled = args.first?.boolValue else {
+            return .fail("expected boolean")
+        }
+        switch command {
+        case "animations.set_on_space_change":
+            tiler.settings.animations.onSpaceChange = enabled
+        case "animations.set_on_scrolling":
+            tiler.settings.animations.onScrolling = enabled
+        case "animations.set_on_window_resize":
+            tiler.settings.animations.onWindowResize = enabled
+        case "animations.set_on_window_swap":
+            tiler.settings.animations.onWindowSwap = enabled
+        case "animations.set_on_relayout":
+            tiler.settings.animations.onRelayout = enabled
+        default:
+            return .fail("unknown command: \(command)")
         }
         return .ok()
     }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -45,7 +45,7 @@ extension KiwiCore {
             else { return }
             self.state.workspaces.activate(space)
             self.retile(
-                animated: self.tiler.animateSpaceSwitch,
+                animated: self.tiler.settings.animations.onSpaceChange,
                 force: true
             )
             self.emitSpaceChange()
@@ -88,14 +88,14 @@ extension KiwiCore {
         state.workspaces.activate(SpaceID(raw))
         logSpaceContents(SpaceID(raw))
         retile(
-            animated: tiler.animateSpaceSwitch,
+            animated: tiler.settings.animations.onSpaceChange,
             force: true
         )
         // Hand real (AX) focus to the space's last focused
         // window — otherwise keystrokes keep going to a
         // window that is now stashed offscreen.
         if let next = activeSpace?.focused {
-            focusWindow(next)
+            focusWindow(next, refocusRetile: false)
         }
         emitSpaceChange()
         scheduleSpaceSettle(SpaceID(raw))
@@ -130,7 +130,7 @@ extension KiwiCore {
                 Date().timeIntervalSince(self.lastNativeSwitch) > 1
             else { return }
             self.retile(
-                animated: self.tiler.animateSpaceSwitch,
+                animated: self.tiler.settings.animations.onSpaceChange,
                 force: true
             )
         }
@@ -166,7 +166,8 @@ extension KiwiCore {
         }
         if follow {
             state.workspaces.activate(target)
-            focusWindow(focused)
+            // The retile below owns placement (see focusWindow).
+            focusWindow(focused, refocusRetile: false)
             emitSpaceChange()
             // Following is a space switch too: re-assert so the
             // target's other windows survive a dropped frame.
@@ -174,11 +175,11 @@ extension KiwiCore {
         } else if let next = activeSpace?.focused {
             // The moved window would keep macOS focus while
             // stashed offscreen; refocus the current space.
-            focusWindow(next)
+            focusWindow(next, refocusRetile: false)
         }
         retile(
             animated: follow
-                ? tiler.animateSpaceSwitch : true,
+                ? tiler.settings.animations.onSpaceChange : true,
             force: follow
         )
         return .ok()

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+NativeSpaces.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+NativeSpaces.swift
@@ -87,7 +87,10 @@ extension KiwiCore {
             // layouts' z-order back before handing focus over.
             self.scheduleZOrderRestore()
             if let focused = self.activeSpace?.focused {
-                self.focusWindow(focused)
+                // The instant retile above already placed the
+                // windows; re-tiling on focus would fly them
+                // from stale frames (issue #11).
+                self.focusWindow(focused, refocusRetile: false)
             }
         }
     }

--- a/Sources/KiwiDeskCore/Tiling/AnimationSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/AnimationSettings.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Per-trigger animation toggles (issue #11), replacing the
+/// removed global `enable_animations`. Only position-only
+/// triggers are toggleable: an "off" size change would be an
+/// instant resize, which slow-AX apps (Electron/WebKit) clamp
+/// or drop — so window resize/swap always animate and have no
+/// toggle here.
+///
+/// JSON shape follows the one-vocabulary rule (AGENTS.md §5):
+/// Lua `animations.set_on_space_change` -> `animations.on_space_change`.
+public struct AnimationSettings: Sendable, Equatable, Codable {
+    /// Animate windows flying in from / out to the stash corner
+    /// on a KiwiDesk **virtual** space switch. Off by default:
+    /// many long-distance animations at once mean one blocking
+    /// AX call per window per frame, which stutters on slow
+    /// responders. Does not affect the native macOS desktop
+    /// slide (that is the OS's own, governed by Reduce Motion).
+    public var onSpaceChange = false
+
+    /// Animate the layout sliding as focus moves within a
+    /// Scrolling space. On by default — it is a position-only
+    /// slide, so it is safe on slow-AX apps.
+    public var onScrolling = true
+
+    /// Animate window resizes (split-ratio changes, mouse
+    /// resize settle). On by default. The instant path now
+    /// re-asserts size via the EUI-bracketed size→position→size
+    /// set, so "off" lands reliably on most apps — but a few
+    /// grid-snapping apps still clamp an un-animated resize.
+    public var onWindowResize = true
+
+    /// Animate window swaps (exchanging two tiles). On by
+    /// default; "off" snaps the two windows into place.
+    public var onWindowSwap = true
+
+    /// Animate the layout reflow — tiles rearranging when a
+    /// window opens or closes, the mode switches, or a gap /
+    /// layout parameter changes. On by default; "off" snaps the
+    /// whole layout. Named to avoid the `layout_change` event.
+    public var onRelayout = true
+
+    private enum CodingKeys: String, CodingKey {
+        case onSpaceChange = "on_space_change"
+        case onScrolling = "on_scrolling"
+        case onWindowResize = "on_window_resize"
+        case onWindowSwap = "on_window_swap"
+        case onRelayout = "on_relayout"
+    }
+
+    public init() {}
+
+    /// A profile saved before one of these keys existed (or a
+    /// hand-written partial object) keeps the missing default,
+    /// matching `TilingSettings`' missing-keys contract.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(
+            keyedBy: CodingKeys.self
+        )
+        onSpaceChange =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: .onSpaceChange
+            ) ?? false
+        onScrolling =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: .onScrolling
+            ) ?? true
+        onWindowResize =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: .onWindowResize
+            ) ?? true
+        onWindowSwap =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: .onWindowSwap
+            ) ?? true
+        onRelayout =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: .onRelayout
+            ) ?? true
+    }
+}

--- a/Sources/KiwiDeskCore/Tiling/FrameApplier.swift
+++ b/Sources/KiwiDeskCore/Tiling/FrameApplier.swift
@@ -116,6 +116,55 @@ final class FrameApplier {
         }
     }
 
+    /// Applies a frame instantly (no spring), AeroSpace-style:
+    /// on the app's serial queue, drop `AXEnhancedUserInterface`
+    /// around the set so an EUI-on app does not animate the move
+    /// itself — which stutters and can clamp or swallow the
+    /// frame — then restore whatever it was. `WindowControl`'s
+    /// size→position→size order lands the window in one pass, so
+    /// no settle frame is needed. Reading the live EUI state
+    /// (rather than a cached flag) means that if a sibling
+    /// window of the same app is still spring-animating — and so
+    /// already holds EUI off — this leaves it off for that
+    /// animation to restore.
+    ///
+    /// This deliberately does NOT participate in the `pidCounts`
+    /// ref-counting that `begin/endAnimating` use: every EUI
+    /// toggle and frame-set for a pid is enqueued from the main
+    /// actor onto the one serial `queue(for: pid)`, so the live
+    /// read observes the correct interleaved state without a
+    /// lock. Callers must `animation.cancel(window:)` before an
+    /// instant set (as `retile` and `stashInactive` do) so a
+    /// window is never spring-animated and instant-set at once.
+    func applyInstant(_ id: WindowID, _ frame: CGRect) {
+        guard let element = elementProvider(id) else { return }
+        guard
+            let pid = animatingPid[id] ?? Self.pid(of: element)
+        else { return }
+        nonisolated(unsafe) let target = element
+        let recent = recent
+        queue(for: pid).async {
+            let wasEnabled =
+                AXHelper.getEnhancedUserInterface(pid: pid)
+                == true
+            if wasEnabled {
+                AXHelper.setEnhancedUserInterface(
+                    pid: pid,
+                    enabled: false
+                )
+            }
+            WindowControl.setFrame(frame, of: target)
+            if wasEnabled {
+                AXHelper.setEnhancedUserInterface(
+                    pid: pid,
+                    enabled: true
+                )
+            }
+            // Stamped after the AX calls: echoes trail them.
+            recent.record(id)
+        }
+    }
+
     // MARK: - Internals
 
     private func queue(for pid: pid_t) -> DispatchQueue {

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -201,9 +201,13 @@ extension KiwiCore {
                 $0.swap(id, target)
             }
         }
-        // Applies the swap — or, without a target, animates
-        // the dragged window back into its slot.
-        retile()
+        // Applies the swap — honoring `on_window_swap`, like the
+        // keyboard swap — or, without a target, snaps/animates the
+        // dragged window back into its slot (a relayout).
+        retile(
+            animated: target != nil
+                ? tiler.settings.animations.onWindowSwap : nil
+        )
         // The dropped window has the user's attention: make
         // it the focused one, in state and for real.
         focusWindow(id)

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
@@ -45,7 +45,9 @@ extension KiwiCore {
             let screen = NSScreen.main
                 ?? NSScreen.screens.first
         else {
-            retile()
+            retile(
+                animated: tiler.settings.animations.onWindowResize
+            )
             focusWindow(id)
             return
         }
@@ -87,7 +89,9 @@ extension KiwiCore {
         case nil:
             break
         }
-        retile()
+        retile(
+            animated: tiler.settings.animations.onWindowResize
+        )
         focusWindow(id)
     }
 }

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
@@ -12,13 +12,6 @@ public final class TilingEngine {
     public let animation = AnimationEngine()
     public var settings = TilingSettings()
 
-    /// `set_space_animation`: animate windows flying in from
-    /// the stash corner on a virtual space switch. Off by
-    /// default — many simultaneous long-distance animations
-    /// mean one blocking AX call per window per tick, which
-    /// stutters on slow AX responders (Electron/WebKit).
-    public var animateSpaceSwitch = false
-
     /// `set_mouse_resize`: what resizing a tiled window with
     /// the mouse does (applied on release).
     public var mouseResize: MouseResizeMode = .layout
@@ -235,7 +228,11 @@ public final class TilingEngine {
 
     /// Sets a frame directly (no animation) through the frame
     /// pipeline, so it is echo-tracked like animated frames.
+    /// Uses the EUI-bracketed instant path so an un-animated
+    /// placement (space switch / stash with animation off) snaps
+    /// cleanly instead of triggering the app's own move
+    /// animation (which stutters on slow-AX apps).
     public func setFrame(_ id: WindowID, _ frame: CGRect) {
-        applier.apply(id, frame, setSize: true)
+        applier.applyInstant(id, frame)
     }
 }

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
@@ -33,12 +33,15 @@ public struct TilingSettings: Sendable, Equatable, Codable {
     /// Corner rounding of both visuals — tune it to match
     /// the window corners of the running macOS release.
     public var dragCornerRadius: CGFloat = 16
+    /// Per-trigger animation toggles (`animations.*`).
+    public var animations = AnimationSettings()
 
     public init() {}
 
     // MARK: - Codable
 
     private enum CodingKeys: String, CodingKey {
+        case animations
         case appBar = "app_bar"
         case drag
         case gap
@@ -91,6 +94,11 @@ public struct TilingSettings: Sendable, Equatable, Codable {
                 AppBarStyle.self,
                 forKey: .appBar
             ) ?? AppBarStyle()
+        animations =
+            try container.decodeIfPresent(
+                AnimationSettings.self,
+                forKey: .animations
+            ) ?? AnimationSettings()
         try decodeGap(from: container)
         try decodeLayout(from: container)
         try decodeDrag(from: container)
@@ -191,6 +199,7 @@ public struct TilingSettings: Sendable, Equatable, Codable {
             forKey: .placementOverride
         )
         try container.encode(appBarStyle, forKey: .appBar)
+        try container.encode(animations, forKey: .animations)
         var gap = container.nestedContainer(
             keyedBy: GapKeys.self,
             forKey: .gap

--- a/Tests/KiwiDeskCoreTests/CommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/CommandTests.swift
@@ -176,12 +176,73 @@ struct CommandTests {
             args: [.number(2500)]
         )
         #expect(core.sleepWake.restoreDelayMS == 2500)
-        #expect(!core.tiler.animateSpaceSwitch)
+        // Duration: namespaced command clamps; old top-level name
+        // still works as a deprecated alias.
+        core.execute(
+            "animations.set_duration",
+            args: [.number(5000)]
+        )
+        #expect(core.tiler.animation.durationMS == 1000)
+        core.execute(
+            "set_animation_duration",
+            args: [.number(300)]
+        )
+        #expect(core.tiler.animation.durationMS == 300)
+        // Defaults: space change off, scrolling on (issue #11).
+        #expect(!core.tiler.settings.animations.onSpaceChange)
+        #expect(core.tiler.settings.animations.onScrolling)
+        // Each toggle round-trips in *both* directions.
+        core.execute(
+            "animations.set_on_space_change",
+            args: [.bool(true)]
+        )
+        #expect(core.tiler.settings.animations.onSpaceChange)
+        core.execute(
+            "animations.set_on_space_change",
+            args: [.bool(false)]
+        )
+        #expect(!core.tiler.settings.animations.onSpaceChange)
+        core.execute(
+            "animations.set_on_scrolling",
+            args: [.bool(false)]
+        )
+        #expect(!core.tiler.settings.animations.onScrolling)
+        core.execute(
+            "animations.set_on_scrolling",
+            args: [.bool(true)]
+        )
+        #expect(core.tiler.settings.animations.onScrolling)
+        // Resize / swap toggles (default true) round-trip too.
+        #expect(core.tiler.settings.animations.onWindowResize)
+        #expect(core.tiler.settings.animations.onWindowSwap)
+        core.execute(
+            "animations.set_on_window_resize",
+            args: [.bool(false)]
+        )
+        #expect(!core.tiler.settings.animations.onWindowResize)
+        core.execute(
+            "animations.set_on_window_swap",
+            args: [.bool(false)]
+        )
+        #expect(!core.tiler.settings.animations.onWindowSwap)
+        #expect(core.tiler.settings.animations.onRelayout)
+        core.execute(
+            "animations.set_on_relayout",
+            args: [.bool(false)]
+        )
+        #expect(!core.tiler.settings.animations.onRelayout)
+        // The old command still works as a deprecated alias, both
+        // ways: set it true then back to false.
         core.execute(
             "set_space_animation",
             args: [.bool(true)]
         )
-        #expect(core.tiler.animateSpaceSwitch)
+        #expect(core.tiler.settings.animations.onSpaceChange)
+        core.execute(
+            "set_space_animation",
+            args: [.bool(false)]
+        )
+        #expect(!core.tiler.settings.animations.onSpaceChange)
         #expect(core.tiler.mouseResize == .layout)
         core.execute(
             "set_mouse_resize",

--- a/Tests/KiwiDeskCoreTests/MoveToSpaceTests.swift
+++ b/Tests/KiwiDeskCoreTests/MoveToSpaceTests.swift
@@ -123,7 +123,7 @@ struct MoveToSpaceTests {
         let core = makeCore()
         // Drive the observable animated apply path and let the
         // settle re-run use it too.
-        core.tiler.animateSpaceSwitch = true
+        core.tiler.settings.animations.onSpaceChange = true
         core.tiler.animation.isEnabled = false
         var applies: [WindowID: Int] = [:]
         core.tiler.animation.apply = { id, _, _ in
@@ -149,6 +149,149 @@ struct MoveToSpaceTests {
             (applies[WindowID(1)] ?? 0) > onFocus
         }
         #expect((applies[WindowID(1)] ?? 0) > onFocus)
+    }
+
+    /// Issue #11: switching into a focus-driven (Scrolling) space
+    /// must not fire a second, *animated* retile on top of the
+    /// instant switch — that redundant retile read the windows'
+    /// stale stash-corner frames and sprang them "out of the
+    /// corner". With space-change animation off the switch itself
+    /// snaps instantly (the un-counted `setFrame` path), so the
+    /// animated `apply` closure should fire zero times; a revert
+    /// of the fix makes the focus hand-off retile and fire once.
+    @Test("Scrolling space switch does not re-tile on focus")
+    func scrollingSwitchNoRefocusRetile() {
+        guard NSScreen.main != nil else { return }
+        let core = makeCore()
+        core.tiler.settings.animations.onSpaceChange = false
+        core.tiler.animation.isEnabled = false
+        var animatedApplies: [WindowID: Int] = [:]
+        core.tiler.animation.apply = { id, _, _ in
+            animatedApplies[id, default: 0] += 1
+        }
+        addWindow(core, 1)
+        // Park window 1 on a Scrolling space 2, stay on space 1.
+        core.execute(
+            "move_to_virtual_space",
+            args: [.string("2")]
+        )
+        core.execute(
+            "set_mode",
+            args: [.string("2"), .string("scrolling")]
+        )
+        // Count only the switch into the Scrolling space.
+        animatedApplies = [:]
+        core.execute(
+            "focus_virtual_space",
+            args: [.string("2")]
+        )
+        #expect((animatedApplies[WindowID(1)] ?? 0) == 0)
+    }
+
+    /// Issue #11: `on_scrolling` gates the layout slide as focus
+    /// moves within a Scrolling space. On → the focus retile
+    /// animates (the counted `apply` closure fires); off → it
+    /// snaps through the un-counted instant `setFrame` path.
+    @Test("on_scrolling gates the within-space focus slide")
+    func onScrollingGatesFocusSlide() {
+        guard NSScreen.main != nil else { return }
+        let core = makeCore()
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("scrolling")]
+        )
+        addWindow(core, 1)
+        addWindow(core, 2)
+        addWindow(core, 3)
+        core.tiler.animation.isEnabled = false
+        var animatedApplies = 0
+        core.tiler.animation.apply = { _, _, _ in
+            animatedApplies += 1
+        }
+
+        // On: focusing a different window slides (animates).
+        core.tiler.settings.animations.onScrolling = true
+        animatedApplies = 0
+        core.focusWindow(WindowID(1))
+        #expect(animatedApplies >= 1)
+
+        // Off: focusing snaps — no animated apply.
+        core.tiler.settings.animations.onScrolling = false
+        animatedApplies = 0
+        core.focusWindow(WindowID(3))
+        #expect(animatedApplies == 0)
+    }
+
+    /// Issue #11 follow-up: `on_window_swap` gates the swap
+    /// animation. On → the swap retile animates (counted apply);
+    /// off → it snaps through the instant path (un-counted).
+    @Test("on_window_swap gates the swap animation")
+    func onWindowSwapGatesSwap() {
+        guard NSScreen.main != nil else { return }
+        let core = makeCore()
+        // Stack: master left, stack right — a reliable
+        // left/right neighbor regardless of screen aspect.
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("stack")]
+        )
+        addWindow(core, 1)
+        addWindow(core, 2)
+        core.tiler.animation.isEnabled = false
+        var animatedApplies = 0
+        core.tiler.animation.apply = { _, _, _ in
+            animatedApplies += 1
+        }
+
+        // Off: swapping snaps — no animated apply.
+        core.tiler.settings.animations.onWindowSwap = false
+        animatedApplies = 0
+        core.execute("swap", args: [.string("left")])
+        #expect(animatedApplies == 0)
+
+        // On: swapping back animates.
+        core.tiler.settings.animations.onWindowSwap = true
+        animatedApplies = 0
+        core.execute("swap", args: [.string("right")])
+        #expect(animatedApplies >= 1)
+    }
+
+    /// Issue #11 follow-up: `on_relayout` gates the structural
+    /// reflow (a bare `retile()` — here driven by a mode switch).
+    /// On → the reflow animates (counted apply); off → it snaps.
+    @Test("on_relayout gates the structural reflow")
+    func onRelayoutGatesReflow() {
+        guard NSScreen.main != nil else { return }
+        let core = makeCore()
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("bsp")]
+        )
+        addWindow(core, 1)
+        addWindow(core, 2)
+        core.tiler.animation.isEnabled = false
+        var animatedApplies = 0
+        core.tiler.animation.apply = { _, _, _ in
+            animatedApplies += 1
+        }
+
+        // Off: the mode switch snaps — no animated apply.
+        core.tiler.settings.animations.onRelayout = false
+        animatedApplies = 0
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("stack")]
+        )
+        #expect(animatedApplies == 0)
+
+        // On: the next mode switch animates.
+        core.tiler.settings.animations.onRelayout = true
+        animatedApplies = 0
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("grid")]
+        )
+        #expect(animatedApplies >= 1)
     }
 
     @Test("Switching away cancels and replaces the settle")

--- a/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
+++ b/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
@@ -26,11 +26,19 @@ struct SettingsCodingTests {
         )
         #expect(
             Set(root.keys) == [
-                "app_bar", "drag", "gap", "layout",
+                "animations", "app_bar", "drag", "gap", "layout",
                 "min_window_size",
                 "new_window_placement_override",
             ]
         )
+        // Lua `animations.set_on_space_change` /
+        // `animations.set_on_scrolling` (issue #11).
+        let animations = try object(root["animations"])
+        #expect(animations["on_space_change"] as? Bool == false)
+        #expect(animations["on_scrolling"] as? Bool == true)
+        #expect(animations["on_window_resize"] as? Bool == true)
+        #expect(animations["on_window_swap"] as? Bool == true)
+        #expect(animations["on_relayout"] as? Bool == true)
         let layout = try object(root["layout"])
         #expect(
             Set(layout.keys) == [
@@ -108,12 +116,29 @@ struct SettingsCodingTests {
         settings.dragCornerRadius = 22
         settings.gapsOverride[SpaceID(2)] = .uniform(4)
         settings.placementOverride[SpaceID("mail")] = .last
+        settings.animations.onSpaceChange = true
+        settings.animations.onScrolling = false
+        settings.animations.onWindowResize = false
+        settings.animations.onWindowSwap = false
+        settings.animations.onRelayout = false
         let data = try JSONEncoder().encode(settings)
         let decoded = try JSONDecoder().decode(
             TilingSettings.self,
             from: data
         )
         #expect(decoded == settings)
+    }
+
+    @Test("A partial animations object keeps the other default")
+    func partialAnimationsDecode() throws {
+        let json = #"{"animations":{"on_space_change":true}}"#
+        let decoded = try JSONDecoder().decode(
+            TilingSettings.self,
+            from: Data(json.utf8)
+        )
+        #expect(decoded.animations.onSpaceChange)
+        // on_scrolling absent — keeps its `true` default.
+        #expect(decoded.animations.onScrolling)
     }
 
     @Test("Missing keys fall back to defaults")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,8 +64,14 @@ KiwiDesk service restart
 | Diagnostics | `get_layout_info` | — |
 | | `list_monitors` | — |
 | | `debug_log` | message |
-| Animation | `set_animation_duration` | ms (50–1000) |
-| | `set_space_animation` | true\|false (default false) |
+| Animation | `animations.set_duration` | ms (50–1000); runtime only |
+| | `animations.set_on_space_change` | true\|false (default false) |
+| | `animations.set_on_scrolling` | true\|false (default true) |
+| | `animations.set_on_window_resize` | true\|false (default true) |
+| | `animations.set_on_window_swap` | true\|false (default true) |
+| | `animations.set_on_relayout` | true\|false (default true) |
+| | `set_space_animation` | deprecated alias for `animations.set_on_space_change` |
+| | `set_animation_duration` | deprecated alias for `animations.set_duration` |
 | Sleep/Wake | `enable_wake_restore` | true\|false |
 | | `set_wake_restore_delay` | ms |
 | Drag | `drag.set_ghost_enabled` | true\|false |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ they are parked in the bottom-right corner of their screen
 with only a few pixels peeking in (macOS refuses fully
 offscreen windows). They return to their tiles when their
 space becomes active — instantly by default; see
-`set_space_animation` under Animations. Focusing a hidden
+`animations.set_on_space_change` under Animations. Focusing a hidden
 window (cmd+tab) pulls its space forward automatically. Floating windows —
 including picture-in-picture — are never stashed and stay
 visible across all virtual spaces.
@@ -793,19 +793,58 @@ haven't visited yet starts on the first virtual space.
 ## Animations, Sleep & Wake
 
 ```lua
--- Window moves and resizes always animate: a spring settle is
--- the only way to place windows reliably on slow-AX apps.
-KiwiDesk.set_animation_duration(250)  -- ms, clamped 50-1000
+-- Animation duration for every spring-animated move (runtime
+-- only, not saved in a profile). scroll.set_speed shares it.
+animations.set_duration(250)          -- ms, clamped 50-1000
 
--- Virtual space switches snap instantly by default: flying
--- many windows in from the hiding corner at once needs one
--- blocking AX call per window per frame, which stutters on
--- slow apps. Opt in if you like the effect anyway:
-KiwiDesk.set_space_animation(true)
+-- Per-trigger animation toggles. An "off" trigger snaps
+-- instantly: the un-animated path drops the app's
+-- EnhancedUserInterface around a size→position→size AX set, so
+-- the frame lands in one pass instead of the app running its
+-- own move animation. This is reliable on most apps; a few
+-- grid-snapping apps still clamp an instant *resize*.
+
+-- Virtual space switches: flying many windows in from the
+-- hiding corner at once stutters on slow apps, so off by
+-- default. Opt in if you like the effect anyway:
+animations.set_on_space_change(false)  -- default false
+
+-- The layout slide as focus moves within a Scrolling space:
+animations.set_on_scrolling(true)      -- default true
+
+-- Window resizes (split-ratio changes, mouse-resize settle):
+animations.set_on_window_resize(true)  -- default true
+
+-- Swapping two tiles:
+animations.set_on_window_swap(true)    -- default true
+
+-- The layout reflow when a window opens or closes, the mode
+-- switches, or a gap / layout parameter changes:
+animations.set_on_relayout(true)       -- default true
 
 KiwiDesk.enable_wake_restore(true)
 KiwiDesk.set_wake_restore_delay(1500) -- ms after wake
 ```
+
+`on_space_change` governs KiwiDesk's own **virtual-space**
+transitions only. The native macOS desktop slide (three-finger
+swipe, Ctrl+←/→) is the OS's own animation — KiwiDesk cannot
+turn it off; use System Settings › Accessibility › Display ›
+Reduce Motion for that.
+
+> **Profiles own these toggles.** Like every other tiling
+> setting, `animations.*` is saved in a profile. When a profile
+> is bound to a native macOS Space
+> (`bind_profile_to_native_space`), switching to that Space
+> loads the profile and **replaces** the live settings — so the
+> `animations.*` calls in `init.lua` apply only until a bound
+> profile activates. To make a toggle stick on a bound Space,
+> set it and re-save that profile (or edit the profile JSON).
+
+> The old `KiwiDesk.set_space_animation(bool)` and
+> `KiwiDesk.set_animation_duration(ms)` still work as deprecated
+> aliases for `animations.set_on_space_change` and
+> `animations.set_duration`.
 
 ### Quit & restart
 


### PR DESCRIPTION
## Description

Replaces the removed global `enable_animations` with a persisted, per-trigger
`animations.*` group, and makes the un-animated "off" state actually snap
reliably instead of stuttering.

**Toggles** (Lua `animations.set_on_*`, JSON `animations.on_*`):
- `on_space_change` (default false) — virtual-space fly-in; renames the
  runtime-only `set_space_animation` (kept as a deprecated alias). The native
  macOS desktop slide is the OS's own (Reduce Motion).
- `on_scrolling` (default true) — scrolling focus slide.
- `on_window_resize` / `on_window_swap` (default true).
- `on_relayout` (default true) — window open/close, mode/gap/param reflow. A
  bare `retile()` defaults to it; specific triggers pass an explicit flag.
- `animations.set_duration` regroups `set_animation_duration` (deprecated
  alias); runtime-only, shared with `scroll.set_speed`.

**Reliable instant path:** un-animated placements go through
`FrameApplier.applyInstant`, which drops `AXEnhancedUserInterface` around a
`size→position→size` AX set (the yabai/AeroSpace trick) so an EUI-on app no
longer runs its own move animation — the stutter/misplacement the old
`enable_animations` removal hit. Reading live EUI state leaves it off when a
sibling window is still spring-animating.

Also fixes the "fly out of the corner": a virtual-space switch no longer fires
a redundant focus-driven retile from stale stash-corner frames, and the
`windowFocused` event's retile obeys `on_scrolling` too.

## Related Issue(s)

Closes #11

## Checklist

- [x] Commits follow Conventional Commits format
- [x] New behavior is tested (SettingsCoding, Command, MoveToSpace round-trip +
  per-trigger gate tests)
- [x] User-facing changes documented in `docs/` (configuration.md, cli.md)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes (300 tests)
- [x] Release build passes
- [x] PR is focused

## Notes for Reviewer

Reviewed by `code-reviewer` + `architect-reviewer` (per AGENTS.md §3.6); their
findings were addressed in-branch. Two conscious calls: (1) declined a
`RetileTrigger` enum in favor of flat explicit call sites per §2.4; (2)
`animations.set_duration` stays runtime-only — persisting it needs to reconcile
with `scroll.set_speed`, tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)