### PR TITLE
feat(gui): General/Behavior settings section (#12)

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -23,11 +23,18 @@ struct SettingsView: View {
             LuaEditorTab(model: model)
         } else {
             TabView {
-                GeneralTab(model: model)
+                PresetsTab(model: model)
                     .tabItem {
                         Label(
                             "Presets",
                             systemImage: "square.grid.2x2"
+                        )
+                    }
+                GeneralTab(model: model)
+                    .tabItem {
+                        Label(
+                            "General",
+                            systemImage: "gearshape"
                         )
                     }
                 CanvasTab(model: model)

--- a/Sources/KiwiDesk/Settings/Tabs/GeneralTab.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/GeneralTab.swift
@@ -1,9 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Tab 1 — General & Presets: the active config file, best-
-/// practice presets, saved-profile management, and the door to
-/// the raw Lua editor (05_GUI_Concept §2, Tab 1).
+/// Tab 2 — General: behavior tuning (mouse resize, animations) and
+/// advanced settings (05_GUI_Concept §2, Tab 2).
 struct GeneralTab: View {
     @ObservedObject var model: SettingsModel
     /// Advanced is collapsed by default — only interested users
@@ -13,66 +12,58 @@ struct GeneralTab: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                presetSection
-                profileSection
+                behaviourSection
                 advancedSection
             }
             .padding(16)
         }
     }
 
-    private var presetSection: some View {
-        SettingsSection("Presets") {
-            Text(
-                "Applying a preset rewrites the visual tuning. "
-                    + "Your keybindings and app rules are kept. "
-                    + "Nothing is written until you press Save."
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            ForEach(ConfigPreset.allCases) { preset in
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(preset.title).font(.headline)
-                        Text(preset.summary)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    Button("Apply") {
-                        model.applyPreset(preset)
-                    }
-                }
-                .padding(.vertical, 2)
+    private var behaviourSection: some View {
+        SettingsSection("General behavior") {
+            Picker(
+                "Mouse resize action",
+                selection: $model.config.settings.mouseResize
+            ) {
+                Text("Resize adjacent windows")
+                    .tag(MouseResizeMode.layout)
+                Text("Snap back to slot")
+                    .tag(MouseResizeMode.snapBack)
             }
-        }
-    }
+            .pickerStyle(.segmented)
+            .padding(.bottom, 4)
 
-    private var profileSection: some View {
-        SettingsSection("Saved profiles") {
-            if model.profiles.isEmpty {
-                Text("No profiles saved yet.")
-                    .font(.caption)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Animations")
+                    .font(.subheadline)
+                    .bold()
                     .foregroundStyle(.secondary)
-            }
-            ForEach(model.profiles, id: \.self) { name in
-                HStack {
-                    Image(systemName: "square.stack.3d.up")
-                        .foregroundStyle(.secondary)
-                    Text(name)
-                    if name == model.activeProfile {
-                        Text("active")
-                            .font(.caption2)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 1)
-                            .background(.tint.opacity(0.2))
-                            .clipShape(Capsule())
-                    }
-                    Spacer()
-                    Button("Load") {
-                        model.loadProfile(named: name)
-                    }
-                }
+
+                Toggle(
+                    "Virtual space switches",
+                    isOn: $model.config.settings.animations
+                        .onSpaceChange
+                )
+                Toggle(
+                    "Scrolling space focus shifts",
+                    isOn: $model.config.settings.animations
+                        .onScrolling
+                )
+                Toggle(
+                    "Window resizes",
+                    isOn: $model.config.settings.animations
+                        .onWindowResize
+                )
+                Toggle(
+                    "Window swaps",
+                    isOn: $model.config.settings.animations
+                        .onWindowSwap
+                )
+                Toggle(
+                    "Layout reflows",
+                    isOn: $model.config.settings.animations
+                        .onRelayout
+                )
             }
         }
     }

--- a/Sources/KiwiDesk/Settings/Tabs/GeneralTab.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/GeneralTab.swift
@@ -118,36 +118,3 @@ struct GeneralTab: View {
         )
     }
 }
-
-/// A titled group used across the dashboard tabs.
-struct SettingsSection<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: Content
-
-    init(
-        _ title: String,
-        @ViewBuilder content: () -> Content
-    ) {
-        self.title = title
-        self.content = content()
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.headline)
-            VStack(alignment: .leading, spacing: 8) {
-                content
-            }
-            .padding(12)
-            .frame(
-                maxWidth: .infinity,
-                alignment: .leading
-            )
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Color(nsColor: .controlBackgroundColor))
-            )
-        }
-    }
-}

--- a/Sources/KiwiDesk/Settings/Tabs/GeneralTab.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/GeneralTab.swift
@@ -12,14 +12,14 @@ struct GeneralTab: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                behaviourSection
+                behaviorSection
                 advancedSection
             }
             .padding(16)
         }
     }
 
-    private var behaviourSection: some View {
+    private var behaviorSection: some View {
         SettingsSection("General behavior") {
             Picker(
                 "Mouse resize action",

--- a/Sources/KiwiDesk/Settings/Tabs/PresetsTab.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/PresetsTab.swift
@@ -1,0 +1,74 @@
+import KiwiDeskCore
+import SwiftUI
+
+/// Tab 1 — Presets & Profiles: applying visual presets and managing
+/// saved profiles (05_GUI_Concept §2, Tab 1).
+struct PresetsTab: View {
+    @ObservedObject var model: SettingsModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                presetSection
+                profileSection
+            }
+            .padding(16)
+        }
+    }
+
+    private var presetSection: some View {
+        SettingsSection("Presets") {
+            Text(
+                "Applying a preset rewrites the visual tuning. "
+                    + "Your keybindings and app rules are kept. "
+                    + "Nothing is written until you press Save."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            ForEach(ConfigPreset.allCases) { preset in
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text(preset.title).font(.headline)
+                        Text(preset.summary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button("Apply") {
+                        model.applyPreset(preset)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+        }
+    }
+
+    private var profileSection: some View {
+        SettingsSection("Saved profiles") {
+            if model.profiles.isEmpty {
+                Text("No profiles saved yet.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(model.profiles, id: \.self) { name in
+                HStack {
+                    Image(systemName: "square.stack.3d.up")
+                        .foregroundStyle(.secondary)
+                    Text(name)
+                    if name == model.activeProfile {
+                        Text("active")
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(.tint.opacity(0.2))
+                            .clipShape(Capsule())
+                    }
+                    Spacer()
+                    Button("Load") {
+                        model.loadProfile(named: name)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/KiwiDesk/Settings/Tabs/SettingsSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SettingsSection.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// A titled group used across the dashboard tabs.
+struct SettingsSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    init(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            VStack(alignment: .leading, spacing: 8) {
+                content
+            }
+            .padding(12)
+            .frame(
+                maxWidth: .infinity,
+                alignment: .leading
+            )
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SettingsCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SettingsCommands.swift
@@ -37,7 +37,7 @@ extension KiwiCore {
             else {
                 return .fail("expected layout|snap_back")
             }
-            tiler.mouseResize = mode
+            tiler.settings.mouseResize = mode
         case "enable_wake_restore":
             guard let enabled = args.first?.boolValue else {
                 return .fail("expected boolean")

--- a/Sources/KiwiDeskCore/Config/LuaConfigWriter.swift
+++ b/Sources/KiwiDeskCore/Config/LuaConfigWriter.swift
@@ -26,7 +26,8 @@ public enum LuaConfigWriter {
         sections.append(appBarStyle(config.settings.appBarStyle))
         sections.append(layoutParams(config.settings))
         sections.append(dragVisuals(config.settings))
-        sections.append(generalBehavior(config.settings))
+        sections.append(mouseResize(config.settings))
+        sections.append(animations(config.settings))
         sections.append(appRules(config.appRules))
         sections.append(floatRules(config.floatRules))
         sections.append(
@@ -164,40 +165,30 @@ public enum LuaConfigWriter {
             .joined(separator: "\n")
     }
 
-    /// Mouse-resize mode and the per-trigger animation toggles
-    /// (issue #12). Sleep/wake restore (`enable_wake_restore`,
-    /// `set_wake_restore_delay`) is deliberately not emitted —
-    /// it's an advanced knob left to hand-written `init.lua`.
-    static func generalBehavior(
-        _ settings: TilingSettings
-    ) -> String {
-        var lines: [String] = []
-        lines.append(
-            "KiwiDesk.set_mouse_resize("
-                + LuaLiteral.string(settings.mouseResize.rawValue)
-                + ")"
-        )
+    /// `set_mouse_resize` (issue #12). Sleep/wake restore
+    /// (`enable_wake_restore`, `set_wake_restore_delay`) is
+    /// deliberately not emitted — it's an advanced knob left to
+    /// hand-written `init.lua`.
+    static func mouseResize(_ settings: TilingSettings) -> String {
+        "KiwiDesk.set_mouse_resize("
+            + LuaLiteral.string(settings.mouseResize.rawValue)
+            + ")"
+    }
+
+    /// The per-trigger `animations.*` toggles (issue #11/#12).
+    static func animations(_ settings: TilingSettings) -> String {
         let anims = settings.animations
-        lines.append(
+        return [
             "animations.set_on_space_change("
-                + LuaLiteral.bool(anims.onSpaceChange) + ")"
-        )
-        lines.append(
+                + LuaLiteral.bool(anims.onSpaceChange) + ")",
             "animations.set_on_scrolling("
-                + LuaLiteral.bool(anims.onScrolling) + ")"
-        )
-        lines.append(
+                + LuaLiteral.bool(anims.onScrolling) + ")",
             "animations.set_on_window_resize("
-                + LuaLiteral.bool(anims.onWindowResize) + ")"
-        )
-        lines.append(
+                + LuaLiteral.bool(anims.onWindowResize) + ")",
             "animations.set_on_window_swap("
-                + LuaLiteral.bool(anims.onWindowSwap) + ")"
-        )
-        lines.append(
+                + LuaLiteral.bool(anims.onWindowSwap) + ")",
             "animations.set_on_relayout("
-                + LuaLiteral.bool(anims.onRelayout) + ")"
-        )
-        return lines.joined(separator: "\n")
+                + LuaLiteral.bool(anims.onRelayout) + ")",
+        ].joined(separator: "\n")
     }
 }

--- a/Sources/KiwiDeskCore/Config/LuaConfigWriter.swift
+++ b/Sources/KiwiDeskCore/Config/LuaConfigWriter.swift
@@ -26,7 +26,7 @@ public enum LuaConfigWriter {
         sections.append(appBarStyle(config.settings.appBarStyle))
         sections.append(layoutParams(config.settings))
         sections.append(dragVisuals(config.settings))
-        sections.append(generalBehaviour(config.settings))
+        sections.append(generalBehavior(config.settings))
         sections.append(appRules(config.appRules))
         sections.append(floatRules(config.floatRules))
         sections.append(
@@ -164,7 +164,11 @@ public enum LuaConfigWriter {
             .joined(separator: "\n")
     }
 
-    static func generalBehaviour(
+    /// Mouse-resize mode and the per-trigger animation toggles
+    /// (issue #12). Sleep/wake restore (`enable_wake_restore`,
+    /// `set_wake_restore_delay`) is deliberately not emitted —
+    /// it's an advanced knob left to hand-written `init.lua`.
+    static func generalBehavior(
         _ settings: TilingSettings
     ) -> String {
         var lines: [String] = []

--- a/Sources/KiwiDeskCore/Config/LuaConfigWriter.swift
+++ b/Sources/KiwiDeskCore/Config/LuaConfigWriter.swift
@@ -26,6 +26,7 @@ public enum LuaConfigWriter {
         sections.append(appBarStyle(config.settings.appBarStyle))
         sections.append(layoutParams(config.settings))
         sections.append(dragVisuals(config.settings))
+        sections.append(generalBehaviour(config.settings))
         sections.append(appRules(config.appRules))
         sections.append(floatRules(config.floatRules))
         sections.append(
@@ -161,5 +162,38 @@ public enum LuaConfigWriter {
                 }
             }
             .joined(separator: "\n")
+    }
+
+    static func generalBehaviour(
+        _ settings: TilingSettings
+    ) -> String {
+        var lines: [String] = []
+        lines.append(
+            "KiwiDesk.set_mouse_resize("
+                + LuaLiteral.string(settings.mouseResize.rawValue)
+                + ")"
+        )
+        let anims = settings.animations
+        lines.append(
+            "animations.set_on_space_change("
+                + LuaLiteral.bool(anims.onSpaceChange) + ")"
+        )
+        lines.append(
+            "animations.set_on_scrolling("
+                + LuaLiteral.bool(anims.onScrolling) + ")"
+        )
+        lines.append(
+            "animations.set_on_window_resize("
+                + LuaLiteral.bool(anims.onWindowResize) + ")"
+        )
+        lines.append(
+            "animations.set_on_window_swap("
+                + LuaLiteral.bool(anims.onWindowSwap) + ")"
+        )
+        lines.append(
+            "animations.set_on_relayout("
+                + LuaLiteral.bool(anims.onRelayout) + ")"
+        )
+        return lines.joined(separator: "\n")
     }
 }

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
@@ -41,7 +41,7 @@ extension KiwiCore {
         frame: CGRect,
         in space: Space
     ) {
-        guard tiler.mouseResize == .layout,
+        guard tiler.settings.mouseResize == .layout,
             let screen = NSScreen.main
                 ?? NSScreen.screens.first
         else {

--- a/Sources/KiwiDeskCore/Tiling/MouseResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/MouseResize.swift
@@ -1,7 +1,7 @@
 import CoreGraphics
 
 /// What a mouse resize of a tiled window does.
-public enum MouseResizeMode: String, Sendable {
+public enum MouseResizeMode: String, Sendable, Codable {
     /// Adjust the layout like the `resize` command: neighbors
     /// give or take space (default).
     case layout

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
@@ -12,10 +12,6 @@ public final class TilingEngine {
     public let animation = AnimationEngine()
     public var settings = TilingSettings()
 
-    /// `set_mouse_resize`: what resizing a tiled window with
-    /// the mouse does (applied on release).
-    public var mouseResize: MouseResizeMode = .layout
-
     /// Applies frames off the main thread with frame-dropping
     /// and per-app EnhancedUserInterface toggling.
     private let applier = FrameApplier()

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
@@ -35,6 +35,8 @@ public struct TilingSettings: Sendable, Equatable, Codable {
     public var dragCornerRadius: CGFloat = 16
     /// Per-trigger animation toggles (`animations.*`).
     public var animations = AnimationSettings()
+    /// What resizing a tiled window with the mouse does.
+    public var mouseResize: MouseResizeMode = .layout
 
     public init() {}
 
@@ -49,6 +51,7 @@ public struct TilingSettings: Sendable, Equatable, Codable {
         case minWindowSize = "min_window_size"
         case placementOverride =
             "new_window_placement_override"
+        case mouseResize = "mouse_resize"
     }
 
     private enum DragKeys: String, CodingKey {
@@ -99,6 +102,11 @@ public struct TilingSettings: Sendable, Equatable, Codable {
                 AnimationSettings.self,
                 forKey: .animations
             ) ?? AnimationSettings()
+        mouseResize =
+            try container.decodeIfPresent(
+                MouseResizeMode.self,
+                forKey: .mouseResize
+            ) ?? .layout
         try decodeGap(from: container)
         try decodeLayout(from: container)
         try decodeDrag(from: container)
@@ -200,6 +208,7 @@ public struct TilingSettings: Sendable, Equatable, Codable {
         )
         try container.encode(appBarStyle, forKey: .appBar)
         try container.encode(animations, forKey: .animations)
+        try container.encode(mouseResize, forKey: .mouseResize)
         var gap = container.nestedContainer(
             keyedBy: GapKeys.self,
             forKey: .gap

--- a/Tests/KiwiDeskCoreTests/CommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/CommandTests.swift
@@ -243,12 +243,12 @@ struct CommandTests {
             args: [.bool(false)]
         )
         #expect(!core.tiler.settings.animations.onSpaceChange)
-        #expect(core.tiler.mouseResize == .layout)
+        #expect(core.tiler.settings.mouseResize == .layout)
         core.execute(
             "set_mouse_resize",
             args: [.string("snap_back")]
         )
-        #expect(core.tiler.mouseResize == .snapBack)
+        #expect(core.tiler.settings.mouseResize == .snapBack)
         #expect(
             !core.execute(
                 "set_mouse_resize",

--- a/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
+++ b/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
@@ -32,6 +32,9 @@ private func richConfig() -> GuiConfig {
     config.settings.monocle.appBar.thickness = 40
     config.settings.monocle.appBar.textColor = "#112233"
     config.settings.dragCornerRadius = 12
+    config.settings.mouseResize = .snapBack
+    config.settings.animations.onSpaceChange = true
+    config.settings.animations.onScrolling = false
     config.settings.placementOverride[SpaceID("mail")] = .last
     config.spaceModes = [
         SpaceID(1): .stack, SpaceID("music"): .floating,

--- a/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
+++ b/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
@@ -27,10 +27,11 @@ struct SettingsCodingTests {
         #expect(
             Set(root.keys) == [
                 "animations", "app_bar", "drag", "gap", "layout",
-                "min_window_size",
+                "min_window_size", "mouse_resize",
                 "new_window_placement_override",
             ]
         )
+        #expect(root["mouse_resize"] as? String == "layout")
         // Lua `animations.set_on_space_change` /
         // `animations.set_on_scrolling` (issue #11).
         let animations = try object(root["animations"])


### PR DESCRIPTION
## Description

Adds a **General/Behavior** settings section so behavior tuning
survives an Adopt/round-trip instead of dropping to the commented
backup (roadmap #12, Wave 4).

- Splits the old GeneralTab into **PresetsTab** (presets + saved
  profiles) and a slimmed **GeneralTab** (mouse-resize mode +
  per-trigger animation toggles, plus the existing advanced
  section). Tab order updated in `SettingsView`.
- Moves `mouseResize` out of `TilingEngine` (runtime-only) into the
  Codable `TilingSettings`, and makes `MouseResizeMode` `Codable`,
  so the setting persists to `gui.json` and emits to `init.lua`.
- `LuaConfigWriter` now emits `KiwiDesk.set_mouse_resize(...)` and
  the `animations.set_on_*(...)` calls.

**Also fixes a latent #11 bug:** the granular animation toggles
were persisted to the JSON sidecar but never emitted into the Lua
managed block, so GUI edits silently reverted on the next
reload/Adopt. The new writer output closes that gap.

**Intentionally out of scope:** sleep/wake restore
(`enable_wake_restore`, `set_wake_restore_delay`) stays an advanced
`init.lua`-only knob (documented in the writer). The #9 language
picker lands with its own wave.

## Related Issue(s)

Closes #12

## Checklist

- [x] Commits follow Conventional Commits format
- [x] New behavior is tested (round-trip + coding tests updated)
- [x] User-facing changes are documented in `docs/` (Lua knobs
  already documented; GUI tab reorg maps to local `plan/`)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## Notes for Reviewer

Reviewed by both `code-reviewer` and `architect-reviewer`
(AGENTS.md §6) — both merge-ready, no critical/high findings. The
two follow-up commits address their low-severity cohesion nits
(per-namespace writer split; `SettingsSection` extracted to its own
file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)