### PR TITLE
feat(keybindings): recover live shortcuts into the GUI editor (#4)

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -70,7 +70,12 @@ final class SettingsModel: ObservableObject {
     /// the core into the view model (discards unsaved edits).
     func reload() {
         suppressDirty = true
-        config = core.loadGuiConfig()
+        var loaded = core.loadGuiConfig()
+        // Recovered rows arrive as `.custom`; sort the ones that
+        // match a catalog action into their sections before the
+        // tabs render them (#4).
+        KeybindingImportClassifier.classify(&loaded)
+        config = loaded
         suppressDirty = false
         forcedLuaEditor = core.configHasForeignCode
         luaSource =
@@ -89,6 +94,24 @@ final class SettingsModel: ObservableObject {
         nativeSpaceCount =
             NativeSpaces.allSpaces().filter(\.isUser).count
         currentNativeSpace = NativeSpaces.activeSpaceNumber()
+    }
+
+    // MARK: - Import live keybindings (#4)
+
+    /// Merges the shortcuts currently active in `init.lua` into
+    /// the edited config: each recovered mode is matched by name
+    /// (created if new), every recovered row upserted by combo,
+    /// and the result reclassified so known actions land in their
+    /// sections. Marks the config dirty so the user reviews the
+    /// import before Save writes it.
+    func importCurrentShortcuts() {
+        var updated = config
+        KeybindingMerge.merge(
+            recovered: core.recoverKeybindings(),
+            into: &updated
+        )
+        KeybindingImportClassifier.classify(&updated)
+        config = updated
     }
 
     // MARK: - Persistence
@@ -133,10 +156,11 @@ final class SettingsModel: ObservableObject {
             try core.adoptConfigIntoGui()
             showLuaEditor = false
             reload()
-            // Keybindings can't be recovered from adopted Lua
-            // (see adoptConfigIntoGui), but the check is cheap
-            // and keeps this path consistent with Lua-editor
-            // save: set or clear the banner from the result.
+            // Adopt recovers the file's keybindings (see
+            // adoptConfigIntoGui / recoverKeybindings), so a
+            // conflict can arrive with the seeded config: set or
+            // clear the banner from the result, matching the
+            // Lua-editor save path.
             warnIfAnyConflict()
         } catch {
             core.onLog("adopt failed: \(error)")

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingAppSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingAppSection.swift
@@ -89,8 +89,9 @@ struct ApplicationsSection: View {
         name: String
     ) {
         binding.wrappedValue.label = name
-        binding.wrappedValue.lua =
-            "KiwiDesk.pull_or_spawn(\"\(name)\")"
+        binding.wrappedValue.lua = KeybindingCatalog.appCommand(
+            name
+        )
     }
 
     private func chooseBundle(_ binding: Binding<KeyBinding>) {

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog.swift
@@ -91,6 +91,41 @@ enum KeybindingCatalog {
         SpaceLuaArg.quote(raw)
     }
 
+    // MARK: - Change-mode & application commands (single source)
+
+    /// The Change-Modes row that switches to `name`. The one
+    /// authority for this Lua so the writer (`ChangeModesSection`)
+    /// and the import classifier match byte-for-byte — a drift
+    /// here would silently demote imports to Custom (#4).
+    static func switchModeCommand(_ name: String) -> NavCommand {
+        NavCommand(
+            label: "Switch to \(name)",
+            lua: "KiwiDesk.switch_mode(\(quote(name)))"
+        )
+    }
+
+    /// The Open-Applications action that pulls or launches `name`.
+    /// Paired with `appName(from:)`, its exact inverse.
+    static func appCommand(_ name: String) -> String {
+        "KiwiDesk.pull_or_spawn(\"\(name)\")"
+    }
+
+    /// The app name inside `appCommand`'s output, or nil when
+    /// `lua` isn't exactly that call — the inverse used by import
+    /// classification. An embedded quote means escaped content the
+    /// app menu never authors, so such Lua stays unmatched.
+    static func appName(from lua: String) -> String? {
+        let prefix = "KiwiDesk.pull_or_spawn(\""
+        let suffix = "\")"
+        guard lua.hasPrefix(prefix), lua.hasSuffix(suffix),
+            lua.count > prefix.count + suffix.count
+        else { return nil }
+        let inner = lua.dropFirst(prefix.count)
+            .dropLast(suffix.count)
+        guard !inner.contains("\"") else { return nil }
+        return String(inner)
+    }
+
     /// Installed application names, scanned once per launch.
     static let installedApps: [String] = {
         let manager = FileManager.default

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingImportClassifier.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingImportClassifier.swift
@@ -1,0 +1,62 @@
+import KiwiDeskCore
+
+/// Upgrades imported `.custom` keybinding rows to `.navigation`
+/// or `.application` by exact-matching the `KeybindingCatalog`, so
+/// a recovered shortcut lands in the section that authored it with
+/// its proper label. Only the GUI knows the catalog, so this runs
+/// GUI-side after Core's `recoverKeybindings` (#4). Rows matching
+/// nothing stay `.custom` and show in Custom Bindings.
+enum KeybindingImportClassifier {
+    /// Reclassifies every `.custom` row in `config` in place,
+    /// rebuilding the navigation and change-mode commands the
+    /// keybindings tab would generate from the config's own
+    /// spaces and mode names.
+    static func classify(_ config: inout GuiConfig) {
+        let navigation = navigationLabels(for: config)
+        for mode in config.modes.indices {
+            for row in config.modes[mode].bindings.indices {
+                reclassify(
+                    &config.modes[mode].bindings[row],
+                    navigation: navigation
+                )
+            }
+        }
+    }
+
+    /// Lua action → label for every navigation and change-mode
+    /// command the keybindings tab can produce for this config.
+    private static func navigationLabels(
+        for config: GuiConfig
+    ) -> [String: String] {
+        var map: [String: String] = [:]
+        let groups = KeybindingCatalog.navigationGroups(
+            spaces: config.spaces
+        )
+        for group in groups {
+            for command in group.commands {
+                map[command.lua] = command.label
+            }
+        }
+        for name in config.modes.map(\.name) {
+            let command = KeybindingCatalog.switchModeCommand(name)
+            map[command.lua] = command.label
+        }
+        return map
+    }
+
+    private static func reclassify(
+        _ binding: inout KeyBinding,
+        navigation: [String: String]
+    ) {
+        guard binding.kind == .custom else { return }
+        if let label = navigation[binding.lua] {
+            binding.kind = .navigation
+            binding.label = label
+        } else if let app = KeybindingCatalog.appName(
+            from: binding.lua
+        ) {
+            binding.kind = .application
+            binding.label = app
+        }
+    }
+}

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingSections.swift
@@ -45,10 +45,8 @@ struct ChangeModesSection: View {
                 NavRow(
                     model: model,
                     bindings: $bindings,
-                    command: NavCommand(
-                        label: "Switch to \(name)",
-                        lua: "KiwiDesk.switch_mode"
-                            + "(\(KeybindingCatalog.quote(name)))"
+                    command: KeybindingCatalog.switchModeCommand(
+                        name
                     )
                 )
             }

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingsTab.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingsTab.swift
@@ -38,10 +38,34 @@ struct KeybindingsTab: View {
                     model: model,
                     bindings: bindingsBinding
                 )
+                importSection
             }
             .padding(16)
         }
         .onAppear(perform: ensureSelection)
+    }
+
+    // MARK: - Import current shortcuts (#4)
+
+    private var importSection: some View {
+        SettingsSection("Import current shortcuts") {
+            HStack {
+                Button("Import current shortcuts") {
+                    model.importCurrentShortcuts()
+                    ensureSelection()
+                }
+                Spacer()
+            }
+            Text(
+                "Reads the shortcuts active in init.lua and adds "
+                    + "them here, matching each combo. Known "
+                    + "actions are sorted into the sections above; "
+                    + "anything else lands in Custom Bindings. "
+                    + "Review, then Save."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
     }
 
     // MARK: - Mode header

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -67,13 +67,34 @@ extension KiwiCore {
         )
     }
 
+    /// Recovers the live keybindings as editable modes (#4): each
+    /// bound combo plus its action text, sliced from the source
+    /// file via `debug.getinfo`. Rows come back as `.custom`; the
+    /// GUI classifies known catalog actions afterwards. Returns at
+    /// least the default mode (empty when nothing is bound or the
+    /// interpreter is unavailable).
+    public func recoverKeybindings() -> [KeyMode] {
+        guard let lua else { return [KeyMode.defaultMode] }
+        return KeybindingImporter.modes(
+            from: keys,
+            interpreter: lua,
+            readFile: { path in
+                try? String(
+                    contentsOfFile: path,
+                    encoding: .utf8
+                )
+            }
+        )
+    }
+
     /// Migrates a hand-written config into GUI management: the
     /// current file is preserved verbatim as a commented backup,
     /// and a fresh managed block is generated from the live
-    /// (executed) state — gaps, layouts, and rules carry over.
-    /// Keybindings can't be recovered from executed Lua, so they
-    /// remain only in the backup for the user to re-enter.
-    /// Returns the seeded model now under GUI ownership.
+    /// (executed) state — gaps, layouts, rules, and keybindings
+    /// carry over (bindings are recovered from the file via
+    /// `recoverKeybindings`; any that can't be read back stay
+    /// only in the backup). Returns the seeded model now under
+    /// GUI ownership.
     @discardableResult
     public func adoptConfigIntoGui() throws -> GuiConfig {
         let original =
@@ -104,14 +125,15 @@ extension KiwiCore {
     }
 
     /// Builds an editable model from the running configuration.
-    /// Keybinding actions and mode icons can't be recovered
-    /// from live Lua state, so modes start with just an empty
-    /// default (the sidecar owns them once saved).
+    /// Keybindings and mode icons are recovered from the source
+    /// file via `recoverKeybindings` (#4); the sidecar owns them
+    /// once saved.
     func guiConfigSeed() -> GuiConfig {
         var config = GuiConfig()
         config.settings = tiler.settings
         config.appRules = state.appRules
         config.spaceMonitorMap = spaceMonitorMap
+        config.modes = recoverKeybindings()
         config.floatRules = eventLoop.floatRules.rawRules
         var modes: [SpaceID: LayoutMode] = [:]
         var defined: [SpaceID] = []

--- a/Sources/KiwiDeskCore/Keys/KeyCombo.swift
+++ b/Sources/KiwiDeskCore/Keys/KeyCombo.swift
@@ -73,6 +73,20 @@ public struct KeyCombo: Hashable, Sendable {
         return parts.joined(separator: "+")
     }
 
+    /// This combo formatted as a canonical string
+    /// (`"control+option+r"`), reversing `parse`. Returns nil
+    /// when the key code has no known name. Used when importing
+    /// live bindings back into the GUI (#4).
+    public func comboString() -> String? {
+        Self.comboString(
+            keyCode: keyCode,
+            command: modifiers.contains(.command),
+            option: modifiers.contains(.option),
+            control: modifiers.contains(.control),
+            shift: modifiers.contains(.shift)
+        )
+    }
+
     /// The canonical name for a key code (reverse of
     /// `keyCodes`). Codes that carry both a symbol and a word
     /// alias resolve to the readable word form for display.

--- a/Sources/KiwiDeskCore/Keys/KeybindingImporter.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingImporter.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Reconstructs the GUI's `[KeyMode]` from the live keybindings
+/// (#4). Each bound `(KeyCombo, ref)` becomes a row: the combo is
+/// formatted back to its canonical string, and the action text is
+/// recovered from the source file via `debug.getinfo`'s line
+/// range (`LuaBindingBody`).
+///
+/// Every recovered row is emitted as `.custom` holding the raw
+/// body; the GUI upgrades exact catalog matches to
+/// `.navigation`/`.application` afterwards, since only the GUI
+/// knows that catalog. A row whose action cannot be recovered is
+/// dropped rather than emitted with an empty body — an empty body
+/// would overwrite a working binding with a no-op on the next
+/// save. Combos alone are never enough (issue #4).
+///
+/// `@MainActor`: reads the main-actor `LuaInterpreter` and
+/// `KeybindingManager`, matching its only caller,
+/// `KiwiCore.recoverKeybindings`.
+@MainActor
+enum KeybindingImporter {
+    /// Builds modes from `manager`, reading each binding's source
+    /// through `interpreter` and `readFile` (path → contents).
+    static func modes(
+        from manager: KeybindingManager,
+        interpreter: LuaInterpreter,
+        readFile: (String) -> String?
+    ) -> [KeyMode] {
+        var cache: [String: String] = [:]
+        return manager.definedModes.map { name in
+            var rows: [KeyBinding] = []
+            for (combo, ref) in manager.bindings(for: name) {
+                guard let text = combo.comboString(),
+                    let lua = action(
+                        ref: ref,
+                        interpreter: interpreter,
+                        readFile: readFile,
+                        cache: &cache
+                    )
+                else { continue }
+                rows.append(
+                    KeyBinding(combo: text, lua: lua, kind: .custom)
+                )
+            }
+            rows.sort { $0.combo < $1.combo }
+            return KeyMode(
+                name: name,
+                icon: manager.icon(for: name),
+                bindings: rows
+            )
+        }
+    }
+
+    /// The recovered, non-empty action body for one binding, or
+    /// nil when its source is a C function, a named (non-inline)
+    /// Lua handler, an unreadable file, or an unbalanced range —
+    /// see `LuaBindingBody` for the inline-literal assumption.
+    private static func action(
+        ref: Int32,
+        interpreter: LuaInterpreter,
+        readFile: (String) -> String?,
+        cache: inout [String: String]
+    ) -> String? {
+        guard let info = interpreter.functionSource(ref: ref),
+            info.source.hasPrefix("@")
+        else { return nil }
+        let path = String(info.source.dropFirst())
+        let contents: String
+        if let cached = cache[path] {
+            contents = cached
+        } else if let loaded = readFile(path) {
+            cache[path] = loaded
+            contents = loaded
+        } else {
+            return nil
+        }
+        let body = LuaBindingBody.extract(
+            from: contents,
+            firstLine: info.firstLine,
+            lastLine: info.lastLine
+        )
+        guard let body, !body.isEmpty else { return nil }
+        return body
+    }
+}

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
@@ -49,6 +49,17 @@ public final class KeybindingManager {
         modes[mode] ?? [:]
     }
 
+    /// Every defined mode name, the default first and the rest
+    /// sorted, so the GUI import (#4) can enumerate them in a
+    /// stable order. The default is always present even with no
+    /// bindings, matching the always-present GUI default mode.
+    public var definedModes: [String] {
+        let others = modes.keys
+            .filter { $0 != Self.defaultMode }
+            .sorted()
+        return [Self.defaultMode] + others
+    }
+
     // MARK: - Registration (from Lua)
 
     /// `KiwiDesk.bind(combo, fn)` — default mode.

--- a/Sources/KiwiDeskCore/Keys/KeybindingMerge.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingMerge.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Folds recovered keybinding modes into an edited `GuiConfig`
+/// for the GUI's "Import current shortcuts" (#4): modes are
+/// matched by name (appended when new) and rows upserted by their
+/// combo, so re-importing refreshes an existing shortcut instead
+/// of duplicating it. Pure and Core-typed, so the dedup logic the
+/// import depends on is unit-tested without the SwiftUI layer.
+public enum KeybindingMerge {
+    /// Merges every recovered mode into `config` in place.
+    public static func merge(
+        recovered: [KeyMode],
+        into config: inout GuiConfig
+    ) {
+        for mode in recovered {
+            merge(mode, into: &config)
+        }
+    }
+
+    /// Folds one recovered mode into `config` — updating the
+    /// same-named mode's rows, or appending the mode when new. An
+    /// existing mode keeps its icon unless it had none.
+    private static func merge(
+        _ recovered: KeyMode,
+        into config: inout GuiConfig
+    ) {
+        guard
+            let index = config.modes.firstIndex(
+                where: { $0.name == recovered.name }
+            )
+        else {
+            config.modes.append(recovered)
+            return
+        }
+        if config.modes[index].icon == nil {
+            config.modes[index].icon = recovered.icon
+        }
+        for row in recovered.bindings {
+            upsert(row, into: &config.modes[index].bindings)
+        }
+    }
+
+    /// Replaces the row bound to the same combo, or appends when
+    /// that combo is free. A combo-less recovered row is ignored —
+    /// it can't be keyed and would never fire.
+    static func upsert(
+        _ row: KeyBinding,
+        into bindings: inout [KeyBinding]
+    ) {
+        guard !row.combo.isEmpty else { return }
+        if let index = bindings.firstIndex(
+            where: { $0.combo == row.combo }
+        ) {
+            bindings[index].lua = row.lua
+            bindings[index].kind = row.kind
+            bindings[index].label = row.label
+        } else {
+            bindings.append(row)
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/Keys/LuaBindingBody.swift
+++ b/Sources/KiwiDeskCore/Keys/LuaBindingBody.swift
@@ -1,0 +1,302 @@
+import Foundation
+
+/// Extracts the body of a bound `function() ... end` literal from
+/// its source range, so a keybinding's action text can be
+/// recovered from init.lua (#4).
+///
+/// `debug.getinfo` reports only the line range of a function, not
+/// its columns, so the slice for `KiwiDesk.bind("alt+h",
+/// function() KiwiDesk.focus("left") end)` still holds the whole
+/// call. This scanner walks that slice — skipping strings and
+/// comments so their contents never count as syntax — to find the
+/// `function` header, then the matching `end`, and returns the
+/// text between them (dedented; the writer re-indents).
+///
+/// Block depth uses the classic Lua-lexer trick: `function`, `if`,
+/// and `do` each open a block closed by `end`, while `for`/`while`
+/// are opened by their own `do` and so are not counted. This
+/// covers plain literals and multi-statement custom bodies; it
+/// does not evaluate the code, only balances its block keywords.
+///
+/// Two assumptions, both true for GUI-authored configs (each bind
+/// on its own line with an inline literal) and only relevant to
+/// hand-written files adopted once:
+/// - The action is an inline `function() … end` literal. A bind to
+///   a named handler (`KiwiDesk.bind("x", my_handler)`) has no
+///   literal in range and yields nil, so that row is dropped.
+/// - One function literal per source line: `debug.getinfo` reports
+///   the same range for every literal sharing a line, so only the
+///   first is recovered.
+enum LuaBindingBody {
+    /// Slices the 1-based inclusive line range out of `source`
+    /// and returns the dedented function body, or nil when the
+    /// range holds no balanced `function ... end`.
+    static func extract(
+        from source: String,
+        firstLine: Int,
+        lastLine: Int
+    ) -> String? {
+        let normalized = source.replacingOccurrences(
+            of: "\r\n",
+            with: "\n"
+        )
+        let lines = normalized.components(separatedBy: "\n")
+        guard firstLine >= 1, lastLine <= lines.count,
+            firstLine <= lastLine
+        else { return nil }
+        let region = lines[(firstLine - 1)...(lastLine - 1)]
+            .joined(separator: "\n")
+        return body(in: Array(region))
+    }
+
+    // MARK: - Scanning
+
+    /// The dedented body between the first `function` header and
+    /// its matching `end` in `chars`.
+    private static func body(in chars: [Character]) -> String? {
+        guard let paramsEnd = functionParamsEnd(chars) else {
+            return nil
+        }
+        var i = paramsEnd
+        var depth = 1
+        while i < chars.count {
+            if let skip = skipTrivia(chars, i) {
+                i = skip
+                continue
+            }
+            if isWordStart(chars[i]) {
+                let start = i
+                let (word, next) = readWord(chars, i)
+                i = next
+                switch word {
+                case "function", "if", "do":
+                    depth += 1
+                case "end":
+                    depth -= 1
+                    if depth == 0 {
+                        return dedent(
+                            String(chars[paramsEnd..<start])
+                        )
+                    }
+                default:
+                    break
+                }
+                continue
+            }
+            i += 1
+        }
+        return nil
+    }
+
+    /// The index just past the `)` of the first `function (...)`
+    /// header, skipping any leading call syntax and its strings.
+    private static func functionParamsEnd(
+        _ chars: [Character]
+    ) -> Int? {
+        var i = 0
+        while i < chars.count {
+            if let skip = skipTrivia(chars, i) {
+                i = skip
+                continue
+            }
+            if isWordStart(chars[i]) {
+                let (word, next) = readWord(chars, i)
+                i = next
+                if word == "function" {
+                    return paramListEnd(chars, i)
+                }
+                continue
+            }
+            i += 1
+        }
+        return nil
+    }
+
+    /// The index just past the matching `)` of a `(...)` param
+    /// list beginning at or after `from`.
+    private static func paramListEnd(
+        _ chars: [Character],
+        _ from: Int
+    ) -> Int? {
+        var i = from
+        while i < chars.count, chars[i] != "(" {
+            if isSpace(chars[i]) { i += 1 } else { return nil }
+        }
+        guard i < chars.count else { return nil }
+        var depth = 0
+        while i < chars.count {
+            if chars[i] == "(" { depth += 1 }
+            if chars[i] == ")" {
+                depth -= 1
+                if depth == 0 { return i + 1 }
+            }
+            i += 1
+        }
+        return nil
+    }
+
+    // MARK: - Trivia (strings & comments)
+
+    /// If a string or comment starts at `i`, the index just past
+    /// it; otherwise nil. Keeps keyword-like text inside literals
+    /// from being counted as block syntax.
+    private static func skipTrivia(
+        _ chars: [Character],
+        _ i: Int
+    ) -> Int? {
+        let c = chars[i]
+        if c == "-", i + 1 < chars.count, chars[i + 1] == "-" {
+            return skipComment(chars, i + 2)
+        }
+        if c == "\"" || c == "'" {
+            return skipShortString(chars, i)
+        }
+        if c == "[", let open = longOpen(chars, i) {
+            return skipLongBracket(chars, open.afterOpen, open.level)
+        }
+        return nil
+    }
+
+    /// A `--` comment: a long bracket if one opens here, else to
+    /// the end of the line.
+    private static func skipComment(
+        _ chars: [Character],
+        _ i: Int
+    ) -> Int {
+        if i < chars.count, chars[i] == "[",
+            let open = longOpen(chars, i)
+        {
+            return skipLongBracket(chars, open.afterOpen, open.level)
+        }
+        var j = i
+        while j < chars.count, chars[j] != "\n" { j += 1 }
+        return j
+    }
+
+    private static func skipShortString(
+        _ chars: [Character],
+        _ i: Int
+    ) -> Int {
+        let quote = chars[i]
+        var j = i + 1
+        while j < chars.count {
+            let c = chars[j]
+            if c == "\\" {
+                j += 2
+                continue
+            }
+            if c == quote { return j + 1 }
+            if c == "\n" { return j }
+            j += 1
+        }
+        return chars.count
+    }
+
+    /// The `=` level of a long-bracket opener (`[[`, `[==[`) at
+    /// `i`, and the index just past it — else nil.
+    private static func longOpen(
+        _ chars: [Character],
+        _ i: Int
+    ) -> (level: Int, afterOpen: Int)? {
+        guard chars[i] == "[" else { return nil }
+        var k = i + 1
+        var eq = 0
+        while k < chars.count, chars[k] == "=" {
+            eq += 1
+            k += 1
+        }
+        guard k < chars.count, chars[k] == "[" else { return nil }
+        return (eq, k + 1)
+    }
+
+    private static func skipLongBracket(
+        _ chars: [Character],
+        _ from: Int,
+        _ level: Int
+    ) -> Int {
+        var j = from
+        while j < chars.count {
+            if chars[j] == "]" {
+                var k = j + 1
+                var eq = 0
+                while k < chars.count, chars[k] == "=" {
+                    eq += 1
+                    k += 1
+                }
+                if eq == level, k < chars.count, chars[k] == "]" {
+                    return k + 1
+                }
+            }
+            j += 1
+        }
+        return chars.count
+    }
+
+    // MARK: - Words & whitespace
+
+    private static func readWord(
+        _ chars: [Character],
+        _ i: Int
+    ) -> (String, Int) {
+        var j = i
+        while j < chars.count, isWordChar(chars[j]) { j += 1 }
+        return (String(chars[i..<j]), j)
+    }
+
+    private static func isWordStart(_ c: Character) -> Bool {
+        c == "_" || c.isLetter
+    }
+
+    private static func isWordChar(_ c: Character) -> Bool {
+        c == "_" || c.isLetter || c.isNumber
+    }
+
+    private static func isSpace(_ c: Character) -> Bool {
+        c == " " || c == "\t" || c == "\n" || c == "\r"
+    }
+
+    /// Trims blank edges, removes the common leading indent, and
+    /// strips each line's trailing whitespace so the writer's
+    /// re-indentation starts from column zero and a one-line
+    /// `function() … end` doesn't keep the space before `end`.
+    /// (Trailing whitespace is only meaningful inside a multi-line
+    /// `[[…]]` string — vanishingly rare in a keybinding body, and
+    /// the user reviews the import before saving.)
+    private static func dedent(_ text: String) -> String {
+        var lines = text.components(separatedBy: "\n")
+        while let first = lines.first, isBlank(first) {
+            lines.removeFirst()
+        }
+        while let last = lines.last, isBlank(last) {
+            lines.removeLast()
+        }
+        guard !lines.isEmpty else { return "" }
+        let indents = lines.filter { !isBlank($0) }.map {
+            $0.prefix { $0 == " " || $0 == "\t" }.count
+        }
+        let common = indents.min() ?? 0
+        return lines.map { line in
+            isBlank(line)
+                ? ""
+                : trimTrailing(String(line.dropFirst(common)))
+        }
+        .joined(separator: "\n")
+    }
+
+    /// `line` without its trailing spaces and tabs.
+    private static func trimTrailing(_ line: String) -> String {
+        var end = line.endIndex
+        while end > line.startIndex {
+            let prev = line.index(before: end)
+            guard line[prev] == " " || line[prev] == "\t" else {
+                break
+            }
+            end = prev
+        }
+        return String(line[line.startIndex..<end])
+    }
+
+    private static func isBlank(_ line: String) -> Bool {
+        line.allSatisfy { $0 == " " || $0 == "\t" || $0 == "\r" }
+    }
+}

--- a/Sources/KiwiDeskCore/Lua/LuaInterpreter.swift
+++ b/Sources/KiwiDeskCore/Lua/LuaInterpreter.swift
@@ -134,6 +134,30 @@ public final class LuaInterpreter {
         luaL_unref(state, SHIM_LUA_REGISTRYINDEX, ref)
     }
 
+    /// The source location of a Lua function captured as a
+    /// registry `ref` — the chunk name plus the 1-based line
+    /// range it spans. Used to recover a keybinding's action
+    /// text from init.lua (#4). `source` is the raw
+    /// `lua_getinfo` name (`"@/path/to/init.lua"` for a file
+    /// chunk); callers strip the `@`. Returns nil for a stale
+    /// ref, a non-function, or a C function.
+    public func functionSource(
+        ref: Int32
+    ) -> (source: String, firstLine: Int, lastLine: Int)? {
+        guard let state else { return nil }
+        var first: Int32 = 0
+        var last: Int32 = 0
+        guard
+            let cString = shim_func_source(
+                state,
+                ref,
+                &first,
+                &last
+            )
+        else { return nil }
+        return (String(cString: cString), Int(first), Int(last))
+    }
+
     // MARK: - Registration
 
     /// Exposes a Swift closure as `tableName.name(...)`. The

--- a/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
+++ b/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
@@ -351,9 +351,13 @@ struct ConfigWriteTests {
             encoding: .utf8
         )
         #expect(file.contains("-- KiwiDesk.bind(\"cmd+h\""))
-        // Keybindings can't be imported — dropped from live
-        // state until the user re-adds them.
+        // Keybindings are recovered from the original file and
+        // re-emitted into the managed block, so the combo is live
+        // again after adopt — normalized to its canonical form
+        // (#4). The commented backup above still uses the
+        // hand-written "cmd+h".
+        #expect(file.contains("KiwiDesk.bind(\"command+h\""))
         let combo = try #require(KeyCombo.parse("cmd+h"))
-        #expect(core.keys.bindings(for: "default")[combo] == nil)
+        #expect(core.keys.bindings(for: "default")[combo] != nil)
     }
 }

--- a/Tests/KiwiDeskCoreTests/KeybindingImporterTests.swift
+++ b/Tests/KiwiDeskCoreTests/KeybindingImporterTests.swift
@@ -1,0 +1,259 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+@Suite("LuaBindingBody extraction")
+struct LuaBindingBodyTests {
+    @Test("Pulls a one-line body out of the whole call")
+    func inlineBody() {
+        let source =
+            "KiwiDesk.bind(\"alt+h\", function() "
+            + "KiwiDesk.focus(\"left\") end)"
+        #expect(
+            // Leading indent and per-line trailing space are both
+            // stripped, so the inline form has no dangling space.
+            LuaBindingBody.extract(
+                from: source,
+                firstLine: 1,
+                lastLine: 1
+            ) == "KiwiDesk.focus(\"left\")"
+        )
+    }
+
+    @Test("Balances nested if/end and dedents")
+    func nestedIf() {
+        let source = """
+            KiwiDesk.bind("x", function()
+              if cond then
+                do_thing()
+              end
+            end)
+            """
+        #expect(
+            LuaBindingBody.extract(
+                from: source,
+                firstLine: 1,
+                lastLine: 5
+            ) == "if cond then\n  do_thing()\nend"
+        )
+    }
+
+    @Test("A for loop's do is closed by its own end")
+    func forLoop() {
+        let source = """
+            bind(function()
+              for i = 1, 3 do
+                step(i)
+              end
+            end)
+            """
+        #expect(
+            LuaBindingBody.extract(
+                from: source,
+                firstLine: 1,
+                lastLine: 5
+            ) == "for i = 1, 3 do\n  step(i)\nend"
+        )
+    }
+
+    @Test("`end` inside a string or comment isn't counted")
+    func endInTrivia() {
+        let source = """
+            bind(function()
+              local s = "end"  -- end here
+              print(s)
+            end)
+            """
+        #expect(
+            LuaBindingBody.extract(
+                from: source,
+                firstLine: 1,
+                lastLine: 4
+            ) == "local s = \"end\"  -- end here\nprint(s)"
+        )
+    }
+
+    @Test("An empty body comes back empty, not nil")
+    func emptyBody() {
+        #expect(
+            LuaBindingBody.extract(
+                from: "bind(function() end)",
+                firstLine: 1,
+                lastLine: 1
+            ) == ""
+        )
+    }
+
+    @Test("A range with no function returns nil")
+    func noFunction() {
+        #expect(
+            LuaBindingBody.extract(
+                from: "local x = 1",
+                firstLine: 1,
+                lastLine: 1
+            ) == nil
+        )
+    }
+}
+
+@Suite("KeyCombo instance round-trip")
+struct KeyComboInstanceTests {
+    @Test("comboString() reverses parse for import")
+    func roundTrip() throws {
+        let combo = try #require(KeyCombo.parse("cmd+shift+left"))
+        let text = try #require(combo.comboString())
+        #expect(text == "shift+command+left")
+        #expect(KeyCombo.parse(text) == combo)
+    }
+}
+
+@Suite("KeybindingMerge")
+struct KeybindingMergeTests {
+    private func mode(
+        _ name: String,
+        _ rows: [KeyBinding],
+        icon: String? = nil
+    ) -> KeyMode {
+        KeyMode(name: name, icon: icon, bindings: rows)
+    }
+
+    private func row(
+        _ combo: String,
+        _ lua: String,
+        _ kind: KeyBinding.Kind = .custom
+    ) -> KeyBinding {
+        KeyBinding(combo: combo, lua: lua, kind: kind)
+    }
+
+    @Test("A new mode is appended whole")
+    func appendsNewMode() {
+        var config = GuiConfig()
+        config.modes = [mode("default", [])]
+        KeybindingMerge.merge(
+            recovered: [mode("resize", [row("h", "x()")])],
+            into: &config
+        )
+        #expect(config.modes.map(\.name) == ["default", "resize"])
+        #expect(config.modes[1].bindings.count == 1)
+    }
+
+    @Test("Same combo is replaced, a free combo appended")
+    func upsertByCombo() {
+        var config = GuiConfig()
+        config.modes = [
+            mode("default", [row("alt+h", "old()")])
+        ]
+        KeybindingMerge.merge(
+            recovered: [
+                mode(
+                    "default",
+                    [
+                        row("alt+h", "new()", .navigation),
+                        row("alt+j", "down()"),
+                    ]
+                )
+            ],
+            into: &config
+        )
+        let rows = config.modes[0].bindings
+        #expect(rows.count == 2)
+        let updated = rows.first { $0.combo == "alt+h" }
+        #expect(updated?.lua == "new()")
+        #expect(updated?.kind == .navigation)
+        #expect(rows.contains { $0.combo == "alt+j" })
+    }
+
+    @Test("A combo-less recovered row is ignored")
+    func ignoresComboless() {
+        var bindings = [row("alt+h", "keep()")]
+        KeybindingMerge.upsert(row("", "noop()"), into: &bindings)
+        #expect(bindings.count == 1)
+        #expect(bindings[0].lua == "keep()")
+    }
+
+    @Test("An existing mode keeps its icon unless it had none")
+    func iconFill() {
+        var config = GuiConfig()
+        config.modes = [
+            mode("kept", [], icon: "📐"),
+            mode("filled", []),
+        ]
+        KeybindingMerge.merge(
+            recovered: [
+                mode("kept", [], icon: "🆕"),
+                mode("filled", [], icon: "🆕"),
+            ],
+            into: &config
+        )
+        #expect(config.modes[0].icon == "📐")
+        #expect(config.modes[1].icon == "🆕")
+    }
+}
+
+/// Minimal registrar so a `KeybindingManager` can accept binds in
+/// the importer integration test.
+@MainActor
+private final class CapturingRegistrar: HotkeyRegistrar {
+    private var next: UInt32 = 1
+    func register(
+        keyCode: UInt32,
+        modifiers: HotkeyModifiers,
+        handler: @escaping @MainActor () -> Void
+    ) -> UInt32? {
+        defer { next += 1 }
+        return next
+    }
+    func unregister(id: UInt32) {}
+}
+
+@Suite("KeybindingImporter integration", .serialized)
+@MainActor
+struct KeybindingImporterIntegrationTests {
+    @Test("Recovers combos and bodies from a real file")
+    func recoversFromFile() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kiwi-import-\(UUID())")
+        try FileManager.default.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true
+        )
+        let file = dir.appendingPathComponent("init.lua")
+        try """
+        KiwiDesk.grab("alt+h", function()
+          KiwiDesk.focus("left")
+        end)
+        """.write(to: file, atomically: true, encoding: .utf8)
+
+        let lua = try #require(LuaInterpreter())
+        let manager = KeybindingManager(
+            registrar: CapturingRegistrar()
+        )
+        // Mimic the real `KiwiDesk.bind`: capture the combo and
+        // the function ref straight from the loaded file.
+        lua.register("grab") { args in
+            guard case .string(let comboText) = args.first,
+                case .functionRef(let ref) = args.dropFirst().first,
+                let combo = KeyCombo.parse(comboText)
+            else { return .none }
+            manager.bind(combo, ref: ref)
+            return .none
+        }
+        try lua.runFile(file).get()
+
+        let modes = KeybindingImporter.modes(
+            from: manager,
+            interpreter: lua,
+            readFile: {
+                try? String(contentsOfFile: $0, encoding: .utf8)
+            }
+        )
+        let defaultMode = try #require(
+            modes.first { $0.name == KeyMode.defaultName }
+        )
+        let row = try #require(defaultMode.bindings.first)
+        #expect(row.combo == "option+h")
+        #expect(row.lua == "KiwiDesk.focus(\"left\")")
+        #expect(row.kind == .custom)
+    }
+}

--- a/Vendor/CLua/include/CLuaShim.h
+++ b/Vendor/CLua/include/CLuaShim.h
@@ -116,4 +116,34 @@ static inline void shim_enable_timeout_hook(lua_State *L,
     lua_sethook(L, shim_timeout_hook, LUA_MASKCOUNT, count);
 }
 
+/*
+ * Source range of a Lua function stored as a registry ref
+ * (`luaL_ref`), via `lua_getinfo(L, ">S", ...)`. Used to recover
+ * a keybinding's action text from init.lua (#4): the returned
+ * pointer is the interned source name (`"@/path"` for a file
+ * chunk), valid while the ref keeps the function alive, so the
+ * caller must copy it before releasing the ref. Returns NULL for
+ * a stale ref, a non-function, or a C function (linedefined -1).
+ */
+static inline const char *shim_func_source(lua_State *L, int ref,
+                                           int *first,
+                                           int *last) {
+    lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+    if (!lua_isfunction(L, -1)) {
+        lua_pop(L, 1);
+        return NULL;
+    }
+    lua_Debug ar;
+    /* ">S" pops the function and fills the source fields. */
+    if (lua_getinfo(L, ">S", &ar) == 0) {
+        return NULL;
+    }
+    if (ar.linedefined < 1) {
+        return NULL;
+    }
+    *first = ar.linedefined;
+    *last = ar.lastlinedefined;
+    return ar.source;
+}
+
 #endif /* CLUA_SHIM_H */

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,10 +36,20 @@ saves. If the app finds custom Lua it can't represent with its
 visual controls, it opens the integrated Lua editor for the
 whole file instead of risking your code. From there you can keep
 editing raw Lua, or click **Adopt into the GUI** to import your
-current gaps, layouts, and rules into a fresh managed block —
-your previous file is kept verbatim as a commented backup, and
-keybindings (which can't be recovered from executed Lua) are
-re-added from the Keybindings tab. The editor's own
+current gaps, layouts, rules, and keybindings into a fresh
+managed block — your previous file is kept verbatim as a
+commented backup. Keybindings are recovered from the file: each
+bound combo and its action text are read back and sorted into
+the Keybindings tab (known Focus, Window Movement, and app-launch
+actions land in their sections; anything else becomes a Custom
+binding). You can also pull them in without adopting the whole
+file — **Import current shortcuts** at the bottom of the
+Keybindings tab reads the shortcuts active in `init.lua` and adds
+them for review before you Save. Recovery expects each shortcut to be an inline
+`function() … end` on its own line (the form the app writes). A
+binding whose action can't be read back — one bound to a named
+handler or a C function, rather than an inline function — is left
+only in the backup and can be re-added from the tab. The editor's own
 state (keybinding actions, mode icons) is mirrored to
 `~/.config/KiwiDesk/gui.json`; delete that file to reset the
 GUI to what `init.lua` currently declares. Custom keybinding


### PR DESCRIPTION
## Description

Recovers bound keybindings back into the Settings editor so the GUI
can show and manage shortcuts that were defined in `init.lua`.

- **Recovery (Core):** `debug.getinfo` gives each bound function's
  source range (`CLuaShim.shim_func_source` →
  `LuaInterpreter.functionSource`); a string/comment-aware scanner
  (`LuaBindingBody`) extracts the `function() … end` body;
  `KeybindingImporter` rebuilds editable `[KeyMode]`. All rows come
  back as `.custom`.
- **Classification (GUI):** `KeybindingImportClassifier` upgrades
  rows that exactly match `KeybindingCatalog` to
  `.navigation`/`.application`, on load and via a new **Import
  current shortcuts** button (`SettingsModel.importCurrentShortcuts`,
  upsert by combo).
- **Adopt-into-GUI** now recovers keybindings instead of dropping
  them.
- **Hardening from review:** `switch_mode`/`pull_or_spawn` Lua is now
  single-sourced in `KeybindingCatalog` (writer + classifier can't
  drift); merge/upsert moved to Core (`KeybindingMerge`) and
  unit-tested.

## Related Issue(s)

Closes #4

## Checklist

- [x] Commits follow Conventional Commits format (see AGENTS.md §3)
- [x] New behavior is tested (body extraction, combo round-trip,
  importer integration, merge/upsert — 321 tests total)
- [x] User-facing changes are documented in `docs/`
  (`configuration.md`: adopt/import + inline-literal restriction)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## Notes for Reviewer

Reviewed by `code-reviewer` + `architect-reviewer` before opening
(AGENTS.md §6) — no critical/high findings; the DRY and Core-side
testability findings are addressed in this branch. Smoke-tested
against a real `init.lua`: all 25 bindings recovered with correct
combos and bodies.

Follow-up filed: #56 (true 2-axis resize) — the keybinding-catalog
completeness (resize/make_floating rows, section rename) lands with
#23; #27 roadmap updated accordingly.
