### PR TITLE
feat(keybindings): render shortcuts as native macOS glyphs (#23)

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/KeyRecorderField.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeyRecorderField.swift
@@ -43,7 +43,16 @@ struct KeyRecorderField: View {
 
     private var label: String {
         if recording { return "Press keys…" }
-        return combo.isEmpty ? "Record" : combo
+        guard !combo.isEmpty else { return "Record" }
+        // Show the shortcut as native macOS glyphs, mapped through
+        // the active keyboard layout (#23). The stored combo stays
+        // the canonical word form; only the display changes, so a
+        // parse failure just shows the raw string.
+        guard let parsed = KeyCombo.parse(combo) else { return combo }
+        return ComboSymbols.render(
+            parsed,
+            layoutChar: LayoutKeyGlyph.char
+        )
     }
 
     private func toggle() {

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog.swift
@@ -22,9 +22,11 @@ struct NavGroup: Identifiable {
 /// conflict detection live in Core's `SystemShortcuts`
 /// (05_GUI_Concept §2, Tab 5).
 enum KeybindingCatalog {
+    // dir is the Lua argument; phrase is the positional wording
+    // used in labels ("above"/"below" read better than "up"/"down").
     private static let directions = [
-        ("Left", "left"), ("Down", "down"),
-        ("Up", "up"), ("Right", "right"),
+        ("left", "to the left"), ("down", "below"),
+        ("up", "above"), ("right", "to the right"),
     ]
 
     /// The fixed step a Grow/Shrink preset nudges the layout by, in
@@ -40,9 +42,9 @@ enum KeybindingCatalog {
     static func navigationGroups(
         spaces: [SpaceID]
     ) -> [NavGroup] {
-        var focus = directions.map { name, dir in
+        var focus = directions.map { dir, phrase in
             NavCommand(
-                label: "Focus \(name)",
+                label: "Focus window \(phrase)",
                 lua: "KiwiDesk.focus(\"\(dir)\")"
             )
         }
@@ -51,15 +53,15 @@ enum KeybindingCatalog {
         for space in spaces {
             focus.append(
                 NavCommand(
-                    label: "Go to \(space.raw)",
+                    label: "Go to Space \(space.raw)",
                     lua: "KiwiDesk.focus_virtual_space"
                         + "(\(spaceArg(space)))"
                 )
             )
         }
-        var movement = directions.map { _, dir in
+        var movement = directions.map { dir, phrase in
             NavCommand(
-                label: "Swap with window on the \(dir)",
+                label: "Swap with window \(phrase)",
                 lua: "KiwiDesk.swap(\"\(dir)\")"
             )
         }

--- a/Sources/KiwiDesk/Settings/Tabs/LayoutKeyGlyph.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/LayoutKeyGlyph.swift
@@ -15,62 +15,62 @@ import Foundation
 /// layout data.
 enum LayoutKeyGlyph {
     static func char(for keyCode: UInt32) -> String? {
-        guard let layout = currentLayout() ?? asciiLayout() else {
-            return nil
-        }
-        return translate(keyCode: keyCode, layout: layout)
-    }
-
-    private static func currentLayout() -> CFData? {
-        source(TISCopyCurrentKeyboardLayoutInputSource())
-    }
-
-    private static func asciiLayout() -> CFData? {
-        source(TISCopyCurrentASCIICapableKeyboardLayoutInputSource())
-    }
-
-    /// The Unicode layout data of an input source, or nil.
-    private static func source(
-        _ source: Unmanaged<TISInputSource>?
-    ) -> CFData? {
-        guard let input = source?.takeRetainedValue(),
-            let pointer = TISGetInputSourceProperty(
-                input,
-                kTISPropertyUnicodeKeyLayoutData
-            )
+        guard let source = currentSource() ?? asciiSource()
         else { return nil }
-        return Unmanaged<CFData>
-            .fromOpaque(pointer)
-            .takeUnretainedValue()
+        return translate(keyCode: keyCode, source: source)
+    }
+
+    private static func currentSource() -> TISInputSource? {
+        TISCopyCurrentKeyboardLayoutInputSource()?
+            .takeRetainedValue()
+    }
+
+    private static func asciiSource() -> TISInputSource? {
+        TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?
+            .takeRetainedValue()
     }
 
     private static func translate(
         keyCode: UInt32,
-        layout: CFData
+        source: TISInputSource
     ) -> String? {
-        guard let bytes = CFDataGetBytePtr(layout) else {
-            return nil
+        guard
+            let pointer = TISGetInputSourceProperty(
+                source,
+                kTISPropertyUnicodeKeyLayoutData
+            )
+        else { return nil }
+        let layout = Unmanaged<CFData>
+            .fromOpaque(pointer)
+            .takeUnretainedValue()
+        // Keep `source` alive across UCKeyTranslate: it owns the
+        // layout data (a CF *Get*, not retained), which must not
+        // be released while UCKeyTranslate dereferences it.
+        return withExtendedLifetime(source) { () -> String? in
+            guard let bytes = CFDataGetBytePtr(layout) else {
+                return nil
+            }
+            let keyLayout = UnsafeRawPointer(bytes)
+                .assumingMemoryBound(to: UCKeyboardLayout.self)
+            var deadKeys: UInt32 = 0
+            var length = 0
+            var chars = [UniChar](repeating: 0, count: 4)
+            let status = UCKeyTranslate(
+                keyLayout,
+                UInt16(keyCode),
+                UInt16(kUCKeyActionDisplay),
+                0,  // no modifiers → the key's base glyph
+                UInt32(LMGetKbdType()),
+                OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                &deadKeys,
+                chars.count,
+                &length,
+                &chars
+            )
+            guard status == noErr, length > 0 else { return nil }
+            let text = String(utf16CodeUnits: chars, count: length)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return text.isEmpty ? nil : text
         }
-        let keyLayout = UnsafeRawPointer(bytes)
-            .assumingMemoryBound(to: UCKeyboardLayout.self)
-        var deadKeys: UInt32 = 0
-        var length = 0
-        var chars = [UniChar](repeating: 0, count: 4)
-        let status = UCKeyTranslate(
-            keyLayout,
-            UInt16(keyCode),
-            UInt16(kUCKeyActionDisplay),
-            0,  // no modifiers → the key's base glyph
-            UInt32(LMGetKbdType()),
-            OptionBits(kUCKeyTranslateNoDeadKeysBit),
-            &deadKeys,
-            chars.count,
-            &length,
-            &chars
-        )
-        guard status == noErr, length > 0 else { return nil }
-        let text = String(utf16CodeUnits: chars, count: length)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return text.isEmpty ? nil : text
     }
 }

--- a/Sources/KiwiDesk/Settings/Tabs/LayoutKeyGlyph.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/LayoutKeyGlyph.swift
@@ -1,0 +1,76 @@
+import Carbon.HIToolbox
+import Foundation
+
+/// Resolves a virtual key code to its base character on the
+/// *active* keyboard layout via `UCKeyTranslate`, so the
+/// keybinding editor renders layout-correct glyphs — a German
+/// layout shows `+` where a US layout shows `]` (#23). Returns nil
+/// for keys with no printable base character (arrows, function
+/// keys); `ComboSymbols` then falls back to a fixed glyph.
+///
+/// Translation uses no modifier state, so it yields the key's base
+/// glyph (the modifiers are shown separately as ⌃⌥⇧⌘). The current
+/// layout is queried first, with the ASCII-capable layout as a
+/// fallback for input sources (some IMEs) that expose no Unicode
+/// layout data.
+enum LayoutKeyGlyph {
+    static func char(for keyCode: UInt32) -> String? {
+        guard let layout = currentLayout() ?? asciiLayout() else {
+            return nil
+        }
+        return translate(keyCode: keyCode, layout: layout)
+    }
+
+    private static func currentLayout() -> CFData? {
+        source(TISCopyCurrentKeyboardLayoutInputSource())
+    }
+
+    private static func asciiLayout() -> CFData? {
+        source(TISCopyCurrentASCIICapableKeyboardLayoutInputSource())
+    }
+
+    /// The Unicode layout data of an input source, or nil.
+    private static func source(
+        _ source: Unmanaged<TISInputSource>?
+    ) -> CFData? {
+        guard let input = source?.takeRetainedValue(),
+            let pointer = TISGetInputSourceProperty(
+                input,
+                kTISPropertyUnicodeKeyLayoutData
+            )
+        else { return nil }
+        return Unmanaged<CFData>
+            .fromOpaque(pointer)
+            .takeUnretainedValue()
+    }
+
+    private static func translate(
+        keyCode: UInt32,
+        layout: CFData
+    ) -> String? {
+        guard let bytes = CFDataGetBytePtr(layout) else {
+            return nil
+        }
+        let keyLayout = UnsafeRawPointer(bytes)
+            .assumingMemoryBound(to: UCKeyboardLayout.self)
+        var deadKeys: UInt32 = 0
+        var length = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+        let status = UCKeyTranslate(
+            keyLayout,
+            UInt16(keyCode),
+            UInt16(kUCKeyActionDisplay),
+            0,  // no modifiers → the key's base glyph
+            UInt32(LMGetKbdType()),
+            OptionBits(kUCKeyTranslateNoDeadKeysBit),
+            &deadKeys,
+            chars.count,
+            &length,
+            &chars
+        )
+        guard status == noErr, length > 0 else { return nil }
+        let text = String(utf16CodeUnits: chars, count: length)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
+    }
+}

--- a/Sources/KiwiDeskCore/Keys/ComboSymbols.swift
+++ b/Sources/KiwiDeskCore/Keys/ComboSymbols.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Renders a `KeyCombo` as the compact macOS-native glyph string
+/// menus use (`⇧⌘,`, `⌃⌥←`): modifier symbols in the canonical
+/// ⌃⌥⇧⌘ order (Command last, adjacent to the key) followed by the
+/// key glyph, with **no `+` separator**.
+///
+/// Dropping the separator resolves the combinator ambiguity #23
+/// raises: with no `+` between tokens, any `+` that appears is the
+/// key itself (`⌘+`), never a "together with" combinator.
+///
+/// The glyph for a printable key is resolved through the *active*
+/// keyboard layout by the injected `layoutChar` closure — the GUI
+/// backs it with `UCKeyTranslate`, so a German layout shows `+`
+/// where a US layout shows `]`. Non-printable keys (arrows,
+/// return, function keys) use fixed symbols; when the layout
+/// lookup yields nothing, the US key name falls back to a symbol.
+/// This type is pure and Core-testable — only the injected closure
+/// touches the OS.
+public enum ComboSymbols {
+    /// The combo as a native glyph string. `layoutChar` maps a
+    /// virtual key code to its base character on the active
+    /// layout, or nil for keys with no printable character.
+    public static func render(
+        _ combo: KeyCombo,
+        layoutChar: (UInt32) -> String?
+    ) -> String {
+        modifierSymbols(combo.modifiers)
+            + keyGlyph(combo.keyCode, layoutChar)
+    }
+
+    /// Modifier symbols in the macOS-canonical ⌃⌥⇧⌘ order.
+    static func modifierSymbols(
+        _ modifiers: HotkeyModifiers
+    ) -> String {
+        var out = ""
+        if modifiers.contains(.control) { out += "⌃" }
+        if modifiers.contains(.option) { out += "⌥" }
+        if modifiers.contains(.shift) { out += "⇧" }
+        if modifiers.contains(.command) { out += "⌘" }
+        return out
+    }
+
+    private static func keyGlyph(
+        _ code: UInt32,
+        _ layoutChar: (UInt32) -> String?
+    ) -> String {
+        if let special = specialKeyGlyph(code) { return special }
+        if let char = layoutChar(code), !char.isEmpty {
+            return char.uppercased()
+        }
+        if let name = KeyCombo.keyName(for: code) {
+            return fallbackGlyph(name)
+        }
+        return ""
+    }
+
+    /// Fixed glyphs for keys that carry no printable character —
+    /// arrows, editing, whitespace, and function keys. Nil means
+    /// the key is printable and resolves through the layout.
+    static func specialKeyGlyph(_ code: UInt32) -> String? {
+        specials[code]
+    }
+
+    private static let specials: [UInt32: String] = [
+        123: "←", 124: "→", 125: "↓", 126: "↑",
+        36: "↩", 76: "⌤", 48: "⇥", 49: "␣",
+        51: "⌫", 117: "⌦", 53: "⎋",
+        115: "↖", 119: "↘", 116: "⇞", 121: "⇟",
+        122: "F1", 120: "F2", 99: "F3", 118: "F4",
+        96: "F5", 97: "F6", 98: "F7", 100: "F8",
+        101: "F9", 109: "F10", 103: "F11", 111: "F12",
+    ]
+
+    /// A symbol for a US key name when the active layout gives no
+    /// character (punctuation words → their glyph; a bare letter/
+    /// digit uppercases). Mirrors `KeyCombo.keyName` word aliases.
+    static func fallbackGlyph(_ name: String) -> String {
+        let symbols: [String: String] = [
+            "comma": ",", "period": ".", "slash": "/",
+            "backslash": "\\", "quote": "'", "grave": "`",
+            "minus": "-", "equal": "=", "semicolon": ";",
+            "leftbracket": "[", "rightbracket": "]",
+        ]
+        return symbols[name] ?? name.uppercased()
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ComboSymbolsTests.swift
+++ b/Tests/KiwiDeskCoreTests/ComboSymbolsTests.swift
@@ -1,0 +1,74 @@
+import Testing
+
+@testable import KiwiDeskCore
+
+@Suite("ComboSymbols native glyph rendering")
+struct ComboSymbolsTests {
+    /// A US-layout stand-in: printable keys resolve to their US
+    /// glyph, everything else (arrows, F-keys) returns nil so the
+    /// fixed-glyph path is exercised.
+    private func usLayout(_ code: UInt32) -> String? {
+        KeyCombo.keyName(for: code).map(ComboSymbols.fallbackGlyph)
+    }
+
+    private func render(_ text: String) -> String {
+        let combo = KeyCombo.parse(text)!
+        return ComboSymbols.render(combo, layoutChar: usLayout)
+    }
+
+    @Test("Modifiers render in canonical ⌃⌥⇧⌘ order, Command last")
+    func modifierOrder() {
+        #expect(
+            ComboSymbols.modifierSymbols(
+                [.command, .shift, .option, .control]
+            ) == "⌃⌥⇧⌘"
+        )
+    }
+
+    @Test("Command+Shift+comma is ⇧⌘, with no separator")
+    func glyphCombo() {
+        #expect(render("command+shift+comma") == "⇧⌘,")
+    }
+
+    @Test("A bare letter uppercases; digits stay")
+    func letterAndDigit() {
+        #expect(render("command+a") == "⌘A")
+        #expect(render("control+1") == "⌃1")
+    }
+
+    @Test("Punctuation words render as their glyph")
+    func punctuation() {
+        #expect(render("command+slash") == "⌘/")
+        #expect(render("command+grave") == "⌘`")
+    }
+
+    @Test("Arrows and function keys use fixed symbols")
+    func specialKeys() {
+        #expect(render("control+option+left") == "⌃⌥←")
+        #expect(render("command+f1") == "⌘F1")
+        #expect(render("shift+space") == "⇧␣")
+    }
+
+    @Test("The + key shows as + with no combinator ambiguity")
+    func plusKey() {
+        // On a US layout the equal key shifted is "+", but the
+        // stored base key is "equal"; a layout that maps it to "+"
+        // must still be unambiguous — no separator precedes it.
+        #expect(
+            ComboSymbols.render(
+                KeyCombo.parse("command+equal")!,
+                layoutChar: { _ in "+" }
+            ) == "⌘+"
+        )
+    }
+
+    @Test("Locale glyph comes from the injected layout")
+    func localeMapping() {
+        // A German layout renders the US "]" key (code 30) as "+".
+        let german: (UInt32) -> String? = { code in
+            code == 30 ? "+" : self.usLayout(code)
+        }
+        let combo = KeyCombo.parse("shift+rightbracket")!
+        #expect(ComboSymbols.render(combo, layoutChar: german) == "⇧+")
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -482,6 +482,15 @@ same key — likewise `comma`/`,`, `period`/`.`, `slash`/`/`,
 long forms (`command`, `option`, `semicolon`, …) for
 readability; every alias round-trips.
 
+In the editor each recorded shortcut *displays* as the compact
+macOS-native glyph string menus use — modifier symbols `⌃⌥⇧⌘`
+(Command last) followed by the key glyph, with no `+` separator,
+e.g. `⇧⌘,`. The key glyph is mapped through your **active
+keyboard layout**, so a German layout shows `+` where a US layout
+shows `]`. Because there is no `+` combinator, a literal `+` key
+is unambiguous (`⌘+`). Only the display changes; the stored config
+keeps the long word forms above.
+
 Hotkeys use the Carbon API: macOS filters them before they
 reach any app, and KiwiDesk never needs the Input Monitoring
 permission. Left and right modifiers are treated as the same


### PR DESCRIPTION
## Summary

Wave 6 (#23), part B — **combo rendering**. Renders keybinding
shortcuts as native macOS glyphs in the editor:

- Locale-correct key glyphs via the *active* keyboard layout
  (`UCKeyTranslate`) — a German layout shows `+` where US shows `]`.
- macOS modifier symbols (⌃⌥⇧⌘) and fixed glyphs for arrows /
  function / navigation keys.
- A distinct color for the `+` combinator.

New pure Core type `ComboSymbols` (with 7 unit tests) does the
combo → glyph string mapping; `LayoutKeyGlyph` isolates the Carbon
TIS / `UCKeyTranslate` bridge in the GUI target.

(Part A — catalog rename + resize/float presets — already landed
on `main` via #59.)

## Review

Both `code-reviewer` and `architect-reviewer` ran on the change.
Design judged sound with no blocking findings. Addressed:

- **CFData lifetime**: `TISGetInputSourceProperty` returns layout
  data under CF's *Get* rule; the input source is now held alive
  across `UCKeyTranslate` via `withExtendedLifetime` so the data
  can't dangle.
- **Label clarity**: focus/swap rows now read as full positional
  phrases ("Focus window to the left/above/below/to the right").

Deferred to Wave 8 (tracked): keying `ComboSymbols` glyphs by
canonical key *name* rather than raw code, and localizing the
catalog labels.

## Verification

`swift build` · `swift test` (328 pass) · `swift build -c release`
· `scripts/lint.sh` — all green.