### PR TITLE
feat(profiles): edit stored profiles from a top dropdown (#18)

### DIFF
--- a/.claude/rules/profiles.md
+++ b/.claude/rules/profiles.md
@@ -6,23 +6,18 @@ paths:
 
 # Profiles & config ownership
 
-See AGENTS.md §5. Architecture invariants (from the #53/#36 work):
+The binding rules live in **AGENTS.md §5** (canonical) — read them
+before editing this subsystem. The ones this code trips over most,
+as a checklist (rationale is in §5, not restated here):
 
-- **Profiles own tiling only** — they serialize tiling state, not
-  keybindings or app rules. A new profile-serialized setting
-  belongs *inside* `TilingSettings`, so it rides the config split
-  automatically (follow the `gap.override` precedent).
-- **`ProfileManager` mutators are `internal` by design.** Mutate
-  through a `KiwiCore` facade (e.g. a `persistProfile`-style
-  method); never re-publicize the mutators. `read(name:)` is the
-  public load-for-edit primitive (path-traversal guarded).
-- **`ProfileManager.save()` adopts** (sets `currentName`, clears
-  dirty). An edit-without-activating path must be a separate,
-  non-adopting write — don't overload `save()`.
-- **One ownership predicate.** GUI-vs-Lua ownership is centralized
-  in `KiwiCore.isGuiManaged` (`KiwiCore+GuiConfig.swift`). Refine
-  that single predicate (e.g. token-scoped `configHasForeignCode`);
-  never introduce a second ownership check.
-- **Merge order:** per-field merge first, cross-field clamps last,
-  on the *merged* values (`AppBarStyle.resolved…` pattern).
-  Resolution happens before layout math — layout stays pure.
+- Profiles own **tiling only** — a new profile-serialized setting
+  goes *inside* `TilingSettings` (the `gap.override` precedent).
+- `ProfileManager` mutators are `internal`; go through a `KiwiCore`
+  facade. `read(name:)` loads for edit; `save()` **adopts** — an
+  edit-without-activating path is a separate, non-adopting write.
+- One ownership predicate: `KiwiCore.isGuiManaged`. Never add a
+  second.
+- Resolve before layout; merge per-field first, cross-field clamps
+  last (`AppBarStyle.resolved…`).
+- One vocabulary across Lua and profile JSON — see
+  [config-vocabulary.md](config-vocabulary.md).

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -5,15 +5,16 @@ paths:
 
 # Tests
 
-See AGENTS.md §2 & §5. Lesson learned the hard way on large PRs:
+The binding rules live in **AGENTS.md §2 & §5** (canonical). The
+ones that bite large test PRs, as a checklist (rationale is in §5):
 
-- **Split suites early.** The 79-char limit and the 350-line
-  ceiling repeatedly bit large test files. Break a suite into
-  focused files *before* it approaches the ceiling, not after.
+- **Split suites early** — the 79-char limit and 350-line ceiling
+  bite large test files. Break a suite into focused files *before*
+  it approaches the ceiling.
 - **Per-file private helpers are the convention** — small
-  duplication across suites is fine; do not build a shared test
-  harness or deep helper hierarchy to avoid it.
-- Config/profile shape is pinned by `SettingsCodingTests`; extend
-  it when adding a setting (Lua name → JSON key via `CodingKeys`).
-- Pre-release, single-user: profile JSON needs no migration
-  scripts — re-saving is the migration.
+  duplication across suites is fine; no shared test harness.
+- Config/profile shape is pinned by `SettingsCodingTests` — extend
+  it when adding a setting (Lua name → JSON key via `CodingKeys`;
+  see [config-vocabulary.md](config-vocabulary.md)).
+- Pre-release, single-user: profile JSON needs no migration — see
+  [profiles.md](profiles.md) and §5.

--- a/.claude/skills/review-change/SKILL.md
+++ b/.claude/skills/review-change/SKILL.md
@@ -1,20 +1,20 @@
 ---
-description: Run KiwiDesk's two-agent review workflow (code-reviewer + architect-reviewer) with the AGENTS.md §3.6 sequencing. Use on a finished, verified, committed change before opening a PR.
+description: Run KiwiDesk's two-agent review workflow (code-reviewer + architect-reviewer) with the AGENTS.md §3 (Review step) sequencing. Use on a finished, verified, committed change before opening a PR.
 argument-hint: "[optional: base ref, e.g. main or a commit/PR]"
 ---
 
-Run the review workflow from AGENTS.md §3.6 on the current change.
-Precondition: the change should already be finished, verified
-(`/verify-gate`), and committed. If it clearly is not, say so and
-stop.
+Run the review workflow from AGENTS.md §3 (the Review step) on the
+current change. Precondition: the change should already be
+finished, verified (`/verify-gate`), and committed. If it clearly
+is not, say so and stop.
 
 ## 1. Establish the diff
 
-Determine the review range from `$ARGUMENTS` if given, else the
-last review point: the branch's merge base with `main`, or the
-last reviewed commit / PR if there is one.
+Determine the review range from `$ARGUMENTS` if given (a base ref —
+the last reviewed commit or PR merge point), else the branch's
+merge base with `main`.
 
-!`git merge-base HEAD main 2>/dev/null && echo "--- diff stat vs merge-base ---" && git diff --stat $(git merge-base HEAD main)...HEAD 2>/dev/null`
+!`BASE="$ARGUMENTS"; BASE="${BASE:-$(git merge-base HEAD main)}"; echo "--- diff stat vs $BASE ---" && git diff --stat "$BASE"...HEAD 2>/dev/null`
 
 ## 2. First round — parallel
 

--- a/.claude/skills/verify-gate/SKILL.md
+++ b/.claude/skills/verify-gate/SKILL.md
@@ -1,11 +1,12 @@
 ---
-description: Run KiwiDesk's full verification gate — debug build, tests, lint, and the mandatory release build (AGENTS.md §3.4). Use before any commit or PR.
+description: Run KiwiDesk's full verification gate — debug build, tests, lint, and the mandatory release build (AGENTS.md §3, the Verify step). Use before any commit or PR.
 argument-hint: "[optional: file/dir to scope the lint]"
 ---
 
-Run KiwiDesk's verification gate from AGENTS.md §3.4, in order, and
-report the result of each step. Stop and surface the failure the
-moment a step fails — do not continue to later steps.
+Run KiwiDesk's verification gate from AGENTS.md §3 (the Verify
+step), in order, and report the result of each step. Stop and
+surface the failure the moment a step fails — do not continue to
+later steps.
 
 ## Fast inner loop
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,18 @@ Keep this list updated whenever a recurring mistake is found.
   *inside* `TilingSettings` so they ride the config split for free
   (see `gap.override`). `ProfileManager` mutators are `internal` by
   design — mutate through a `KiwiCore` facade, never re-publicize
-  them. The GUI-vs-Lua ownership predicate is centralized in
+  them. `read(name:)` is the public load-for-edit primitive
+  (path-traversal guarded, touches no state); `save()` **adopts**
+  (sets `currentName`, clears dirty), so an edit-without-activating
+  path must be a separate, non-adopting write — never overload
+  `save()`. The GUI-vs-Lua ownership predicate is centralized in
   `KiwiCore.isGuiManaged` (`KiwiCore+GuiConfig.swift`); refine that
-  one predicate, never add a second.
+  one predicate, never add a second. Pre-release (single user):
+  profile JSON needs no migration scripts — re-saving is the
+  migration.
+- **Resolve before layout, and merge per-field first.** Settings
+  that layer (global → layout → space) merge field-by-field, with
+  cross-field clamps applied *last* on the already-merged values
+  (the `AppBarStyle.resolved…` pattern). Resolution runs before
+  layout math so the layout functions stay pure over the flat
+  array.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,12 +36,15 @@ The binding style and workflow rules live in
 ## Using AI Assistants
 
 AI coding assistants are **welcome and encouraged** here. Much of
-the repo is set up specifically to make them productive: the
-committed `.claude/` config (`AGENTS.md`, path-scoped `rules/`,
-`skills/`, and project-tailored review agents) teaches an assistant
-KiwiDesk's conventions so its output lands on-style instead of
-generic. If you use Claude Code or a similar tool, run
-`./scripts/install-subagents.sh` once to pull the review agents.
+the repo is set up specifically to make them productive:
+[AGENTS.md](AGENTS.md) at the repo root, plus the committed
+`.claude/rules/` (path-scoped conventions) and `.claude/skills/`
+(verify/review workflows), teach an assistant KiwiDesk's
+conventions so its output lands on-style instead of generic. The
+project-tailored review agents themselves are *not* committed —
+they are regenerated per-clone: run `./scripts/install-subagents.sh`
+once and it pulls the review agents, appending the committed
+`scripts/kiwidesk-review-context.md` tailoring to each.
 
 One rule, though: **understand what you submit.** A pull request is
 yours regardless of how it was written — know what your change does

--- a/Sources/KiwiDesk/Settings/ProfileSyncBanner.swift
+++ b/Sources/KiwiDesk/Settings/ProfileSyncBanner.swift
@@ -1,0 +1,176 @@
+import KiwiDeskCore
+import SwiftUI
+
+/// Top banner: a dropdown to pick which profile to edit (the
+/// live/active config or any saved profile — #18), the
+/// transient/dirty state, and profile-action warnings (#36).
+/// Saving lives in the footer's profile buttons.
+struct ProfileSyncBanner: View {
+    @ObservedObject var model: SettingsModel
+    @State private var confirmingSwitch = false
+    @State private var switchTarget: String?
+
+    private var showDivergence: Bool {
+        model.profileDirty && !model.editingStoredProfile
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "rectangle.3.group")
+                    .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 1) {
+                    profilePicker
+                    Text(statusText)
+                        .font(.caption)
+                        .foregroundStyle(
+                            showDivergence ? .orange : .secondary
+                        )
+                }
+                Spacer()
+                if showDivergence {
+                    Image(
+                        systemName:
+                            "exclamationmark.triangle.fill"
+                    )
+                    .foregroundStyle(.orange)
+                    .help(
+                        "The live layout diverged from the "
+                            + "saved profile."
+                    )
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            if let warning = model.profileWarning {
+                warningRow(warning)
+            }
+        }
+        .confirmationDialog(
+            "Discard unsaved changes?",
+            isPresented: $confirmingSwitch,
+            titleVisibility: .visible
+        ) {
+            Button("Discard & switch", role: .destructive) {
+                model.selectEditTarget(switchTarget)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "Switching profiles drops the edits you "
+                    + "haven't saved."
+            )
+        }
+    }
+
+    /// The banner title doubles as a dropdown: pick any saved
+    /// profile to edit it in place (Model A) — editing a
+    /// non-loaded profile never switches the running layout (#18).
+    private var profilePicker: some View {
+        Menu {
+            Button {
+                requestSelect(nil)
+            } label: {
+                Text(liveEntryLabel)
+            }
+            if !model.profileSummaries.isEmpty {
+                Divider()
+                ForEach(model.profileSummaries) { summary in
+                    Button {
+                        requestSelect(summary.name)
+                    } label: {
+                        Text(menuRowLabel(summary.name))
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(title).font(.headline)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help(
+            "Pick a saved profile to edit — editing it won't "
+                + "switch your layout."
+        )
+    }
+
+    private func requestSelect(_ name: String?) {
+        if model.isDirty {
+            switchTarget = name
+            confirmingSwitch = true
+        } else {
+            model.selectEditTarget(name)
+        }
+    }
+
+    private var liveEntryLabel: String {
+        let mark = model.editingProfile == nil ? "✓ " : ""
+        if model.activeProfile != nil {
+            return "\(mark)Live (currently loaded)"
+        }
+        if let standard = model.activeStandard {
+            return "\(mark)Live — Standard: \(standard)"
+        }
+        return "\(mark)Live — transient layout"
+    }
+
+    private func menuRowLabel(_ name: String) -> String {
+        let mark = model.editingProfile == name ? "✓ " : ""
+        let loaded =
+            name == model.activeProfile
+            ? " (currently loaded)" : ""
+        return "\(mark)\(name)\(loaded)"
+    }
+
+    private var title: String {
+        if let editing = model.editingProfile { return editing }
+        if let profile = model.activeProfile { return profile }
+        if let standard = model.activeStandard {
+            return "Standard: \(standard)"
+        }
+        return "Transient layout"
+    }
+
+    private var statusText: String {
+        if model.editingStoredProfile {
+            return "Editing a saved profile — changes won't "
+                + "switch your layout."
+        }
+        if model.activeStandard != nil {
+            return "Built-in layout — save as a profile to "
+                + "make it yours."
+        }
+        if model.profileDirty {
+            return "Unsaved monitor changes — update the "
+                + "profile to keep them."
+        }
+        return model.activeProfile == nil
+            ? "No profile matches this monitor setup."
+            : "Profile is up to date."
+    }
+
+    private func warningRow(_ warning: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.bubble")
+                .foregroundStyle(.orange)
+            Text(warning)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button {
+                model.profileWarning = nil
+            } label: {
+                Image(systemName: "xmark.circle")
+            }
+            .buttonStyle(.borderless)
+            .help("Dismiss")
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+}

--- a/Sources/KiwiDesk/Settings/ProfileSyncBanner.swift
+++ b/Sources/KiwiDesk/Settings/ProfileSyncBanner.swift
@@ -100,6 +100,11 @@ struct ProfileSyncBanner: View {
     }
 
     private func requestSelect(_ name: String?) {
+        // Resolve to the same target `selectEditTarget` will use,
+        // so re-picking the profile already open is a no-op that
+        // never pops a pointless discard dialog.
+        let target = (name == model.activeProfile) ? nil : name
+        guard target != model.editingProfile else { return }
         if model.isDirty {
             switchTarget = name
             confirmingSwitch = true

--- a/Sources/KiwiDesk/Settings/SettingsModel+Profiles.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Profiles.swift
@@ -98,6 +98,38 @@ extension SettingsModel {
             || saved.spaces != config.spaces
     }
 
+    // MARK: - Editing a stored profile (#18)
+
+    /// Switches the dashboard's edit target. Passing `nil` (or the
+    /// active profile's own name) returns to live editing; any
+    /// other saved profile enters edit-without-activating mode.
+    /// Pending edits are discarded on switch — the caller confirms
+    /// first.
+    func selectEditTarget(_ name: String?) {
+        // Selecting the currently-loaded profile is just editing
+        // live: it is the same data, on the live save path.
+        let target = (name == activeProfile) ? nil : name
+        guard target != editingProfile else { return }
+        editingProfile = target
+        reload()
+    }
+
+    /// Writes the edited tiling into the stored profile without
+    /// switching the live layout, then hot-reloads it only if it
+    /// is the layout currently on screen (#18).
+    func saveEditedProfile() {
+        guard let name = editingProfile else { return }
+        do {
+            try core.overwriteProfile(named: name, with: config)
+        } catch {
+            profileWarning = "Saving failed: \(error)"
+            core.onLog("profile edit save failed: \(error)")
+            return
+        }
+        core.reapplyIfInEffect(name)
+        reload()
+    }
+
     func loadProfile(named name: String) {
         _ = core.execute(
             "load_profile",

--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -106,6 +106,9 @@ final class SettingsModel: ObservableObject {
             return
         }
         suppressDirty = true
+        // Only meaningful while editing a stored profile; reset it
+        // so a stale `false` never lingers into live editing.
+        placementEditable = true
         var loaded = core.loadGuiConfig()
         // Recovered rows arrive as `.custom`; sort the ones that
         // match a catalog action into their sections before the
@@ -150,7 +153,11 @@ final class SettingsModel: ObservableObject {
         KeybindingImportClassifier.classify(&loaded)
         config = loaded
         suppressDirty = false
+        // Stored-profile editing is mutually exclusive with the
+        // raw Lua editor — leaving it on would let a global
+        // init.lua write escape edit mode.
         forcedLuaEditor = false
+        showLuaEditor = false
         savedSidecar = nil
         let live = displays.map(\.fingerprint)
         placementEditable =

--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -34,6 +34,16 @@ final class SettingsModel: ObservableObject {
     /// The live state diverged from the saved profile (e.g.
     /// after a monitor change) — the update prompt.
     @Published var profileDirty = false
+    /// A *stored* profile being edited via the banner dropdown,
+    /// or nil for the live/active config (#18). Editing a stored
+    /// profile seeds the tabs from its JSON and never switches
+    /// the running layout.
+    @Published var editingProfile: String?
+    /// Whether the Canvas (monitor placement) is editable for the
+    /// current target: always true live; for a stored profile
+    /// only when its monitor set is the one connected now (else
+    /// there is no live geometry to render — #18).
+    @Published var placementEditable = true
     @Published var profiles: [String] = []
     /// Rich rows for the saved-profiles list (#36): monitor
     /// sets, screen count, default flag, live match.
@@ -81,11 +91,20 @@ final class SettingsModel: ObservableObject {
     /// Whether the raw Lua editor is currently shown.
     var editingLua: Bool { forcedLuaEditor || showLuaEditor }
 
+    /// Whether the dashboard is editing a stored profile rather
+    /// than the live config (#18) — hides the global-only tabs
+    /// (Shortcuts, App Rules) and swaps the footer's save action.
+    var editingStoredProfile: Bool { editingProfile != nil }
+
     // MARK: - Sync with the backend
 
     /// Pulls the current configuration and profile state from
     /// the core into the view model (discards unsaved edits).
     func reload() {
+        if let name = editingProfile {
+            reloadEditingProfile(name)
+            return
+        }
         suppressDirty = true
         var loaded = core.loadGuiConfig()
         // Recovered rows arrive as `.custom`; sort the ones that
@@ -110,6 +129,33 @@ final class SettingsModel: ObservableObject {
         // the overlaid spaces union, and deleting + re-adding
         // a transient space alone doesn't read as an edit.
         savedSidecar = core.isGuiManaged ? config : nil
+        refreshProfiles()
+        isDirty = false
+    }
+
+    /// Reload path for the profile-dropdown edit mode (#18): seed
+    /// the tabs from a stored profile's JSON instead of live
+    /// state. A profile that has vanished falls back to live
+    /// editing. Stored-profile edits never touch the raw Lua
+    /// editor or the global sidecar — only the profile JSON is
+    /// written — so `savedSidecar` is cleared.
+    private func reloadEditingProfile(_ name: String) {
+        guard var loaded = try? core.loadGuiConfig(editing: name)
+        else {
+            editingProfile = nil
+            reload()
+            return
+        }
+        suppressDirty = true
+        KeybindingImportClassifier.classify(&loaded)
+        config = loaded
+        suppressDirty = false
+        forcedLuaEditor = false
+        savedSidecar = nil
+        let live = displays.map(\.fingerprint)
+        placementEditable =
+            (try? core.profiles.read(name: name))?
+            .set(matching: live) != nil
         refreshProfiles()
         isDirty = false
     }

--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -58,108 +58,29 @@ struct SettingsView: View {
                             systemImage: "menubar.rectangle"
                         )
                     }
-                AppRulesTab(model: model)
-                    .tabItem {
-                        Label(
-                            "App Rules",
-                            systemImage: "app.badge"
-                        )
-                    }
-                KeybindingsTab(model: model)
-                    .tabItem {
-                        Label(
-                            "Shortcuts",
-                            systemImage: "keyboard"
-                        )
-                    }
+                // Shortcuts and App Rules are global, not part of
+                // any profile (Model A) — hidden while editing a
+                // stored profile (#18).
+                if !model.editingStoredProfile {
+                    AppRulesTab(model: model)
+                        .tabItem {
+                            Label(
+                                "App Rules",
+                                systemImage: "app.badge"
+                            )
+                        }
+                    KeybindingsTab(model: model)
+                        .tabItem {
+                            Label(
+                                "Shortcuts",
+                                systemImage: "keyboard"
+                            )
+                        }
+                }
             }
             .padding(.horizontal, 12)
             .padding(.top, 10)
         }
-    }
-}
-
-/// Top banner: the active profile (or resolving Standard), the
-/// transient/dirty state, and profile-action warnings (#36).
-/// Saving lives in the footer's two profile buttons.
-struct ProfileSyncBanner: View {
-    @ObservedObject var model: SettingsModel
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 10) {
-                Image(systemName: "rectangle.3.group")
-                    .foregroundStyle(.secondary)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(title).font(.headline)
-                    Text(statusText)
-                        .font(.caption)
-                        .foregroundStyle(
-                            model.profileDirty
-                                ? .orange : .secondary
-                        )
-                }
-                Spacer()
-                if model.profileDirty {
-                    Image(
-                        systemName:
-                            "exclamationmark.triangle.fill"
-                    )
-                    .foregroundStyle(.orange)
-                    .help(
-                        "The live layout diverged from the "
-                            + "saved profile."
-                    )
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-            if let warning = model.profileWarning {
-                warningRow(warning)
-            }
-        }
-    }
-
-    private var title: String {
-        if let profile = model.activeProfile { return profile }
-        if let standard = model.activeStandard {
-            return "Standard: \(standard)"
-        }
-        return "Transient layout"
-    }
-
-    private var statusText: String {
-        if model.activeStandard != nil {
-            return "Built-in layout — save as a profile to "
-                + "make it yours."
-        }
-        if model.profileDirty {
-            return "Unsaved monitor changes — update the "
-                + "profile to keep them."
-        }
-        return model.activeProfile == nil
-            ? "No profile matches this monitor setup."
-            : "Profile is up to date."
-    }
-
-    private func warningRow(_ warning: String) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.bubble")
-                .foregroundStyle(.orange)
-            Text(warning)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Spacer()
-            Button {
-                model.profileWarning = nil
-            } label: {
-                Image(systemName: "xmark.circle")
-            }
-            .buttonStyle(.borderless)
-            .help("Dismiss")
-        }
-        .padding(.horizontal, 16)
-        .padding(.bottom, 8)
     }
 }
 
@@ -204,6 +125,8 @@ struct SettingsFooter: View {
                 Button("Save") { model.saveLuaSource() }
                     .keyboardShortcut("s")
                     .disabled(!model.isDirty)
+            } else if model.editingStoredProfile {
+                editProfileSaveButton
             } else {
                 updateButton
                 saveAsNewButton
@@ -259,6 +182,18 @@ struct SettingsFooter: View {
     private var saveAsNewButton: some View {
         Button("Save as new…") { namingNewProfile = true }
             .buttonStyle(.borderedProminent)
+    }
+
+    /// Stored-profile edit mode (#18): write the edits into that
+    /// profile's JSON without switching the live layout.
+    @ViewBuilder private var editProfileSaveButton: some View {
+        let name = model.editingProfile ?? ""
+        Button("Save to \u{201C}\(name)\u{201D}") {
+            model.saveEditedProfile()
+        }
+        .keyboardShortcut("s")
+        .buttonStyle(.borderedProminent)
+        .disabled(!model.isDirty)
     }
 
     private var adoptButton: some View {

--- a/Sources/KiwiDesk/Settings/Tabs/CanvasTab.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/CanvasTab.swift
@@ -14,23 +14,60 @@ struct CanvasTab: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                SettingsSection("Monitor layout") {
-                    if model.displays.isEmpty {
-                        Text("No monitors detected.")
-                            .foregroundStyle(.secondary)
-                    } else {
-                        MonitorCanvas(model: model)
-                            .frame(height: 260)
-                        MainDropTarget(model: model)
+                if model.editingStoredProfile
+                    && !model.placementEditable
+                {
+                    // Editing a stored profile whose monitors
+                    // aren't attached: there is no live geometry
+                    // to render, so placement is read-only here
+                    // (#18). The other tabs still edit it.
+                    placementUnavailable
+                } else {
+                    SettingsSection("Monitor layout") {
+                        if model.displays.isEmpty {
+                            Text("No monitors detected.")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            MonitorCanvas(model: model)
+                                .frame(height: 260)
+                            MainDropTarget(model: model)
+                        }
                     }
+                    if !model.displays.isEmpty {
+                        SpaceMonitorAssignments(model: model)
+                    }
+                    // Native-Space bindings are global, not part
+                    // of a profile — only offered in live editing.
+                    if !model.editingStoredProfile {
+                        NativeSpacesSection(model: model)
+                    }
+                    fingerprintSection
                 }
-                if !model.displays.isEmpty {
-                    SpaceMonitorAssignments(model: model)
-                }
-                NativeSpacesSection(model: model)
-                fingerprintSection
             }
             .padding(16)
+        }
+    }
+
+    private var placementUnavailable: some View {
+        SettingsSection("Monitor layout") {
+            VStack(alignment: .leading, spacing: 8) {
+                Label(
+                    "Monitors not connected",
+                    systemImage:
+                        "display.trianglebadge.exclamationmark"
+                )
+                .font(.headline)
+                Text(
+                    "This profile's monitors aren't attached "
+                        + "right now, so its space placement "
+                        + "can't be edited here. Connect its "
+                        + "monitor setup to arrange spaces — the "
+                        + "other tabs still edit this profile."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 

--- a/Sources/KiwiDesk/Settings/Tabs/GeneralTab.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/GeneralTab.swift
@@ -13,7 +13,12 @@ struct GeneralTab: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 behaviorSection
-                advancedSection
+                // The advanced block reveals and edits the global
+                // init.lua — hidden while editing a stored profile
+                // (that mode writes only the profile JSON, #18).
+                if !model.editingStoredProfile {
+                    advancedSection
+                }
             }
             .padding(16)
         }

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -56,14 +56,20 @@ extension KiwiCore {
     ) {
         config.settings = profile.settings
         config.spaceModes = profile.spaceModes
-        config.spaces = GuiConfig.orderedSpaces(
-            config.spaces + Array(profile.spaceModes.keys)
-        )
         config.mainSpaces = Set(profile.mainSpaces)
         let live = state.workspaces.allDisplays
             .map(\.fingerprint)
         config.spacePins =
             profile.set(matching: live)?.spaceMonitorMap ?? [:]
+        // The space set is the profile's own — NOT unioned with
+        // the live sidecar's spaces, or editing a profile for
+        // other hardware would graft this machine's spaces into
+        // it on save (mirrors `applyProfileScopedState`, #18).
+        config.spaces = GuiConfig.orderedSpaces(
+            Array(profile.spaceModes.keys)
+                + profile.mainSpaces
+                + Array(config.spacePins.keys)
+        )
     }
 
     /// Copies the live profile-scoped state into the model:

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -29,6 +29,43 @@ extension KiwiCore {
         return config
     }
 
+    /// The editable model for **a stored profile**, not the live
+    /// one (#18): global fields come from the sidecar/live seed
+    /// exactly as `loadGuiConfig()`, but the profile-scoped
+    /// fields are overlaid from `name`'s JSON instead of live
+    /// state — so the dashboard can edit a saved profile without
+    /// switching the running layout. Throws if the profile is
+    /// unreadable (the caller falls back to live editing).
+    public func loadGuiConfig(
+        editing name: String
+    ) throws -> GuiConfig {
+        let profile = try profiles.read(name: name)
+        var config = guiConfigStore.load() ?? guiConfigSeed()
+        overlayProfileState(&config, from: profile)
+        return config
+    }
+
+    /// Copies a *stored* profile's tiling into the model —
+    /// sibling of `overlayLiveProfileState`, reading the profile
+    /// instead of live state. Pins come from the set covering the
+    /// connected monitors (empty when none matches, i.e. the
+    /// Canvas can't be edited for this profile right now).
+    private func overlayProfileState(
+        _ config: inout GuiConfig,
+        from profile: Profile
+    ) {
+        config.settings = profile.settings
+        config.spaceModes = profile.spaceModes
+        config.spaces = GuiConfig.orderedSpaces(
+            config.spaces + Array(profile.spaceModes.keys)
+        )
+        config.mainSpaces = Set(profile.mainSpaces)
+        let live = state.workspaces.allDisplays
+            .map(\.fingerprint)
+        config.spacePins =
+            profile.set(matching: live)?.spaceMonitorMap ?? [:]
+    }
+
     /// Copies the live profile-scoped state into the model:
     /// tiling settings, per-space modes, monitor pins, and the
     /// Main role.

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
@@ -145,6 +145,73 @@ extension KiwiCore {
         try profiles.save(existing)
     }
 
+    /// Writes the edited tiling from `config` into the stored
+    /// profile `name` **without adopting it** — no change to
+    /// `current`/`dirty`, no touch to live state. Edit-without-
+    /// activating for the dashboard's profile dropdown (#18).
+    ///
+    /// The live monitor set's pins are refreshed only when the
+    /// profile already covers the connected monitors; a profile
+    /// whose monitors aren't attached never gets them injected
+    /// (its Canvas is read-only in that case, so `spacePins` is
+    /// empty here anyway).
+    public func overwriteProfile(
+        named name: String,
+        with config: GuiConfig
+    ) throws {
+        var existing = try profiles.read(name: name)
+        existing.settings = config.settings
+        // Dense over the profile's own spaces (mirrors
+        // `buildProfile`): an undeclared space reads as bsp.
+        var modes: [SpaceID: LayoutMode] = [:]
+        for space in config.spaces {
+            modes[space] = config.spaceModes[space] ?? .bsp
+        }
+        existing.spaceModes = modes
+        existing.mainSpaces = config.mainSpaces.sorted {
+            $0.raw < $1.raw
+        }
+        let live = state.workspaces.allDisplays
+            .map(\.fingerprint)
+        if existing.set(matching: live) != nil {
+            existing.upsert(
+                MonitorSet(
+                    monitors: live,
+                    spaceMonitorMap: config.spacePins
+                )
+            )
+        }
+        existing.savedAt = .now
+        try profiles.write(existing)
+    }
+
+    /// Whether `name` is the layout currently on screen — it is
+    /// the active profile, or a native Space bound to it is the
+    /// active one — so a non-adopting edit should hot-reload it
+    /// (#18).
+    public func isProfileInEffect(_ name: String) -> Bool {
+        if profiles.currentName == name { return true }
+        guard let active = NativeSpaces.activeSpaceNumber()
+        else { return false }
+        return nativeSpaceBindings[active] == name
+    }
+
+    /// Re-applies `name` to the live layout after an in-effect
+    /// edit. The active profile re-applies in place (no adopt);
+    /// a profile merely bound to the active native Space
+    /// re-resolves through the shared monitor-change path so the
+    /// binding picks up the freshly-written JSON (#18).
+    public func reapplyIfInEffect(_ name: String) {
+        guard isProfileInEffect(name) else { return }
+        if profiles.currentName == name,
+            let fresh = try? profiles.read(name: name)
+        {
+            apply(profile: fresh)
+        } else {
+            handleMonitorChange()
+        }
+    }
+
     /// Names of profiles (other than `name`) already claiming
     /// the live monitor set — the GUI warns before Update
     /// makes the set ambiguous (#36 overlap policy).

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
@@ -162,9 +162,15 @@ extension KiwiCore {
         var existing = try profiles.read(name: name)
         existing.settings = config.settings
         // Dense over the profile's own spaces (mirrors
-        // `buildProfile`): an undeclared space reads as bsp.
+        // `buildProfile`): an undeclared space reads as bsp. The
+        // union with `spaceModes.keys` keeps a just-set mode even
+        // if its space hasn't landed in the list yet; `spaces` is
+        // profile-derived (see `overlayProfileState`), so no
+        // live-only space can leak in here.
         var modes: [SpaceID: LayoutMode] = [:]
-        for space in config.spaces {
+        let declared = Set(config.spaces)
+            .union(config.spaceModes.keys)
+        for space in declared {
             modes[space] = config.spaceModes[space] ?? .bsp
         }
         existing.spaceModes = modes
@@ -200,7 +206,10 @@ extension KiwiCore {
     /// edit. The active profile re-applies in place (no adopt);
     /// a profile merely bound to the active native Space
     /// re-resolves through the shared monitor-change path so the
-    /// binding picks up the freshly-written JSON (#18).
+    /// binding picks up the freshly-written JSON (#18). That
+    /// bound path runs the normal resolver, which *adopts* the
+    /// bound profile (it is now the on-screen layout) — an
+    /// intended live-state change, unlike the in-place branch.
     public func reapplyIfInEffect(_ name: String) {
         guard isProfileInEffect(name) else { return }
         if profiles.currentName == name,

--- a/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
+++ b/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
@@ -254,7 +254,12 @@ public final class ProfileManager {
         isDirty = true
     }
 
-    private func write(_ profile: Profile) throws {
+    /// The non-adopting write: persists the JSON only, touching
+    /// no `current`/`dirty` state. `save()` layers adoption on
+    /// top; an edit-without-activating path (`overwriteProfile`)
+    /// writes through here directly so editing a stored profile
+    /// never switches the live layout (#18).
+    func write(_ profile: Profile) throws {
         let name = try validated(profile.name)
         try FileManager.default.createDirectory(
             at: directory,

--- a/Tests/KiwiDeskCoreTests/ProfileEditTests.swift
+++ b/Tests/KiwiDeskCoreTests/ProfileEditTests.swift
@@ -1,0 +1,170 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+// Edit-without-activating (#18): editing a stored profile from
+// the dashboard dropdown must write that profile's JSON without
+// switching the live layout. Per-file helpers by convention.
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    KiwiCore(
+        configDirectory: FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent(
+                "kiwi-edit-\(UUID().uuidString)"
+            )
+    )
+}
+
+@MainActor
+private func connect(_ core: KiwiCore, _ displays: [Display]) {
+    for display in displays {
+        core.state.workspaces.upsertDisplay(display)
+    }
+}
+
+/// A display named `name` with a 100x100 frame, so its
+/// fingerprint is `"<name>:100x100"`.
+private func display(
+    _ id: UInt32,
+    _ name: String,
+    x: CGFloat = 0
+) -> Display {
+    Display(
+        id: DisplayID(id),
+        name: name,
+        frame: CGRect(x: x, y: 0, width: 100, height: 100)
+    )
+}
+
+@Suite("Profile editing (#18)", .serialized)
+@MainActor
+struct ProfileEditTests {
+    @Test("overwriteProfile writes without adopting")
+    func overwriteIsNonAdopting() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute("save_profile", args: [.string("stored")])
+        core.execute("save_profile", args: [.string("active")])
+        // "active" is current; "stored" is an idle saved profile.
+
+        var cfg = try core.loadGuiConfig(editing: "stored")
+        cfg.settings.gapsGlobal = .uniform(42)
+        cfg.spaceModes[SpaceID(1)] = .grid
+        try core.overwriteProfile(named: "stored", with: cfg)
+
+        // Live state and current-profile tracking are untouched.
+        #expect(core.profiles.currentName == "active")
+        #expect(!core.profiles.isDirty)
+        // The edit landed in the stored profile's JSON.
+        let read = try core.profiles.read(name: "stored")
+        #expect(read.settings.gapsGlobal == .uniform(42))
+        #expect(read.spaceModes[SpaceID(1)] == .grid)
+    }
+
+    @Test("overwriteProfile round-trips the Main role")
+    func overwriteRoundTripsMain() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute("save_profile", args: [.string("p")])
+
+        var cfg = try core.loadGuiConfig(editing: "p")
+        cfg.mainSpaces = [SpaceID(2)]
+        try core.overwriteProfile(named: "p", with: cfg)
+
+        let read = try core.profiles.read(name: "p")
+        #expect(read.mainSpaces == [SpaceID(2)])
+    }
+
+    @Test("overwriteProfile refreshes the matching set's pins")
+    func overwriteUpdatesMatchingSetPins() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute("save_profile", args: [.string("multi")])
+        // Same count, other monitor: a second stored set.
+        core.state.workspaces.removeDisplay(DisplayID(1))
+        connect(core, [display(2, "B")])
+        core.execute("save_profile", args: [.string("multi")])
+        // Reconnect A so the live monitors match the {A} set.
+        core.state.workspaces.removeDisplay(DisplayID(2))
+        connect(core, [display(1, "A")])
+
+        var cfg = try core.loadGuiConfig(editing: "multi")
+        cfg.spacePins[SpaceID(1)] = "A:100x100"
+        try core.overwriteProfile(named: "multi", with: cfg)
+
+        let read = try core.profiles.read(name: "multi")
+        #expect(read.monitorSets.count == 2)
+        let setA = read.set(matching: ["A:100x100"])
+        #expect(setA?.spaceMonitorMap[SpaceID(1)] == "A:100x100")
+    }
+
+    @Test("overwriteProfile injects no set for absent monitors")
+    func overwriteNeverInjectsLiveSet() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute("save_profile", args: [.string("single")])
+        // Live monitors (B) don't match the stored {A} set.
+        core.state.workspaces.removeDisplay(DisplayID(1))
+        connect(core, [display(2, "B")])
+
+        var cfg = try core.loadGuiConfig(editing: "single")
+        cfg.settings.gapsGlobal = .uniform(9)
+        try core.overwriteProfile(named: "single", with: cfg)
+
+        let read = try core.profiles.read(name: "single")
+        // The connected monitors were not grafted on.
+        #expect(read.monitorSets.count == 1)
+        #expect(read.set(matching: ["A:100x100"]) != nil)
+        #expect(read.set(matching: ["B:100x100"]) == nil)
+        #expect(read.settings.gapsGlobal == .uniform(9))
+    }
+
+    @Test("loadGuiConfig(editing:) overlays stored, not live")
+    func loadEditingReadsStoredTiling() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute("set_gap_global", args: [.number(30)])
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("grid")]
+        )
+        core.execute("save_profile", args: [.string("p")])
+        // Diverge the live layout after saving.
+        core.execute("set_gap_global", args: [.number(2)])
+
+        let cfg = try core.loadGuiConfig(editing: "p")
+        // Reflects the profile's saved tiling, not live's gap 2.
+        #expect(cfg.settings.gapsGlobal == .uniform(30))
+        #expect(cfg.spaceModes[SpaceID(1)] == .grid)
+    }
+
+    @Test("isProfileInEffect true only for the active profile")
+    func inEffectPredicate() {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute("save_profile", args: [.string("cur")])
+        #expect(core.isProfileInEffect("cur"))
+        #expect(!core.isProfileInEffect("other"))
+    }
+
+    @Test("reapplyIfInEffect hot-reloads the active profile")
+    func reapplyActive() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute("set_gap_global", args: [.number(30)])
+        core.execute("save_profile", args: [.string("cur")])
+
+        var cfg = try core.loadGuiConfig(editing: "cur")
+        cfg.settings.gapsGlobal = .uniform(50)
+        try core.overwriteProfile(named: "cur", with: cfg)
+        // The JSON changed but live state is still the old gap.
+        #expect(core.tiler.settings.gapsGlobal == .uniform(30))
+
+        core.reapplyIfInEffect("cur")
+        #expect(core.tiler.settings.gapsGlobal == .uniform(50))
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ProfileEditTests.swift
+++ b/Tests/KiwiDeskCoreTests/ProfileEditTests.swift
@@ -151,6 +151,77 @@ struct ProfileEditTests {
         #expect(!core.isProfileInEffect("other"))
     }
 
+    @Test("reapplyIfInEffect leaves an idle profile's live state")
+    func reapplyIdleIsNoop() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute("set_gap_global", args: [.number(30)])
+        core.execute("save_profile", args: [.string("stored")])
+        core.execute("save_profile", args: [.string("active")])
+        // "active" is current; live gap is 30.
+        var cfg = try core.loadGuiConfig(editing: "stored")
+        cfg.settings.gapsGlobal = .uniform(77)
+        try core.overwriteProfile(named: "stored", with: cfg)
+
+        // "stored" is not on screen — no live reapply.
+        core.reapplyIfInEffect("stored")
+        #expect(core.tiler.settings.gapsGlobal == .uniform(30))
+    }
+
+    @Test("Editing a profile never grafts live-only spaces")
+    func editKeepsOwnSpaceSet() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("grid")]
+        )
+        core.execute("save_profile", args: [.string("small")])
+        #expect(
+            try core.profiles.read(name: "small")
+                .spaceModes[SpaceID(9)] == nil
+        )
+        // A live-only space 9 appears; another profile is active.
+        core.execute(
+            "set_mode",
+            args: [.string("9"), .string("stack")]
+        )
+        core.execute("save_profile", args: [.string("live")])
+
+        var cfg = try core.loadGuiConfig(editing: "small")
+        cfg.settings.gapsGlobal = .uniform(5)
+        try core.overwriteProfile(named: "small", with: cfg)
+
+        let after = try core.profiles.read(name: "small")
+        #expect(after.spaceModes[SpaceID(9)] == nil)
+        #expect(after.settings.gapsGlobal == .uniform(5))
+    }
+
+    @Test("Editing an absent-monitor profile drops stray pins")
+    func absentMonitorDropsPins() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+        core.execute("save_profile", args: [.string("deskA")])
+        // Live monitors change to B: deskA's {A} set won't match.
+        core.state.workspaces.removeDisplay(DisplayID(1))
+        connect(core, [display(2, "B")])
+
+        var cfg = try core.loadGuiConfig(editing: "deskA")
+        // No matching set → no pins come back for editing.
+        #expect(cfg.spacePins.isEmpty)
+        // Even a stray pin is dropped: {A} untouched, no {B} set.
+        cfg.spacePins[SpaceID(1)] = "B:100x100"
+        try core.overwriteProfile(named: "deskA", with: cfg)
+
+        let after = try core.profiles.read(name: "deskA")
+        #expect(after.monitorSets.count == 1)
+        #expect(after.set(matching: ["B:100x100"]) == nil)
+        #expect(
+            after.set(matching: ["A:100x100"])?
+                .spaceMonitorMap[SpaceID(1)] == nil
+        )
+    }
+
     @Test("reapplyIfInEffect hot-reloads the active profile")
     func reapplyActive() throws {
         let core = makeCore()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -880,6 +880,34 @@ Both also regenerate `init.lua`/`gui.json` when a global
 setting (keybindings, app/float rules, Space bindings)
 changed — a tiling-only edit touches only the profile JSON.
 
+### Editing a saved profile (not just the active one)
+
+The banner title is a **dropdown**. It defaults to the
+live/loaded config (marked *(currently loaded)*), but you can
+pick any saved profile and edit it **in place** — without
+switching the running layout. Selecting the loaded profile
+returns to normal live editing.
+
+Because a profile stores tiling only, editing a *non-loaded*
+one is scoped to what a profile actually holds: the
+**General**, **Spaces**, **App Bar**, and **Canvas** tabs.
+The **Shortcuts** and **App Rules** tabs are hidden — those
+are global, shared across every profile, not per-profile
+settings. The footer collapses to a single **Save to
+"\<profile\>"**.
+
+Saving writes only that profile's JSON. It hot-reloads the
+live layout **only if the profile you edited is the one on
+screen** (the loaded profile, or the profile bound to the
+active native Space); otherwise the change simply waits until
+the profile is next loaded. No global files are regenerated.
+
+The **Canvas** tab needs the profile's monitors attached to
+draw them, so when you edit a profile whose monitor setup
+isn't connected, Canvas shows a read-only note instead of the
+placement grid — the other tabs still edit that profile.
+Connect its monitors to arrange space placement.
+
 ### Native macOS Spaces (Mission Control)
 
 KiwiDesk's spaces above are *virtual* workspaces, independent

--- a/scripts/kiwidesk-review-context.md
+++ b/scripts/kiwidesk-review-context.md
@@ -23,7 +23,10 @@ raise findings against thresholds the project has not adopted.
   Flag any tree/container structure creeping into state or layout.
 - **Private APIs:** SkyLight/CGS symbols resolve via `dlsym`, never
   `@_silgen_name`. Every private fast path MUST have a public-AX
-  fallback. Flag a linked private symbol or a missing fallback.
+  fallback. Flag a linked **SkyLight/CGS** symbol or a missing
+  fallback. (The one sanctioned `@_silgen_name` is
+  `_AXUIElementGetWindow` in `AX/AXHelper.swift` — a stable AX
+  symbol, not SkyLight/CGS; do not flag it.)
 - **Never disable SIP** or suggest the user do so.
 - **Lua watchdog can't interrupt blocking C.** Flag any new API
   that blocks in C on the main thread (`system()`, pipe reads) —


### PR DESCRIPTION
## Description

Adds a **dropdown** to the dashboard banner that lets you pick *any*
saved profile and edit it in place — **without switching the running
layout** (edit-without-activating). It defaults to the live/loaded
config, marked *(currently loaded)*.

Because a `Profile` stores tiling only (settings, space modes, main
role, monitor sets/pins) — never keybindings or app rules, which are
global — editing a non-loaded profile is scoped to what a profile
actually holds (**Model A**): the General / Spaces / App Bar / Canvas
tabs. Shortcuts + App Rules are hidden while editing a stored profile.

Design decisions (confirmed with the maintainer):
- **Model A** — scope the editor to profile-held tabs, hide the
  global ones, rather than expanding profiles to store everything.
- **Canvas fallback** — the Canvas renders live `Display` geometry,
  so when the edited profile's monitors aren't connected it shows a
  read-only note instead of the placement grid (synthetic tiles were
  rejected: a profile can hold several monitor-set groups).

### Core seam
- `ProfileManager.write` promoted private→internal: the non-adopting
  JSON write (`save()` adopts; edit-without-activating must not).
- `KiwiCore.overwriteProfile(named:with:)` — writes an edited
  `GuiConfig` into a stored profile's JSON, touching neither
  current/dirty nor live state; refreshes the live monitor set's pins
  only when the profile already covers the connected monitors.
- `KiwiCore.loadGuiConfig(editing:)` + `overlayProfileState` — map a
  stored `Profile` into an editable `GuiConfig` (globals from the
  sidecar/seed, tiling from the profile).
- `isProfileInEffect` / `reapplyIfInEffect` — hot-reload the edit
  only when that profile is the layout on screen.

### GUI
- `SettingsModel.editingProfile` drives a second reload path;
  `savedSidecar` cleared so a stored-profile save never regenerates
  gui.json/init.lua.
- `ProfileSyncBanner` (split into its own file) hosts the picker with
  a discard-unsaved-edits confirm; footer swaps to `Save to "<name>"`.
- `CanvasTab` placeholder + `GeneralTab` Advanced/raw-Lua block hidden
  in edit mode.

## Related Issue(s)

Closes #18. Follow-up structural refactor tracked in #64 (collapse the
edit target into an explicit `EditTarget` enum).

## Checklist

- [x] I understand what this change does and have run it in the app —
  see "How I verified" (automated gate + two review rounds; a manual
  GUI click-through is still recommended)
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested (`Tests/KiwiDeskCoreTests/ProfileEditTests.swift`)
- [x] User-facing changes are documented (`docs/configuration.md`)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && scripts/lint.sh` passes (381 tests)
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated (enum refactor deferred to #64)

## How I verified

- Full gate green: `swift build`, `swift test` (381 tests, incl. 10 in
  the new `ProfileEditTests` suite), `scripts/lint.sh`, and the
  mandatory `swift build -c release`.
- New tests pin the core invariants: non-adopting write; tiling / Main
  round-trip; matching-set pin refresh; **no** live set injected for
  absent monitors; idle reapply is a no-op on live tiling; a profile
  keeps its own space set across load→edit→save; absent-monitor edit
  drops stray pins.
- Reviewed by `code-reviewer` + `architect-reviewer` (parallel first
  round), fixes applied in `8a2cf47`, then a focused fix-range
  re-review returned clean.
- manual GUI click-through of the
  dropdown in the running settings app — recommend a quick pass
  (pick a non-loaded profile → confirm Shortcuts/App Rules hidden,
  Canvas placeholder when its monitors are absent, Save writes only
  that profile's JSON without switching the live layout).

## Notes for Reviewer

The GUI edit-mode logic is a `String?` with two reload paths; the
round-1 review surfaced two drift defects there (raw-Lua-editor leak,
stale `placementEditable`) — both fixed. The structural fix that
removes the *class* (an `EditTarget` enum with one reset-everything
reload) is intentionally deferred to #64 to keep this PR focused.