### PR TITLE
feat(bar): one app bar per display (#16)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+AppBar.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+AppBar.swift
@@ -1,25 +1,86 @@
 import AppKit
 
-/// Keeps the indicator bar in sync with the active space. Driven
-/// from `retile()`, which already fires on every structural,
-/// focus, mode, and settings change. Any layout that hosts a bar
-/// (monocle, scrolling) drives the one shared overlay; the bar's
-/// look is the global `AppBarStyle` overlaid by that layout's own
-/// overrides.
+/// Keeps the indicator bars in sync with the spaces on screen.
+/// Driven from `retile()`, which already fires on every
+/// structural, focus, mode, and settings change. One bar per
+/// display (#16): each display shows the bar of the space
+/// currently visible on it, resolved through the total
+/// space→display assignment (`resolveSpaceDisplays`). Any layout
+/// that hosts a bar (monocle, scrolling) drives its display's
+/// overlay; the bar's look is the global `AppBarStyle` overlaid
+/// by that layout's own overrides.
 extension KiwiCore {
     func updateAppBar() {
         let settings = tiler.settings
+        let displays = state.workspaces.allDisplays
+        // Before displays are tracked (cold start) fall back to
+        // the active space on the main screen — the pre-#16
+        // single-bar behavior.
+        guard !displays.isEmpty else {
+            appBars.sync(mainScreenFallback(settings: settings))
+            return
+        }
+        let bars = displays.compactMap {
+            bar(for: $0, settings: settings)
+        }
+        appBars.sync(bars)
+    }
+
+    /// The bar for the space currently shown on `display`, or nil
+    /// when that space hosts no enabled, non-empty bar.
+    private func bar(
+        for display: Display,
+        settings: TilingSettings
+    ) -> AppBarManager.Bar? {
+        guard
+            let id = state.workspaces.currentSpace(on: display.id),
+            let space = state.workspaces[id],
+            let host = barHost(for: space.mode),
+            host.appBar.enabled,
+            let screen = screen(for: display.id)
+        else { return nil }
+        return buildBar(
+            space: space,
+            display: display.id,
+            bounds: GeometryUtils.axVisibleFrame(of: screen),
+            host: host,
+            settings: settings
+        )
+    }
+
+    /// Single bar for the active space on the main screen, used
+    /// only until the display list is populated.
+    private func mainScreenFallback(
+        settings: TilingSettings
+    ) -> [AppBarManager.Bar] {
         guard let space = activeSpace,
             let host = barHost(for: space.mode),
             host.appBar.enabled,
-            let screen = NSScreen.main ?? NSScreen.screens.first
-        else {
-            appBar.hide()
-            return
-        }
+            let screen = NSScreen.main ?? NSScreen.screens.first,
+            let bar = buildBar(
+                space: space,
+                display: screen.kiwiDisplay?.id
+                    ?? DisplayID(CGMainDisplayID()),
+                bounds: GeometryUtils.axVisibleFrame(of: screen),
+                host: host,
+                settings: settings
+            )
+        else { return [] }
+        return [bar]
+    }
+
+    /// Assembles one display's bar from its space and usable
+    /// bounds; nil when the space has no items or the bar is off.
+    private func buildBar(
+        space: Space,
+        display: DisplayID,
+        bounds: CGRect,
+        host: AppBarHosting,
+        settings: TilingSettings
+    ) -> AppBarManager.Bar? {
         let style = host.resolvedBar(global: settings.appBarStyle)
         let context = settings.context(
-            bounds: GeometryUtils.axVisibleFrame(of: screen),
+            bounds: bounds,
             space: space
         )
         let groups = barGroups(
@@ -31,11 +92,10 @@ extension KiwiCore {
                 in: context.usable,
                 global: settings.appBarStyle
             )
-        else {
-            appBar.hide()
-            return
-        }
-        appBar.show(
+        else { return nil }
+        return AppBarManager.Bar(
+            display: display,
+            space: space.id,
             items: groups.map(barItem),
             activeIndex: groups.firstIndex { group in
                 space.focused.map(group.contains) ?? false
@@ -43,6 +103,13 @@ extension KiwiCore {
             strip: strip,
             style: style
         )
+    }
+
+    /// The `NSScreen` backing a tracked display, matched by its
+    /// `CGDirectDisplayID`. Nil when the display is not currently
+    /// connected to a screen.
+    private func screen(for display: DisplayID) -> NSScreen? {
+        NSScreen.screens.first { $0.kiwiDisplay?.id == display }
     }
 
     /// The bar-hosting layout for a space mode, or nil for modes
@@ -55,86 +122,12 @@ extension KiwiCore {
         }
     }
 
-    /// The bar's items: the space's tiled windows in order,
-    /// with adjacent same-app runs collapsed into one group
-    /// while `grouping` is on. Same-app windows that are not
-    /// adjacent stay separate items.
-    ///
-    /// The group holding the focused window renders *expanded*
-    /// — its members become individual items, so after clicking
-    /// a group (which focuses its first member) any member can
-    /// be picked or dragged directly. Focus leaving the group
-    /// collapses it again.
-    func barGroups(
-        in space: Space,
-        grouping: Bool
-    ) -> [[WindowID]] {
-        let tiled = space.windows.filter {
-            state.windows[$0]?.isFloating == false
-        }
-        guard grouping else {
-            return tiled.map { [$0] }
-        }
-        let names = tiled.map {
-            state.windows[$0]?.appName ?? "?"
-        }
-        let runs = Self.adjacentRuns(of: names).map {
-            Array(tiled[$0])
-        }
-        return runs.flatMap { group -> [[WindowID]] in
-            let focusedInside =
-                space.focused.map(group.contains) ?? false
-            return focusedInside && group.count > 1
-                ? group.map { [$0] } : [group]
-        }
-    }
-
-    /// Runs of equal adjacent values:
-    /// ["Zed", "Zed", "Finder", "Zed"] ->
-    /// [0..<2, 2..<3, 3..<4] — the trailing Zed is not next
-    /// to the first two, so it stays its own run.
-    nonisolated static func adjacentRuns(
-        of names: [String]
-    ) -> [Range<Int>] {
-        var runs: [Range<Int>] = []
-        var start = 0
-        for index in names.indices
-        where index + 1 == names.count
-            || names[index + 1] != names[index]
-        {
-            runs.append(start..<(index + 1))
-            start = index + 1
-        }
-        return runs
-    }
-
-    private func barItem(
-        for group: [WindowID]
-    ) -> AppBarOverlay.Item {
-        let window = group.first.flatMap {
-            state.windows[$0]
-        }
-        // Clicking a collapsed group focuses its first
-        // member; the resulting re-render expands the group
-        // into individual items (see barGroups).
-        return AppBarOverlay.Item(
-            id: group.first ?? WindowID(0),
-            name: window?.appName ?? "?",
-            icon: window.flatMap {
-                NSRunningApplication(
-                    processIdentifier: $0.pid
-                )?.icon
-            },
-            count: group.count
-        )
-    }
-
     /// Drag-and-drop reorder from the bar: moves the item at
     /// slot `from` (a single window or a whole group) to slot
-    /// `to`, rewriting the tiled order in place — floating
-    /// windows keep their positions in the flat array.
-    func moveBarItem(from: Int, to: Int) {
-        guard let space = activeSpace,
+    /// `to` within `space`, rewriting the tiled order in place —
+    /// floating windows keep their positions in the flat array.
+    func moveBarItem(space id: SpaceID, from: Int, to: Int) {
+        guard let space = state.workspaces[id],
             let host = barHost(for: space.mode)
         else { return }
         let style = host.resolvedBar(

--- a/Sources/KiwiDeskCore/App/KiwiCore+AppBar.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+AppBar.swift
@@ -13,9 +13,16 @@ extension KiwiCore {
     func updateAppBar() {
         let settings = tiler.settings
         let displays = state.workspaces.allDisplays
-        // Before displays are tracked (cold start) fall back to
-        // the active space on the main screen — the pre-#16
-        // single-bar behavior.
+        // Cold start: `loadConfig()` can apply a profile and
+        // retile before `eventLoop.start()` publishes the
+        // displays, so `allDisplays` is briefly empty while a
+        // bar-hosting space is already active. Fall back to the
+        // active space on the main screen — the pre-#16
+        // single-bar behavior — until the display list seeds.
+        // Once seeded, an active space that resolves to no
+        // display (so `resolveSpaceDisplays` never assigned it)
+        // shows no bar; in the normal flow resolution always
+        // assigns it first.
         guard !displays.isEmpty else {
             appBars.sync(mainScreenFallback(settings: settings))
             return

--- a/Sources/KiwiDeskCore/App/KiwiCore+AppBarGroups.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+AppBarGroups.swift
@@ -1,0 +1,81 @@
+import AppKit
+
+/// Building a bar's items from a space's windows: the tiled
+/// windows in order, with adjacent same-app runs optionally
+/// collapsed into groups. Shared by the per-display driver
+/// (`KiwiCore+AppBar`) and the drag reorder.
+extension KiwiCore {
+    /// The bar's items: the space's tiled windows in order,
+    /// with adjacent same-app runs collapsed into one group
+    /// while `grouping` is on. Same-app windows that are not
+    /// adjacent stay separate items.
+    ///
+    /// The group holding the focused window renders *expanded*
+    /// — its members become individual items, so after clicking
+    /// a group (which focuses its first member) any member can
+    /// be picked or dragged directly. Focus leaving the group
+    /// collapses it again.
+    func barGroups(
+        in space: Space,
+        grouping: Bool
+    ) -> [[WindowID]] {
+        let tiled = space.windows.filter {
+            state.windows[$0]?.isFloating == false
+        }
+        guard grouping else {
+            return tiled.map { [$0] }
+        }
+        let names = tiled.map {
+            state.windows[$0]?.appName ?? "?"
+        }
+        let runs = Self.adjacentRuns(of: names).map {
+            Array(tiled[$0])
+        }
+        return runs.flatMap { group -> [[WindowID]] in
+            let focusedInside =
+                space.focused.map(group.contains) ?? false
+            return focusedInside && group.count > 1
+                ? group.map { [$0] } : [group]
+        }
+    }
+
+    /// Runs of equal adjacent values:
+    /// ["Zed", "Zed", "Finder", "Zed"] ->
+    /// [0..<2, 2..<3, 3..<4] — the trailing Zed is not next
+    /// to the first two, so it stays its own run.
+    nonisolated static func adjacentRuns(
+        of names: [String]
+    ) -> [Range<Int>] {
+        var runs: [Range<Int>] = []
+        var start = 0
+        for index in names.indices
+        where index + 1 == names.count
+            || names[index + 1] != names[index]
+        {
+            runs.append(start..<(index + 1))
+            start = index + 1
+        }
+        return runs
+    }
+
+    func barItem(
+        for group: [WindowID]
+    ) -> AppBarOverlay.Item {
+        let window = group.first.flatMap {
+            state.windows[$0]
+        }
+        // Clicking a collapsed group focuses its first
+        // member; the resulting re-render expands the group
+        // into individual items (see barGroups).
+        return AppBarOverlay.Item(
+            id: group.first ?? WindowID(0),
+            name: window?.appName ?? "?",
+            icon: window.flatMap {
+                NSRunningApplication(
+                    processIdentifier: $0.pid
+                )?.icon
+            },
+            count: group.count
+        )
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -14,7 +14,7 @@ public final class KiwiCore {
     public let keys = KeybindingManager()
     public let drag = DragCoordinator()
     public let dragOverlay = DragOverlay()
-    public let appBar = AppBarOverlay()
+    public let appBars = AppBarManager()
     public let mouse = MouseTracker()
     public let profiles: ProfileManager
     public let crash: CrashRecovery
@@ -121,11 +121,11 @@ public final class KiwiCore {
             self?.onLog(message)
         }
         wireDrag()
-        appBar.onSelect = { [weak self] id in
+        appBars.onSelect = { [weak self] id in
             self?.focusWindow(id)
         }
-        appBar.onMove = { [weak self] from, to in
-            self?.moveBarItem(from: from, to: to)
+        appBars.onMove = { [weak self] space, from, to in
+            self?.moveBarItem(space: space, from: from, to: to)
         }
         tiler.animation.onAllAnimationsEnded = { [weak self] in
             self?.runPendingZOrderRestore()

--- a/Sources/KiwiDeskCore/Bar/AppBarManager.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarManager.swift
@@ -1,0 +1,111 @@
+import AppKit
+
+/// One app bar per display (#16). Owns an `AppBarOverlay` keyed by
+/// `DisplayID`, so several monitors can each show the bar of the
+/// space currently visible on them at the same time. The driver
+/// (`KiwiCore.updateAppBar`) computes the bars; this manager just
+/// creates, shows, and retires overlays and routes their callbacks.
+@MainActor
+public final class AppBarManager {
+    /// One display's resolved bar. `space` rides along so a drag
+    /// on that bar reorders the right space (not the global
+    /// active one) — displays other than the focused one host
+    /// their own space's bar.
+    public struct Bar {
+        public let display: DisplayID
+        public let space: SpaceID
+        public let items: [AppBarOverlay.Item]
+        public let activeIndex: Int?
+        public let strip: CGRect
+        public let style: AppBarStyle
+
+        public init(
+            display: DisplayID,
+            space: SpaceID,
+            items: [AppBarOverlay.Item],
+            activeIndex: Int?,
+            strip: CGRect,
+            style: AppBarStyle
+        ) {
+            self.display = display
+            self.space = space
+            self.items = items
+            self.activeIndex = activeIndex
+            self.strip = strip
+            self.style = style
+        }
+    }
+
+    /// Click-to-focus hook; wired to `KiwiCore.focusWindow`.
+    public var onSelect: @MainActor (WindowID) -> Void = { _ in }
+    /// Drag reorder hook (space, from slot, to slot); wired to
+    /// `KiwiCore.moveBarItem`. The space is the one whose bar the
+    /// dragged overlay is currently showing.
+    public var onMove: @MainActor (SpaceID, Int, Int) -> Void = {
+        _,
+        _,
+        _ in
+    }
+
+    private var overlays: [DisplayID: AppBarOverlay] = [:]
+    private var spaceOfDisplay: [DisplayID: SpaceID] = [:]
+
+    public init() {}
+
+    /// Displays currently showing a bar; the manager's contract
+    /// surface for tests and diagnostics.
+    public var shownDisplays: Set<DisplayID> {
+        Set(spaceOfDisplay.keys)
+    }
+
+    /// Shows exactly `bars` — one per display — and hides the
+    /// overlays of any display no longer in the set.
+    public func sync(_ bars: [Bar]) {
+        let wanted = Set(bars.map(\.display))
+        for (id, overlay) in overlays where !wanted.contains(id) {
+            overlay.hide()
+            spaceOfDisplay[id] = nil
+        }
+        for bar in bars {
+            let overlay = overlay(for: bar.display)
+            spaceOfDisplay[bar.display] = bar.space
+            overlay.show(
+                items: bar.items,
+                activeIndex: bar.activeIndex,
+                strip: bar.strip,
+                style: bar.style
+            )
+        }
+    }
+
+    /// Hides every bar (no display hosts one right now).
+    public func hideAll() {
+        for overlay in overlays.values { overlay.hide() }
+        spaceOfDisplay.removeAll()
+    }
+
+    #if DEBUG
+        /// Test seam: the overlay currently backing a display.
+        func overlayForTesting(
+            _ display: DisplayID
+        ) -> AppBarOverlay? {
+            overlays[display]
+        }
+    #endif
+
+    private func overlay(for display: DisplayID) -> AppBarOverlay {
+        if let existing = overlays[display] { return existing }
+        let overlay = AppBarOverlay()
+        overlay.onSelect = { [weak self] id in
+            self?.onSelect(id)
+        }
+        overlay.onMove = { [weak self] from, to in
+            guard let self,
+                let space = self.spaceOfDisplay[display]
+            else { return }
+            self.onMove(space, from, to)
+        }
+        overlays[display] = overlay
+        return overlay
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/AppBarManager.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarManager.swift
@@ -58,15 +58,28 @@ public final class AppBarManager {
         Set(spaceOfDisplay.keys)
     }
 
-    /// Shows exactly `bars` — one per display — and hides the
-    /// overlays of any display no longer in the set.
+    /// Shows exactly `bars` — one per display — and retires the
+    /// overlays of any display no longer in the set (passing an
+    /// empty array retires them all). Retiring releases the
+    /// panel, so a display that never returns leaves nothing
+    /// behind.
     public func sync(_ bars: [Bar]) {
-        let wanted = Set(bars.map(\.display))
+        // A bar whose strip/items can't render is treated as
+        // absent — AppBarOverlay.show would hide it anyway — so
+        // its display retires instead of keeping a stale panel,
+        // and the "shown" bookkeeping (and thus onMove routing)
+        // never claims a display whose panel is hidden.
+        let valid = bars.filter {
+            !$0.items.isEmpty
+                && $0.strip.width >= 1 && $0.strip.height >= 1
+        }
+        let wanted = Set(valid.map(\.display))
         for (id, overlay) in overlays where !wanted.contains(id) {
             overlay.hide()
+            overlays[id] = nil
             spaceOfDisplay[id] = nil
         }
-        for bar in bars {
+        for bar in valid {
             let overlay = overlay(for: bar.display)
             spaceOfDisplay[bar.display] = bar.space
             overlay.show(
@@ -76,12 +89,6 @@ public final class AppBarManager {
                 style: bar.style
             )
         }
-    }
-
-    /// Hides every bar (no display hosts one right now).
-    public func hideAll() {
-        for overlay in overlays.values { overlay.hide() }
-        spaceOfDisplay.removeAll()
     }
 
     #if DEBUG

--- a/Sources/KiwiDeskCore/State/WorkspaceManager.swift
+++ b/Sources/KiwiDeskCore/State/WorkspaceManager.swift
@@ -150,4 +150,18 @@ public struct WorkspaceManager: Sendable {
     public func spaces(on display: DisplayID) -> [SpaceID] {
         order.filter { spaceDisplay[$0] == display }
     }
+
+    /// The space a display currently shows: the globally active
+    /// space when it is assigned to this display, otherwise the
+    /// first space assigned to it (creation order). Nil when no
+    /// space is assigned. Drives the per-display app bar (#16);
+    /// the composed layouts give each secondary display exactly
+    /// one space, so the first-assigned fallback is the visible
+    /// one there and the active space covers the main display.
+    public func currentSpace(on display: DisplayID) -> SpaceID? {
+        if let active = activeSpace, spaceDisplay[active] == display {
+            return active
+        }
+        return spaces(on: display).first
+    }
 }

--- a/Tests/KiwiDeskCoreTests/AppBarManagerTests.swift
+++ b/Tests/KiwiDeskCoreTests/AppBarManagerTests.swift
@@ -1,0 +1,80 @@
+import AppKit
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+@Suite("App bar manager (per-display)", .serialized)
+@MainActor
+struct AppBarManagerTests {
+    private func bar(
+        display: UInt32,
+        space: String
+    ) -> AppBarManager.Bar {
+        AppBarManager.Bar(
+            display: DisplayID(display),
+            space: SpaceID(space),
+            items: [
+                AppBarOverlay.Item(
+                    id: WindowID(1),
+                    name: "A",
+                    icon: nil
+                )
+            ],
+            activeIndex: 0,
+            strip: CGRect(x: 0, y: 0, width: 100, height: 32),
+            style: AppBarStyle()
+        )
+    }
+
+    @Test("sync tracks one shown bar per display")
+    func syncTracksDisplays() {
+        let manager = AppBarManager()
+        manager.sync([
+            bar(display: 1, space: "1"),
+            bar(display: 2, space: "web"),
+        ])
+        #expect(
+            manager.shownDisplays == [DisplayID(1), DisplayID(2)]
+        )
+    }
+
+    @Test("a display dropped from sync stops showing its bar")
+    func dropRetiresDisplay() {
+        let manager = AppBarManager()
+        manager.sync([
+            bar(display: 1, space: "1"),
+            bar(display: 2, space: "web"),
+        ])
+        manager.sync([bar(display: 1, space: "1")])
+        #expect(manager.shownDisplays == [DisplayID(1)])
+    }
+
+    @Test("hideAll retires every bar")
+    func hideAllClears() {
+        let manager = AppBarManager()
+        manager.sync([bar(display: 1, space: "1")])
+        manager.hideAll()
+        #expect(manager.shownDisplays.isEmpty)
+    }
+
+    @Test("a drag routes to the bar's own space")
+    func moveRoutesToSpace() {
+        let manager = AppBarManager()
+        var moved: (SpaceID, Int, Int)?
+        manager.onMove = { space, from, to in
+            moved = (space, from, to)
+        }
+        // Two displays showing different spaces; the reorder
+        // hook must carry the space of the dragged display, not
+        // a global active one.
+        manager.sync([
+            bar(display: 1, space: "1"),
+            bar(display: 2, space: "web"),
+        ])
+        manager.overlayForTesting(DisplayID(2))?.onMove(0, 3)
+        #expect(moved?.0 == SpaceID("web"))
+        #expect(moved?.1 == 0)
+        #expect(moved?.2 == 3)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/AppBarManagerTests.swift
+++ b/Tests/KiwiDeskCoreTests/AppBarManagerTests.swift
@@ -50,11 +50,26 @@ struct AppBarManagerTests {
         #expect(manager.shownDisplays == [DisplayID(1)])
     }
 
-    @Test("hideAll retires every bar")
-    func hideAllClears() {
+    @Test("syncing an empty set retires every bar")
+    func emptySyncClears() {
         let manager = AppBarManager()
         manager.sync([bar(display: 1, space: "1")])
-        manager.hideAll()
+        manager.sync([])
+        #expect(manager.shownDisplays.isEmpty)
+    }
+
+    @Test("a degenerate strip retires rather than claims a bar")
+    func degenerateStripNotShown() {
+        let manager = AppBarManager()
+        let empty = AppBarManager.Bar(
+            display: DisplayID(1),
+            space: SpaceID("1"),
+            items: [],
+            activeIndex: nil,
+            strip: .zero,
+            style: AppBarStyle()
+        )
+        manager.sync([empty])
         #expect(manager.shownDisplays.isEmpty)
     }
 

--- a/Tests/KiwiDeskCoreTests/AppBarTests.swift
+++ b/Tests/KiwiDeskCoreTests/AppBarTests.swift
@@ -311,7 +311,7 @@ struct AppBarCommandTests {
                 )
             )
         }
-        core.moveBarItem(from: 0, to: 2)
+        core.moveBarItem(space: SpaceID(1), from: 0, to: 2)
         #expect(core.activeSpace?.windows == [w2, w3, w1])
     }
 

--- a/Tests/KiwiDeskCoreTests/MonocleTests.swift
+++ b/Tests/KiwiDeskCoreTests/MonocleTests.swift
@@ -768,10 +768,10 @@ struct MonocleGroupingTests {
     @Test("Dragging an item reorders the window array")
     func moveSingle() {
         let core = makeNamedCore(["A", "B", "C"])
-        core.moveBarItem(from: 0, to: 2)
+        core.moveBarItem(space: SpaceID(1), from: 0, to: 2)
         #expect(core.activeSpace?.windows == [w2, w3, w1])
         // Out-of-range moves are ignored.
-        core.moveBarItem(from: 0, to: 9)
+        core.moveBarItem(space: SpaceID(1), from: 0, to: 9)
         #expect(core.activeSpace?.windows == [w2, w3, w1])
     }
 
@@ -779,7 +779,7 @@ struct MonocleGroupingTests {
     func moveGroup() {
         let core = makeNamedCore(["Zed", "Zed", "Finder"])
         // Items: [Zed ×2] [Finder] — swap their slots.
-        core.moveBarItem(from: 0, to: 1)
+        core.moveBarItem(space: SpaceID(1), from: 0, to: 1)
         #expect(core.activeSpace?.windows == [w3, w1, w2])
     }
 }

--- a/Tests/KiwiDeskCoreTests/StateTests.swift
+++ b/Tests/KiwiDeskCoreTests/StateTests.swift
@@ -83,6 +83,37 @@ struct WorkspaceManagerTests {
         manager.removeDisplay(display.id)
         #expect(manager.display(of: "code") == nil)
     }
+
+    @Test("currentSpace prefers the active space on a display")
+    func currentSpaceActive() {
+        var manager = WorkspaceManager()
+        let main = DisplayID(1)
+        let side = DisplayID(2)
+        // "web" first on side, then two on main; "main2" active.
+        manager.assign("web", to: side)
+        manager.assign("main1", to: main)
+        manager.assign("main2", to: main)
+        manager.activate("main2")
+        // The active space wins on its own display; the other
+        // display shows its first-assigned space.
+        #expect(manager.currentSpace(on: main) == "main2")
+        #expect(manager.currentSpace(on: side) == "web")
+    }
+
+    @Test("currentSpace falls back to the first assigned space")
+    func currentSpaceFallback() {
+        var manager = WorkspaceManager()
+        let side = DisplayID(2)
+        manager.assign("a", to: side)
+        manager.assign("b", to: side)
+        // Active space lives on another (untracked) display, so
+        // the side display shows its first-assigned space.
+        manager.assign("elsewhere", to: DisplayID(9))
+        manager.activate("elsewhere")
+        #expect(manager.currentSpace(on: side) == "a")
+        // No space assigned → nil.
+        #expect(manager.currentSpace(on: DisplayID(3)) == nil)
+    }
 }
 
 @Suite("StateCoordinator")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,11 @@ layouts where windows can hide each other (**monocle**) or
 scroll off-screen (**scrolling**) — so you always see what's
 there. Click an item to focus its window; drag to reorder.
 
+With **multiple monitors** each display shows its own bar for
+the space currently on it, all at once — a bar-hosting space on
+a secondary display draws its bar there, not on the main
+screen. Dragging an item reorders that display's own space.
+
 Its look is **global**: set it once with `app_bar.set_*` and
 every layout's bar shares it. Each layout then decides only
 whether it shows a bar and, if it wants, **overrides** any


### PR DESCRIPTION
## Summary

Closes #16. The app bar was a single overlay pinned to the main screen (`NSScreen.main`), so a bar-hosting space shown on a **secondary** display drew its bar on the main monitor, and two monitors couldn't each show a bar. This lands **one bar per display**, each showing the space currently visible on it, several at once.

## What changed

- **`AppBarManager`** (new, `Bar/`) — owns `[DisplayID: AppBarOverlay]`, `sync(_ bars:)` shows/retires overlays (releasing the panel on disconnect), and routes `onSelect` + `onMove(space, from, to)` so a drag reorders the dragged bar's *own* space.
- **`WorkspaceManager.currentSpace(on:)`** (new, pure) — the space a display shows: the active space when it's assigned there, else its first-assigned space. Reads only the total space→display assignment that `resolveSpaceDisplays()` already writes (no `space_monitor_map`/`NSScreen.main` reads).
- **`KiwiCore+AppBar` driver** — `updateAppBar()` iterates `allDisplays`, resolves each display's `NSScreen` (by `CGDirectDisplayID`) + current space, and builds that display's bar from its own screen bounds. A main-screen fallback preserves pre-#16 behavior during the cold-start window before displays seed. `moveBarItem` now takes an explicit `space:`.
- Grouping helpers extracted verbatim to **`KiwiCore+AppBarGroups`**. The `AppBarOverlay` view/renderer is unchanged.

## Tests

- `StateTests` — `currentSpace(on:)` active-vs-first-assigned, nil when unassigned.
- `AppBarManagerTests` — sync bookkeeping, drop-retires-display, empty-sync retirement, degenerate-strip guard, and per-space `onMove` routing (the multi-display drag hazard).
- Existing `moveBarItem` callers updated to pass the space.

## Review

Ran `code-reviewer` + `architect-reviewer` (AGENTS.md §3.6 first round, parallel). **No major findings.** Addressed the minors in `ad0c911`: release retired panels, harden the shown/onMove bookkeeping against a degenerate strip, drop the unused `hideAll()`, and justify the cold-start fallback. Architect flagged that #17 (space-tier bar resolution) must thread its override through `resolvedBar`/`barFrame`/`windowFrame` together — noted for that issue.

## Verify

`swift build` · `swift test` (388) · `scripts/lint.sh` · `swift build -c release` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)