### PR TITLE
feat(config): token-scoped foreign-code coexistence (#14)

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -21,6 +21,12 @@ final class SettingsModel: ObservableObject {
     @Published var luaSource = ""
     /// True while foreign Lua forces the raw editor.
     @Published var forcedLuaEditor = false
+    /// True when init.lua has harmless custom Lua outside the
+    /// managed block (code that doesn't touch managed
+    /// vocabulary). Shows the informational coexistence banner
+    /// in the visual editor. Always false when
+    /// `forcedLuaEditor` is true.
+    @Published var hasCustomLua = false
     /// User toggle to edit init.lua directly.
     @Published var showLuaEditor = false
     /// Unsaved GUI edits are pending.
@@ -117,6 +123,8 @@ final class SettingsModel: ObservableObject {
         config = loaded
         suppressDirty = false
         forcedLuaEditor = core.configHasForeignCode
+        hasCustomLua =
+            !forcedLuaEditor && core.configHasCustomCode
         luaSource =
             (try? String(
                 contentsOf: configURL,
@@ -157,6 +165,7 @@ final class SettingsModel: ObservableObject {
         // raw Lua editor — leaving it on would let a global
         // init.lua write escape edit mode.
         forcedLuaEditor = false
+        hasCustomLua = false
         showLuaEditor = false
         savedSidecar = nil
         let live = displays.map(\.fingerprint)

--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -122,14 +122,14 @@ final class SettingsModel: ObservableObject {
         KeybindingImportClassifier.classify(&loaded)
         config = loaded
         suppressDirty = false
-        forcedLuaEditor = core.configHasForeignCode
-        hasCustomLua =
-            !forcedLuaEditor && core.configHasCustomCode
         luaSource =
             (try? String(
                 contentsOf: configURL,
                 encoding: .utf8
             )) ?? ""
+        let flags = ManagedConfig.classify(luaSource)
+        forcedLuaEditor = flags.foreign
+        hasCustomLua = !flags.foreign && flags.custom
         // Baseline for `globalsChanged`: the *overlaid* model,
         // not the raw sidecar — live profile state merged in
         // (e.g. composed monocle-fill spaces in the spaces

--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -22,64 +22,74 @@ struct SettingsView: View {
         if model.editingLua {
             LuaEditorTab(model: model)
         } else {
-            TabView {
-                PresetsTab(model: model)
-                    .tabItem {
-                        Label(
-                            "Presets",
-                            systemImage: "square.grid.2x2"
-                        )
-                    }
-                GeneralTab(model: model)
-                    .tabItem {
-                        Label(
-                            "General",
-                            systemImage: "gearshape"
-                        )
-                    }
-                CanvasTab(model: model)
-                    .tabItem {
-                        Label(
-                            "Canvas",
-                            systemImage: "rectangle.on.rectangle"
-                        )
-                    }
-                SpacesTab(model: model)
-                    .tabItem {
-                        Label(
-                            "Spaces",
-                            systemImage: "rectangle.split.3x1"
-                        )
-                    }
-                AppBarTab(model: model)
-                    .tabItem {
-                        Label(
-                            "App Bar",
-                            systemImage: "menubar.rectangle"
-                        )
-                    }
-                // Shortcuts and App Rules are global, not part of
-                // any profile (Model A) — hidden while editing a
-                // stored profile (#18).
-                if !model.editingStoredProfile {
-                    AppRulesTab(model: model)
-                        .tabItem {
-                            Label(
-                                "App Rules",
-                                systemImage: "app.badge"
-                            )
-                        }
-                    KeybindingsTab(model: model)
-                        .tabItem {
-                            Label(
-                                "Shortcuts",
-                                systemImage: "keyboard"
-                            )
-                        }
+            VStack(spacing: 0) {
+                if model.hasCustomLua {
+                    CustomLuaBanner()
+                        .padding(.horizontal, 12)
+                        .padding(.top, 10)
+                    Divider()
                 }
+                TabView {
+                    PresetsTab(model: model)
+                        .tabItem {
+                            Label(
+                                "Presets",
+                                systemImage: "square.grid.2x2"
+                            )
+                        }
+                    GeneralTab(model: model)
+                        .tabItem {
+                            Label(
+                                "General",
+                                systemImage: "gearshape"
+                            )
+                        }
+                    CanvasTab(model: model)
+                        .tabItem {
+                            Label(
+                                "Canvas",
+                                systemImage:
+                                    "rectangle.on.rectangle"
+                            )
+                        }
+                    SpacesTab(model: model)
+                        .tabItem {
+                            Label(
+                                "Spaces",
+                                systemImage:
+                                    "rectangle.split.3x1"
+                            )
+                        }
+                    AppBarTab(model: model)
+                        .tabItem {
+                            Label(
+                                "App Bar",
+                                systemImage: "menubar.rectangle"
+                            )
+                        }
+                    // Shortcuts and App Rules are global, not
+                    // part of any profile (Model A) — hidden
+                    // while editing a stored profile (#18).
+                    if !model.editingStoredProfile {
+                        AppRulesTab(model: model)
+                            .tabItem {
+                                Label(
+                                    "App Rules",
+                                    systemImage: "app.badge"
+                                )
+                            }
+                        KeybindingsTab(model: model)
+                            .tabItem {
+                                Label(
+                                    "Shortcuts",
+                                    systemImage: "keyboard"
+                                )
+                            }
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
             }
-            .padding(.horizontal, 12)
-            .padding(.top, 10)
         }
     }
 }

--- a/Sources/KiwiDesk/Settings/Tabs/CustomLuaBanner.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/CustomLuaBanner.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Informational banner shown in the visual editor when
+/// `init.lua` contains custom Lua outside the managed block
+/// that does NOT touch the GUI's managed vocabulary (app rules,
+/// keybindings, etc.). Such code coexists safely — it is
+/// preserved verbatim on every save and has no conflict with
+/// what the visual editor writes.
+struct CustomLuaBanner: View {
+    var body: some View {
+        Label {
+            Text(
+                "This config also has custom Lua outside "
+                    + "the managed block. It doesn\u{2019}t "
+                    + "conflict with the visual editor and is "
+                    + "preserved on every save."
+            )
+        } icon: {
+            Image(systemName: "info.circle")
+                .foregroundStyle(.blue)
+        }
+        .font(.callout)
+        .foregroundStyle(.secondary)
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -144,7 +144,12 @@ extension KiwiCore {
     }
 
     /// Whether `init.lua` holds code outside the managed block
-    /// (so the visual editor can't safely own the file).
+    /// that touches the managed vocabulary — verbs the GUI
+    /// itself generates. When true the visual editor cannot
+    /// safely co-own the file and falls back to raw Lua mode.
+    /// Harmless custom Lua (e.g. `print`, sketchybar hooks)
+    /// does NOT set this; use `configHasCustomCode` for the
+    /// informational banner.
     public var configHasForeignCode: Bool {
         guard
             let source = try? String(
@@ -153,6 +158,22 @@ extension KiwiCore {
             )
         else { return false }
         return ManagedConfig.hasForeignCode(source)
+    }
+
+    /// Whether `init.lua` holds any non-blank, non-comment Lua
+    /// outside the managed block (including harmless code that
+    /// does not touch managed vocabulary). Used to show the
+    /// "you also have custom Lua" banner in the visual editor.
+    /// Always `false` when `configHasForeignCode` is `true`
+    /// (the raw editor is shown instead of the banner).
+    public var configHasCustomCode: Bool {
+        guard
+            let source = try? String(
+                contentsOf: configURL,
+                encoding: .utf8
+            )
+        else { return false }
+        return ManagedConfig.hasCustomCode(source)
     }
 
     /// Persists the model and applies it: writes `gui.json`,

--- a/Sources/KiwiDeskCore/Config/ManagedConfig.swift
+++ b/Sources/KiwiDeskCore/Config/ManagedConfig.swift
@@ -20,18 +20,30 @@ public enum ManagedConfig {
 
     // MARK: - Managed vocabulary
 
-    /// Token substrings that appear in the GUI's generated
-    /// managed block (derived from `LuaConfigWriter`). Code
-    /// outside the block that contains one of these tokens
-    /// forces the raw editor — the GUI cannot safely own
-    /// the file when the same vocabulary appears in both
-    /// regions. Harmless custom Lua (none of these tokens)
-    /// coexists with the visual editor instead.
+    /// Tokens matched against non-comment lines outside the
+    /// managed block (see `touchesManagedVocabulary`). A
+    /// match forces the raw editor because the GUI cannot
+    /// safely co-own that vocabulary. Harmless custom Lua
+    /// (no matching token) coexists with the visual editor.
+    ///
+    /// Matching rules (see `lineMatchesToken`):
+    /// - Tokens ending with `(` (method calls): optional
+    ///   whitespace before `(` is collapsed first, so
+    ///   `KiwiDesk.bind (` also matches `KiwiDesk.bind(`.
+    /// - Bare-identifier tokens (`app_rules`, `float_rules`):
+    ///   require a word boundary and `\s*=` after the token
+    ///   so a substring inside a longer identifier
+    ///   (`app_rules_count`) or a string literal
+    ///   (`"app_rules"`) does not match.
+    ///
+    /// Known limitation: receiver aliasing
+    /// (`local K = KiwiDesk; K.bind(…)`) escapes detection.
+    /// Token-based scanning (not full Lua parsing) is a
+    /// deliberate pre-release tradeoff.
     ///
     /// Drift guard: `ManagedVocabularyTests` verifies that
     /// every line `LuaConfigWriter` emits is covered by at
-    /// least one token here — add to this list whenever the
-    /// writer gains a new top-level construct.
+    /// least one token here.
     public static let managedTokens: [String] = [
         "app_rules",
         "float_rules",
@@ -167,6 +179,28 @@ public enum ManagedConfig {
         return isCode(split.before) || isCode(split.after)
     }
 
+    /// Classifies a config source in a single scan: returns
+    /// both `foreign` and `custom` flags without reading the
+    /// file twice. `foreign` implies `custom` by construction.
+    ///
+    /// Prefer this over the two separate predicates when the
+    /// source is already in memory (e.g. `SettingsModel
+    /// .reload()`), avoiding triple file reads for one
+    /// logical check.
+    public static func classify(
+        _ source: String
+    ) -> (foreign: Bool, custom: Bool) {
+        let sp = split(source)
+        let foreign =
+            touchesManagedVocabulary(sp.before)
+            || touchesManagedVocabulary(sp.after)
+        let custom =
+            foreign
+            || isCode(sp.before)
+            || isCode(sp.after)
+        return (foreign: foreign, custom: custom)
+    }
+
     // MARK: - Internals
 
     /// Drops any line that is itself a block marker.
@@ -180,7 +214,13 @@ public enum ManagedConfig {
     }
 
     /// True if `text` holds a line that is not blank and not a
-    /// full-line comment (`-- ...`).
+    /// full-line Lua comment (lines starting with `--`).
+    ///
+    /// Known limitation: `--[[ … ]]` block comment interior
+    /// lines that don't start with `--` are treated as code
+    /// by this line-by-line scan. The behavior is
+    /// over-conservative (not dangerous); it is pinned by
+    /// `ManagedConfigTests.blockCommentInteriorIsTreatedAsCode`.
     private static func isCode(_ text: String) -> Bool {
         for line in text.components(separatedBy: "\n") {
             let t = line.trimmed
@@ -191,7 +231,8 @@ public enum ManagedConfig {
     }
 
     /// True if any non-blank, non-comment line in `text`
-    /// contains a managed-vocabulary token.
+    /// contains a managed-vocabulary token (matched via
+    /// `lineMatchesToken` for token-type-aware rules).
     private static func touchesManagedVocabulary(
         _ text: String
     ) -> Bool {
@@ -200,10 +241,49 @@ public enum ManagedConfig {
             guard !t.isEmpty else { continue }
             if t.hasPrefix("--") { continue }
             for token in managedTokens {
-                if t.contains(token) { return true }
+                if lineMatchesToken(t, token: token) {
+                    return true
+                }
             }
         }
         return false
+    }
+
+    /// Matches `line` against `token` with token-type-aware
+    /// rules:
+    /// - Tokens ending with `(` (method calls): optional
+    ///   whitespace before `(` is collapsed first so that
+    ///   `KiwiDesk.bind ("alt+h", …)` matches the token
+    ///   `KiwiDesk.bind(`.
+    /// - Bare-identifier tokens (`app_rules`, `float_rules`):
+    ///   a word boundary followed by `\s*=` is required so
+    ///   that a substring inside a longer identifier
+    ///   (`app_rules_count`) or inside a string literal
+    ///   (`"app_rules"`) does not produce a false positive.
+    private static func lineMatchesToken(
+        _ line: String,
+        token: String
+    ) -> Bool {
+        if token.hasSuffix("(") {
+            // Collapse whitespace immediately before ( so
+            // `KiwiDesk.bind (` also matches `KiwiDesk.bind(`.
+            let norm = line.replacingOccurrences(
+                of: #"\s+\("#,
+                with: "(",
+                options: .regularExpression
+            )
+            return norm.contains(token)
+        }
+        // Bare-identifier tokens: require word boundary + =
+        // so app_rules_count and "app_rules" don't match.
+        let pat =
+            #"\b"#
+            + NSRegularExpression.escapedPattern(for: token)
+            + #"\s*="#
+        return line.range(
+            of: pat,
+            options: .regularExpression
+        ) != nil
     }
 }
 

--- a/Sources/KiwiDeskCore/Config/ManagedConfig.swift
+++ b/Sources/KiwiDeskCore/Config/ManagedConfig.swift
@@ -5,15 +5,42 @@ import Foundation
 /// back in without touching anything else.
 ///
 /// The GUI owns exactly one delimited region; everything a user
-/// hand-writes outside it survives a "Save". When meaningful
-/// Lua exists outside the region, the GUI shows the raw code
-/// editor instead of the visual controls (05_GUI_Concept §2).
+/// hand-writes outside it survives a "Save". The GUI only falls
+/// back to the raw Lua editor when the surrounding code touches
+/// the managed vocabulary — verbs the GUI itself emits. Harmless
+/// custom Lua (print calls, debug hooks, sketchybar integrations)
+/// coexists with the visual editor; it shows an informational
+/// banner instead of locking the user out.
 public enum ManagedConfig {
     public static let beginMarker =
         "-- >>> KiwiDesk managed block "
         + "(edit in the app, not by hand) >>>"
     public static let endMarker =
         "-- <<< KiwiDesk managed block <<<"
+
+    // MARK: - Managed vocabulary
+
+    /// Token substrings that appear in the GUI's generated
+    /// managed block (derived from `LuaConfigWriter`). Code
+    /// outside the block that contains one of these tokens
+    /// forces the raw editor — the GUI cannot safely own
+    /// the file when the same vocabulary appears in both
+    /// regions. Harmless custom Lua (none of these tokens)
+    /// coexists with the visual editor instead.
+    ///
+    /// Drift guard: `ManagedVocabularyTests` verifies that
+    /// every line `LuaConfigWriter` emits is covered by at
+    /// least one token here — add to this list whenever the
+    /// writer gains a new top-level construct.
+    public static let managedTokens: [String] = [
+        "app_rules",
+        "float_rules",
+        "KiwiDesk.bind(",
+        "KiwiDesk.define_mode(",
+        "KiwiDesk.bind_profile_to_native_space(",
+    ]
+
+    // MARK: - Split / merge
 
     /// The three regions of a config file. `managed` excludes
     /// the marker lines; it is nil when no block is present.
@@ -109,6 +136,39 @@ public enum ManagedConfig {
             + "\n"
     }
 
+    // MARK: - Foreign-code detection
+
+    /// Whether code outside the managed block touches the GUI's
+    /// managed vocabulary — verbs the GUI itself writes into the
+    /// block (`app_rules`, `float_rules`, `KiwiDesk.bind(`,
+    /// etc.). When `true` the visual editor cannot safely co-own
+    /// those constructs, so it yields to the raw Lua editor.
+    ///
+    /// Harmless custom Lua that does NOT touch any managed token
+    /// returns `false` here (the visual editor stays active) and
+    /// `true` from `hasCustomCode(_:)` (a banner is shown).
+    public static func hasForeignCode(_ source: String) -> Bool {
+        let split = split(source)
+        return touchesManagedVocabulary(split.before)
+            || touchesManagedVocabulary(split.after)
+    }
+
+    /// Whether any non-blank, non-comment Lua exists outside the
+    /// managed block. This includes harmless code that does NOT
+    /// touch the managed vocabulary. Used by the GUI to show an
+    /// informational banner while keeping the visual editor
+    /// active.
+    ///
+    /// When `hasForeignCode(_:)` is `true`, this is also `true`
+    /// — every file that forces the raw editor also has custom
+    /// code — but the converse does not hold.
+    public static func hasCustomCode(_ source: String) -> Bool {
+        let split = split(source)
+        return isCode(split.before) || isCode(split.after)
+    }
+
+    // MARK: - Internals
+
     /// Drops any line that is itself a block marker.
     private static func stripMarkers(_ text: String) -> String {
         text.components(separatedBy: "\n")
@@ -119,22 +179,29 @@ public enum ManagedConfig {
             .joined(separator: "\n")
     }
 
-    /// Whether the code outside the managed block contains
-    /// anything other than blank lines and comments. Such a
-    /// file cannot be fully represented by the visual editor,
-    /// so the GUI falls back to the Lua editor.
-    public static func hasForeignCode(_ source: String) -> Bool {
-        let split = split(source)
-        return isCode(split.before) || isCode(split.after)
-    }
-
-    /// True if the text holds a line that is not blank and not
-    /// a full-line comment (`-- ...`).
+    /// True if `text` holds a line that is not blank and not a
+    /// full-line comment (`-- ...`).
     private static func isCode(_ text: String) -> Bool {
         for line in text.components(separatedBy: "\n") {
-            let trimmed = line.trimmed
-            guard !trimmed.isEmpty else { continue }
-            if !trimmed.hasPrefix("--") { return true }
+            let t = line.trimmed
+            guard !t.isEmpty else { continue }
+            if !t.hasPrefix("--") { return true }
+        }
+        return false
+    }
+
+    /// True if any non-blank, non-comment line in `text`
+    /// contains a managed-vocabulary token.
+    private static func touchesManagedVocabulary(
+        _ text: String
+    ) -> Bool {
+        for line in text.components(separatedBy: "\n") {
+            let t = line.trimmed
+            guard !t.isEmpty else { continue }
+            if t.hasPrefix("--") { continue }
+            for token in managedTokens {
+                if t.contains(token) { return true }
+            }
         }
         return false
     }

--- a/Sources/KiwiDeskCore/Config/ManagedConfig.swift
+++ b/Sources/KiwiDeskCore/Config/ManagedConfig.swift
@@ -160,9 +160,7 @@ public enum ManagedConfig {
     /// returns `false` here (the visual editor stays active) and
     /// `true` from `hasCustomCode(_:)` (a banner is shown).
     public static func hasForeignCode(_ source: String) -> Bool {
-        let split = split(source)
-        return touchesManagedVocabulary(split.before)
-            || touchesManagedVocabulary(split.after)
+        classify(source).foreign
     }
 
     /// Whether any non-blank, non-comment Lua exists outside the
@@ -175,18 +173,20 @@ public enum ManagedConfig {
     /// — every file that forces the raw editor also has custom
     /// code — but the converse does not hold.
     public static func hasCustomCode(_ source: String) -> Bool {
-        let split = split(source)
-        return isCode(split.before) || isCode(split.after)
+        classify(source).custom
     }
 
     /// Classifies a config source in a single scan: returns
     /// both `foreign` and `custom` flags without reading the
     /// file twice. `foreign` implies `custom` by construction.
     ///
-    /// Prefer this over the two separate predicates when the
-    /// source is already in memory (e.g. `SettingsModel
-    /// .reload()`), avoiding triple file reads for one
-    /// logical check.
+    /// This is the **single definition** of the foreign/custom
+    /// signal; `hasForeignCode`/`hasCustomCode` are thin
+    /// wrappers over it, so the "one ownership predicate"
+    /// invariant (AGENTS.md §5) holds structurally — there is
+    /// no second composition to keep in lockstep. Prefer
+    /// calling this directly when the source is already in
+    /// memory (e.g. `SettingsModel.reload()`).
     public static func classify(
         _ source: String
     ) -> (foreign: Bool, custom: Bool) {

--- a/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
+++ b/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
@@ -74,54 +74,11 @@ private func richConfig() -> GuiConfig {
     return config
 }
 
+/// Writer, round-trip, and KiwiCore-level config tests.
+/// Split/detection and parity tests live in `ManagedConfigTests`.
 @Suite("Config write-back", .serialized)
 @MainActor
 struct ConfigWriteTests {
-    @Test("managed block splits and preserves user code")
-    func managedSplit() {
-        let source = """
-            -- my own comment
-            KiwiDesk.debug_log("hi")
-
-            \(ManagedConfig.beginMarker)
-            KiwiDesk.set_gap_global(10)
-            \(ManagedConfig.endMarker)
-
-            KiwiDesk.debug_log("after")
-            """
-        let split = ManagedConfig.split(source)
-        #expect(split.managed?.contains("set_gap_global") == true)
-        #expect(split.before.contains("my own comment"))
-        #expect(split.after.contains("after"))
-        #expect(ManagedConfig.hasForeignCode(source))
-    }
-
-    @Test("comment-only files carry no foreign code")
-    func noForeignCode() {
-        let source = """
-            -- just a comment
-            \(ManagedConfig.beginMarker)
-            KiwiDesk.set_gap_global(10)
-            \(ManagedConfig.endMarker)
-            """
-        #expect(!ManagedConfig.hasForeignCode(source))
-    }
-
-    @Test("merge replaces the block, keeps the surroundings")
-    func mergeReplaces() {
-        let original = ManagedConfig.merge(
-            block: "KiwiDesk.set_gap_global(10)",
-            into: "-- header\n"
-        )
-        let updated = ManagedConfig.merge(
-            block: "KiwiDesk.set_gap_global(20)",
-            into: original
-        )
-        #expect(updated.contains("set_gap_global(20)"))
-        #expect(!updated.contains("set_gap_global(10)"))
-        #expect(updated.contains("-- header"))
-    }
-
     @Test(
         "default mode never emits an icon; other modes do"
     )
@@ -265,43 +222,6 @@ struct ConfigWriteTests {
         #expect(
             saved.settings.stack.masterRatio == 2.0 / 7.0
         )
-    }
-
-    @Test("merge tolerates CRLF and keeps one block")
-    func crlfMerge() {
-        let source =
-            "-- header\r\n" + ManagedConfig.beginMarker
-            + "\r\nKiwiDesk.set_gap_global(10)\r\n"
-            + ManagedConfig.endMarker + "\r\n"
-        #expect(ManagedConfig.split(source).managed != nil)
-        let merged = ManagedConfig.merge(
-            block: "KiwiDesk.set_gap_global(20)",
-            into: source
-        )
-        let begins =
-            merged.components(
-                separatedBy: ManagedConfig.beginMarker
-            ).count - 1
-        #expect(begins == 1)
-        #expect(merged.contains("set_gap_global(20)"))
-        #expect(!merged.contains("set_gap_global(10)"))
-    }
-
-    @Test("merge strips an orphaned begin marker")
-    func orphanMarker() {
-        let source =
-            "-- header\n" + ManagedConfig.beginMarker
-            + "\nKiwiDesk.set_gap_global(10)\n"
-        let merged = ManagedConfig.merge(
-            block: "KiwiDesk.set_gap_global(20)",
-            into: source
-        )
-        let begins =
-            merged.components(
-                separatedBy: ManagedConfig.beginMarker
-            ).count - 1
-        #expect(begins == 1)
-        #expect(merged.contains("-- header"))
     }
 
     @Test("adopt migrates a hand-written config into the GUI")

--- a/Tests/KiwiDeskCoreTests/GuiOwnershipTests.swift
+++ b/Tests/KiwiDeskCoreTests/GuiOwnershipTests.swift
@@ -85,6 +85,41 @@ struct GuiOwnershipTests {
     }
 
     @Test(
+        "tiling Lua beside gui.json yields to Standard"
+    )
+    func tilingLuaYieldsToStandardOnMonitorChange() throws {
+        let core = makeGuiManagedCore()
+        connect(core, [display(1, "A")])
+        core.state.workspaces.ensureSpace(SpaceID(1))
+        // set_gap_global is NOT managed vocabulary: no raw
+        // editor forced, isGuiManaged stays true (#14).
+        // But once gui.json exists the Standard owns tiling
+        // on a monitor change and overrides this Lua call.
+        // This is INTENDED: harmless tiling Lua flips back
+        // to GUI ownership; set_gap_global is not in the
+        // managed block (tiling lives in profiles, #36).
+        let lua = "KiwiDesk.set_gap_global(30)"
+        try lua.write(
+            to: core.configURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        #expect(!core.configHasForeignCode)
+        #expect(core.configHasCustomCode)
+        #expect(core.isGuiManaged)
+        // Simulate the Lua tiling call having been applied.
+        core.tiler.settings.gapsGlobal = .uniform(30)
+
+        core.handleMonitorChange()
+        // The composed Standard is applied (Developer: 8 pt
+        // uniform gaps), overriding the hand-set 30 pt gap.
+        #expect(core.profiles.currentStandard != nil)
+        #expect(
+            core.tiler.settings.gapsGlobal == .uniform(8)
+        )
+    }
+
+    @Test(
         "harmless custom Lua beside gui.json stays GUI-managed"
     )
     func harmlessCustomLuaIsGuiManaged() throws {

--- a/Tests/KiwiDeskCoreTests/GuiOwnershipTests.swift
+++ b/Tests/KiwiDeskCoreTests/GuiOwnershipTests.swift
@@ -1,0 +1,109 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    KiwiCore(
+        configDirectory: FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent(
+                "kiwi-own-\(UUID().uuidString)"
+            )
+    )
+}
+
+/// A core whose config is GUI-managed (a `gui.json` sidecar
+/// exists).
+@MainActor
+private func makeGuiManagedCore() -> KiwiCore {
+    let core = makeCore()
+    try? core.guiConfigStore.save(GuiConfig())
+    return core
+}
+
+@MainActor
+private func connect(
+    _ core: KiwiCore,
+    _ displays: [Display]
+) {
+    for display in displays {
+        core.state.workspaces.upsertDisplay(display)
+    }
+}
+
+private func display(
+    _ id: UInt32,
+    _ name: String,
+    x: CGFloat = 0
+) -> Display {
+    Display(
+        id: DisplayID(id),
+        name: name,
+        frame: CGRect(x: x, y: 0, width: 100, height: 100)
+    )
+}
+
+/// Verifies the token-scoped GUI-ownership semantics (#14):
+/// harmless custom Lua coexists with the visual editor
+/// (isGuiManaged stays true); only code touching the managed
+/// vocabulary demotes ownership.
+@Suite("GUI ownership / coexistence", .serialized)
+@MainActor
+struct GuiOwnershipTests {
+    @Test(
+        "managed-vocab Lua beside gui.json keeps tiling Lua-owned"
+    )
+    func managedVocabCodeKeepsLuaOwned() throws {
+        let core = makeGuiManagedCore()
+        connect(core, [display(1, "A")])
+        core.state.workspaces.ensureSpace(SpaceID(1))
+        // A binding outside the block touches KiwiDesk.bind(,
+        // which the GUI also writes inside the block — the
+        // visual editor yields to the raw Lua fallback.
+        let lua =
+            "KiwiDesk.bind(\"alt+h\", function() end)"
+        try lua.write(
+            to: core.configURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        #expect(core.configHasForeignCode)
+        #expect(!core.isGuiManaged)
+        core.tiler.settings.gapsGlobal = .uniform(30)
+
+        core.handleMonitorChange()
+        // The Standard must NOT be applied — tiling stays
+        // Lua-owned, no dirty state from the monitor change.
+        #expect(core.profiles.currentStandard == nil)
+        #expect(!core.profiles.isDirty)
+        #expect(
+            core.tiler.settings.gapsGlobal == .uniform(30)
+        )
+    }
+
+    @Test(
+        "harmless custom Lua beside gui.json stays GUI-managed"
+    )
+    func harmlessCustomLuaIsGuiManaged() throws {
+        let core = makeGuiManagedCore()
+        connect(core, [display(1, "A")])
+        // Code that does NOT touch managed vocabulary — e.g.
+        // a debug call or a sketchybar hook. The visual editor
+        // remains active; the GUI still owns tiling (#14).
+        try "KiwiDesk.debug_log(\"hello\")".write(
+            to: core.configURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        #expect(!core.configHasForeignCode)
+        #expect(core.configHasCustomCode)
+        #expect(core.isGuiManaged)
+        // The Standard is applied on monitor change because
+        // GUI ownership is intact.
+        core.handleMonitorChange()
+        #expect(core.profiles.currentStandard != nil)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ManagedConfigTests.swift
+++ b/Tests/KiwiDeskCoreTests/ManagedConfigTests.swift
@@ -204,89 +204,100 @@ struct ManagedConfigTests {
         #expect(!ManagedConfig.hasForeignCode(source))
         #expect(!ManagedConfig.hasCustomCode(source))
     }
-}
 
-// MARK: - Vocabulary parity test
+    // MARK: - Whitespace-before-paren (Fix 1)
 
-/// Verifies that every top-level construct `LuaConfigWriter`
-/// emits into a managed block is covered by at least one token
-/// in `ManagedConfig.managedTokens`. If `LuaConfigWriter` gains
-/// a new top-level construct without a matching token, this test
-/// fails — preventing silent drift between the writer and the
-/// detection logic.
-@Suite("Managed-vocabulary parity")
-struct ManagedVocabularyTests {
-    /// A config that exercises all five managed-vocabulary
-    /// constructs: app rules, float rules, profile bindings,
-    /// a default-mode bind, and a named mode.
-    private func vocabConfig() -> GuiConfig {
-        var c = GuiConfig()
-        c.appRules = ["Finder": SpaceID(1)]
-        c.floatRules = ["Calculator"]
-        c.profileBindings = [1: "Desk"]
-        c.modes = [
-            KeyMode(
-                name: "default",
-                bindings: [
-                    KeyBinding(
-                        combo: "alt+h",
-                        lua: "-- noop"
-                    )
-                ]
-            ),
-            KeyMode(
-                name: "resize",
-                bindings: [
-                    KeyBinding(
-                        combo: "alt+l",
-                        lua: "-- noop"
-                    )
-                ]
-            ),
-        ]
-        return c
+    @Test("KiwiDesk.bind with space before ( is foreign")
+    func bindWithSpaceBeforeParenIsForeign() {
+        // A space between the method name and ( must not
+        // escape token detection (#14 fix: whitespace is
+        // normalized before matching).
+        let source = """
+            KiwiDesk.bind ("alt+h", function()
+                KiwiDesk.focus("left")
+            end)
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(ManagedConfig.hasForeignCode(source))
     }
 
-    @Test(
-        "every managed token appears in a full block"
-    )
-    func tokensAppearInGeneratedBlock() {
-        let block = LuaConfigWriter.block(for: vocabConfig())
-        for token in ManagedConfig.managedTokens {
-            #expect(
-                block.contains(token),
-                "token \"\(token)\" not found in generated block"
-            )
-        }
+    @Test("KiwiDesk.define_mode with space before ( is foreign")
+    func defineModeWithSpaceBeforeParenIsForeign() {
+        let source = """
+            KiwiDesk.define_mode ("resize", {})
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(ManagedConfig.hasForeignCode(source))
     }
 
+    // MARK: - Substring anchoring for bare identifiers (Fix 4)
+
+    @Test("app_rules inside longer identifier is not foreign")
+    func appRulesSubstringNotForeign() {
+        // app_rules_count contains app_rules but is a
+        // different identifier: the word-boundary + assignment
+        // anchor prevents a false positive.
+        let source = """
+            local app_rules_count = 0
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(!ManagedConfig.hasForeignCode(source))
+        // It IS custom (a non-comment Lua line).
+        #expect(ManagedConfig.hasCustomCode(source))
+    }
+
+    @Test("app_rules inside a string literal is not foreign")
+    func appRulesInStringNotForeign() {
+        // A string literal containing the token word must
+        // not be detected as foreign (no assignment).
+        let source = """
+            print("app_rules")
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(!ManagedConfig.hasForeignCode(source))
+    }
+
+    @Test("app_rules assignment outside block is foreign")
+    func appRulesAssignmentForeign() {
+        let source = """
+            app_rules = { ["Finder"] = "1" }
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(ManagedConfig.hasForeignCode(source))
+    }
+
+    // MARK: - Block-comment behavior (Fix 5 — pinned)
+
     @Test(
-        "every top-level writer line is covered by a token"
+        "block-comment interior lines are treated as code"
     )
-    func writerLinesAreCovered() {
-        let block = LuaConfigWriter.block(for: vocabConfig())
-        for line in block.components(separatedBy: "\n") {
-            // Skip blank lines and full-line comments.
-            let trimmed = line.trimmingCharacters(
-                in: .whitespaces
-            )
-            guard !trimmed.isEmpty else { continue }
-            guard !trimmed.hasPrefix("--") else { continue }
-            // Skip indented lines (table entries, bodies).
-            guard
-                line.first != " ", line.first != "\t"
-            else { continue }
-            // Skip structural closing tokens.
-            guard
-                !trimmed.hasPrefix("}"),
-                !trimmed.hasPrefix("end")
-            else { continue }
-            let covered = ManagedConfig.managedTokens
-                .contains { trimmed.contains($0) }
-            #expect(
-                covered,
-                "unrecognized top-level line: \"\(trimmed)\""
-            )
-        }
+    func blockCommentInteriorIsTreatedAsCode() {
+        // --[[ … ]] block comments: interior lines that don't
+        // start with -- are treated as code by the current
+        // line-by-line scan (known limitation — see isCode).
+        // This test pins the behavior so it is not mistaken
+        // for handled.
+        let source = """
+            --[[ multi-line block comment
+            this line has no leading dashes
+            ]]
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        // Over-conservative: interior is seen as code.
+        #expect(ManagedConfig.hasCustomCode(source))
+        // No managed vocabulary → not foreign.
+        #expect(!ManagedConfig.hasForeignCode(source))
     }
 }

--- a/Tests/KiwiDeskCoreTests/ManagedConfigTests.swift
+++ b/Tests/KiwiDeskCoreTests/ManagedConfigTests.swift
@@ -1,0 +1,292 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Tests for `ManagedConfig`'s split/merge logic and the
+/// token-scoped foreign-code detection introduced in #14.
+/// Round-trip and KiwiCore tests live in `ConfigWriteTests`.
+@Suite("ManagedConfig split / detection")
+struct ManagedConfigTests {
+    // MARK: - Split & merge
+
+    @Test("managed block splits and preserves user code")
+    func managedSplit() {
+        let source = """
+            -- my own comment
+            KiwiDesk.debug_log("hi")
+
+            \(ManagedConfig.beginMarker)
+            KiwiDesk.set_gap_global(10)
+            \(ManagedConfig.endMarker)
+
+            KiwiDesk.debug_log("after")
+            """
+        let split = ManagedConfig.split(source)
+        #expect(split.managed?.contains("set_gap_global") == true)
+        #expect(split.before.contains("my own comment"))
+        #expect(split.after.contains("after"))
+        // debug_log is NOT managed vocabulary: the visual editor
+        // stays active; hasForeignCode must be false (#14).
+        #expect(!ManagedConfig.hasForeignCode(source))
+        // But there IS non-comment Lua outside the block.
+        #expect(ManagedConfig.hasCustomCode(source))
+    }
+
+    @Test("comment-only files are neither foreign nor custom")
+    func noForeignCode() {
+        let source = """
+            -- just a comment
+            \(ManagedConfig.beginMarker)
+            KiwiDesk.set_gap_global(10)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(!ManagedConfig.hasForeignCode(source))
+        #expect(!ManagedConfig.hasCustomCode(source))
+    }
+
+    @Test("merge replaces the block, keeps the surroundings")
+    func mergeReplaces() {
+        let original = ManagedConfig.merge(
+            block: "KiwiDesk.set_gap_global(10)",
+            into: "-- header\n"
+        )
+        let updated = ManagedConfig.merge(
+            block: "KiwiDesk.set_gap_global(20)",
+            into: original
+        )
+        #expect(updated.contains("set_gap_global(20)"))
+        #expect(!updated.contains("set_gap_global(10)"))
+        #expect(updated.contains("-- header"))
+    }
+
+    @Test("merge tolerates CRLF and keeps one block")
+    func crlfMerge() {
+        let source =
+            "-- header\r\n" + ManagedConfig.beginMarker
+            + "\r\nKiwiDesk.set_gap_global(10)\r\n"
+            + ManagedConfig.endMarker + "\r\n"
+        #expect(ManagedConfig.split(source).managed != nil)
+        let merged = ManagedConfig.merge(
+            block: "KiwiDesk.set_gap_global(20)",
+            into: source
+        )
+        let begins =
+            merged.components(
+                separatedBy: ManagedConfig.beginMarker
+            ).count - 1
+        #expect(begins == 1)
+        #expect(merged.contains("set_gap_global(20)"))
+        #expect(!merged.contains("set_gap_global(10)"))
+    }
+
+    @Test("merge strips an orphaned begin marker")
+    func orphanMarker() {
+        let source =
+            "-- header\n" + ManagedConfig.beginMarker
+            + "\nKiwiDesk.set_gap_global(10)\n"
+        let merged = ManagedConfig.merge(
+            block: "KiwiDesk.set_gap_global(20)",
+            into: source
+        )
+        let begins =
+            merged.components(
+                separatedBy: ManagedConfig.beginMarker
+            ).count - 1
+        #expect(begins == 1)
+        #expect(merged.contains("-- header"))
+    }
+
+    // MARK: - Token-scoped detection (#14)
+
+    @Test("harmless custom Lua: not foreign, is custom")
+    func harmlessCustomCode() {
+        // Calls like debug_log, print, or sketchybar hooks
+        // do not touch managed vocabulary → visual editor stays.
+        let source = """
+            KiwiDesk.debug_log("started")
+            print("sketchybar hook")
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(!ManagedConfig.hasForeignCode(source))
+        #expect(ManagedConfig.hasCustomCode(source))
+    }
+
+    @Test("managed-vocabulary Lua outside block is foreign")
+    func managedVocabIsForeign() {
+        // A binding outside the block touches KiwiDesk.bind(,
+        // which the GUI writes inside the block → raw editor.
+        let source = """
+            KiwiDesk.bind("alt+h", function()
+                KiwiDesk.focus("left")
+            end)
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(ManagedConfig.hasForeignCode(source))
+        #expect(ManagedConfig.hasCustomCode(source))
+    }
+
+    @Test("app_rules outside the block is foreign")
+    func appRulesIsForeign() {
+        let source = """
+            app_rules = { ["Finder"] = "1" }
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(ManagedConfig.hasForeignCode(source))
+    }
+
+    @Test("float_rules outside the block is foreign")
+    func floatRulesIsForeign() {
+        let source = """
+            float_rules = { "Calculator" }
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(ManagedConfig.hasForeignCode(source))
+    }
+
+    @Test("define_mode outside the block is foreign")
+    func defineModeIsForeign() {
+        let source = """
+            KiwiDesk.define_mode("resize", {})
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(ManagedConfig.hasForeignCode(source))
+    }
+
+    @Test("bind_profile_to_native_space outside block is foreign")
+    func profileBindingIsForeign() {
+        let source = """
+            KiwiDesk.bind_profile_to_native_space(1, "Desk")
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(ManagedConfig.hasForeignCode(source))
+    }
+
+    @Test("tiling-only Lua beside the block is NOT foreign")
+    func tilingOnlyIsNotForeign() {
+        // set_gap_global, set_mode etc. are not in the managed
+        // block (tiling moved to profiles, #36) — they're
+        // harmless alongside the visual editor.
+        let source = """
+            KiwiDesk.set_gap_global(30)
+            KiwiDesk.set_mode(1, "stack")
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(!ManagedConfig.hasForeignCode(source))
+        #expect(ManagedConfig.hasCustomCode(source))
+    }
+
+    @Test("commented-out managed vocab is not foreign")
+    func commentedManagedVocab() {
+        // Comments are inert: a line that begins with -- is
+        // skipped even if it contains a managed token.
+        let source = """
+            -- app_rules = { ["Finder"] = "1" }
+            -- KiwiDesk.bind("x", function() end)
+
+            \(ManagedConfig.beginMarker)
+            \(ManagedConfig.endMarker)
+            """
+        #expect(!ManagedConfig.hasForeignCode(source))
+        #expect(!ManagedConfig.hasCustomCode(source))
+    }
+}
+
+// MARK: - Vocabulary parity test
+
+/// Verifies that every top-level construct `LuaConfigWriter`
+/// emits into a managed block is covered by at least one token
+/// in `ManagedConfig.managedTokens`. If `LuaConfigWriter` gains
+/// a new top-level construct without a matching token, this test
+/// fails — preventing silent drift between the writer and the
+/// detection logic.
+@Suite("Managed-vocabulary parity")
+struct ManagedVocabularyTests {
+    /// A config that exercises all five managed-vocabulary
+    /// constructs: app rules, float rules, profile bindings,
+    /// a default-mode bind, and a named mode.
+    private func vocabConfig() -> GuiConfig {
+        var c = GuiConfig()
+        c.appRules = ["Finder": SpaceID(1)]
+        c.floatRules = ["Calculator"]
+        c.profileBindings = [1: "Desk"]
+        c.modes = [
+            KeyMode(
+                name: "default",
+                bindings: [
+                    KeyBinding(
+                        combo: "alt+h",
+                        lua: "-- noop"
+                    )
+                ]
+            ),
+            KeyMode(
+                name: "resize",
+                bindings: [
+                    KeyBinding(
+                        combo: "alt+l",
+                        lua: "-- noop"
+                    )
+                ]
+            ),
+        ]
+        return c
+    }
+
+    @Test(
+        "every managed token appears in a full block"
+    )
+    func tokensAppearInGeneratedBlock() {
+        let block = LuaConfigWriter.block(for: vocabConfig())
+        for token in ManagedConfig.managedTokens {
+            #expect(
+                block.contains(token),
+                "token \"\(token)\" not found in generated block"
+            )
+        }
+    }
+
+    @Test(
+        "every top-level writer line is covered by a token"
+    )
+    func writerLinesAreCovered() {
+        let block = LuaConfigWriter.block(for: vocabConfig())
+        for line in block.components(separatedBy: "\n") {
+            // Skip blank lines and full-line comments.
+            let trimmed = line.trimmingCharacters(
+                in: .whitespaces
+            )
+            guard !trimmed.isEmpty else { continue }
+            guard !trimmed.hasPrefix("--") else { continue }
+            // Skip indented lines (table entries, bodies).
+            guard
+                line.first != " ", line.first != "\t"
+            else { continue }
+            // Skip structural closing tokens.
+            guard
+                !trimmed.hasPrefix("}"),
+                !trimmed.hasPrefix("end")
+            else { continue }
+            let covered = ManagedConfig.managedTokens
+                .contains { trimmed.contains($0) }
+            #expect(
+                covered,
+                "unrecognized top-level line: \"\(trimmed)\""
+            )
+        }
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ManagedVocabularyTests.swift
+++ b/Tests/KiwiDeskCoreTests/ManagedVocabularyTests.swift
@@ -132,6 +132,11 @@ struct ManagedVocabularyTests {
     /// entry to `managedTokens` so `tokensAppearInGeneratedBlock`
     /// also catches the drift.
     ///
+    /// A non-collection field (`Bool`/enum/`Int`) is neither
+    /// `EmptyCheckable` nor `settings`, so it trips the `else`
+    /// branch and fails until the guard is extended — the net
+    /// cannot silently rot on the next scalar field.
+    ///
     /// Limitation: the Mirror net catches a missing *property*,
     /// not a forgotten line in `encode`/`resolved()`. The
     /// struct `settings` cannot be compared through `Any`, so
@@ -148,6 +153,14 @@ struct ManagedVocabularyTests {
                     !c.anyIsEmpty,
                     "GuiConfig.\(label) empty — populate vocabConfig()"
                 )
+            } else if label != "settings" {
+                // A new non-collection field slipped the net —
+                // it is neither EmptyCheckable nor the struct
+                // checked below. Fail so the guard is extended.
+                let msg =
+                    "GuiConfig.\(label): unhandled field type "
+                    + "— extend allFieldsNonDefault to cover it"
+                Issue.record("\(msg)")
             }
         }
         // Non-collection struct: compared directly because

--- a/Tests/KiwiDeskCoreTests/ManagedVocabularyTests.swift
+++ b/Tests/KiwiDeskCoreTests/ManagedVocabularyTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+// MARK: - Mirror helper
+
+/// Enables the Mirror-based field-population check in
+/// `allFieldsNonDefault` without losing type information when
+/// iterating `Mirror.children` (whose values are `Any`).
+private protocol EmptyCheckable {
+    var anyIsEmpty: Bool { get }
+}
+
+extension Array: EmptyCheckable {
+    var anyIsEmpty: Bool { isEmpty }
+}
+
+extension Dictionary: EmptyCheckable {
+    var anyIsEmpty: Bool { isEmpty }
+}
+
+extension Set: EmptyCheckable {
+    var anyIsEmpty: Bool { isEmpty }
+}
+
+// MARK: - Fixture
+
+/// Exercises every `GuiConfig` stored property with a
+/// non-default value so the Mirror-based guard in
+/// `allFieldsNonDefault` can detect a newly-added field
+/// that the author forgot to populate here.
+private func vocabConfig() -> GuiConfig {
+    var c = GuiConfig()
+    // Global fields (sidecar / LuaConfigWriter):
+    c.spaces = [SpaceID(1), SpaceID(2)]
+    c.appRules = ["Finder": SpaceID(1)]
+    c.floatRules = ["Calculator"]
+    c.profileBindings = [1: "Desk"]
+    c.modes = [
+        KeyMode(
+            name: "default",
+            bindings: [
+                KeyBinding(
+                    combo: "alt+h",
+                    lua: "-- noop"
+                )
+            ]
+        ),
+        KeyMode(
+            name: "resize",
+            bindings: [
+                KeyBinding(
+                    combo: "alt+l",
+                    lua: "-- noop"
+                )
+            ]
+        ),
+    ]
+    // Profile-scoped fields (don't affect the Lua block
+    // but must be non-default so a future writer that
+    // starts reading them is caught by the parity test):
+    c.spaceModes = [SpaceID(2): .stack]
+    c.spacePins = [SpaceID(1): "A:100x100"]
+    c.mainSpaces = [SpaceID(2)]
+    var s = TilingSettings()
+    s.gapsGlobal = .uniform(8)
+    c.settings = s
+    return c
+}
+
+// MARK: - Parity suite
+
+/// Verifies that every top-level construct `LuaConfigWriter`
+/// emits into a managed block is covered by at least one
+/// token in `ManagedConfig.managedTokens`, and that the
+/// `vocabConfig()` fixture populates every `GuiConfig` stored
+/// property — so a future `LuaConfigWriter` branch gated on
+/// a new field that the author forgets to populate in the
+/// fixture does not silently pass green.
+@Suite("Managed-vocabulary parity")
+struct ManagedVocabularyTests {
+    @Test(
+        "every managed token appears in a full block"
+    )
+    func tokensAppearInGeneratedBlock() {
+        let block = LuaConfigWriter.block(for: vocabConfig())
+        for token in ManagedConfig.managedTokens {
+            #expect(
+                block.contains(token),
+                "token \"\(token)\" not found in generated block"
+            )
+        }
+    }
+
+    @Test(
+        "every top-level writer line is covered by a token"
+    )
+    func writerLinesAreCovered() {
+        let block = LuaConfigWriter.block(for: vocabConfig())
+        for line in block.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(
+                in: .whitespaces
+            )
+            guard !trimmed.isEmpty else { continue }
+            guard !trimmed.hasPrefix("--") else { continue }
+            // Skip indented lines (table entries, bodies).
+            guard
+                line.first != " ", line.first != "\t"
+            else { continue }
+            // Skip structural closing tokens: } closes a
+            // table/mode block; end closes a function body.
+            // These are not top-level vocabulary markers.
+            guard
+                !trimmed.hasPrefix("}"),
+                !trimmed.hasPrefix("end")
+            else { continue }
+            let covered = ManagedConfig.managedTokens
+                .contains { trimmed.contains($0) }
+            #expect(
+                covered,
+                "unrecognized top-level line: \"\(trimmed)\""
+            )
+        }
+    }
+
+    /// Mirror-based guard: every `GuiConfig` stored property
+    /// must be non-default in `vocabConfig()`. A collection
+    /// or set field that is left empty fails here immediately,
+    /// which forces the author to populate it and — if the
+    /// writer starts reading that field — to add a matching
+    /// entry to `managedTokens` so `tokensAppearInGeneratedBlock`
+    /// also catches the drift.
+    ///
+    /// Limitation: the Mirror net catches a missing *property*,
+    /// not a forgotten line in `encode`/`resolved()`. The
+    /// struct `settings` cannot be compared through `Any`, so
+    /// it is checked directly below the loop.
+    @Test(
+        "every GuiConfig field is non-default in vocabConfig()"
+    )
+    func allFieldsNonDefault() {
+        let config = vocabConfig()
+        for child in Mirror(reflecting: config).children {
+            guard let label = child.label else { continue }
+            if let c = child.value as? EmptyCheckable {
+                #expect(
+                    !c.anyIsEmpty,
+                    "GuiConfig.\(label) empty — populate vocabConfig()"
+                )
+            }
+        }
+        // Non-collection struct: compared directly because
+        // Swift can't use Equatable through Any.
+        #expect(
+            config.settings != TilingSettings(),
+            "settings is still default in vocabConfig()"
+        )
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ProfileResolutionTests.swift
+++ b/Tests/KiwiDeskCoreTests/ProfileResolutionTests.swift
@@ -153,28 +153,8 @@ struct MonitorChangeTests {
         )
     }
 
-    @Test("Foreign Lua beside gui.json keeps tiling Lua-owned")
-    func hybridConfigStaysLuaOwned() throws {
-        let core = makeGuiManagedCore()
-        connect(core, [display(1, "A")])
-        core.state.workspaces.ensureSpace(SpaceID(1))
-        // Hand-written code outside the managed block demotes
-        // GUI ownership — the editor already falls back to
-        // raw Lua; the monitor-change gate must agree.
-        try "KiwiDesk.set_gap_global(30)".write(
-            to: core.configURL,
-            atomically: true,
-            encoding: .utf8
-        )
-        core.tiler.settings.gapsGlobal = .uniform(30)
-
-        core.handleMonitorChange()
-        #expect(core.profiles.currentStandard == nil)
-        #expect(!core.profiles.isDirty)
-        #expect(
-            core.tiler.settings.gapsGlobal == .uniform(30)
-        )
-    }
+    // GUI-ownership coexistence tests (#14) live in
+    // GuiOwnershipTests.swift (token-scoped detection).
 
     @Test("CLI-only: active profile goes dirty on no match")
     func luaOwnedActiveProfileGoesDirty() throws {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,17 @@ block — is left completely untouched on every save and a small
 informational banner is shown to confirm it. The visual editor
 stays active.
 
+Tiling commands (`set_gap_global`, `set_mode`, and similar
+calls) also fall into this harmless category and do not force
+the raw Lua editor. However, **once `gui.json` exists the
+visual editor owns tiling**: on a monitor change when no saved
+profile matches the connected displays, KiwiDesk applies the
+closest built-in Standard profile, resetting gaps, modes, and
+layout parameters. Hand-written tiling calls written outside
+the managed block do not survive that reset. To persist custom
+tiling across monitor changes, configure it in the Layouts &
+Gaps controls and save it as a profile.
+
 **The raw Lua editor replaces the visual controls** only when
 custom code outside the block touches the same vocabulary the
 GUI writes — declaring `app_rules`, `float_rules`, a keybinding,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,30 +32,44 @@ KiwiDesk.set_gap_global(10)
 ```
 
 Anything you write **outside** that region is preserved across
-saves. If the app finds custom Lua it can't represent with its
-visual controls, it opens the integrated Lua editor for the
-whole file instead of risking your code. From there you can keep
-editing raw Lua, or click **Adopt into the GUI** to import your
-current gaps, layouts, rules, and keybindings into a fresh
-managed block — your previous file is kept verbatim as a
-commented backup. Keybindings are recovered from the file: each
-bound combo and its action text are read back and sorted into
-the Keybindings tab (known Focus, Window Movement, and app-launch
-actions land in their sections; anything else becomes a Custom
-binding). You can also pull them in without adopting the whole
-file — **Import current shortcuts** at the bottom of the
-Keybindings tab reads the shortcuts active in `init.lua` and adds
-them for review before you Save. Recovery expects each shortcut to be an inline
-`function() … end` on its own line (the form the app writes). A
-binding whose action can't be read back — one bound to a named
-handler or a C function, rather than an inline function — is left
-only in the backup and can be re-added from the tab. The editor's own
-state (keybinding actions, mode icons) is mirrored to
-`~/.config/KiwiDesk/gui.json`; delete that file to reset the
-GUI to what `init.lua` currently declares. Custom keybinding
-Lua is stored there and runs on reload, so treat `gui.json`
-with the same trust as `init.lua` — don't import one from an
-untrusted source.
+saves.
+
+**Harmless custom Lua coexists** with the visual editor. A
+`print`, a debug call, a sketchybar hook — any Lua that doesn't
+declare `app_rules`, `float_rules`, keybindings
+(`KiwiDesk.bind`, `KiwiDesk.define_mode`), or profile bindings
+(`KiwiDesk.bind_profile_to_native_space`) alongside the managed
+block — is left completely untouched on every save and a small
+informational banner is shown to confirm it. The visual editor
+stays active.
+
+**The raw Lua editor replaces the visual controls** only when
+custom code outside the block touches the same vocabulary the
+GUI writes — declaring `app_rules`, `float_rules`, a keybinding,
+or a profile binding in two places at once would create a
+conflict. In that case the app opens the integrated Lua editor
+for the whole file so you can edit it directly. From there you
+can keep editing raw Lua, or click **Adopt into the GUI** to
+import your current settings into a fresh managed block — your
+previous file is kept verbatim as a commented backup.
+Keybindings are recovered from the file: each bound combo and
+its action text are read back and sorted into the Keybindings
+tab (known Focus, Window Movement, and app-launch actions land
+in their sections; anything else becomes a Custom binding). You
+can also pull them in without adopting the whole file —
+**Import current shortcuts** at the bottom of the Keybindings
+tab reads the shortcuts active in `init.lua` and adds them for
+review before you Save. Recovery expects each shortcut to be an
+inline `function() … end` on its own line (the form the app
+writes). A binding whose action can't be read back — one bound
+to a named handler or a C function, rather than an inline
+function — is left only in the backup and can be re-added from
+the tab. The editor's own state (keybinding actions, mode icons)
+is mirrored to `~/.config/KiwiDesk/gui.json`; delete that file
+to reset the GUI to what `init.lua` currently declares. Custom
+keybinding Lua is stored there and runs on reload, so treat
+`gui.json` with the same trust as `init.lua` — don't import one
+from an untrusted source.
 
 ## Layouts & Gaps
 


### PR DESCRIPTION
## Summary

Closes #14. The visual editor now **coexists** with harmless custom Lua instead of forcing the all-or-nothing raw editor for any custom line.

`ManagedConfig` foreign-code detection is now **token-scoped**: a config outside the managed block only forces the raw editor / marks itself non-GUI-managed when it touches the **managed vocabulary** (`app_rules`, `float_rules`, `KiwiDesk.bind(`, `KiwiDesk.define_mode(`, `KiwiDesk.bind_profile_to_native_space(`). Harmless custom Lua keeps the visual editor and shows an informational banner.

## Key points

- **Single ownership predicate preserved.** `isGuiManaged` stays the one discriminator; `classify(source) -> (foreign, custom)` is the single definition of the signal, with `hasForeignCode`/`hasCustomCode` as thin wrappers over it (§5 "one predicate" held structurally). `reload()` reads the config once.
- **Vocabulary can't silently drift.** `managedTokens` mirrors `LuaConfigWriter`'s output, guarded by `ManagedVocabularyTests` — a Mirror net that fails on any unpopulated collection field *and* on any unhandled non-collection field, plus round-trip coverage over the actually-emitted block (§5 forget-proof parity).
- **Whitespace-tolerant + assignment-anchored matching** (`KiwiDesk.bind (` caught; `local app_rules_count`/`print("app_rules")` not). Receiver-aliasing and `--[[ ]]` block comments are documented limitations.
- **Intentional tiling-ownership flip pinned.** Once a `gui.json` sidecar exists, the composed Standard owns tiling on a monitor change — hand-written `set_gap_global` does *not* survive. Documented in `docs/configuration.md` and pinned by a gate test.

## Verification

`swift build && swift test` (466 tests) `&& scripts/lint.sh && swift build -c release` — all green.

Reviewed by code-reviewer + architect-reviewer (two rounds each, AGENTS.md §3.6); all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)