### PR TITLE
feat(profiles): persisted space order + move-to-first primitive (#75)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -97,7 +97,7 @@ extension KiwiCore {
         let ordered = config.spaces.filter { liveSet.contains($0) }
         let inOrdered = Set(config.spaces)
         let extra = live.filter { !inOrdered.contains($0) }
-        config.spaces = GuiConfig.deduplicated(ordered + extra)
+        config.spaces = SpaceID.deduplicated(ordered + extra)
         config.spacePins = spacePins
         config.mainSpaces = mainSpaces
     }
@@ -110,11 +110,19 @@ extension KiwiCore {
         from config: GuiConfig
     ) {
         tiler.settings = config.settings
-        var known = Set(config.spaces)
-        known.formUnion(config.spaceModes.keys)
-        known.formUnion(config.spacePins.keys)
-        known.formUnion(config.mainSpaces)
-        for space in known {
+        // Ensure spaces in display order first (config.spaces
+        // is the authoritative list, so insertion order matches
+        // the user's chosen Spaces ordering). Any extras that
+        // appear only in modes/pins/main get appended after.
+        let inList = Set(config.spaces)
+        var extra: Set<SpaceID> = []
+        extra.formUnion(config.spaceModes.keys)
+        extra.formUnion(config.spacePins.keys)
+        extra.formUnion(config.mainSpaces)
+        for space in config.spaces {
+            state.workspaces.ensureSpace(space)
+        }
+        for space in extra.subtracting(inList) {
             state.workspaces.ensureSpace(space)
         }
         for space in state.workspaces.allSpaces {
@@ -291,7 +299,7 @@ extension KiwiCore {
         }
         config.spaceModes = modes
         // De-dup only — live order is authoritative (#75).
-        config.spaces = GuiConfig.deduplicated(
+        config.spaces = SpaceID.deduplicated(
             defined + Array(modes.keys)
         )
         if config.spaces.isEmpty {

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -65,11 +65,9 @@ extension KiwiCore {
         // the live sidecar's spaces, or editing a profile for
         // other hardware would graft this machine's spaces into
         // it on save (mirrors `applyProfileScopedState`, #18).
-        config.spaces = GuiConfig.orderedSpaces(
-            Array(profile.spaceModes.keys)
-                + profile.mainSpaces
-                + Array(config.spacePins.keys)
-        )
+        // Stored order is authoritative (#75); `orderedSpaces`
+        // appends any declared space absent from the list.
+        config.spaces = profile.orderedSpaces
     }
 
     /// Copies the live profile-scoped state into the model:
@@ -88,17 +86,18 @@ extension KiwiCore {
             }
         }
         config.spaceModes = modes
-        // Live state is authoritative for which spaces exist: a
-        // profile load prunes stale spaces from it, and every
-        // `persist` re-ensures the edited spaces into live, so the
-        // tab must not resurrect pruned spaces from the (still-
-        // stale) sidecar `spaces`. Edge (accepted, pre-release):
-        // a bare space that lives *only* in `gui.json` — no mode,
-        // pin, window, or active profile — isn't seeded into live
-        // at cold boot (`loadConfig` doesn't), so it drops on the
-        // next reload. Closing that means reconciling the sidecar
-        // space list against live (#77; config-cascade #55/#75).
-        config.spaces = GuiConfig.orderedSpaces(live)
+        // Live state is authoritative for which spaces EXIST (#75).
+        // Order: use the sidecar's stored list as the base (keeps
+        // the user's chosen display order across reloads), filter
+        // to live members, then append any live space absent from
+        // the sidecar. Stale sidecar spaces (no longer live after a
+        // profile-load prune) drop via the filter. A bare space
+        // only in `gui.json` drops too — it wasn't seeded at boot.
+        let liveSet = Set(live)
+        let ordered = config.spaces.filter { liveSet.contains($0) }
+        let inOrdered = Set(config.spaces)
+        let extra = live.filter { !inOrdered.contains($0) }
+        config.spaces = GuiConfig.deduplicated(ordered + extra)
         config.spacePins = spacePins
         config.mainSpaces = mainSpaces
     }
@@ -291,7 +290,8 @@ extension KiwiCore {
             if space.mode != .bsp { modes[space.id] = space.mode }
         }
         config.spaceModes = modes
-        config.spaces = GuiConfig.orderedSpaces(
+        // De-dup only — live order is authoritative (#75).
+        config.spaces = GuiConfig.deduplicated(
             defined + Array(modes.keys)
         )
         if config.spaces.isEmpty {

--- a/Sources/KiwiDeskCore/Config/GuiConfig.swift
+++ b/Sources/KiwiDeskCore/Config/GuiConfig.swift
@@ -110,40 +110,12 @@ public struct GuiConfig: Codable, Equatable, Sendable {
         return true
     }
 
-    /// De-duplicates space ids preserving insertion order (first
-    /// occurrence wins). Does NOT sort — use `orderedSpaces` for
-    /// numeric-then-lexical ordering.
-    public static func deduplicated(
-        _ ids: [SpaceID]
-    ) -> [SpaceID] {
-        var seen: Set<String> = []
-        return ids.filter { seen.insert($0.raw).inserted }
-    }
-
-    /// De-duplicates and sorts space ids for display: numeric
-    /// ids ascending, then named ids alphabetically.
-    public static func orderedSpaces(
-        _ ids: [SpaceID]
-    ) -> [SpaceID] {
-        var seen: Set<String> = []
-        var unique: [SpaceID] = []
-        for id in ids where seen.insert(id.raw).inserted {
-            unique.append(id)
-        }
-        return unique.sorted { first, second in
-            switch (Int(first.raw), Int(second.raw)) {
-            case (let left?, let right?): return left < right
-            case (_?, nil): return true
-            case (nil, _?): return false
-            default: return first.raw < second.raw
-            }
-        }
-    }
-
     /// Moves `space` to the front of the ordered list. A no-op
     /// when `space` is absent or is already the first element.
     /// This is the primitive a future fallback-space chooser
-    /// (#68) will call.
+    /// (#68) will call; wire it through the edit-stored-profile
+    /// path (`overwriteProfile`), not a live save, so the
+    /// reorder reaches `Profile.spaces` faithfully.
     public mutating func moveToFirst(_ space: SpaceID) {
         guard let index = spaces.firstIndex(of: space),
             index != 0

--- a/Sources/KiwiDeskCore/Config/GuiConfig.swift
+++ b/Sources/KiwiDeskCore/Config/GuiConfig.swift
@@ -110,7 +110,17 @@ public struct GuiConfig: Codable, Equatable, Sendable {
         return true
     }
 
-    /// De-duplicates and orders space ids for display: numeric
+    /// De-duplicates space ids preserving insertion order (first
+    /// occurrence wins). Does NOT sort — use `orderedSpaces` for
+    /// numeric-then-lexical ordering.
+    public static func deduplicated(
+        _ ids: [SpaceID]
+    ) -> [SpaceID] {
+        var seen: Set<String> = []
+        return ids.filter { seen.insert($0.raw).inserted }
+    }
+
+    /// De-duplicates and sorts space ids for display: numeric
     /// ids ascending, then named ids alphabetically.
     public static func orderedSpaces(
         _ ids: [SpaceID]
@@ -128,6 +138,18 @@ public struct GuiConfig: Codable, Equatable, Sendable {
             default: return first.raw < second.raw
             }
         }
+    }
+
+    /// Moves `space` to the front of the ordered list. A no-op
+    /// when `space` is absent or is already the first element.
+    /// This is the primitive a future fallback-space chooser
+    /// (#68) will call.
+    public mutating func moveToFirst(_ space: SpaceID) {
+        guard let index = spaces.firstIndex(of: space),
+            index != 0
+        else { return }
+        spaces.remove(at: index)
+        spaces.insert(space, at: 0)
     }
 
     /// Only the global fields persist in the sidecar — the

--- a/Sources/KiwiDeskCore/Models/SpaceModel.swift
+++ b/Sources/KiwiDeskCore/Models/SpaceModel.swift
@@ -56,6 +56,40 @@ public struct SpaceID: Hashable, Sendable, Codable,
     }
 }
 
+// MARK: - Ordering helpers
+
+extension SpaceID {
+    /// Sorts space IDs: numeric ids ascending, then named ids
+    /// alphabetically. Stable within equal-valued elements.
+    ///
+    /// Shared by `Profile.orderedSpaces` and
+    /// `GuiConfig` sort helpers — the single canonical
+    /// numeric-then-lexical comparator for space lists.
+    public static func numericLexicalSorted(
+        _ ids: [SpaceID]
+    ) -> [SpaceID] {
+        ids.sorted { a, b in
+            switch (Int(a.raw), Int(b.raw)) {
+            case (let l?, let r?): return l < r
+            case (_?, nil): return true
+            case (nil, _?): return false
+            default: return a.raw < b.raw
+            }
+        }
+    }
+
+    /// Order-preserving de-duplication: first occurrence wins.
+    ///
+    /// Shared by `Profile` and `GuiConfig` — the single
+    /// canonical dedup helper for space ID arrays.
+    public static func deduplicated(
+        _ ids: [SpaceID]
+    ) -> [SpaceID] {
+        var seen: Set<SpaceID> = []
+        return ids.filter { seen.insert($0).inserted }
+    }
+}
+
 /// Dictionaries keyed by SpaceID serialize as JSON objects
 /// (`{"2": ...}`) instead of flattened key/value arrays.
 extension SpaceID: CodingKeyRepresentable {

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
@@ -22,7 +22,10 @@ extension KiwiCore {
             state.workspaces.ensureSpace(id)
         }
         if pruneStaleSpaces {
-            pruneSpaces(keeping: declared)
+            pruneSpaces(
+                keeping: declared,
+                orderedBy: profile.orderedSpaces
+            )
         }
         // Dense over all live spaces: a space a (hand-edited,
         // sparse) profile doesn't declare reverts to bsp
@@ -48,16 +51,25 @@ extension KiwiCore {
 
     /// Explicit-load reconcile: drop live spaces whose name isn't
     /// in the new profile, forwarding any windows they hold to the
-    /// profile's first space so none are orphaned. A space whose
-    /// name also exists in the new profile is kept untouched — its
-    /// windows stay put regardless of the layout difference. The
-    /// fallback follows the same order the Spaces list shows; a
-    /// user-chosen order is a follow-up (roadmap #27).
-    private func pruneSpaces(keeping survivors: Set<SpaceID>) {
-        guard
-            let fallback =
-                GuiConfig.orderedSpaces(Array(survivors)).first
-        else { return }
+    /// rehome target so none are orphaned. A space whose name also
+    /// exists in the new profile is kept untouched — its windows
+    /// stay put regardless of the layout difference.
+    ///
+    /// `orderedBy` is the profile's `orderedSpaces` list (#75):
+    /// the rehome target is the first element that is also a
+    /// survivor, so windows land in the first space of the new
+    /// profile's displayed list. Falls back to a sorted-survivor
+    /// if none of the ordered spaces survived (degenerate).
+    private func pruneSpaces(
+        keeping survivors: Set<SpaceID>,
+        orderedBy storedOrder: [SpaceID]
+    ) {
+        let fallback =
+            storedOrder.first { survivors.contains($0) }
+            ?? GuiConfig.orderedSpaces(
+                Array(survivors)
+            ).first
+        guard let fallback else { return }
         for space in state.workspaces.allSpaces
         where !survivors.contains(space.id) {
             for window in space.windows {

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
@@ -18,7 +18,13 @@ extension KiwiCore {
     ) {
         tiler.settings = profile.settings
         let declared = profile.declaredSpaces
-        for id in declared {
+        // Seed live order from the profile's stored list so
+        // creation order matches display order. Using
+        // orderedSpaces (never the declaredSpaces Set) means
+        // WorkspaceManager.order follows the profile's list,
+        // not Set-hash order — making the subsequent
+        // buildProfile capture deterministic and faithful.
+        for id in profile.orderedSpaces {
             state.workspaces.ensureSpace(id)
         }
         if pruneStaleSpaces {
@@ -50,25 +56,26 @@ extension KiwiCore {
     }
 
     /// Explicit-load reconcile: drop live spaces whose name isn't
-    /// in the new profile, forwarding any windows they hold to the
-    /// rehome target so none are orphaned. A space whose name also
-    /// exists in the new profile is kept untouched — its windows
-    /// stay put regardless of the layout difference.
+    /// in the new profile, forwarding any windows they hold to
+    /// the rehome target so none are orphaned. A space whose
+    /// name also exists in the new profile is kept untouched —
+    /// its windows stay put regardless of the layout difference.
     ///
     /// `orderedBy` is the profile's `orderedSpaces` list (#75):
     /// the rehome target is the first element that is also a
     /// survivor, so windows land in the first space of the new
-    /// profile's displayed list. Falls back to a sorted-survivor
-    /// if none of the ordered spaces survived (degenerate).
+    /// profile's displayed list. When both lists are empty
+    /// (degenerate call) the guard skips pruning entirely.
     private func pruneSpaces(
         keeping survivors: Set<SpaceID>,
         orderedBy storedOrder: [SpaceID]
     ) {
-        let fallback =
-            storedOrder.first { survivors.contains($0) }
-            ?? GuiConfig.orderedSpaces(
-                Array(survivors)
-            ).first
+        // `orderedSpaces ⊆ declaredSpaces == survivors` so a
+        // non-empty storedOrder always has a match — nil only
+        // when storedOrder itself is empty (empty profile).
+        let fallback = storedOrder.first {
+            survivors.contains($0)
+        }
         guard let fallback else { return }
         for space in state.workspaces.allSpaces
         where !survivors.contains(space.id) {

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
@@ -106,16 +106,21 @@ extension KiwiCore {
     }
 
     /// Snapshot of the current configuration as a new profile
-    /// carrying only the live monitor set.
+    /// carrying only the live monitor set. The live space order
+    /// from `allSpaces` is captured as the profile's stored
+    /// order (#75) so the Spaces list round-trips unchanged.
     func buildProfile(name: String) -> Profile {
         var modes: [SpaceID: LayoutMode] = [:]
+        var liveSpaces: [SpaceID] = []
         for space in state.workspaces.allSpaces {
             modes[space.id] = space.mode
+            liveSpaces.append(space.id)
         }
         return Profile(
             name: name,
             monitorSets: [liveMonitorSet()],
             mainSpaces: mainSpaces.sorted { $0.raw < $1.raw },
+            spaces: liveSpaces,
             spaceModes: modes,
             settings: tiler.settings
         )
@@ -141,6 +146,7 @@ extension KiwiCore {
             )
         }
         let fresh = buildProfile(name: name)
+        existing.spaces = fresh.spaces
         existing.spaceModes = fresh.spaceModes
         existing.mainSpaces = fresh.mainSpaces
         existing.settings = fresh.settings
@@ -164,6 +170,10 @@ extension KiwiCore {
     ) throws {
         var existing = try profiles.read(name: name)
         existing.settings = config.settings
+        // Capture the display order from the GUI model (#75):
+        // the config's `spaces` list is the profile's new
+        // authoritative order.
+        existing.spaces = config.spaces
         // Dense over the profile's own spaces (mirrors
         // `buildProfile`): an undeclared space reads as bsp. The
         // union with `spaceModes.keys` keeps a just-set mode even

--- a/Sources/KiwiDeskCore/Profiles/Profile.swift
+++ b/Sources/KiwiDeskCore/Profiles/Profile.swift
@@ -75,6 +75,14 @@ public struct Profile: Codable, Sendable, Equatable {
     /// for the reconcile rehome fallback on profile switch.
     /// New spaces append; existing profiles without this key
     /// decode to `[]` and fall back to the derived order.
+    ///
+    /// Authority: `gui.json` owns live display order across the
+    /// session; `Profile.spaces` owns per-profile order,
+    /// consulted when that profile is loaded. The two stay in
+    /// sync because `apply(profile:)` seeds live order from
+    /// this list and both save paths (`persistProfile`,
+    /// `overwriteProfile`) capture the resulting live order
+    /// back here.
     public var spaces: [SpaceID]
     /// Layout mode per space.
     public var spaceModes: [SpaceID: LayoutMode]
@@ -109,28 +117,14 @@ public struct Profile: Codable, Sendable, Equatable {
     /// that predate the `spaces` key.
     public var orderedSpaces: [SpaceID] {
         if spaces.isEmpty {
-            return Self.numericLexicalSort(
+            return SpaceID.numericLexicalSorted(
                 Array(declaredSpaces)
             )
         }
         let stored = Set(spaces)
         let extra = declaredSpaces.subtracting(stored)
-        return spaces + Self.numericLexicalSort(Array(extra))
-    }
-
-    /// Sorts space IDs: numeric ids ascending, then named
-    /// ids alphabetically.
-    static func numericLexicalSort(
-        _ ids: [SpaceID]
-    ) -> [SpaceID] {
-        ids.sorted { a, b in
-            switch (Int(a.raw), Int(b.raw)) {
-            case (let l?, let r?): return l < r
-            case (_?, nil): return true
-            case (nil, _?): return false
-            default: return a.raw < b.raw
-            }
-        }
+        return spaces
+            + SpaceID.numericLexicalSorted(Array(extra))
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -158,18 +152,10 @@ public struct Profile: Codable, Sendable, Equatable {
         self.monitorSets = Self.sanitized(monitorSets)
         self.mainSpaces = mainSpaces.sorted { $0.raw < $1.raw }
         self.isDefault = isDefault
-        self.spaces = Self.deduplicated(spaces)
+        self.spaces = SpaceID.deduplicated(spaces)
         self.spaceModes = spaceModes
         self.settings = settings
         self.savedAt = savedAt
-    }
-
-    /// Order-preserving de-duplication: first occurrence wins.
-    private static func deduplicated(
-        _ spaces: [SpaceID]
-    ) -> [SpaceID] {
-        var seen: Set<SpaceID> = []
-        return spaces.filter { seen.insert($0).inserted }
     }
 
     /// Lenient where safe (missing flags default), strict where
@@ -206,7 +192,7 @@ public struct Profile: Codable, Sendable, Equatable {
             ) ?? false
         // Lenient: missing key on legacy profiles → empty,
         // which `orderedSpaces` converts to the derived order.
-        spaces = Self.deduplicated(
+        spaces = SpaceID.deduplicated(
             try container.decodeIfPresent(
                 [SpaceID].self,
                 forKey: .spaces

--- a/Sources/KiwiDeskCore/Profiles/Profile.swift
+++ b/Sources/KiwiDeskCore/Profiles/Profile.swift
@@ -70,6 +70,12 @@ public struct Profile: Codable, Sendable, Equatable {
     /// Marks this profile as its screen count's default (the
     /// dirty-load fallback when no set matches exactly).
     public var isDefault: Bool
+    /// Persisted display order of the profile's spaces (#75).
+    /// This is the authoritative order for the Spaces list and
+    /// for the reconcile rehome fallback on profile switch.
+    /// New spaces append; existing profiles without this key
+    /// decode to `[]` and fall back to the derived order.
+    public var spaces: [SpaceID]
     /// Layout mode per space.
     public var spaceModes: [SpaceID: LayoutMode]
     public var settings: TilingSettings
@@ -80,12 +86,13 @@ public struct Profile: Codable, Sendable, Equatable {
         monitorSets.first?.monitors.count ?? 0
     }
 
-    /// Every space the profile declares — by mode, Main role, or a
-    /// monitor pin. The one definition of "this profile's spaces",
-    /// so an authoritative load prunes to exactly what the editor
-    /// shows (a hand-edited pin/main on a mode-less space counts).
+    /// Every space the profile declares — by ordered list, mode,
+    /// Main role, or a monitor pin. The one definition of "this
+    /// profile's spaces", so an authoritative load prunes to
+    /// exactly what the editor shows.
     public var declaredSpaces: Set<SpaceID> {
-        var all = Set(spaceModes.keys)
+        var all = Set(spaces)
+        all.formUnion(spaceModes.keys)
         all.formUnion(mainSpaces)
         for set in monitorSets {
             all.formUnion(set.spaceMonitorMap.keys)
@@ -93,11 +100,45 @@ public struct Profile: Codable, Sendable, Equatable {
         return all
     }
 
+    /// Authoritative display order for this profile's spaces.
+    ///
+    /// Returns `spaces` when non-empty, with any declared space
+    /// absent from the list appended (sorted numerically then
+    /// lexically) — guards against hand-edited JSON gaps.
+    /// Falls back to sorted `declaredSpaces` for legacy profiles
+    /// that predate the `spaces` key.
+    public var orderedSpaces: [SpaceID] {
+        if spaces.isEmpty {
+            return Self.numericLexicalSort(
+                Array(declaredSpaces)
+            )
+        }
+        let stored = Set(spaces)
+        let extra = declaredSpaces.subtracting(stored)
+        return spaces + Self.numericLexicalSort(Array(extra))
+    }
+
+    /// Sorts space IDs: numeric ids ascending, then named
+    /// ids alphabetically.
+    static func numericLexicalSort(
+        _ ids: [SpaceID]
+    ) -> [SpaceID] {
+        ids.sorted { a, b in
+            switch (Int(a.raw), Int(b.raw)) {
+            case (let l?, let r?): return l < r
+            case (_?, nil): return true
+            case (nil, _?): return false
+            default: return a.raw < b.raw
+            }
+        }
+    }
+
     private enum CodingKeys: String, CodingKey {
         case name
         case monitorSets = "monitor_sets"
         case mainSpaces = "main_spaces"
         case isDefault = "default"
+        case spaces
         case spaceModes = "space_modes"
         case settings
         case savedAt = "saved_at"
@@ -108,6 +149,7 @@ public struct Profile: Codable, Sendable, Equatable {
         monitorSets: [MonitorSet],
         mainSpaces: [SpaceID] = [],
         isDefault: Bool = false,
+        spaces: [SpaceID] = [],
         spaceModes: [SpaceID: LayoutMode],
         settings: TilingSettings,
         savedAt: Date = .now
@@ -116,9 +158,18 @@ public struct Profile: Codable, Sendable, Equatable {
         self.monitorSets = Self.sanitized(monitorSets)
         self.mainSpaces = mainSpaces.sorted { $0.raw < $1.raw }
         self.isDefault = isDefault
+        self.spaces = Self.deduplicated(spaces)
         self.spaceModes = spaceModes
         self.settings = settings
         self.savedAt = savedAt
+    }
+
+    /// Order-preserving de-duplication: first occurrence wins.
+    private static func deduplicated(
+        _ spaces: [SpaceID]
+    ) -> [SpaceID] {
+        var seen: Set<SpaceID> = []
+        return spaces.filter { seen.insert($0).inserted }
     }
 
     /// Lenient where safe (missing flags default), strict where
@@ -153,6 +204,14 @@ public struct Profile: Codable, Sendable, Equatable {
                 Bool.self,
                 forKey: .isDefault
             ) ?? false
+        // Lenient: missing key on legacy profiles → empty,
+        // which `orderedSpaces` converts to the derived order.
+        spaces = Self.deduplicated(
+            try container.decodeIfPresent(
+                [SpaceID].self,
+                forKey: .spaces
+            ) ?? []
+        )
         spaceModes = try container.decode(
             [SpaceID: LayoutMode].self,
             forKey: .spaceModes

--- a/Tests/KiwiDeskCoreTests/ProfileSpaceOrderTests.swift
+++ b/Tests/KiwiDeskCoreTests/ProfileSpaceOrderTests.swift
@@ -1,0 +1,167 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+// Write-path round-trip tests for space-order preservation (#75).
+// Exercises the CAPTURE path: load_profile + save_profile, where
+// the live WorkspaceManager order is seeded by apply(profile:)
+// and then read back by buildProfile.  The existing
+// `rehomeUsesStoredOrder` test in ProfileSpaceReconcileTests
+// hand-builds a Profile and calls apply() directly; these tests
+// go through the command path so the full encode→disk→load→live
+// →encode cycle is exercised.
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    KiwiCore(
+        configDirectory: FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent(
+                "kiwi-order-\(UUID().uuidString)"
+            )
+    )
+}
+
+/// A display named `name` with a 100×100 frame.
+/// Fingerprint: `"<name>:100x100"`.
+private func display(
+    _ id: UInt32,
+    _ name: String
+) -> Display {
+    Display(
+        id: DisplayID(id),
+        name: name,
+        frame: CGRect(x: 0, y: 0, width: 100, height: 100)
+    )
+}
+
+@MainActor
+private func connect(
+    _ core: KiwiCore,
+    _ displays: [Display]
+) {
+    for d in displays { core.state.workspaces.upsertDisplay(d) }
+}
+
+@Suite("Space order write-path round-trip (#75)", .serialized)
+@MainActor
+struct ProfileSpaceOrderTests {
+
+    // MARK: load → save preserves stored order
+
+    /// The core defect: `apply(profile:)` used to iterate
+    /// `declaredSpaces` (a Set) when calling `ensureSpace`,
+    /// so WorkspaceManager.order became Set-hash order instead
+    /// of the profile's stored display order.  A subsequent
+    /// `save_profile` then captured that scrambled order into
+    /// `Profile.spaces`.
+    ///
+    /// Fix: iterate `profile.orderedSpaces` (not the Set).
+    @Test("load_profile + save_profile preserves stored order")
+    func loadSavePreservesOrder() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+
+        // Write a profile directly (bypassing buildProfile) so
+        // we can set the stored `spaces` to a non-sorted order
+        // ["z","m","a"] that is distinct from both numeric-
+        // ascending and alphabetical order.  All three IDs are
+        // unknown to the live state (it only has SpaceID(1) from
+        // StateCoordinator.init), so they will be created fresh
+        // by the ensureSpace loop inside apply(profile:) and the
+        // insertion order is what the test verifies.
+        let stored = Profile(
+            name: "ordered",
+            monitorSets: [
+                MonitorSet(monitors: ["A:100x100"])
+            ],
+            spaces: [
+                SpaceID("z"),
+                SpaceID("m"),
+                SpaceID("a"),
+            ],
+            spaceModes: [
+                SpaceID("z"): .stack,
+                SpaceID("m"): .bsp,
+                SpaceID("a"): .grid,
+            ],
+            settings: TilingSettings()
+        )
+        try core.profiles.save(stored)
+
+        // load_profile: "z","m","a" don't exist yet in live
+        // state; SpaceID(1) (the init default) is stale and
+        // gets pruned.  Before the fix the three new spaces were
+        // created in Set-hash order; after the fix they follow
+        // orderedSpaces = ["z","m","a"].
+        let load = core.execute(
+            "load_profile",
+            args: [.string("ordered")]
+        )
+        #expect(load.isSuccess)
+
+        // save_profile: buildProfile captures allSpaces in
+        // WorkspaceManager.order, which is now ["z","m","a"].
+        core.execute(
+            "save_profile",
+            args: [.string("ordered")]
+        )
+
+        let after = try core.profiles.read(name: "ordered")
+        // Order must survive the full load→save round-trip.
+        #expect(
+            after.spaces == [
+                SpaceID("z"),
+                SpaceID("m"),
+                SpaceID("a"),
+            ]
+        )
+    }
+
+    // MARK: sidecar and profile agree after load
+
+    /// After loading a profile with stored order ["z","m","a"],
+    /// `loadGuiConfig()` (which seeds from live state when no
+    /// sidecar exists) must return the same order — not the
+    /// alphabetical sort that the old Set-iteration produced.
+    @Test("guiConfigSeed reflects stored order after load")
+    func seedReflectsStoredOrderAfterLoad() throws {
+        let core = makeCore()
+        connect(core, [display(1, "A")])
+
+        let stored = Profile(
+            name: "q",
+            monitorSets: [
+                MonitorSet(monitors: ["A:100x100"])
+            ],
+            spaces: [
+                SpaceID("z"),
+                SpaceID("m"),
+                SpaceID("a"),
+            ],
+            spaceModes: [
+                SpaceID("z"): .bsp,
+                SpaceID("m"): .bsp,
+                SpaceID("a"): .bsp,
+            ],
+            settings: TilingSettings()
+        )
+        try core.profiles.save(stored)
+
+        let load = core.execute(
+            "load_profile",
+            args: [.string("q")]
+        )
+        #expect(load.isSuccess)
+
+        // No sidecar → guiConfigSeed() uses allSpaces order.
+        let cfg = core.loadGuiConfig()
+        // Spaces section must agree with the profile's order.
+        let profileSpaces = [
+            SpaceID("z"), SpaceID("m"), SpaceID("a"),
+        ]
+        #expect(cfg.spaces == profileSpaces)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ProfileSpaceReconcileTests.swift
+++ b/Tests/KiwiDeskCoreTests/ProfileSpaceReconcileTests.swift
@@ -113,6 +113,37 @@ struct ProfileSpaceReconcileTests {
         #expect(core.state.workspaces.activeSpace == SpaceID("1"))
     }
 
+    // MARK: - Stored-order rehome (#75)
+
+    @Test("Rehome uses profile's stored space order")
+    func rehomeUsesStoredOrder() {
+        // Verify that the reconcile fallback is the first space
+        // in the profile's *stored* order, not the sorted order.
+        // With stored order ["2", "1"], the sorted order would
+        // give "1" first — ensure "2" is used instead.
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("2"))
+        core.state.workspaces.add(WindowID(42), to: SpaceID("old"))
+        let p = Profile(
+            name: "p",
+            monitorSets: [],
+            spaces: [SpaceID("2"), SpaceID("1")],
+            spaceModes: [
+                SpaceID("1"): .bsp,
+                SpaceID("2"): .bsp,
+            ],
+            settings: TilingSettings()
+        )
+        core.apply(profile: p, pruneStaleSpaces: true)
+        // "old" pruned; its window rehomes to "2" (first in
+        // stored order), not "1" (first in numeric order).
+        #expect(
+            core.state.workspaces.space(of: WindowID(42))
+                == SpaceID("2")
+        )
+    }
+
     @Test("Hardware-driven applies keep spaces, reset stale modes")
     func noPruneByDefault() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/ProfileTests.swift
+++ b/Tests/KiwiDeskCoreTests/ProfileTests.swift
@@ -171,6 +171,120 @@ struct ProfileModelTests {
         #expect(json.contains("\"space_modes\":{\"1\""))
     }
 
+    // MARK: - spaces field (#75)
+
+    @Test("Profile.spaces round-trips preserving order")
+    func spacesRoundTrip() throws {
+        // Parity test: the `spaces` field must survive a full
+        // encode→decode cycle without re-sorting.
+        let profile = Profile(
+            name: "ordered",
+            monitorSets: [MonitorSet(monitors: ["A:1x1"])],
+            spaces: [
+                SpaceID("c"), SpaceID("a"), SpaceID("b"),
+            ],
+            spaceModes: ["a": .stack],
+            settings: TilingSettings(),
+            savedAt: Date(timeIntervalSince1970: 1_780_000_000)
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(profile)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(
+            Profile.self,
+            from: data
+        )
+        // Order must be c, a, b — not sorted alphabetically.
+        #expect(
+            decoded.spaces
+                == [SpaceID("c"), SpaceID("a"), SpaceID("b")]
+        )
+    }
+
+    @Test("Profile.spaces defaults to [] when key is absent")
+    func spacesDecodeDefault() throws {
+        // Parity test: legacy profiles without the `spaces`
+        // key must decode without error and default to [].
+        let json = """
+            {"name":"old",
+             "monitor_sets":[{"monitors":["A:1x1"]}],
+             "space_modes":{},
+             "settings":{},
+             "saved_at":"2026-06-01T00:00:00Z"}
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let profile = try decoder.decode(
+            Profile.self,
+            from: Data(json.utf8)
+        )
+        #expect(profile.spaces == [])
+    }
+
+    @Test("Profile JSON encodes a spaces key")
+    func spacesKeyPresent() throws {
+        // Round-trip sentinel: the encoded JSON must contain the
+        // "spaces" key so stored profiles carry the order.
+        let profile = Profile(
+            name: "p",
+            monitorSets: [MonitorSet(monitors: ["A:1x1"])],
+            spaces: [SpaceID(1), SpaceID(2)],
+            spaceModes: [:],
+            settings: TilingSettings(),
+            savedAt: Date(timeIntervalSince1970: 1_780_000_000)
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let json = String(
+            decoding: try encoder.encode(profile),
+            as: UTF8.self
+        )
+        #expect(json.contains("\"spaces\":["))
+    }
+
+    @Test("Profile.orderedSpaces uses stored order")
+    func orderedSpacesUsesStoredOrder() {
+        let profile = Profile(
+            name: "p",
+            monitorSets: [],
+            spaces: [
+                SpaceID("z"), SpaceID("a"), SpaceID("m"),
+            ],
+            spaceModes: [
+                SpaceID("z"): .bsp,
+                SpaceID("a"): .stack,
+            ],
+            settings: TilingSettings()
+        )
+        // Stored order "z, a, m" beats alphabetical "a, m, z".
+        #expect(
+            profile.orderedSpaces
+                == [SpaceID("z"), SpaceID("a"), SpaceID("m")]
+        )
+    }
+
+    @Test("Profile.orderedSpaces appends undeclared extras")
+    func orderedSpacesAppendsExtras() {
+        // A hand-edited profile may have a spaceModes key not in
+        // the spaces list: orderedSpaces appends it at the end.
+        let profile = Profile(
+            name: "p",
+            monitorSets: [],
+            spaces: [SpaceID("1"), SpaceID("2")],
+            spaceModes: [
+                SpaceID("1"): .stack,
+                SpaceID("3"): .grid,
+            ],
+            settings: TilingSettings()
+        )
+        let ordered = profile.orderedSpaces
+        // "1" and "2" first (stored order); "3" appended.
+        #expect(ordered.prefix(2) == [SpaceID("1"), SpaceID("2")])
+        #expect(ordered.contains(SpaceID("3")))
+    }
+
     @Test("Upsert replaces the same set, refuses new lengths")
     func upsert() {
         var profile = makeProfile(

--- a/Tests/KiwiDeskCoreTests/RenameSpaceTests.swift
+++ b/Tests/KiwiDeskCoreTests/RenameSpaceTests.swift
@@ -190,3 +190,50 @@ struct RenameSpaceTests {
         #expect(config.spaceModes[SpaceID("2")] == .stack)
     }
 }
+
+/// `GuiConfig.moveToFirst` and `GuiConfig.deduplicated` (#75).
+@Suite("GuiConfig space-order helpers")
+struct GuiConfigSpaceOrderTests {
+    @Test("moveToFirst moves a middle space to index 0")
+    func moveToFirstMid() {
+        var config = GuiConfig()
+        config.spaces = [SpaceID("a"), SpaceID("b"), SpaceID("c")]
+        config.moveToFirst(SpaceID("b"))
+        #expect(
+            config.spaces
+                == [SpaceID("b"), SpaceID("a"), SpaceID("c")]
+        )
+    }
+
+    @Test("moveToFirst is a no-op when already first")
+    func moveToFirstAlreadyFirst() {
+        var config = GuiConfig()
+        config.spaces = [SpaceID("a"), SpaceID("b")]
+        config.moveToFirst(SpaceID("a"))
+        #expect(
+            config.spaces == [SpaceID("a"), SpaceID("b")]
+        )
+    }
+
+    @Test("moveToFirst is a no-op for absent spaces")
+    func moveToFirstAbsent() {
+        var config = GuiConfig()
+        config.spaces = [SpaceID("a"), SpaceID("b")]
+        config.moveToFirst(SpaceID("z"))
+        #expect(
+            config.spaces == [SpaceID("a"), SpaceID("b")]
+        )
+    }
+
+    @Test("deduplicated preserves insertion order, no sort")
+    func deduplicatedOrder() {
+        let result = GuiConfig.deduplicated([
+            SpaceID("z"), SpaceID("a"), SpaceID("m"),
+            SpaceID("z"),  // duplicate — dropped
+        ])
+        // Order is z, a, m — NOT sorted alphabetically.
+        #expect(
+            result == [SpaceID("z"), SpaceID("a"), SpaceID("m")]
+        )
+    }
+}

--- a/Tests/KiwiDeskCoreTests/RenameSpaceTests.swift
+++ b/Tests/KiwiDeskCoreTests/RenameSpaceTests.swift
@@ -191,7 +191,9 @@ struct RenameSpaceTests {
     }
 }
 
-/// `GuiConfig.moveToFirst` and `GuiConfig.deduplicated` (#75).
+/// `GuiConfig.moveToFirst` and `SpaceID.deduplicated` (#75).
+/// `deduplicated` was hoisted from `GuiConfig` to `SpaceID`
+/// (Models) so `Profile` and `GuiConfig` share one helper.
 @Suite("GuiConfig space-order helpers")
 struct GuiConfigSpaceOrderTests {
     @Test("moveToFirst moves a middle space to index 0")
@@ -227,7 +229,7 @@ struct GuiConfigSpaceOrderTests {
 
     @Test("deduplicated preserves insertion order, no sort")
     func deduplicatedOrder() {
-        let result = GuiConfig.deduplicated([
+        let result = SpaceID.deduplicated([
             SpaceID("z"), SpaceID("a"), SpaceID("m"),
             SpaceID("z"),  // duplicate — dropped
         ])

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -835,10 +835,13 @@ window in a space whose name also exists in the new profile
 stays put — regardless of any layout difference. A space whose
 name the new profile doesn't define is dropped, and any windows
 it held are forwarded to the **first space** of the new profile
-(the first in the Spaces-tab list) so nothing is lost. This
-reconcile happens only on an explicit `load_profile`; automatic
-applies on a monitor change or a native-Space binding leave
-your spaces untouched.
+— the first in its Spaces-tab list, which is the order the
+profile stores. The Settings app preserves that order; if you
+reorder the list and save the profile, the new first space
+becomes the rehome target for future profile switches.
+This reconcile happens only on an explicit `load_profile`;
+automatic applies on a monitor change or a native-Space binding
+leave your spaces untouched.
 
 A profile covers one or more concrete **monitor sets** — each
 a list of monitor fingerprints plus the space→monitor pins


### PR DESCRIPTION
## Summary

Closes #75. Spaces now have a **stable, persisted order** instead of being force-sorted numeric-then-lexically at every consumer.

- `Profile` gains a persisted ordered `spaces: [SpaceID]` (lenient decode, round-trip + parity tested); `gui.json` already stored the ordered list.
- Display + rehoming consumers honor stored order: `orderedSpaces()`'s sort is split into an order-preserving `SpaceID.deduplicated` (hoisted to `Models` with the shared numeric-lexical comparator) so callers stop re-sorting.
- Reconcile rehome target follows stored order (first surviving space of the loaded profile), replacing the interim `orderedSpaces(...).first`.
- A `moveToFirst` primitive is added for the future #68 fallback-space chooser (no GUI surface yet).

## Notes for reviewers / follow-up

- **Order authority:** `gui.json` owns live display order; `Profile.spaces` owns per-profile order; kept in sync by seeding live order from the ordered list on `apply(profile:)` and capturing it on save.
- **Deferred to #55/#68 (documented, not reachable today):** the live-save path and `overwriteProfile` read two order representations that can only diverge once a reorder UI ships; the cascade resolver in #55 should pick one enforcement point (`applyProfileScopedState` reconciling `WorkspaceManager.order` to `config.spaces`). Captured in `plan/wave7-issue55-plan.md`.

## Verification

`swift build && swift test` (459 tests) `&& scripts/lint.sh && swift build -c release` — all green. Reviewed by code-reviewer + architect-reviewer (two rounds, §3.6); no remaining majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)