### PR TITLE
feat(lifecycle): gather windows onto their monitor on stop (#69)

### DIFF
--- a/Sources/KiwiDesk/AppDelegate.swift
+++ b/Sources/KiwiDesk/AppDelegate.swift
@@ -15,6 +15,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var dashboard = SettingsWindowController(
         core: core
     )
+    /// Held strongly so the source stays active for the
+    /// lifetime of the process.
+    private var sigtermSource: DispatchSourceSignal?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         let statusItem = StatusItemController()
@@ -35,6 +38,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 : self?.core.keys.icon(for: mode)
             self?.statusItem?.setModeIcon(icon)
         }
+
+        // launchctl bootout (restart) delivers SIGTERM. AppKit
+        // isn't guaranteed to translate it into
+        // applicationWillTerminate for a LaunchAgent process, so
+        // redirect it explicitly into AppKit's termination flow.
+        // SIG_IGN prevents the default handler from killing the
+        // process before the DispatchSource fires.
+        signal(SIGTERM, SIG_IGN)
+        let src = DispatchSource.makeSignalSource(
+            signal: SIGTERM,
+            queue: .main
+        )
+        src.setEventHandler { NSApp.terminate(nil) }
+        src.resume()
+        sigtermSource = src
 
         permissions.onChange = { [weak self] trusted in
             self?.permissionChanged(trusted)

--- a/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
@@ -67,6 +67,9 @@ extension KiwiCore {
     }
 
     public func stop() {
+        // Gather windows onto their owning monitors before
+        // any subsystem teardown; AX must still be live here.
+        gatherWindows()
         pendingFocusFollow?.cancel()
         pendingStartupSweep?.cancel()
         pendingSpaceSettle?.cancel()

--- a/Sources/KiwiDeskCore/App/KiwiCore+Teardown.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Teardown.swift
@@ -1,31 +1,42 @@
 import AppKit
+import ApplicationServices
 import CoreGraphics
 
 /// Pure gather-target computation for KiwiDesk shutdown.
 ///
-/// When KiwiDesk stops (quit, disable, restart), managed tiled
-/// windows are centered on their owning display so they are not
-/// left stranded in tiled frames after the WM exits.
+/// When KiwiDesk stops (quit or restart), managed tiled
+/// windows are staggered onto their owning display so they
+/// are not left stranded in tiled frames after the WM exits.
+/// All reachable windows land on the single visible native
+/// Space (inactive-virtual-space windows are parked at the
+/// peek corner on that same native Space).
 ///
 /// **Floating-size decision**: KiwiDesk does not yet track a
 /// "last-floating size" (no `lastFloatingSize` in state; see
 /// issue #70). Gather keeps the window's current frame size —
-/// the tiled size the AX echoes last reported — and centers it
-/// within the display's visible area. This is a safe,
-/// always-visible default. A future pass may record pre-tile
-/// sizes for a richer restore.
+/// the tiled size the AX echoes last reported — and places it
+/// within the display's visible area. A future pass may record
+/// pre-tile sizes for a richer restore.
 public enum WindowGather {
-    /// Returns a gather-target frame: `size` centered in
-    /// `axFrame`, with each edge clamped inside `axFrame`.
+    /// Diagonal step between staggered windows (pts).
+    public static let staggerStep: CGFloat = 40
+
+    /// Returns a staggered gather-target frame: `size`
+    /// centered in `axFrame` with a diagonal `index × step`
+    /// offset, each edge clamped inside `axFrame`.
+    /// Index 0 produces the exact center.
     ///
     /// `axFrame` must be in AX (top-left-origin) coordinates;
     /// the returned rect is also in AX coordinates.
-    public static func centeredFrame(
+    public static func staggeredFrame(
         size: CGSize,
-        in axFrame: CGRect
+        in axFrame: CGRect,
+        index: Int,
+        step: CGFloat = staggerStep
     ) -> CGRect {
-        let x = axFrame.midX - size.width / 2
-        let y = axFrame.midY - size.height / 2
+        let offset = CGFloat(index) * step
+        let x = axFrame.midX - size.width / 2 + offset
+        let y = axFrame.midY - size.height / 2 + offset
         let cx = max(
             axFrame.minX,
             min(x, axFrame.maxX - size.width)
@@ -42,22 +53,52 @@ public enum WindowGather {
         )
     }
 
+    /// Returns a gather-target frame: `size` centered in
+    /// `axFrame`, with each edge clamped inside `axFrame`.
+    ///
+    /// `axFrame` must be in AX (top-left-origin) coordinates;
+    /// the returned rect is also in AX coordinates.
+    public static func centeredFrame(
+        size: CGSize,
+        in axFrame: CGRect
+    ) -> CGRect {
+        staggeredFrame(size: size, in: axFrame, index: 0)
+    }
+
     /// Returns a gather target for every tracked, tiled window.
     ///
     /// `primaryHeight` is `NSScreen.screens.first?.frame.height`
     /// (Cocoa coordinates), used to flip `Display.visibleFrame`
     /// into AX (top-left) coordinates. Windows whose space has
-    /// no display assignment fall back to the first display.
-    /// Floating windows and windows with a zero-size frame are
-    /// excluded.
+    /// no display assignment fall back to the display with the
+    /// lowest raw ID (deterministic on multi-monitor). Floating
+    /// windows and windows with a zero-size frame are excluded.
+    ///
+    /// Windows on the same display are staggered diagonally by
+    /// `staggerStep` pts per window so each is at a distinct,
+    /// findable position rather than an overlapping pile.
+    ///
+    /// NOTE — cross-Space scope (#70): this iterates
+    /// `allSpaces`, which is correct because KiwiDesk keeps
+    /// every managed window on the single visible native Space
+    /// (inactive-virtual-space windows are parked off-screen at
+    /// the peek corner). When #70 introduces true multi-native-
+    /// Space windows, add an explicit native-Space filter here
+    /// (cf. `eventLoop.isListed`) or this will silently move
+    /// background-Space windows.
     public static func targets(
         state: StateCoordinator,
         primaryHeight: CGFloat
     ) -> [WindowID: CGRect] {
         let displays = state.workspaces.allDisplays
         guard !displays.isEmpty else { return [:] }
-        let fallback = displays[0]
+        // Lowest raw ID → deterministic fallback on multi-
+        // monitor; Array(dict.values) order is not stable.
+        let fallback = displays.min { $0.id.raw < $1.id.raw }!
         var result: [WindowID: CGRect] = [:]
+        // Per-display stagger counter so each display's
+        // windows cascade independently.
+        var displayIdx: [DisplayID: Int] = [:]
         for space in state.workspaces.allSpaces {
             let displayID =
                 state.workspaces.display(of: space.id)
@@ -74,9 +115,12 @@ public enum WindowGather {
                     !window.isFloating,
                     window.frame.size != .zero
                 else { continue }
-                result[windowID] = centeredFrame(
+                let idx = displayIdx[display.id, default: 0]
+                displayIdx[display.id] = idx + 1
+                result[windowID] = staggeredFrame(
                     size: window.frame.size,
-                    in: axVisible
+                    in: axVisible,
+                    index: idx
                 )
             }
         }
@@ -86,15 +130,21 @@ public enum WindowGather {
 
 extension KiwiCore {
     /// Moves each managed tiled window onto its owning monitor,
-    /// centered within the display's visible area, so windows
+    /// staggered within the display's visible area, so windows
     /// are not stranded in tiled frames after KiwiDesk exits.
     ///
-    /// Applies frames synchronously (direct AX IPC, 1–20 ms
-    /// per window) inside a SkyLight display-suppression
-    /// bracket so all moves composite as one visual update.
+    /// Applies frames synchronously (direct AX IPC) inside a
+    /// SkyLight display-suppression bracket so all moves
+    /// composite as one visual update. A per-element AX
+    /// messaging timeout (0.25 s) prevents one unresponsive app
+    /// from blocking the quit path; a total wall-clock budget
+    /// of ~1 s caps the worst case across all windows.
     ///
-    /// Called at the top of `stop()` while the event loop and
-    /// AX subsystem are still live.
+    /// Called on quit and restart, at the top of `stop()` while
+    /// the event loop and AX subsystem are still live. When
+    /// called due to AX permission revocation, `setFrame` calls
+    /// return `kAXErrorAPIDisabled` and are silent no-ops —
+    /// windows stay wherever the WM left them.
     func gatherWindows() {
         guard eventLoop.isRunning else { return }
         let primaryH = GeometryUtils.primaryHeight
@@ -104,12 +154,52 @@ extension KiwiCore {
         )
         guard !frames.isEmpty else { return }
         SkyLight.suppressDisplay()
+        // defer ensures resumeDisplay() runs even if the
+        // budget fires a break below.
+        defer { SkyLight.resumeDisplay() }
+        let deadline = Date().addingTimeInterval(1.0)
         for (id, frame) in frames {
+            // Wall-clock budget: one unresponsive cluster of
+            // apps cannot freeze the entire quit path.
+            if Date() > deadline {
+                onLog(
+                    "gatherWindows: 1 s budget exceeded"
+                        + " (targeted \(frames.count) windows)"
+                )
+                break
+            }
             guard
                 let element = eventLoop.element(for: id)
             else { continue }
+            // Per-element timeout: default AX timeout is ~6 s;
+            // 0.25 s caps each call and keeps the total
+            // wall-clock cost bounded per window.
+            AXUIElementSetMessagingTimeout(element, 0.25)
+            // Mirror applyInstant's EUI bracket: EUI-on apps
+            // self-animate frame changes (Electron/WebKit) and
+            // can clamp or swallow the set — drop it for the
+            // move and restore whatever it was.
+            var pid: pid_t = 0
+            let hasPid =
+                AXUIElementGetPid(element, &pid) == .success
+            let wasEUI =
+                hasPid
+                && AXHelper.getEnhancedUserInterface(
+                    pid: pid
+                ) == true
+            if wasEUI {
+                AXHelper.setEnhancedUserInterface(
+                    pid: pid,
+                    enabled: false
+                )
+            }
             WindowControl.setFrame(frame, of: element)
+            if wasEUI {
+                AXHelper.setEnhancedUserInterface(
+                    pid: pid,
+                    enabled: true
+                )
+            }
         }
-        SkyLight.resumeDisplay()
     }
 }

--- a/Sources/KiwiDeskCore/App/KiwiCore+Teardown.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Teardown.swift
@@ -135,10 +135,13 @@ extension KiwiCore {
     ///
     /// Applies frames synchronously (direct AX IPC) inside a
     /// SkyLight display-suppression bracket so all moves
-    /// composite as one visual update. A per-element AX
-    /// messaging timeout (0.25 s) prevents one unresponsive app
-    /// from blocking the quit path; a total wall-clock budget
-    /// of ~1 s caps the worst case across all windows.
+    /// composite as one visual update. A system-wide AX
+    /// messaging timeout (0.25 s) is set once before the loop
+    /// and bounds every AX call in the iteration — EUI reads,
+    /// EUI disable/restore, and setFrame — so Electron/WebKit
+    /// apps (up to ~6 s with the default timeout) cannot stall
+    /// the quit path; a total wall-clock budget of ~1 s caps
+    /// the worst case across all windows.
     ///
     /// Called on quit and restart, at the top of `stop()` while
     /// the event loop and AX subsystem are still live. When
@@ -158,6 +161,14 @@ extension KiwiCore {
         // budget fires a break below.
         defer { SkyLight.resumeDisplay() }
         let deadline = Date().addingTimeInterval(1.0)
+        // Bound every AX call — EUI reads, EUI disable/
+        // restore, setFrame — including on fresh app elements
+        // created inside AXHelper. The system-wide default
+        // covers all elements created after this point.
+        AXUIElementSetMessagingTimeout(
+            AXUIElementCreateSystemWide(),
+            0.25
+        )
         for (id, frame) in frames {
             // Wall-clock budget: one unresponsive cluster of
             // apps cannot freeze the entire quit path.
@@ -171,10 +182,6 @@ extension KiwiCore {
             guard
                 let element = eventLoop.element(for: id)
             else { continue }
-            // Per-element timeout: default AX timeout is ~6 s;
-            // 0.25 s caps each call and keeps the total
-            // wall-clock cost bounded per window.
-            AXUIElementSetMessagingTimeout(element, 0.25)
             // Mirror applyInstant's EUI bracket: EUI-on apps
             // self-animate frame changes (Electron/WebKit) and
             // can clamp or swallow the set — drop it for the

--- a/Sources/KiwiDeskCore/App/KiwiCore+Teardown.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Teardown.swift
@@ -1,0 +1,115 @@
+import AppKit
+import CoreGraphics
+
+/// Pure gather-target computation for KiwiDesk shutdown.
+///
+/// When KiwiDesk stops (quit, disable, restart), managed tiled
+/// windows are centered on their owning display so they are not
+/// left stranded in tiled frames after the WM exits.
+///
+/// **Floating-size decision**: KiwiDesk does not yet track a
+/// "last-floating size" (no `lastFloatingSize` in state; see
+/// issue #70). Gather keeps the window's current frame size —
+/// the tiled size the AX echoes last reported — and centers it
+/// within the display's visible area. This is a safe,
+/// always-visible default. A future pass may record pre-tile
+/// sizes for a richer restore.
+public enum WindowGather {
+    /// Returns a gather-target frame: `size` centered in
+    /// `axFrame`, with each edge clamped inside `axFrame`.
+    ///
+    /// `axFrame` must be in AX (top-left-origin) coordinates;
+    /// the returned rect is also in AX coordinates.
+    public static func centeredFrame(
+        size: CGSize,
+        in axFrame: CGRect
+    ) -> CGRect {
+        let x = axFrame.midX - size.width / 2
+        let y = axFrame.midY - size.height / 2
+        let cx = max(
+            axFrame.minX,
+            min(x, axFrame.maxX - size.width)
+        )
+        let cy = max(
+            axFrame.minY,
+            min(y, axFrame.maxY - size.height)
+        )
+        return CGRect(
+            x: cx,
+            y: cy,
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    /// Returns a gather target for every tracked, tiled window.
+    ///
+    /// `primaryHeight` is `NSScreen.screens.first?.frame.height`
+    /// (Cocoa coordinates), used to flip `Display.visibleFrame`
+    /// into AX (top-left) coordinates. Windows whose space has
+    /// no display assignment fall back to the first display.
+    /// Floating windows and windows with a zero-size frame are
+    /// excluded.
+    public static func targets(
+        state: StateCoordinator,
+        primaryHeight: CGFloat
+    ) -> [WindowID: CGRect] {
+        let displays = state.workspaces.allDisplays
+        guard !displays.isEmpty else { return [:] }
+        let fallback = displays[0]
+        var result: [WindowID: CGRect] = [:]
+        for space in state.workspaces.allSpaces {
+            let displayID =
+                state.workspaces.display(of: space.id)
+            let display =
+                displays.first { $0.id == displayID }
+                ?? fallback
+            let axVisible = GeometryUtils.flip(
+                display.visibleFrame,
+                primaryHeight: primaryHeight
+            )
+            for windowID in space.windows {
+                guard
+                    let window = state.windows[windowID],
+                    !window.isFloating,
+                    window.frame.size != .zero
+                else { continue }
+                result[windowID] = centeredFrame(
+                    size: window.frame.size,
+                    in: axVisible
+                )
+            }
+        }
+        return result
+    }
+}
+
+extension KiwiCore {
+    /// Moves each managed tiled window onto its owning monitor,
+    /// centered within the display's visible area, so windows
+    /// are not stranded in tiled frames after KiwiDesk exits.
+    ///
+    /// Applies frames synchronously (direct AX IPC, 1–20 ms
+    /// per window) inside a SkyLight display-suppression
+    /// bracket so all moves composite as one visual update.
+    ///
+    /// Called at the top of `stop()` while the event loop and
+    /// AX subsystem are still live.
+    func gatherWindows() {
+        guard eventLoop.isRunning else { return }
+        let primaryH = GeometryUtils.primaryHeight
+        let frames = WindowGather.targets(
+            state: state,
+            primaryHeight: primaryH
+        )
+        guard !frames.isEmpty else { return }
+        SkyLight.suppressDisplay()
+        for (id, frame) in frames {
+            guard
+                let element = eventLoop.element(for: id)
+            else { continue }
+            WindowControl.setFrame(frame, of: element)
+        }
+        SkyLight.resumeDisplay()
+    }
+}

--- a/Tests/KiwiDeskCoreTests/GatherWindowsStaggerTests.swift
+++ b/Tests/KiwiDeskCoreTests/GatherWindowsStaggerTests.swift
@@ -197,14 +197,18 @@ struct GatherMultiDisplayTests {
             state: state,
             primaryHeight: pH
         )
-        if let f1 = frames[WindowID(1)] {
-            #expect(abs(f1.midX - axVisible1.midX) < 1)
-            #expect(abs(f1.midY - axVisible1.midY) < 1)
+        guard let f1 = frames[WindowID(1)] else {
+            Issue.record("no frame for window 1")
+            return
         }
-        if let f2 = frames[WindowID(2)] {
-            #expect(abs(f2.midX - axVisible2.midX) < 1)
-            #expect(abs(f2.midY - axVisible2.midY) < 1)
+        guard let f2 = frames[WindowID(2)] else {
+            Issue.record("no frame for window 2")
+            return
         }
+        #expect(abs(f1.midX - axVisible1.midX) < 1)
+        #expect(abs(f1.midY - axVisible1.midY) < 1)
+        #expect(abs(f2.midX - axVisible2.midX) < 1)
+        #expect(abs(f2.midY - axVisible2.midY) < 1)
     }
 
     @Test("two windows on same display are staggered apart")

--- a/Tests/KiwiDeskCoreTests/GatherWindowsStaggerTests.swift
+++ b/Tests/KiwiDeskCoreTests/GatherWindowsStaggerTests.swift
@@ -1,0 +1,328 @@
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+// MARK: - Fixtures
+
+// Two side-by-side 1920×1080 displays in Cocoa coordinates.
+// Display 1: x=[0, 1920), primaryH = 1080
+// Display 2: x=[1920, 3840), same height
+private let pH: CGFloat = 1080
+
+private let display1 = Display(
+    id: DisplayID(1),
+    name: "Main",
+    frame: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+    visibleFrame: CGRect(
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1055
+    )
+)
+
+// AX coordinates: y = 1080 − (0 + 1055) = 25
+private let axVisible1 = CGRect(
+    x: 0,
+    y: 25,
+    width: 1920,
+    height: 1055
+)
+
+private let display2 = Display(
+    id: DisplayID(2),
+    name: "External",
+    frame: CGRect(x: 1920, y: 0, width: 1920, height: 1080),
+    visibleFrame: CGRect(
+        x: 1920,
+        y: 0,
+        width: 1920,
+        height: 1055
+    )
+)
+
+// AX coordinates: y = 25, x offset = 1920
+private let axVisible2 = CGRect(
+    x: 1920,
+    y: 25,
+    width: 1920,
+    height: 1055
+)
+
+private func makeState() -> StateCoordinator {
+    var s = StateCoordinator(defaultSpace: SpaceID(1))
+    s.workspaces.upsertDisplay(display1)
+    s.workspaces.upsertDisplay(display2)
+    s.workspaces.assign(SpaceID(1), to: DisplayID(1))
+    s.workspaces.assign(SpaceID(2), to: DisplayID(2))
+    return s
+}
+
+private func addWindow(
+    _ state: inout StateCoordinator,
+    id: UInt32,
+    space: SpaceID,
+    size: CGSize = CGSize(width: 400, height: 300)
+) {
+    let w = ManagedWindow(
+        id: WindowID(id),
+        pid: 99,
+        appName: "TestApp",
+        title: "",
+        frame: CGRect(
+            x: 0,
+            y: 0,
+            width: size.width,
+            height: size.height
+        )
+    )
+    state.apply(.windowCreated(w))
+    state.workspaces.add(WindowID(id), to: space)
+}
+
+// MARK: - staggeredFrame math
+
+@Suite("WindowGather — staggeredFrame")
+struct GatherStaggerFrameTests {
+    private let frame = CGRect(
+        x: 0,
+        y: 25,
+        width: 1920,
+        height: 1055
+    )
+    private let size = CGSize(width: 400, height: 300)
+
+    @Test("index 0 is centered — same as centeredFrame")
+    func index0MatchesCenteredFrame() {
+        let stag = WindowGather.staggeredFrame(
+            size: size,
+            in: frame,
+            index: 0
+        )
+        let cent = WindowGather.centeredFrame(
+            size: size,
+            in: frame
+        )
+        #expect(stag == cent)
+        #expect(abs(stag.midX - frame.midX) < 1)
+        #expect(abs(stag.midY - frame.midY) < 1)
+    }
+
+    @Test("index 1 offsets diagonally by staggerStep")
+    func index1IsOffset() {
+        let step = WindowGather.staggerStep
+        let s0 = WindowGather.staggeredFrame(
+            size: size,
+            in: frame,
+            index: 0
+        )
+        let s1 = WindowGather.staggeredFrame(
+            size: size,
+            in: frame,
+            index: 1
+        )
+        #expect(abs(s1.minX - (s0.minX + step)) < 1)
+        #expect(abs(s1.minY - (s0.minY + step)) < 1)
+    }
+
+    @Test("large index clamps within axFrame")
+    func largeIndexClamps() {
+        let result = WindowGather.staggeredFrame(
+            size: size,
+            in: frame,
+            index: 10_000
+        )
+        #expect(result.minX >= frame.minX)
+        #expect(result.minY >= frame.minY)
+        #expect(result.maxX <= frame.maxX)
+        #expect(result.maxY <= frame.maxY)
+    }
+
+    @Test("staggered frames remain inside axFrame for many windows")
+    func manyWindowsAllInsideBounds() {
+        for idx in 0..<50 {
+            let r = WindowGather.staggeredFrame(
+                size: size,
+                in: frame,
+                index: idx
+            )
+            #expect(r.minX >= frame.minX)
+            #expect(r.minY >= frame.minY)
+            #expect(r.maxX <= frame.maxX)
+            #expect(r.maxY <= frame.maxY)
+        }
+    }
+}
+
+// MARK: - Multi-display targets
+
+@Suite("WindowGather — multi-display targets")
+struct GatherMultiDisplayTests {
+    @Test("each window lands within its own display's axVisible")
+    func eachWindowOnOwnDisplay() {
+        var state = makeState()
+        addWindow(&state, id: 1, space: SpaceID(1))
+        addWindow(&state, id: 2, space: SpaceID(2))
+        let frames = WindowGather.targets(
+            state: state,
+            primaryHeight: pH
+        )
+        guard let f1 = frames[WindowID(1)] else {
+            Issue.record("no frame for window 1")
+            return
+        }
+        guard let f2 = frames[WindowID(2)] else {
+            Issue.record("no frame for window 2")
+            return
+        }
+        // Window 1 must be inside display1's axVisible frame.
+        #expect(f1.minX >= axVisible1.minX)
+        #expect(f1.maxX <= axVisible1.maxX)
+        #expect(f1.minY >= axVisible1.minY)
+        #expect(f1.maxY <= axVisible1.maxY)
+        // Window 2 must be inside display2's axVisible frame.
+        #expect(f2.minX >= axVisible2.minX)
+        #expect(f2.maxX <= axVisible2.maxX)
+        #expect(f2.minY >= axVisible2.minY)
+        #expect(f2.maxY <= axVisible2.maxY)
+    }
+
+    @Test("first window per display is at display center")
+    func firstWindowPerDisplayIsAtCenter() {
+        var state = makeState()
+        addWindow(&state, id: 1, space: SpaceID(1))
+        addWindow(&state, id: 2, space: SpaceID(2))
+        let frames = WindowGather.targets(
+            state: state,
+            primaryHeight: pH
+        )
+        if let f1 = frames[WindowID(1)] {
+            #expect(abs(f1.midX - axVisible1.midX) < 1)
+            #expect(abs(f1.midY - axVisible1.midY) < 1)
+        }
+        if let f2 = frames[WindowID(2)] {
+            #expect(abs(f2.midX - axVisible2.midX) < 1)
+            #expect(abs(f2.midY - axVisible2.midY) < 1)
+        }
+    }
+
+    @Test("two windows on same display are staggered apart")
+    func twoWindowsSameDisplayAreStaggered() {
+        var state = makeState()
+        addWindow(&state, id: 10, space: SpaceID(1))
+        addWindow(&state, id: 11, space: SpaceID(1))
+        let frames = WindowGather.targets(
+            state: state,
+            primaryHeight: pH
+        )
+        guard let f10 = frames[WindowID(10)],
+            let f11 = frames[WindowID(11)]
+        else {
+            Issue.record("missing frame(s)")
+            return
+        }
+        // They must not be at the exact same position.
+        #expect(f10.origin != f11.origin)
+        // The step should be the configured constant.
+        let step = WindowGather.staggerStep
+        #expect(
+            abs(abs(f11.minX - f10.minX) - step) < 1
+                || f11.minX == axVisible1.minX
+                || f11.maxX == axVisible1.maxX
+        )
+    }
+
+    @Test("unassigned space falls back to lowest-ID display")
+    func deterministicFallback() {
+        // Three displays: IDs 5, 2, 1 — inserted in that
+        // order to exercise the unordered-dict issue.
+        var s = StateCoordinator(defaultSpace: SpaceID(1))
+        let d5 = Display(
+            id: DisplayID(5),
+            name: "D5",
+            frame: CGRect(
+                x: 3840,
+                y: 0,
+                width: 1920,
+                height: 1080
+            ),
+            visibleFrame: CGRect(
+                x: 3840,
+                y: 0,
+                width: 1920,
+                height: 1055
+            )
+        )
+        let d2 = Display(
+            id: DisplayID(2),
+            name: "D2",
+            frame: CGRect(
+                x: 1920,
+                y: 0,
+                width: 1920,
+                height: 1080
+            ),
+            visibleFrame: CGRect(
+                x: 1920,
+                y: 0,
+                width: 1920,
+                height: 1055
+            )
+        )
+        let d1 = Display(
+            id: DisplayID(1),
+            name: "D1",
+            frame: CGRect(
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080
+            ),
+            visibleFrame: CGRect(
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1055
+            )
+        )
+        s.workspaces.upsertDisplay(d5)
+        s.workspaces.upsertDisplay(d2)
+        s.workspaces.upsertDisplay(d1)
+        // Space 99 has no display assignment → fallback.
+        s.workspaces.ensureSpace(SpaceID(99))
+        let w = ManagedWindow(
+            id: WindowID(77),
+            pid: 99,
+            appName: "App",
+            title: "",
+            frame: CGRect(
+                x: 0,
+                y: 0,
+                width: 400,
+                height: 300
+            )
+        )
+        s.apply(.windowCreated(w))
+        s.workspaces.add(WindowID(77), to: SpaceID(99))
+        let frames = WindowGather.targets(
+            state: s,
+            primaryHeight: 1080
+        )
+        guard let f = frames[WindowID(77)] else {
+            Issue.record("no frame for window 77")
+            return
+        }
+        // Lowest raw ID is 1 → display d1, x=[0, 1920).
+        let axD1 = CGRect(
+            x: 0,
+            y: 25,
+            width: 1920,
+            height: 1055
+        )
+        #expect(f.minX >= axD1.minX)
+        #expect(f.maxX <= axD1.maxX)
+        #expect(f.minY >= axD1.minY)
+        #expect(f.maxY <= axD1.maxY)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/GatherWindowsTests.swift
+++ b/Tests/KiwiDeskCoreTests/GatherWindowsTests.swift
@@ -1,0 +1,216 @@
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+// MARK: - Shared fixtures
+
+// Single 1920×1080 display, Cocoa coordinates.
+private let displayFrame = CGRect(
+    x: 0,
+    y: 0,
+    width: 1920,
+    height: 1080
+)
+// visibleFrame excludes the 25-pt menu bar strip (Cocoa).
+private let cocoaVisible = CGRect(
+    x: 0,
+    y: 0,
+    width: 1920,
+    height: 1055
+)
+// AX visible: flip(cocoaVisible, pH: 1080)
+//   y = 1080 − (0 + 1055) = 25, height = 1055
+private let axVisible = CGRect(
+    x: 0,
+    y: 25,
+    width: 1920,
+    height: 1055
+)
+private let primaryH: CGFloat = 1080
+
+// MARK: - Helpers
+
+private func makeState() -> StateCoordinator {
+    var s = StateCoordinator(defaultSpace: SpaceID(1))
+    s.workspaces.upsertDisplay(
+        Display(
+            id: DisplayID(1),
+            name: "Main",
+            frame: displayFrame,
+            visibleFrame: cocoaVisible
+        )
+    )
+    s.workspaces.assign(SpaceID(1), to: DisplayID(1))
+    return s
+}
+
+private func addWindow(
+    _ state: inout StateCoordinator,
+    id: UInt32,
+    size: CGSize = CGSize(width: 800, height: 600),
+    isFloating: Bool = false
+) {
+    let w = ManagedWindow(
+        id: WindowID(id),
+        pid: 99,
+        appName: "TestApp",
+        title: "",
+        frame: CGRect(
+            x: 0,
+            y: 0,
+            width: size.width,
+            height: size.height
+        ),
+        isFloating: isFloating
+    )
+    state.apply(.windowCreated(w))
+}
+
+// MARK: - Centered-frame math
+
+@Suite("WindowGather — centeredFrame")
+struct GatherCenteredFrameTests {
+    @Test("window is centered in the display")
+    func centersWindow() {
+        let size = CGSize(width: 800, height: 600)
+        let result = WindowGather.centeredFrame(
+            size: size,
+            in: axVisible
+        )
+        #expect(abs(result.midX - axVisible.midX) < 1)
+        #expect(abs(result.midY - axVisible.midY) < 1)
+        #expect(result.width == 800)
+        #expect(result.height == 600)
+    }
+
+    @Test("window wider than display clamps to left edge")
+    func clampsTooWide() {
+        let size = CGSize(width: 2000, height: 600)
+        let result = WindowGather.centeredFrame(
+            size: size,
+            in: axVisible
+        )
+        #expect(result.minX == axVisible.minX)
+    }
+
+    @Test("window taller than display clamps to top edge")
+    func clampsTooTall() {
+        let size = CGSize(width: 800, height: 2000)
+        let result = WindowGather.centeredFrame(
+            size: size,
+            in: axVisible
+        )
+        #expect(result.minY == axVisible.minY)
+    }
+
+    @Test("result frame sits entirely within axFrame")
+    func staysInsideBounds() {
+        let size = CGSize(width: 400, height: 300)
+        let result = WindowGather.centeredFrame(
+            size: size,
+            in: axVisible
+        )
+        #expect(result.minX >= axVisible.minX)
+        #expect(result.minY >= axVisible.minY)
+        #expect(result.maxX <= axVisible.maxX)
+        #expect(result.maxY <= axVisible.maxY)
+    }
+}
+
+// MARK: - Target resolution
+
+@Suite("WindowGather — targets")
+struct GatherTargetsTests {
+    @Test("tiled window gets a centered frame on its display")
+    func tiledWindowCentered() {
+        var state = makeState()
+        addWindow(&state, id: 42)
+        let frames = WindowGather.targets(
+            state: state,
+            primaryHeight: primaryH
+        )
+        guard let frame = frames[WindowID(42)] else {
+            Issue.record("no frame resolved for window 42")
+            return
+        }
+        #expect(abs(frame.midX - axVisible.midX) < 1)
+        #expect(abs(frame.midY - axVisible.midY) < 1)
+        #expect(frame.width == 800)
+        #expect(frame.height == 600)
+    }
+
+    @Test("floating windows are excluded")
+    func skipsFloating() {
+        var state = makeState()
+        addWindow(&state, id: 99, isFloating: true)
+        let frames = WindowGather.targets(
+            state: state,
+            primaryHeight: primaryH
+        )
+        #expect(frames[WindowID(99)] == nil)
+    }
+
+    @Test("windows with zero-size frame are excluded")
+    func skipsZeroFrame() {
+        var state = makeState()
+        // Default frame is .zero → should be excluded.
+        let w = ManagedWindow(
+            id: WindowID(7),
+            pid: 99,
+            appName: "App"
+        )
+        state.apply(.windowCreated(w))
+        let frames = WindowGather.targets(
+            state: state,
+            primaryHeight: primaryH
+        )
+        #expect(frames[WindowID(7)] == nil)
+    }
+
+    @Test("empty display list returns no targets")
+    func emptyDisplays() {
+        // No displays registered — targets must be empty.
+        var s = StateCoordinator(defaultSpace: SpaceID(1))
+        addWindow(&s, id: 5)
+        let frames = WindowGather.targets(
+            state: s,
+            primaryHeight: primaryH
+        )
+        #expect(frames.isEmpty)
+    }
+
+    @Test("window in unassigned space falls back to first display")
+    func fallsBackToFirstDisplay() {
+        var state = makeState()
+        // Add a second space with no display assignment,
+        // then move a window there.
+        state.workspaces.ensureSpace(SpaceID(99))
+        let w = ManagedWindow(
+            id: WindowID(55),
+            pid: 99,
+            appName: "App",
+            title: "",
+            frame: CGRect(
+                x: 0,
+                y: 0,
+                width: 800,
+                height: 600
+            )
+        )
+        state.apply(.windowCreated(w))
+        // Relocate to the display-less space.
+        state.workspaces.add(WindowID(55), to: SpaceID(99))
+        let frames = WindowGather.targets(
+            state: state,
+            primaryHeight: primaryH
+        )
+        // Falls back to the first (and only) display.
+        guard let frame = frames[WindowID(55)] else {
+            Issue.record("no frame for window 55")
+            return
+        }
+        #expect(abs(frame.midX - axVisible.midX) < 1)
+        #expect(abs(frame.midY - axVisible.midY) < 1)
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1119,6 +1119,15 @@ logout/reboot; after that, windows are re-tiled fresh).
 Crashes restore from the last autosave (30 s interval)
 instead.
 
+Before exiting (quit, disable, or restart), KiwiDesk moves
+each managed tiled window back onto the monitor its virtual
+space is assigned to, centered in the display's visible
+area. This prevents windows from being stranded in tiled
+frames after the window manager stops. Floating windows are
+left wherever they are. Only windows on the currently
+visible native Space can be reached (windows on background
+native Spaces are out of scope — see issue #70).
+
 ## Extras
 
 ### Per-desktop keybinds (profiles + modes)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1119,14 +1119,22 @@ logout/reboot; after that, windows are re-tiled fresh).
 Crashes restore from the last autosave (30 s interval)
 instead.
 
-Before exiting (quit, disable, or restart), KiwiDesk moves
-each managed tiled window back onto the monitor its virtual
-space is assigned to, centered in the display's visible
-area. This prevents windows from being stranded in tiled
-frames after the window manager stops. Floating windows are
-left wherever they are. Only windows on the currently
-visible native Space can be reached (windows on background
-native Spaces are out of scope — see issue #70).
+On quit or restart, KiwiDesk moves each managed tiled window
+back onto the monitor its virtual space is assigned to and
+staggers them diagonally within the display's visible area,
+so every window is individually findable. Floating windows
+are left wherever they are. Because KiwiDesk keeps all
+managed windows on the single visible native Space (inactive
+virtual spaces are parked off-screen at the peek corner —
+not on a different native macOS Space), every reachable
+window lands there staggered together. Windows on background
+native macOS Spaces are out of scope — see issue #70.
+
+When AX permission is revoked mid-session, KiwiDesk pauses
+window management but cannot gather windows — `setFrame`
+calls return `kAXErrorAPIDisabled` and are silent no-ops.
+Windows stay wherever the WM left them; re-enabling
+Accessibility in System Settings resumes management.
 
 ## Extras
 


### PR DESCRIPTION
## Summary

Closes #69. When KiwiDesk stops (quit or restart), managed windows are re-homed onto their owning monitor instead of being left stranded in tiled frames — copying AeroSpace's `beforeTermination()`, scoped to the reachable slice (windows on the visible native Space; cross-Space is deferred to #70).

- New `KiwiCore+Teardown.swift`: pure `WindowGather` functions (`staggeredFrame`/`targets`, unit-tested) + `KiwiCore.gatherWindows()`, hooked as the first line of `stop()` while AX and the event loop are still live.
- Windows **cascade/stagger** per-display (not piled at one center), each clamped inside its display's visible frame.
- Last-floating-size fallback: keep current size, center/stagger on the owning monitor (no floating-size tracking exists yet; the seam is left clean for a future `ManagedWindow.floatSize`).

## Robustness (review-driven)

- **Bounded AX:** a process-global `AXUIElementSetMessagingTimeout(0.25)` is armed before the loop so EUI reads, EUI disable/restore, and `setFrame` are all bounded — a hung Electron/WebKit app can't freeze quit. A 1s wall-clock budget backstops the loop.
- **EUI handled:** mirrors `FrameApplier.applyInstant`'s read/disable/restore of `AXEnhancedUserInterface` so lazy apps don't swallow the frame.
- **All stop paths covered:** quit and restart both reach `stop()`; an explicit `DispatchSourceSignal` for SIGTERM makes restart robust regardless of AppKit's default disposition. Permission-revoke can't gather (AX gone) — documented.
- `defer`-guarded SkyLight bracket; deterministic lowest-ID fallback display; multi-display test coverage.

## Verification

`swift build && swift test` (464 tests) `&& scripts/lint.sh && swift build -c release` — all green. Reviewed by code-reviewer + architect-reviewer (three rounds, §3.6); no remaining majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)