### PR TITLE
test(parity): forget-proof guards for existing field-list mirrors (#73)

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -12,7 +12,12 @@ ones that bite large test PRs, as a checklist (rationale is in §5):
   bite large test files. Break a suite into focused files *before*
   it approaches the ceiling.
 - **Per-file private helpers are the convention** — small
-  duplication across suites is fine; no shared test harness.
+  duplication across suites is fine; no shared test harness. One
+  ratified exception: *stateless structural-parity primitives*
+  (reflection helpers backing the field-list guards) live shared
+  in `ReflectionParity.swift` — duplicating them would let a
+  divergent copy silently weaken a guard, the exact drift those
+  guards prevent.
 - Config/profile shape is pinned by `SettingsCodingTests` — extend
   it when adding a setting (Lua name → JSON key via `CodingKeys`;
   see [config-vocabulary.md](config-vocabulary.md)).

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
@@ -123,6 +123,9 @@ public struct AppBarStyle: Sendable, Equatable {
 extension AppBarStyle: Codable {
     /// JSON keys are the Lua setters (`app_bar.set_*`) minus the
     /// `set_` verb — the `app_bar` nesting carries the namespace.
+    /// `CaseIterable` is load-bearing: the parity test
+    /// (`AppBarParityTests`) reflects over `allCases` to prove
+    /// every field has a key — do not drop it as "unused".
     enum CodingKeys: String, CodingKey, CaseIterable {
         case position
         case thickness

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
@@ -123,7 +123,7 @@ public struct AppBarStyle: Sendable, Equatable {
 extension AppBarStyle: Codable {
     /// JSON keys are the Lua setters (`app_bar.set_*`) minus the
     /// `set_` verb — the `app_bar` nesting carries the namespace.
-    enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case position
         case thickness
         case style

--- a/Sources/KiwiDeskCore/Layouts/LayoutAppBar.swift
+++ b/Sources/KiwiDeskCore/Layouts/LayoutAppBar.swift
@@ -97,7 +97,7 @@ extension LayoutAppBar: Codable {
     /// written; inherited fields stay absent.
     typealias CodingKeys = Key
 
-    enum Key: String, CodingKey {
+    enum Key: String, CodingKey, CaseIterable {
         case enabled
         case position
         case thickness

--- a/Sources/KiwiDeskCore/Layouts/LayoutAppBar.swift
+++ b/Sources/KiwiDeskCore/Layouts/LayoutAppBar.swift
@@ -97,6 +97,9 @@ extension LayoutAppBar: Codable {
     /// written; inherited fields stay absent.
     typealias CodingKeys = Key
 
+    /// `CaseIterable` is load-bearing: the parity test
+    /// (`AppBarParityTests`) reflects over `allCases` to prove
+    /// every field has a key — do not drop it as "unused".
     enum Key: String, CodingKey, CaseIterable {
         case enabled
         case position

--- a/Tests/KiwiDeskCoreTests/AppBarFixtures.swift
+++ b/Tests/KiwiDeskCoreTests/AppBarFixtures.swift
@@ -1,0 +1,65 @@
+import CoreGraphics
+import Foundation
+
+@testable import KiwiDeskCore
+
+/// Fixtures that set *every* field to a non-default value. Shared
+/// by the JSON round-trip in `AppBarTests` and the reflection
+/// guards in `AppBarParityTests`, so there is a single mirror of
+/// the field list to keep honest — `fixturesAreExhaustive` pins
+/// that both fixtures still touch every field, which is what makes
+/// the round-trip forget-proof (AGENTS.md §5). Lives in its own
+/// file rather than being owned by one suite, symmetric with
+/// `ReflectionParity.swift`.
+enum AppBarFixtures {
+    static func everyGlobalField() -> AppBarStyle {
+        var style = AppBarStyle()
+        style.position = .bottom
+        style.thickness = 44
+        style.style = .segments
+        style.activeStyle = .gap
+        style.itemSize = 120
+        style.itemGap = 3
+        style.content = .name
+        style.groupAdjacentWindows = false
+        style.fontSize = 15
+        style.cornerRadius = 5
+        style.textColor = "#010101"
+        style.boxColor = "#020202"
+        style.activeTextColor = "#030303"
+        style.activeBoxColor = "#040404"
+        style.highlightColor = "#050505"
+        style.hoverColor = "#060606"
+        style.hoverTextColor = "#070707"
+        style.backgroundColor = "#080808"
+        style.groupBadgeColor = "#090909"
+        style.groupBadgeTextColor = "#0A0A0A"
+        return style
+    }
+
+    static func everyOverrideField() -> LayoutAppBar {
+        var bar = LayoutAppBar()
+        bar.enabled = false
+        bar.position = .right
+        bar.thickness = 50
+        bar.style = .underline
+        bar.activeStyle = .highlight
+        bar.itemSize = 88
+        bar.itemGap = 9
+        bar.content = .iconAndName
+        bar.groupAdjacentWindows = true
+        bar.fontSize = 20
+        bar.cornerRadius = 12
+        bar.textColor = "#111111"
+        bar.boxColor = "#222222"
+        bar.activeTextColor = "#333333"
+        bar.activeBoxColor = "#444444"
+        bar.highlightColor = "#555555"
+        bar.hoverColor = "#666666"
+        bar.hoverTextColor = "#777777"
+        bar.backgroundColor = "#888888"
+        bar.groupBadgeColor = "#999999"
+        bar.groupBadgeTextColor = "#AAAAAA"
+        return bar
+    }
+}

--- a/Tests/KiwiDeskCoreTests/AppBarParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/AppBarParityTests.swift
@@ -4,62 +4,8 @@ import Testing
 
 @testable import KiwiDeskCore
 
-/// Fixtures that set *every* field to a non-default value. Shared
-/// by the JSON round-trip in `AppBarTests` and the reflection
-/// guards below, so there is a single mirror of the field list to
-/// keep honest (`AppBarParityTests.fixturesAreExhaustive` pins it).
-enum AppBarFixtures {
-    static func everyGlobalField() -> AppBarStyle {
-        var style = AppBarStyle()
-        style.position = .bottom
-        style.thickness = 44
-        style.style = .segments
-        style.activeStyle = .gap
-        style.itemSize = 120
-        style.itemGap = 3
-        style.content = .name
-        style.groupAdjacentWindows = false
-        style.fontSize = 15
-        style.cornerRadius = 5
-        style.textColor = "#010101"
-        style.boxColor = "#020202"
-        style.activeTextColor = "#030303"
-        style.activeBoxColor = "#040404"
-        style.highlightColor = "#050505"
-        style.hoverColor = "#060606"
-        style.hoverTextColor = "#070707"
-        style.backgroundColor = "#080808"
-        style.groupBadgeColor = "#090909"
-        style.groupBadgeTextColor = "#0A0A0A"
-        return style
-    }
-
-    static func everyOverrideField() -> LayoutAppBar {
-        var bar = LayoutAppBar()
-        bar.enabled = false
-        bar.position = .right
-        bar.thickness = 50
-        bar.style = .underline
-        bar.activeStyle = .highlight
-        bar.itemSize = 88
-        bar.itemGap = 9
-        bar.content = .iconAndName
-        bar.groupAdjacentWindows = true
-        bar.fontSize = 20
-        bar.cornerRadius = 12
-        bar.textColor = "#111111"
-        bar.boxColor = "#222222"
-        bar.activeTextColor = "#333333"
-        bar.activeBoxColor = "#444444"
-        bar.highlightColor = "#555555"
-        bar.hoverColor = "#666666"
-        bar.hoverTextColor = "#777777"
-        bar.backgroundColor = "#888888"
-        bar.groupBadgeColor = "#999999"
-        bar.groupBadgeTextColor = "#AAAAAA"
-        return bar
-    }
-}
+// Exhaustive fixtures live in `AppBarFixtures.swift`, shared with
+// the round-trip in `AppBarTests`.
 
 /// Structural parity for the `AppBarStyle` ↔ `LayoutAppBar`
 /// mirror (#73). A new `AppBarStyle` field that is forgotten in
@@ -166,7 +112,10 @@ struct AppBarCommandParityTests {
             #expect(onStyle == onBar)
             touched.formUnion(onStyle)
         }
-        // Every look field must be reachable by some command.
+        // Every look field must be reachable by some command. If
+        // a future field is intentionally not command-settable,
+        // give it an exclusion set here (cf. the override tests'
+        // `notOverridable`) rather than dropping the assert.
         #expect(touched == fieldNames(AppBarStyle()))
     }
 }

--- a/Tests/KiwiDeskCoreTests/AppBarParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/AppBarParityTests.swift
@@ -1,0 +1,172 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Fixtures that set *every* field to a non-default value. Shared
+/// by the JSON round-trip in `AppBarTests` and the reflection
+/// guards below, so there is a single mirror of the field list to
+/// keep honest (`AppBarParityTests.fixturesAreExhaustive` pins it).
+enum AppBarFixtures {
+    static func everyGlobalField() -> AppBarStyle {
+        var style = AppBarStyle()
+        style.position = .bottom
+        style.thickness = 44
+        style.style = .segments
+        style.activeStyle = .gap
+        style.itemSize = 120
+        style.itemGap = 3
+        style.content = .name
+        style.groupAdjacentWindows = false
+        style.fontSize = 15
+        style.cornerRadius = 5
+        style.textColor = "#010101"
+        style.boxColor = "#020202"
+        style.activeTextColor = "#030303"
+        style.activeBoxColor = "#040404"
+        style.highlightColor = "#050505"
+        style.hoverColor = "#060606"
+        style.hoverTextColor = "#070707"
+        style.backgroundColor = "#080808"
+        style.groupBadgeColor = "#090909"
+        style.groupBadgeTextColor = "#0A0A0A"
+        return style
+    }
+
+    static func everyOverrideField() -> LayoutAppBar {
+        var bar = LayoutAppBar()
+        bar.enabled = false
+        bar.position = .right
+        bar.thickness = 50
+        bar.style = .underline
+        bar.activeStyle = .highlight
+        bar.itemSize = 88
+        bar.itemGap = 9
+        bar.content = .iconAndName
+        bar.groupAdjacentWindows = true
+        bar.fontSize = 20
+        bar.cornerRadius = 12
+        bar.textColor = "#111111"
+        bar.boxColor = "#222222"
+        bar.activeTextColor = "#333333"
+        bar.activeBoxColor = "#444444"
+        bar.highlightColor = "#555555"
+        bar.hoverColor = "#666666"
+        bar.hoverTextColor = "#777777"
+        bar.backgroundColor = "#888888"
+        bar.groupBadgeColor = "#999999"
+        bar.groupBadgeTextColor = "#AAAAAA"
+        return bar
+    }
+}
+
+/// Structural parity for the `AppBarStyle` ↔ `LayoutAppBar`
+/// mirror (#73). A new `AppBarStyle` field that is forgotten in
+/// `LayoutAppBar`, either type's `CodingKeys`, `resolved(with:)`,
+/// or the round-trip fixtures becomes a red build here — not a
+/// silent inherit-the-default bug (AGENTS.md §5).
+@Suite("App bar field-list parity")
+struct AppBarParityTests {
+    @Test("LayoutAppBar mirrors every AppBarStyle field")
+    func propertyParity() {
+        // `enabled` is the one layout-only field; every look
+        // field is an optional override of the global style.
+        #expect(
+            fieldNames(LayoutAppBar()).subtracting(["enabled"])
+                == fieldNames(AppBarStyle())
+        )
+    }
+
+    @Test("AppBarStyle CodingKeys cover every field")
+    func styleKeyParity() {
+        #expect(
+            keyStrings(AppBarStyle.CodingKeys.allCases)
+                == Set(fieldNames(AppBarStyle()).map(snakeCased))
+        )
+    }
+
+    @Test("LayoutAppBar CodingKeys cover every field")
+    func barKeyParity() {
+        #expect(
+            keyStrings(LayoutAppBar.Key.allCases)
+                == Set(fieldNames(LayoutAppBar()).map(snakeCased))
+        )
+    }
+
+    /// The override fixture differs from the base fixture on every
+    /// field, so a forgotten `if let` in `resolved(with:)` leaves
+    /// that field at the base value and this goes red.
+    @Test("resolved(with:) applies every override field")
+    func resolveParity() {
+        let base = AppBarFixtures.everyGlobalField()
+        let resolved =
+            AppBarFixtures.everyOverrideField().resolved(with: base)
+        let baseValues = fieldValues(base)
+        for (field, value) in fieldValues(resolved) {
+            #expect(
+                value != baseValues[field],
+                "resolved() left \(field) at the base value"
+            )
+        }
+    }
+
+    /// The `AppBarTests` round-trip is only forget-proof if its
+    /// fixtures touch every field. Reflection pins that here.
+    @Test("Round-trip fixtures set every field")
+    func fixturesAreExhaustive() {
+        expectAllChanged(
+            AppBarFixtures.everyGlobalField(),
+            from: AppBarStyle()
+        )
+        expectAllChanged(
+            AppBarFixtures.everyOverrideField(),
+            from: LayoutAppBar()
+        )
+    }
+}
+
+/// Parity for `AppBarCommandSetting`'s dual apply switches (#73).
+/// Both switches are exhaustive over the same enum, so the
+/// compiler already forces a new case into both; this pins the
+/// rest: every case writes the *same, single* field on style and
+/// bar, and every `AppBarStyle` field is command-reachable.
+@Suite("App bar command apply parity")
+struct AppBarCommandParityTests {
+    /// One representative setting per case, each value chosen to
+    /// differ from the field's default so the write is visible.
+    /// `applyParity` goes red if this list, either apply switch,
+    /// or `AppBarStyle` drift apart.
+    private static let everySetting: [AppBarCommandSetting] = [
+        .position(.right), .thickness(50), .style(.underline),
+        .activeStyle(.gap), .itemSize(88), .itemGap(9),
+        .content(.name), .groupAdjacentWindows(false),
+        .fontSize(20), .cornerRadius(12),
+        .textColor("#111111"), .boxColor("#222222"),
+        .activeTextColor("#333333"), .activeBoxColor("#444444"),
+        .highlightColor("#555555"), .hoverColor("#666666"),
+        .hoverTextColor("#777777"), .backgroundColor("#888888"),
+        .groupBadgeColor("#999999"),
+        .groupBadgeTextColor("#AAAAAA"),
+    ]
+
+    @Test("Each command sets one matching field on style and bar")
+    func applyParity() {
+        var touched: Set<String> = []
+        for setting in Self.everySetting {
+            var style = AppBarStyle()
+            var bar = LayoutAppBar()
+            setting.apply(to: &style)
+            setting.apply(to: &bar)
+            let onStyle = changedFields(style, from: AppBarStyle())
+            // `enabled` is bar-only, never a command target.
+            let onBar = changedFields(bar, from: LayoutAppBar())
+                .subtracting(["enabled"])
+            #expect(onStyle.count == 1)
+            #expect(onStyle == onBar)
+            touched.formUnion(onStyle)
+        }
+        // Every look field must be reachable by some command.
+        #expect(touched == fieldNames(AppBarStyle()))
+    }
+}

--- a/Tests/KiwiDeskCoreTests/AppBarTests.swift
+++ b/Tests/KiwiDeskCoreTests/AppBarTests.swift
@@ -67,12 +67,15 @@ struct AppBarOverrideTests {
     /// round-trip on both the global style and a per-layout
     /// override. If a field is ever added to `AppBarStyle` but
     /// missed in `LayoutAppBar` / its Codable / `resolved`, one
-    /// of these equalities breaks.
+    /// of these equalities breaks. The fixtures (shared with
+    /// `AppBarParityTests`) are pinned exhaustive there, so a new
+    /// field can't slip past this round-trip unset.
     @Test("Every field round-trips on global and override")
     func fullRoundTrip() throws {
         var settings = TilingSettings()
-        settings.appBarStyle = Self.everyGlobalField()
-        settings.scrolling.appBar = Self.everyOverrideField()
+        settings.appBarStyle = AppBarFixtures.everyGlobalField()
+        settings.scrolling.appBar =
+            AppBarFixtures.everyOverrideField()
         let data = try JSONEncoder().encode(settings)
         let decoded = try JSONDecoder().decode(
             TilingSettings.self,
@@ -82,57 +85,6 @@ struct AppBarOverrideTests {
         #expect(
             decoded.scrolling.appBar == settings.scrolling.appBar
         )
-    }
-
-    private static func everyGlobalField() -> AppBarStyle {
-        var style = AppBarStyle()
-        style.position = .bottom
-        style.thickness = 44
-        style.style = .segments
-        style.activeStyle = .gap
-        style.itemSize = 120
-        style.itemGap = 3
-        style.content = .name
-        style.groupAdjacentWindows = false
-        style.fontSize = 15
-        style.cornerRadius = 5
-        style.textColor = "#010101"
-        style.boxColor = "#020202"
-        style.activeTextColor = "#030303"
-        style.activeBoxColor = "#040404"
-        style.highlightColor = "#050505"
-        style.hoverColor = "#060606"
-        style.hoverTextColor = "#070707"
-        style.backgroundColor = "#080808"
-        style.groupBadgeColor = "#090909"
-        style.groupBadgeTextColor = "#0A0A0A"
-        return style
-    }
-
-    private static func everyOverrideField() -> LayoutAppBar {
-        var bar = LayoutAppBar()
-        bar.enabled = false
-        bar.position = .right
-        bar.thickness = 50
-        bar.style = .underline
-        bar.activeStyle = .highlight
-        bar.itemSize = 88
-        bar.itemGap = 9
-        bar.content = .iconAndName
-        bar.groupAdjacentWindows = true
-        bar.fontSize = 20
-        bar.cornerRadius = 12
-        bar.textColor = "#111111"
-        bar.boxColor = "#222222"
-        bar.activeTextColor = "#333333"
-        bar.activeBoxColor = "#444444"
-        bar.highlightColor = "#555555"
-        bar.hoverColor = "#666666"
-        bar.hoverTextColor = "#777777"
-        bar.backgroundColor = "#888888"
-        bar.groupBadgeColor = "#999999"
-        bar.groupBadgeTextColor = "#AAAAAA"
-        return bar
     }
 }
 

--- a/Tests/KiwiDeskCoreTests/LayoutOverrideCodingParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/LayoutOverrideCodingParityTests.swift
@@ -1,0 +1,119 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Forget-proof coverage for the five per-space `*Override`
+/// structs (#17), brought up to the same standard as the params
+/// structs they mirror (#73 audit). Each hand-writes an optional
+/// mirror, a per-field `resolved(onto:)`, and a manual sparse
+/// `Codable`.
+///
+/// The property mirror itself is already guarded by each struct's
+/// `fieldParity` reflection test (the #17 template). What that net
+/// does *not* reach — a forgotten `encode`/`decode` line or a
+/// forgotten `if let` in `resolved(onto:)` — is closed here:
+/// `expectRoundTrips` pins the sparse Codable (exhaustive fixture
+/// + round-trip), and `expectResolvesEveryField` pins the merge.
+/// Each fixture sets every override field to a value that also
+/// differs from the params default, so resolving onto the default
+/// exercises every branch.
+@Suite("Layout override forget-proof parity")
+struct LayoutOverrideCodingParityTests {
+    @Test("BspOverride round-trips and resolves every field")
+    func bsp() throws {
+        let over = Self.bsp()
+        try expectRoundTrips(over, from: BspOverride())
+        expectResolvesEveryField(
+            resolved: over.resolved(onto: BspParams()),
+            base: BspParams(),
+            covered: fieldNames(BspOverride())
+        )
+    }
+
+    @Test("StackOverride round-trips and resolves every field")
+    func stack() throws {
+        let over = Self.stack()
+        try expectRoundTrips(over, from: StackOverride())
+        expectResolvesEveryField(
+            resolved: over.resolved(onto: StackParams()),
+            base: StackParams(),
+            covered: fieldNames(StackOverride())
+        )
+    }
+
+    @Test("GridOverride round-trips and resolves every field")
+    func grid() throws {
+        let over = Self.grid()
+        try expectRoundTrips(over, from: GridOverride())
+        expectResolvesEveryField(
+            resolved: over.resolved(onto: GridParams()),
+            base: GridParams(),
+            covered: fieldNames(GridOverride())
+        )
+    }
+
+    @Test("ScrollingOverride round-trips and resolves every field")
+    func scrolling() throws {
+        let over = Self.scrolling()
+        try expectRoundTrips(over, from: ScrollingOverride())
+        expectResolvesEveryField(
+            resolved: over.resolved(onto: ScrollingParams()),
+            base: ScrollingParams(),
+            covered: fieldNames(ScrollingOverride())
+        )
+    }
+
+    @Test("MonocleOverride round-trips and resolves every field")
+    func monocle() throws {
+        let over = Self.monocle()
+        try expectRoundTrips(over, from: MonocleOverride())
+        expectResolvesEveryField(
+            resolved: over.resolved(onto: MonocleParams()),
+            base: MonocleParams(),
+            covered: fieldNames(MonocleOverride())
+        )
+    }
+
+    // MARK: Exhaustive fixtures (every field set, ≠ its default)
+
+    private static func bsp() -> BspOverride {
+        var over = BspOverride()
+        over.strategy = .alternating
+        over.splitRatio = 0.7
+        return over
+    }
+
+    private static func stack() -> StackOverride {
+        var over = StackOverride()
+        over.masterCount = 4
+        over.masterRatio = 0.3
+        over.overflowStyle = .cascadeAll
+        return over
+    }
+
+    private static func grid() -> GridOverride {
+        var over = GridOverride()
+        over.type = .rigid
+        over.fillEmptySpace = false
+        over.splitDirection = .vertical
+        over.columns = 7
+        over.rows = 5
+        return over
+    }
+
+    private static func scrolling() -> ScrollingOverride {
+        var over = ScrollingOverride()
+        over.slotSize = .points(250)
+        over.anchor = .left
+        over.orientation = .vertical
+        return over
+    }
+
+    private static func monocle() -> MonocleOverride {
+        var over = MonocleOverride()
+        over.orientation = .vertical
+        return over
+    }
+}

--- a/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
@@ -109,16 +109,3 @@ struct LayoutParamsCodingParityTests {
         return params
     }
 }
-
-/// Asserts `fixture` touches every field, then that it survives a
-/// JSON round-trip. The exhaustiveness check is what keeps the
-/// round-trip forget-proof (see suite doc).
-private func expectRoundTrips<T: Codable & Equatable>(
-    _ fixture: T,
-    from base: T
-) throws {
-    expectAllChanged(fixture, from: base)
-    let data = try JSONEncoder().encode(fixture)
-    let back = try JSONDecoder().decode(T.self, from: data)
-    #expect(back == fixture)
-}

--- a/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Forget-proof coverage for each layout params struct's manual
+/// sparse `Codable` (#73). Every struct hand-writes `CodingKeys`,
+/// `init(from:)`, and `encode(to:)`; a field dropped from any of
+/// the three silently round-trips to its default. Each test pairs
+/// two nets: `expectAllChanged` (reflection) forces the fixture to
+/// touch every field, and the JSON round-trip then proves each of
+/// those fields survives decode ↔ encode ↔ CodingKeys. A new field
+/// left unset trips the first; a forgotten Codable line trips the
+/// second (AGENTS.md §5).
+@Suite("Layout params sparse Codable parity")
+struct LayoutParamsCodingParityTests {
+    @Test("BspParams round-trips every field")
+    func bsp() throws {
+        try expectRoundTrips(Self.bsp(), from: BspParams())
+    }
+
+    @Test("StackParams round-trips every field")
+    func stack() throws {
+        try expectRoundTrips(Self.stack(), from: StackParams())
+    }
+
+    @Test("GridParams round-trips every field")
+    func grid() throws {
+        try expectRoundTrips(Self.grid(), from: GridParams())
+    }
+
+    @Test("ScrollingParams round-trips every field")
+    func scrolling() throws {
+        try expectRoundTrips(
+            Self.scrolling(),
+            from: ScrollingParams()
+        )
+    }
+
+    @Test("MonocleParams round-trips every field")
+    func monocle() throws {
+        try expectRoundTrips(
+            Self.monocle(),
+            from: MonocleParams()
+        )
+    }
+
+    // MARK: Exhaustive fixtures (every field ≠ its default)
+
+    private static let space = SpaceID("2")
+
+    private static func bsp() -> BspParams {
+        var params = BspParams()
+        params.strategy = .alternating
+        params.splitRatio = 0.75
+        params.newWindowPlacement = .last
+        var over = BspOverride()
+        over.splitRatio = 0.4
+        params.override[space] = over
+        return params
+    }
+
+    private static func stack() -> StackParams {
+        var params = StackParams()
+        params.masterCount = 3
+        params.masterRatio = 0.35
+        params.overflowStyle = .cascadeAll
+        params.newWindowPlacement = .last
+        var over = StackOverride()
+        over.masterCount = 2
+        params.override[space] = over
+        return params
+    }
+
+    private static func grid() -> GridParams {
+        var params = GridParams()
+        params.type = .rigid
+        params.fillEmptySpace = false
+        params.splitDirection = .vertical
+        params.columns = 5
+        params.rows = 4
+        params.newWindowPlacement = .first
+        var over = GridOverride()
+        over.columns = 6
+        params.override[space] = over
+        return params
+    }
+
+    private static func scrolling() -> ScrollingParams {
+        var params = ScrollingParams()
+        params.slotSize = .points(300)
+        params.anchor = .left
+        params.orientation = .vertical
+        params.newWindowPlacement = .first
+        params.appBar.enabled = false
+        var over = ScrollingOverride()
+        over.anchor = .right
+        params.override[space] = over
+        return params
+    }
+
+    private static func monocle() -> MonocleParams {
+        var params = MonocleParams()
+        params.orientation = .vertical
+        params.appBar.enabled = false
+        var over = MonocleOverride()
+        over.orientation = .horizontal
+        params.override[space] = over
+        return params
+    }
+}
+
+/// Asserts `fixture` touches every field, then that it survives a
+/// JSON round-trip. The exhaustiveness check is what keeps the
+/// round-trip forget-proof (see suite doc).
+private func expectRoundTrips<T: Codable & Equatable>(
+    _ fixture: T,
+    from base: T
+) throws {
+    expectAllChanged(fixture, from: base)
+    let data = try JSONEncoder().encode(fixture)
+    let back = try JSONDecoder().decode(T.self, from: data)
+    #expect(back == fixture)
+}

--- a/Tests/KiwiDeskCoreTests/ReflectionParity.swift
+++ b/Tests/KiwiDeskCoreTests/ReflectionParity.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Shared reflection helpers for the field-list parity guards
+/// (AGENTS.md §5, `.claude/rules/parity-tests.md`). These let a
+/// parity test discover a struct's fields *structurally* instead
+/// of hand-listing them, so adding a field to one side of a
+/// mirror turns a forgotten sibling into a red build rather than
+/// silent data loss.
+
+/// Stored-property names of `value`, via `Mirror`.
+func fieldNames(_ value: Any) -> Set<String> {
+    Set(Mirror(reflecting: value).children.compactMap(\.label))
+}
+
+/// Field name → `String(describing:)` of its value. String
+/// descriptions compare cleanly across the value types these
+/// structs use (numbers, strings, raw-value enums, optionals).
+func fieldValues(_ value: Any) -> [String: String] {
+    Mirror(reflecting: value).children.reduce(
+        into: [String: String]()
+    ) { acc, child in
+        if let label = child.label {
+            acc[label] = String(describing: child.value)
+        }
+    }
+}
+
+/// JSON spellings (`stringValue`) of a `CodingKey` set — for
+/// comparing keys against the snake_cased field names.
+func keyStrings<K: CodingKey>(_ keys: [K]) -> Set<String> {
+    Set(keys.map(\.stringValue))
+}
+
+/// camelCase → snake_case, matching the project's CodingKey
+/// convention (`activeStyle` → `active_style`). Comparing field
+/// names through this also pins the "one vocabulary" rule
+/// (AGENTS.md §5) that JSON keys stay snake_case.
+func snakeCased(_ name: String) -> String {
+    name.reduce(into: "") { out, character in
+        if character.isUppercase {
+            out += "_" + character.lowercased()
+        } else {
+            out.append(character)
+        }
+    }
+}
+
+/// Fields whose value differs between `value` and `base`.
+func changedFields<T>(_ value: T, from base: T) -> Set<String> {
+    let now = fieldValues(value)
+    let was = fieldValues(base)
+    return Set(now.filter { $0.value != was[$0.key] }.map(\.key))
+}
+
+/// Asserts a fixture touches *every* field: each differs from the
+/// default `base`. This is what makes a hand-built round-trip
+/// fixture forget-proof — a new field left unset (still default)
+/// turns this red, forcing the fixture to cover it.
+func expectAllChanged<T>(
+    _ value: T,
+    from base: T,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    let baseValues = fieldValues(base)
+    for (field, current) in fieldValues(value) {
+        #expect(
+            current != baseValues[field],
+            "fixture leaves \(field) at its default value",
+            sourceLocation: sourceLocation
+        )
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ReflectionParity.swift
+++ b/Tests/KiwiDeskCoreTests/ReflectionParity.swift
@@ -116,12 +116,24 @@ func expectRoundTrips<T: Codable & Equatable>(
 /// (which leaves that field at the base value) goes red. `covered`
 /// is the override's own field-name set; the caller resolves an
 /// all-set override onto a `base` whose covered fields all differ.
+///
+/// A covered field absent from `resolved` would be silently
+/// skipped by the loop, so we first assert `covered` is a subset
+/// of the resolved fields — that keeps this net self-contained
+/// (a rename on the override side goes red here, not only in the
+/// sibling `fieldParity` test).
 func expectResolvesEveryField<P>(
     resolved: P,
     base: P,
     covered: Set<String>,
     sourceLocation: SourceLocation = #_sourceLocation
 ) {
+    let missing = covered.subtracting(fieldNames(resolved))
+    #expect(
+        missing.isEmpty,
+        "covered fields missing from resolved: \(missing)",
+        sourceLocation: sourceLocation
+    )
     let baseValues = fieldValues(base)
     for (field, value) in fieldValues(resolved)
     where covered.contains(field) {

--- a/Tests/KiwiDeskCoreTests/ReflectionParity.swift
+++ b/Tests/KiwiDeskCoreTests/ReflectionParity.swift
@@ -9,15 +9,28 @@ import Testing
 /// of hand-listing them, so adding a field to one side of a
 /// mirror turns a forgotten sibling into a red build rather than
 /// silent data loss.
+///
+/// Convention note: `.claude/rules/tests.md` prefers per-file
+/// private helpers ("no shared test harness"). This file is a
+/// deliberate, ratified exception — these are stateless, generic
+/// *test primitives* (pure reflection mechanics, no setup/teardown
+/// coupling), and a single copy is *safer* than duplication here:
+/// a divergent copy of `snakeCased`/`expectAllChanged` could
+/// silently weaken one guard, which is the exact failure mode #73
+/// exists to prevent.
 
 /// Stored-property names of `value`, via `Mirror`.
 func fieldNames(_ value: Any) -> Set<String> {
     Set(Mirror(reflecting: value).children.compactMap(\.label))
 }
 
-/// Field name → `String(describing:)` of its value. String
-/// descriptions compare cleanly across the value types these
-/// structs use (numbers, strings, raw-value enums, optionals).
+/// Field name → `String(describing:)` of its value. A heuristic,
+/// not true value equality (`Mirror` children are `Any`, not
+/// `Equatable`): string descriptions compare cleanly across the
+/// value types these structs use (numbers, strings, raw-value
+/// enums, optionals). Only ever used as an *exhaustiveness* or
+/// *changed?* net that fails red — real data survival is always
+/// proven separately by an `Equatable` round-trip.
 func fieldValues(_ value: Any) -> [String: String] {
     Mirror(reflecting: value).children.reduce(
         into: [String: String]()
@@ -38,6 +51,13 @@ func keyStrings<K: CodingKey>(_ keys: [K]) -> Set<String> {
 /// convention (`activeStyle` → `active_style`). Comparing field
 /// names through this also pins the "one vocabulary" rule
 /// (AGENTS.md §5) that JSON keys stay snake_case.
+///
+/// Deliberately *naive* — it only inserts `_` before an uppercase
+/// letter (no acronym/digit handling). That is safe: a field
+/// whose key needs more than naive snake_case makes this test
+/// fail **red**, never silently, and is a signal to reconsider
+/// the key (or add an explicit exception), not to complicate
+/// this helper.
 func snakeCased(_ name: String) -> String {
     name.reduce(into: "") { out, character in
         if character.isUppercase {
@@ -69,6 +89,45 @@ func expectAllChanged<T>(
         #expect(
             current != baseValues[field],
             "fixture leaves \(field) at its default value",
+            sourceLocation: sourceLocation
+        )
+    }
+}
+
+/// The forget-proof pair for a manual sparse `Codable`: the
+/// exhaustiveness net (`expectAllChanged`) forces `fixture` to
+/// touch every field, then a real `Equatable` round-trip proves
+/// each survives decode ↔ encode ↔ CodingKeys. A field left unset
+/// trips the first; a forgotten Codable line trips the second.
+func expectRoundTrips<T: Codable & Equatable>(
+    _ fixture: T,
+    from base: T,
+    sourceLocation: SourceLocation = #_sourceLocation
+) throws {
+    expectAllChanged(fixture, from: base, sourceLocation: sourceLocation)
+    let data = try JSONEncoder().encode(fixture)
+    let back = try JSONDecoder().decode(T.self, from: data)
+    #expect(back == fixture, sourceLocation: sourceLocation)
+}
+
+/// Forget-proof net for a per-field `resolved(onto:)`/`resolved
+/// (with:)` merge: `resolved` must differ from `base` on every
+/// field the override actually covers, so a forgotten `if let`
+/// (which leaves that field at the base value) goes red. `covered`
+/// is the override's own field-name set; the caller resolves an
+/// all-set override onto a `base` whose covered fields all differ.
+func expectResolvesEveryField<P>(
+    resolved: P,
+    base: P,
+    covered: Set<String>,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    let baseValues = fieldValues(base)
+    for (field, value) in fieldValues(resolved)
+    where covered.contains(field) {
+        #expect(
+            value != baseValues[field],
+            "resolved() left \(field) at the base value",
             sourceLocation: sourceLocation
         )
     }


### PR DESCRIPTION
## Summary

Retroactive audit (#73) of the hand-mirrored field lists that predate the #17 override guardrail. Adds reflection- and `CodingKeys`-derived parity tests so adding a field to one side of a mirror turns a forgotten sibling into a **red build** instead of silent data loss (AGENTS.md §5, `.claude/rules/parity-tests.md`).

Test-only, plus two `CaseIterable` conformances (to enable the CodingKeys parity check) and their explanatory comments.

## What's guarded now

- **`AppBarStyle` ↔ `LayoutAppBar`** — property parity, CodingKeys↔field parity, a `resolved(with:)` net that catches a forgotten `if let`, and a fixture-exhaustiveness guard that makes `AppBarTests.fullRoundTrip` forget-proof (fixtures now shared + pinned exhaustive).
- **`AppBarCommandSetting`** dual apply switches — each command touches the same single field on style and bar, and every `AppBarStyle` field is command-reachable.
- **Layout params** (Bsp/Stack/Grid/Scrolling/Monocle) — exhaustive fixture + JSON round-trip guarding each manual sparse `Codable`.
- **Per-space `*Override` mirrors** (#17) — brought up to the same standard: exhaustive round-trip + reflection-driven resolve-every-field, closing the gap both reviewers flagged.
- Shared reflection primitives in `ReflectionParity.swift` (ratified carve-out in `.claude/rules/tests.md`).

Each new net was teeth-checked: dropping an `if let` in a `resolved()`, a `resolveIfPresent`/`encodeIfPresent` line, or mismatching an apply case each turns the corresponding test red.

## Verification

`swift build`, `swift test` (569 tests), `scripts/lint.sh`, and `swift build -c release` all pass. Reviewed by `code-reviewer` + `architect-reviewer` (two rounds; no blocking findings).

fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)