### PR TITLE
feat(lua): harden ExecLauncher — bounded output, non-blocking drains, watchdog (#37)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
@@ -70,6 +70,11 @@ extension KiwiCore {
         // Gather windows onto their owning monitors before
         // any subsystem teardown; AX must still be live here.
         gatherWindows()
+        // exec children are fire-and-forget: we do not
+        // terminate or wait for them. They are re-parented to
+        // launchd and finish naturally after the app exits.
+        // Per-command control is available via the optional
+        // timeout argument to KiwiDesk.exec().
         pendingFocusFollow?.cancel()
         pendingStartupSweep?.cancel()
         pendingSpaceSettle?.cancel()

--- a/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
@@ -74,7 +74,11 @@ extension KiwiCore {
         // terminate or wait for them. They are re-parented to
         // launchd and finish naturally after the app exits.
         // Per-command control is available via the optional
-        // timeout argument to KiwiDesk.exec().
+        // timeout argument to KiwiDesk.exec(). stop() also runs
+        // mid-session on an AX-permission revoke, so cancel any
+        // armed timeout watchdogs — they must not SIGTERM a
+        // child after teardown (a start() may reuse the launcher).
+        exec.cancelWatchdogs()
         pendingFocusFollow?.cancel()
         pendingStartupSweep?.cancel()
         pendingSpaceSettle?.cancel()

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -172,8 +172,10 @@ public enum APIReference {
     /// Lua-only entry points on the `KiwiDesk` table that
     /// are not routed through the dispatcher and therefore
     /// absent from the CLI/IPC socket. Listed here so
-    /// `help()` and did-you-mean suggestions cover the full
-    /// Lua API surface (issue #37).
+    /// `help()` / `list_commands` cover the full Lua API
+    /// surface. Deliberately excluded from did-you-mean
+    /// (`suggestion`), which must only hint at commands the
+    /// caller's channel can invoke (issue #37).
     public static let luaOnly: [String] = [
         "exec", "bind", "on", "define_mode", "switch_mode",
     ]

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -169,7 +169,19 @@ public enum APIReference {
         ],
     ]
 
-    /// Every dispatcher-level command name, sorted.
+    /// Lua-only entry points on the `KiwiDesk` table that
+    /// are not routed through the dispatcher and therefore
+    /// absent from the CLI/IPC socket. Listed here so
+    /// `help()` and did-you-mean suggestions cover the full
+    /// Lua API surface (issue #37).
+    public static let luaOnly: [String] = [
+        "exec", "bind", "on", "define_mode", "switch_mode",
+    ]
+
+    /// Every command name visible in `help()` and
+    /// did-you-mean, sorted. Includes dispatcher commands,
+    /// namespace sub-commands, `subscribe`, and Lua-only
+    /// entry points.
     public static var allCommands: [String] {
         var names = Set(commands.map(\.command))
         for (table, functions) in namespaces {
@@ -178,6 +190,7 @@ public enum APIReference {
             }
         }
         names.insert("subscribe")
+        names.formUnion(luaOnly)
         return names.sorted()
     }
 

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -178,11 +178,13 @@ public enum APIReference {
         "exec", "bind", "on", "define_mode", "switch_mode",
     ]
 
-    /// Every command name visible in `help()` and
-    /// did-you-mean, sorted. Includes dispatcher commands,
-    /// namespace sub-commands, `subscribe`, and Lua-only
-    /// entry points.
-    public static var allCommands: [String] {
+    /// Command names reachable through the dispatcher (and thus
+    /// the CLI/IPC socket): dispatcher verbs, namespace
+    /// sub-commands, and `subscribe`. This is the did-you-mean
+    /// set — a typo hint must never point at a command the
+    /// caller's channel cannot invoke, so the Lua-only entry
+    /// points are deliberately excluded here (issue #37).
+    public static var dispatchable: [String] {
         var names = Set(commands.map(\.command))
         for (table, functions) in namespaces {
             for function in functions {
@@ -190,16 +192,26 @@ public enum APIReference {
             }
         }
         names.insert("subscribe")
-        names.formUnion(luaOnly)
         return names.sorted()
     }
 
-    /// A close known command for a typo, if any.
+    /// Every command name shown by `help()` / `list_commands`,
+    /// sorted — the full Lua-visible surface: everything
+    /// dispatchable plus the Lua-only entry points that bypass
+    /// the dispatcher (`exec`, `bind`, …).
+    public static var allCommands: [String] {
+        Set(dispatchable).union(luaOnly).sorted()
+    }
+
+    /// A close known command for a typo, if any. Suggests only
+    /// dispatchable names — the unknown-command path is reached
+    /// from the CLI/IPC socket too, where a Lua-only name would
+    /// be a dead-end hint.
     public static func suggestion(
         for unknown: String
     ) -> String? {
         var best: (name: String, distance: Int)?
-        for name in allCommands {
+        for name in dispatchable {
             let distance = editDistance(unknown, name)
             let limit = max(2, unknown.count / 3)
             guard distance <= limit else { continue }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Diagnostics.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Diagnostics.swift
@@ -89,6 +89,11 @@ extension KiwiCore {
             // SkyLight.
             "native_space": NativeSpaces.activeSpaceNumber()
                 .map { .number(Double($0)) } ?? .null,
+            // Exec children still running; useful for
+            // debugging config hooks (issue #37).
+            "exec_running": .number(
+                Double(exec.runningCount)
+            ),
         ])
     }
 }

--- a/Sources/KiwiDeskCore/Lua/KiwiCore+ExecAPI.swift
+++ b/Sources/KiwiDeskCore/Lua/KiwiCore+ExecAPI.swift
@@ -26,6 +26,15 @@ extension KiwiCore {
             } else {
                 callbackRef = nil
             }
+            // Optional third argument: timeout in seconds.
+            let timeout: TimeInterval?
+            if case .number(let t) =
+                args.dropFirst(2).first ?? .none, t > 0
+            {
+                timeout = t
+            } else {
+                timeout = nil
+            }
             guard let self,
                 let command = args.first?.stringValue,
                 !command.isEmpty
@@ -42,9 +51,9 @@ extension KiwiCore {
             }
             var onExit: ExecLauncher.ExitHandler?
             if let ref = callbackRef {
-                // Bind the ref to the VM that minted it: on a
-                // config reload the weak capture goes nil and
-                // the callback drops silently. A ref must
+                // Bind the ref to the VM that minted it: on
+                // a config reload the weak capture goes nil
+                // and the callback drops silently. A ref must
                 // never reach a different VM's registry —
                 // its slot may already belong to an unrelated
                 // function there.
@@ -70,6 +79,7 @@ extension KiwiCore {
             guard
                 let pid = self.exec.launch(
                     command,
+                    timeout: timeout,
                     onExit: onExit
                 )
             else {
@@ -83,12 +93,16 @@ extension KiwiCore {
         neutralizeBlockingOSCalls(on: lua)
     }
 
-    /// Rewrites the stdlib entry points that block in C where
-    /// the instruction-count watchdog cannot interrupt them:
-    /// `os.execute` becomes fire-and-forget via `exec`, and
-    /// `io.popen` is disabled outright (its synchronous
-    /// read-the-output contract cannot be honored without
-    /// blocking).
+    /// Rewrites stdlib entry points that either block in C
+    /// (where the instruction-count watchdog cannot interrupt
+    /// them) or could instantly kill the app:
+    ///
+    /// - `os.execute` becomes fire-and-forget via `exec`.
+    /// - `io.popen` is disabled (its synchronous
+    ///   read-the-output contract cannot be honored without
+    ///   blocking).
+    /// - `os.exit` is stubbed out; calling it from config
+    ///   would otherwise terminate the app immediately.
     private func neutralizeBlockingOSCalls(
         on lua: LuaInterpreter
     ) {
@@ -112,6 +126,11 @@ extension KiwiCore {
                 return nil, "io.popen is disabled (it "
                     .. "blocks the app); use KiwiDesk.exec("
                     .. "cmd, callback) instead"
+            end
+            os.exit = function(code)
+                KiwiDesk.debug_log(
+                    "os.exit(" .. tostring(code)
+                    .. ") is disabled in KiwiDesk config")
             end
             """
         )

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -204,6 +204,14 @@ public final class ExecLauncher {
     /// which may `start()` again on this same launcher) must not
     /// SIGTERM or force-reap a child after teardown. Children
     /// stay fire-and-forget.
+    ///
+    /// Trade-off: this also voids the force-reap for a child that
+    /// is *already stuck* (grandchild holding the pipe, so EOF
+    /// never arrives) when the stop fires — its `running` entry
+    /// then leaks for the life of the process (`exec` outlives a
+    /// stop/start), inflating `runningCount`. Accepted: avoiding
+    /// a post-teardown SIGTERM outweighs reclaiming one entry in
+    /// that triple-conditional corner.
     func cancelWatchdogs() {
         // Snapshot the keys: the loop mutates `running`.
         for key in Array(running.keys) {

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -205,7 +205,8 @@ public final class ExecLauncher {
     /// SIGTERM or force-reap a child after teardown. Children
     /// stay fire-and-forget.
     func cancelWatchdogs() {
-        for key in running.keys {
+        // Snapshot the keys: the loop mutates `running`.
+        for key in Array(running.keys) {
             running[key]?.watchdog?.cancel()
             running[key]?.watchdog = nil
         }

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -16,11 +16,15 @@ import os
 /// open can only delay its own callback, never stall the app.
 ///
 /// **Child quit policy:** children are fire-and-forget.
-/// `KiwiCore.stop()` does not terminate or wait for them;
-/// they are re-parented to launchd and finish naturally.
-/// This is intentional — hooks like `sketchybar --notify`
-/// should complete even after KiwiDesk exits. Use the optional
-/// `timeout` parameter for per-command control.
+/// `KiwiCore.stop()` neither terminates nor waits for them —
+/// they re-parent to launchd and finish on their own. This is
+/// intentional: hooks like `sketchybar --notify` should
+/// complete even as KiwiDesk quits. Note `stop()` also runs
+/// mid-session on an AX-permission revoke (after which
+/// `start()` may reuse this same launcher), so it calls
+/// `cancelWatchdogs()` — a `timeout` armed before the stop must
+/// not SIGTERM a child once management has torn down. Use the
+/// optional `timeout` parameter for per-command control.
 ///
 /// The launcher knows nothing about Lua: callers bind their
 /// own callback lifetime into `onExit` (see
@@ -36,15 +40,18 @@ public final class ExecLauncher {
         NSLog("KiwiDesk: %@", message)
     }
 
-    /// Children we have launched and not yet reaped, keyed
-    /// by object identity (pids can be recycled). Process
-    /// objects must stay alive until termination or their
-    /// handlers never fire.
-    private var running: [ObjectIdentifier: Process] = [:]
+    /// A launched child and its optional timeout watchdog, kept
+    /// together so the two can never desync — one table, one
+    /// count. The `Process` must stay alive until termination or
+    /// its handlers never fire.
+    private struct Child {
+        let process: Process
+        var watchdog: Task<Void, Never>?
+    }
 
-    /// Per-child watchdog tasks, one per `timeout`-carrying
-    /// call. Cancelled when the child exits normally.
-    private var watchdogs: [ObjectIdentifier: Task<Void, Never>] = [:]
+    /// Children we have launched and not yet reaped, keyed by
+    /// object identity (pids can be recycled).
+    private var running: [ObjectIdentifier: Child] = [:]
 
     public init() {}
 
@@ -123,28 +130,85 @@ public final class ExecLauncher {
             return nil
         }
 
-        running[key] = process
+        running[key] = Child(process: process)
         capture?.drain()
 
         if let timeout {
-            watchdogs[key] = Task {
-                @MainActor [weak self] in
-                let ns = UInt64(
-                    max(0, timeout) * 1_000_000_000
-                )
-                try? await Task.sleep(nanoseconds: ns)
-                guard !Task.isCancelled else { return }
-                guard let self,
-                    self.running[key] != nil
-                else { return }
-                self.running[key]?.terminate()
-                self.onLog(
-                    "exec: '\(command)' timed out "
-                        + "after \(timeout)s"
-                )
-            }
+            running[key]?.watchdog = makeWatchdog(
+                key: key,
+                command: command,
+                timeout: timeout,
+                capture: capture,
+                onExit: onExit
+            )
         }
         return process.processIdentifier
+    }
+
+    /// Grace after SIGTERM for the normal EOF-driven reap to
+    /// land before the watchdog force-reaps (seconds).
+    private static let reapGrace: TimeInterval = 2
+
+    /// Builds a timeout watchdog: SIGTERM at `timeout`, then a
+    /// short grace for the normal EOF-driven reap to land. If the
+    /// child is still un-reaped after that — e.g. it left a
+    /// grandchild holding the output pipe open, so EOF never
+    /// arrives — force-reap with whatever was captured, so the
+    /// bookkeeping entry and any Lua callback ref are released
+    /// instead of leaking (#37 review).
+    private func makeWatchdog(
+        key: ObjectIdentifier,
+        command: String,
+        timeout: TimeInterval,
+        capture: OutputCapture?,
+        onExit: ExitHandler?
+    ) -> Task<Void, Never> {
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(
+                nanoseconds: Self.nanos(timeout)
+            )
+            guard !Task.isCancelled, let self,
+                self.running[key] != nil
+            else { return }
+            self.running[key]?.process.terminate()
+            self.onLog(
+                "exec: '\(command)' timed out after "
+                    + "\(timeout)s"
+            )
+            try? await Task.sleep(
+                nanoseconds: Self.nanos(Self.reapGrace)
+            )
+            guard !Task.isCancelled,
+                self.running[key] != nil
+            else { return }
+            let (out, err) = capture?.snapshot() ?? ("", "")
+            self.reap(
+                key: key,
+                code: 128 + SIGTERM,
+                onExit: onExit,
+                stdout: out,
+                stderr: err
+            )
+        }
+    }
+
+    private static func nanos(
+        _ seconds: TimeInterval
+    ) -> UInt64 {
+        UInt64(max(0, seconds) * 1_000_000_000)
+    }
+
+    /// Cancels outstanding timeout watchdogs without disturbing
+    /// the children. Called from `KiwiCore.stop()`: a `timeout`
+    /// armed before a mid-session stop (AX-permission revoke,
+    /// which may `start()` again on this same launcher) must not
+    /// SIGTERM or force-reap a child after teardown. Children
+    /// stay fire-and-forget.
+    func cancelWatchdogs() {
+        for key in running.keys {
+            running[key]?.watchdog?.cancel()
+            running[key]?.watchdog = nil
+        }
     }
 
     private func reap(
@@ -154,8 +218,14 @@ public final class ExecLauncher {
         stdout: String,
         stderr: String
     ) {
-        watchdogs[key]?.cancel()
-        watchdogs[key] = nil
+        // Idempotent: the normal EOF path and the timeout
+        // force-reap can both target the same child. Whichever
+        // runs first wins; the other finds no entry and is a
+        // no-op — so `onExit` (which releases the Lua ref) fires
+        // exactly once. Both run on the main actor, so the
+        // check-and-clear can't interleave.
+        guard let child = running[key] else { return }
+        child.watchdog?.cancel()
         running[key] = nil
         onExit?(code, stdout, stderr)
     }
@@ -176,107 +246,5 @@ public final class ExecLauncher {
         }
         env["PATH"] = parts.joined(separator: ":")
         return env
-    }
-}
-
-/// Drains a child's stdout and stderr via `readabilityHandler`
-/// and reports both, off the main thread, once both streams hit
-/// EOF. No thread is ever blocked waiting for a pipe; GCD calls
-/// the handler as data arrives.
-///
-/// Each stream is capped at `streamCap` bytes: data beyond the
-/// cap is still read (keeping the pipe drained so the child can
-/// keep writing without blocking) but discarded after the
-/// truncation marker is appended.
-private final class OutputCapture: Sendable {
-    /// Maximum bytes captured per stream (~1 MB).
-    static let streamCap = 1_048_576
-    /// Appended once when a stream's cap is reached.
-    static let truncMark = Data(
-        "\n[output truncated at 1 MB]\n".utf8
-    )
-
-    private let out: Pipe
-    private let err: Pipe
-    private let group = DispatchGroup()
-    private let outBuf = OSAllocatedUnfairLock(
-        initialState: (data: Data(), capped: false)
-    )
-    private let errBuf = OSAllocatedUnfairLock(
-        initialState: (data: Data(), capped: false)
-    )
-
-    init(_ out: Pipe, _ err: Pipe) {
-        self.out = out
-        self.err = err
-        // Enter for both streams up front: the termination
-        // handler can fire before drain() runs on the main
-        // actor, and an empty group would notify immediately
-        // with empty output.
-        group.enter()
-        group.enter()
-    }
-
-    /// Starts both reads; must be called exactly once.
-    func drain() {
-        attach(out.fileHandleForReading, to: outBuf)
-        attach(err.fileHandleForReading, to: errBuf)
-    }
-
-    private func attach(
-        _ handle: FileHandle,
-        to buf: OSAllocatedUnfairLock<
-            (
-                data: Data, capped: Bool
-            )
-        >
-    ) {
-        handle.readabilityHandler = { [group, buf] fh in
-            let chunk = fh.availableData
-            if chunk.isEmpty {
-                // EOF: all write ends of the pipe are closed.
-                fh.readabilityHandler = nil
-                group.leave()
-                return
-            }
-            buf.withLock { state in
-                guard !state.capped else { return }
-                let cap = OutputCapture.streamCap
-                let space = cap - state.data.count
-                if chunk.count <= space {
-                    state.data.append(chunk)
-                } else {
-                    if space > 0 {
-                        state.data.append(
-                            chunk.prefix(space)
-                        )
-                    }
-                    state.data.append(
-                        OutputCapture.truncMark
-                    )
-                    state.capped = true
-                }
-            }
-        }
-    }
-
-    /// Calls `handler` (on a background queue) once both
-    /// streams have hit EOF.
-    func onComplete(
-        _ handler:
-            @escaping @Sendable (
-                String, String
-            ) -> Void
-    ) {
-        group.notify(
-            queue: .global(qos: .utility)
-        ) { [outBuf, errBuf] in
-            let outData = outBuf.withLock { $0.data }
-            let errData = errBuf.withLock { $0.data }
-            handler(
-                String(decoding: outData, as: UTF8.self),
-                String(decoding: errData, as: UTF8.self)
-            )
-        }
     }
 }

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -2,46 +2,67 @@ import Foundation
 import os
 
 /// Launches external commands without ever blocking the main
-/// thread (issue #5): `KiwiDesk.exec` and the async `os.execute`
-/// replacement both funnel through here.
+/// thread (issue #5): `KiwiDesk.exec` and the async
+/// `os.execute` replacement both funnel through here.
 ///
 /// Each command runs as `/bin/sh -c <command>`. The launcher
 /// never waits for the child; the optional `onExit` closure is
 /// invoked back on the main actor once the child exits, with
 /// `(exit_code, stdout, stderr)`. Output pipes are only created
-/// when a closure exists, and they are drained on a background
-/// queue — the main thread never touches a pipe, so even a
-/// child that leaves grandchildren holding the descriptors open
-/// can only delay its own callback, never stall the app.
+/// when a closure exists, and they are drained via
+/// `readabilityHandler` — no thread is ever blocked waiting
+/// for a child. The main thread never touches a pipe, so even
+/// a child that leaves grandchildren holding the descriptors
+/// open can only delay its own callback, never stall the app.
 ///
-/// The launcher knows nothing about Lua: callers bind their own
-/// callback lifetime into `onExit` (see `KiwiCore+ExecAPI`,
-/// which captures the owning interpreter weakly so a config
-/// reload drops pending callbacks).
+/// **Child quit policy:** children are fire-and-forget.
+/// `KiwiCore.stop()` does not terminate or wait for them;
+/// they are re-parented to launchd and finish naturally.
+/// This is intentional — hooks like `sketchybar --notify`
+/// should complete even after KiwiDesk exits. Use the optional
+/// `timeout` parameter for per-command control.
+///
+/// The launcher knows nothing about Lua: callers bind their
+/// own callback lifetime into `onExit` (see
+/// `KiwiCore+ExecAPI`, which captures the owning interpreter
+/// weakly so a config reload drops pending callbacks).
 @MainActor
 public final class ExecLauncher {
     public typealias ExitHandler =
         @MainActor @Sendable (Int32, String, String) -> Void
 
-    public var onLog: @MainActor (String) -> Void = { message in
+    public var onLog: @MainActor (String) -> Void = {
+        message in
         NSLog("KiwiDesk: %@", message)
     }
 
-    /// Children we have launched and not yet reaped, keyed by
-    /// object identity (pids can be recycled). Process objects
-    /// must stay alive until termination or their handlers
-    /// never fire.
+    /// Children we have launched and not yet reaped, keyed
+    /// by object identity (pids can be recycled). Process
+    /// objects must stay alive until termination or their
+    /// handlers never fire.
     private var running: [ObjectIdentifier: Process] = [:]
+
+    /// Per-child watchdog tasks, one per `timeout`-carrying
+    /// call. Cancelled when the child exits normally.
+    private var watchdogs: [ObjectIdentifier: Task<Void, Never>] = [:]
 
     public init() {}
 
+    /// Number of children that have been launched and not
+    /// yet reaped. Exposed in `get_state` as `exec_running`.
     public var runningCount: Int { running.count }
 
     /// Starts `command` and returns its pid, or nil when the
     /// child could not be spawned.
+    ///
+    /// If `timeout` is given (seconds), the child receives
+    /// SIGTERM after that interval if it has not already
+    /// exited; the `onExit` callback is still invoked with
+    /// the termination code.
     @discardableResult
     public func launch(
         _ command: String,
+        timeout: TimeInterval? = nil,
         onExit: ExitHandler? = nil
     ) -> Int32? {
         let process = Process()
@@ -61,13 +82,17 @@ public final class ExecLauncher {
             capture = nil
         }
 
+        // Compute the bookkeeping key before the handler so
+        // the handler can close over it directly rather than
+        // re-deriving it from the Process object.
+        let key = ObjectIdentifier(process)
+
         // Install before run(): a fast child may exit before
         // launch() returns, and a handler set after the fact
         // would never fire. The main-actor reap cannot race
         // the bookkeeping below — it only runs once launch()
         // has returned control to the main actor.
         process.terminationHandler = { [weak self] child in
-            let key = ObjectIdentifier(child)
             let code = child.terminationStatus
             let deliver: @Sendable (String, String) -> Void = {
                 out,
@@ -98,8 +123,27 @@ public final class ExecLauncher {
             return nil
         }
 
-        running[ObjectIdentifier(process)] = process
+        running[key] = process
         capture?.drain()
+
+        if let timeout {
+            watchdogs[key] = Task {
+                @MainActor [weak self] in
+                let ns = UInt64(
+                    max(0, timeout) * 1_000_000_000
+                )
+                try? await Task.sleep(nanoseconds: ns)
+                guard !Task.isCancelled else { return }
+                guard let self,
+                    self.running[key] != nil
+                else { return }
+                self.running[key]?.terminate()
+                self.onLog(
+                    "exec: '\(command)' timed out "
+                        + "after \(timeout)s"
+                )
+            }
+        }
         return process.processIdentifier
     }
 
@@ -110,14 +154,17 @@ public final class ExecLauncher {
         stdout: String,
         stderr: String
     ) {
+        watchdogs[key]?.cancel()
+        watchdogs[key] = nil
         running[key] = nil
         onExit?(code, stdout, stderr)
     }
 
-    /// GUI apps inherit launchd's minimal PATH, not the user's
-    /// shell PATH — `sketchybar`, `borders`, etc. live in the
-    /// Homebrew prefix and would be "command not found" in
-    /// production while working in terminal-launched dev runs.
+    /// GUI apps inherit launchd's minimal PATH, not the
+    /// user's shell PATH — `sketchybar`, `borders`, etc. live
+    /// in the Homebrew prefix and would be "command not
+    /// found" in production while working in
+    /// terminal-launched dev runs.
     private static func childEnvironment() -> [String: String] {
         var env = ProcessInfo.processInfo.environment
         var parts = (env["PATH"] ?? "")
@@ -132,15 +179,31 @@ public final class ExecLauncher {
     }
 }
 
-/// Drains a child's stdout/stderr to end on a background
-/// queue and reports both, off the main thread, once both
-/// reads hit EOF.
+/// Drains a child's stdout and stderr via `readabilityHandler`
+/// and reports both, off the main thread, once both streams hit
+/// EOF. No thread is ever blocked waiting for a pipe; GCD calls
+/// the handler as data arrives.
+///
+/// Each stream is capped at `streamCap` bytes: data beyond the
+/// cap is still read (keeping the pipe drained so the child can
+/// keep writing without blocking) but discarded after the
+/// truncation marker is appended.
 private final class OutputCapture: Sendable {
+    /// Maximum bytes captured per stream (~1 MB).
+    static let streamCap = 1_048_576
+    /// Appended once when a stream's cap is reached.
+    static let truncMark = Data(
+        "\n[output truncated at 1 MB]\n".utf8
+    )
+
     private let out: Pipe
     private let err: Pipe
     private let group = DispatchGroup()
-    private let collected = OSAllocatedUnfairLock(
-        initialState: (out: Data(), err: Data())
+    private let outBuf = OSAllocatedUnfairLock(
+        initialState: (data: Data(), capped: false)
+    )
+    private let errBuf = OSAllocatedUnfairLock(
+        initialState: (data: Data(), capped: false)
     )
 
     init(_ out: Pipe, _ err: Pipe) {
@@ -156,37 +219,60 @@ private final class OutputCapture: Sendable {
 
     /// Starts both reads; must be called exactly once.
     func drain() {
-        read(out.fileHandleForReading) { [collected] data in
-            collected.withLock { $0.out = data }
-        }
-        read(err.fileHandleForReading) { [collected] data in
-            collected.withLock { $0.err = data }
-        }
+        attach(out.fileHandleForReading, to: outBuf)
+        attach(err.fileHandleForReading, to: errBuf)
     }
 
-    private func read(
+    private func attach(
         _ handle: FileHandle,
-        _ store: @escaping @Sendable (Data) -> Void
+        to buf: OSAllocatedUnfairLock<
+            (
+                data: Data, capped: Bool
+            )
+        >
     ) {
-        DispatchQueue.global(qos: .utility).async {
-            [group] in
-            // readToEnd throws on I/O errors; the legacy
-            // readDataToEndOfFile raises an ObjC exception
-            // Swift cannot catch.
-            store((try? handle.readToEnd()) ?? Data())
-            group.leave()
+        handle.readabilityHandler = { [group, buf] fh in
+            let chunk = fh.availableData
+            if chunk.isEmpty {
+                // EOF: all write ends of the pipe are closed.
+                fh.readabilityHandler = nil
+                group.leave()
+                return
+            }
+            buf.withLock { state in
+                guard !state.capped else { return }
+                let cap = OutputCapture.streamCap
+                let space = cap - state.data.count
+                if chunk.count <= space {
+                    state.data.append(chunk)
+                } else {
+                    if space > 0 {
+                        state.data.append(
+                            chunk.prefix(space)
+                        )
+                    }
+                    state.data.append(
+                        OutputCapture.truncMark
+                    )
+                    state.capped = true
+                }
+            }
         }
     }
 
     /// Calls `handler` (on a background queue) once both
-    /// streams are fully read.
+    /// streams have hit EOF.
     func onComplete(
-        _ handler: @escaping @Sendable (String, String) -> Void
+        _ handler:
+            @escaping @Sendable (
+                String, String
+            ) -> Void
     ) {
         group.notify(
             queue: .global(qos: .utility)
-        ) { [collected] in
-            let (outData, errData) = collected.withLock { $0 }
+        ) { [outBuf, errBuf] in
+            let outData = outBuf.withLock { $0.data }
+            let errData = errBuf.withLock { $0.data }
             handler(
                 String(decoding: outData, as: UTF8.self),
                 String(decoding: errData, as: UTF8.self)

--- a/Sources/KiwiDeskCore/OS/OutputCapture.swift
+++ b/Sources/KiwiDeskCore/OS/OutputCapture.swift
@@ -1,0 +1,117 @@
+import Foundation
+import os
+
+/// Drains a child's stdout and stderr via `readabilityHandler`
+/// and reports both, off the main thread, once both streams hit
+/// EOF. No thread is ever blocked waiting for a pipe; GCD calls
+/// the handler as data arrives. Split out of `ExecLauncher` for
+/// file size.
+///
+/// Each stream is capped at `streamCap` bytes: data beyond the
+/// cap is still read (keeping the pipe drained so the child can
+/// keep writing without blocking) but discarded after the
+/// truncation marker is appended.
+final class OutputCapture: Sendable {
+    /// Maximum bytes captured per stream (~1 MB).
+    static let streamCap = 1_048_576
+    /// Appended once when a stream's cap is reached.
+    static let truncMark = Data(
+        "\n[output truncated at 1 MB]\n".utf8
+    )
+
+    private let out: Pipe
+    private let err: Pipe
+    private let group = DispatchGroup()
+    private let outBuf = OSAllocatedUnfairLock(
+        initialState: (data: Data(), capped: false)
+    )
+    private let errBuf = OSAllocatedUnfairLock(
+        initialState: (data: Data(), capped: false)
+    )
+
+    init(_ out: Pipe, _ err: Pipe) {
+        self.out = out
+        self.err = err
+        // Enter for both streams up front: the termination
+        // handler can fire before drain() runs on the main
+        // actor, and an empty group would notify immediately
+        // with empty output.
+        group.enter()
+        group.enter()
+    }
+
+    /// Starts both reads; must be called exactly once.
+    func drain() {
+        attach(out.fileHandleForReading, to: outBuf)
+        attach(err.fileHandleForReading, to: errBuf)
+    }
+
+    private func attach(
+        _ handle: FileHandle,
+        to buf: OSAllocatedUnfairLock<
+            (
+                data: Data, capped: Bool
+            )
+        >
+    ) {
+        handle.readabilityHandler = { [group, buf] fh in
+            let chunk = fh.availableData
+            if chunk.isEmpty {
+                // EOF: all write ends of the pipe are closed.
+                fh.readabilityHandler = nil
+                group.leave()
+                return
+            }
+            buf.withLock { state in
+                guard !state.capped else { return }
+                let cap = OutputCapture.streamCap
+                let space = cap - state.data.count
+                if chunk.count <= space {
+                    state.data.append(chunk)
+                } else {
+                    if space > 0 {
+                        state.data.append(
+                            chunk.prefix(space)
+                        )
+                    }
+                    state.data.append(
+                        OutputCapture.truncMark
+                    )
+                    state.capped = true
+                }
+            }
+        }
+    }
+
+    /// A best-effort read of what has been captured so far,
+    /// without waiting for EOF. Used by the timeout force-reap
+    /// when a stuck pipe means `onComplete` may never fire.
+    func snapshot() -> (String, String) {
+        let outData = outBuf.withLock { $0.data }
+        let errData = errBuf.withLock { $0.data }
+        return (
+            String(decoding: outData, as: UTF8.self),
+            String(decoding: errData, as: UTF8.self)
+        )
+    }
+
+    /// Calls `handler` (on a background queue) once both
+    /// streams have hit EOF.
+    func onComplete(
+        _ handler:
+            @escaping @Sendable (
+                String, String
+            ) -> Void
+    ) {
+        group.notify(
+            queue: .global(qos: .utility)
+        ) { [outBuf, errBuf] in
+            let outData = outBuf.withLock { $0.data }
+            let errData = errBuf.withLock { $0.data }
+            handler(
+                String(decoding: outData, as: UTF8.self),
+                String(decoding: errData, as: UTF8.self)
+            )
+        }
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ExecTests.swift
+++ b/Tests/KiwiDeskCoreTests/ExecTests.swift
@@ -157,4 +157,111 @@ struct ExecTests {
         }
         #expect(message.contains("KiwiDesk.exec"))
     }
+
+    @Test("os.exit is neutralized — does not kill the app")
+    func osExitNeutralized() throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        // If os.exit were real, this would kill the test
+        // process. Reaching the next line proves it is safe.
+        #expect(lua.run("os.exit(0)").succeeded)
+        #expect(lua.run("still_alive = true").succeeded)
+        #expect(
+            lua.global("still_alive") == .bool(true)
+        )
+    }
+
+    @Test("Large output is truncated at 1 MB with a marker")
+    func outputCapTruncation() async throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        // 'yes x' writes "x\n" until head closes the pipe
+        // at 2 MB; the cap stops capture at 1 MB.
+        let script = """
+            KiwiDesk.exec(
+                "yes x | head -c 2097152",
+                function(code, out, err)
+                    cap_out = out
+                end)
+            """
+        #expect(lua.run(script).succeeded)
+        let out = try await awaitGlobal(
+            lua,
+            "cap_out",
+            timeout: 10
+        )
+        guard case .string(let text) = out else {
+            Issue.record("expected string output")
+            return
+        }
+        #expect(text.contains("[output truncated at 1 MB]"))
+        // 1 MB content + short marker — not more.
+        #expect(text.utf8.count <= 1_048_576 + 64)
+    }
+
+    @Test("Timed-out child is terminated and reaped")
+    func execTimeout() async throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        let started = Date()
+        // Third arg is timeout in seconds.
+        let script = """
+            KiwiDesk.exec("sleep 30",
+                function(code, out, err)
+                    timeout_code = code
+                end, 0.4)
+            """
+        #expect(lua.run(script).succeeded)
+        // Watchdog fires after ~0.4s; wait up to 10s.
+        let code = try await awaitGlobal(
+            lua,
+            "timeout_code",
+            timeout: 10
+        )
+        let elapsed = Date().timeIntervalSince(started)
+        #expect(code != .none)
+        // Definitely did not run for 30s.
+        #expect(elapsed < 10)
+        // Process was reaped after termination.
+        let deadline = Date().addingTimeInterval(5)
+        while core.exec.runningCount > 0,
+            Date() < deadline
+        {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(core.exec.runningCount == 0)
+    }
+
+    @Test("get_state includes exec_running count")
+    func getStateExecRunning() async throws {
+        let core = makeCore()
+        // Before any launch: exec_running must be 0.
+        let before = core.execute("get_state")
+        guard case .object(let b)? = before.data else {
+            Issue.record("expected state object")
+            return
+        }
+        #expect(b["exec_running"] == .number(0))
+        // While a child runs, count is 1.
+        core.exec.launch("sleep 5")
+        let during = core.execute("get_state")
+        guard case .object(let d)? = during.data else {
+            Issue.record("expected state object")
+            return
+        }
+        #expect(d["exec_running"] == .number(1))
+    }
+
+    @Test("Lua-only functions appear in help() output")
+    func luaOnlyInHelp() throws {
+        let core = makeCore()
+        let response = core.execute("help")
+        guard case .array(let names)? = response.data else {
+            Issue.record("expected command list")
+            return
+        }
+        for name in APIReference.luaOnly {
+            #expect(names.contains(.string(name)))
+        }
+    }
 }

--- a/Tests/KiwiDeskCoreTests/ExecTests.swift
+++ b/Tests/KiwiDeskCoreTests/ExecTests.swift
@@ -232,6 +232,33 @@ struct ExecTests {
         #expect(core.exec.runningCount == 0)
     }
 
+    @Test("Timeout with an early-exiting child reaps once")
+    func timeoutChildExitsFirst() async throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        // The child exits immediately; the 5s watchdog must
+        // not fire (the normal reap cancels it) and the
+        // callback must run exactly once with the real code.
+        let script = """
+            _calls = 0
+            KiwiDesk.exec("true",
+                function(code, out, err)
+                    _calls = _calls + 1
+                    _code = code
+                end, 5)
+            """
+        #expect(lua.run(script).succeeded)
+        let code = try await awaitGlobal(lua, "_code", timeout: 5)
+        #expect(code == .number(0))
+        // Reaped promptly; the pending watchdog was cancelled.
+        let deadline = Date().addingTimeInterval(2)
+        while core.exec.runningCount > 0, Date() < deadline {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(core.exec.runningCount == 0)
+        #expect(lua.global("_calls") == .number(1))
+    }
+
     @Test("get_state includes exec_running count")
     func getStateExecRunning() async throws {
         let core = makeCore()
@@ -262,6 +289,30 @@ struct ExecTests {
         }
         for name in APIReference.luaOnly {
             #expect(names.contains(.string(name)))
+        }
+    }
+
+    @Test("Every luaOnly name is a real KiwiDesk function")
+    func luaOnlyNamesAreRegistered() throws {
+        let core = makeCore()
+        let lua = try #require(core.lua)
+        // Drives off APIReference.luaOnly so the list can't
+        // name a function that was never registered (or drift
+        // out of sync with the real Lua surface) — the parity
+        // guard the reflection net can't provide here.
+        let checks = APIReference.luaOnly
+            .map { "type(KiwiDesk.\($0)) == 'function'" }
+            .joined(separator: "\n    and ")
+        #expect(lua.run("_ok = (\(checks))").succeeded)
+        #expect(lua.global("_ok") == .bool(true))
+    }
+
+    @Test("did-you-mean never suggests a Lua-only command")
+    func suggestionExcludesLuaOnly() {
+        // The unknown-command path is reached over the socket
+        // too, where a Lua-only name is a dead-end hint (#37).
+        for name in APIReference.luaOnly {
+            #expect(APIReference.suggestion(for: name + "x") != name)
         }
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -53,7 +53,7 @@ KiwiDesk service restart
 | | `set_mouse_resize` | `layout\|snap_back` |
 | | `set_gap_global` | size |
 | | `set_gap_override` | space, size |
-| | `get_state` | — |
+| | `get_state` | — (returns `{active_space, spaces, windows, monitor_count, native_space, exec_running}`) |
 | | `reload_config` | — |
 | | `version` | — (returns `{version, commit}`) |
 | Profiles | `save_profile` | name (updates in place when it exists) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -808,7 +808,9 @@ therefore always run in the background.
 
 - `timeout` — an optional number of seconds. If given and the
   command has not exited by then, it receives SIGTERM and the
-  callback is still invoked with the termination code.
+  callback is still invoked with the termination code — even if
+  the child left a grandchild holding its output pipe open, in
+  which case the callback fires with whatever was captured.
 
 **Does:** starts the command in the background and returns
 immediately — KiwiDesk never waits for it. Returns the
@@ -900,6 +902,10 @@ layout. It is stubbed out to prevent accidental or malicious
 instant app termination. If you want to restart KiwiDesk use
 `KiwiDesk service restart` from a terminal or a keybinding
 via `KiwiDesk.exec`.
+
+Note that, unlike real `os.exit`, the stub **returns** — code
+after the call keeps running. Don't rely on `os.exit()` to
+halt a script; use an explicit `return` or `if/else`.
 
 ## Profiles & Monitors
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -790,18 +790,25 @@ command that waits synchronously there would freeze window
 management, animations, and the menu bar. External commands
 therefore always run in the background.
 
-### `KiwiDesk.exec(command [, callback])`
+### `KiwiDesk.exec(command [, callback [, timeout]])`
 
-**Expects:** `command` — a string, run via `/bin/sh -c`, so
-pipes, quoting, `&&`, and `$PATH` lookups work exactly as in
-a terminal. `callback` — an optional Lua function; if given,
-it is called once the command has exited, with:
+**Expects:**
+
+- `command` — a string, run via `/bin/sh -c`, so pipes,
+  quoting, `&&`, and `$PATH` lookups work exactly as in a
+  terminal.
+- `callback` — an optional Lua function called once the
+  command has exited, with:
 
 | Callback argument | Type | Meaning |
 |---|---|---|
 | `code` | number | exit code (`0` = success) |
 | `stdout` | string | everything written to stdout |
 | `stderr` | string | everything written to stderr |
+
+- `timeout` — an optional number of seconds. If given and the
+  command has not exited by then, it receives SIGTERM and the
+  callback is still invoked with the termination code.
 
 **Does:** starts the command in the background and returns
 immediately — KiwiDesk never waits for it. Returns the
@@ -812,6 +819,17 @@ finishes, the callback is dropped silently. The child's
 appended, so Homebrew tools (`sketchybar`, `borders`, …)
 resolve even when KiwiDesk was launched from Finder — GUI
 apps inherit launchd's minimal `PATH`, not your shell's.
+
+**Output cap:** stdout and stderr are each capped at ~1 MB.
+Output beyond the cap is still read (so the child never
+blocks writing), but the string delivered to the callback is
+truncated and ends with `[output truncated at 1 MB]`.
+
+**Quit policy:** exec children are fire-and-forget. When
+KiwiDesk exits, running children are re-parented to launchd
+and finish naturally — a `sketchybar --notify` hook will
+complete even if KiwiDesk quits first. Use `timeout` for
+commands that must not outlive a reasonable interval.
 
 **Example:**
 
@@ -824,6 +842,11 @@ KiwiDesk.exec("defaults read -g AppleInterfaceStyle",
     function(code, out, err)
         dark = (code == 0 and out:match("Dark") ~= nil)
     end)
+
+-- With a 5-second timeout:
+KiwiDesk.exec("some-slow-tool", function(code, out, err)
+    -- code is non-zero if killed by the watchdog
+end, 5)
 ```
 
 ### `os.execute(command)` — asynchronous in KiwiDesk
@@ -866,6 +889,17 @@ KiwiDesk.exec("pmset -g batt", function(code, out)
     battery_info = out
 end)
 ```
+
+### `os.exit(code)` — disabled
+
+**Expects:** n/a — any call is a no-op with a log message.
+
+**Does:** calling `os.exit()` from a config file would kill
+the KiwiDesk process immediately, including your window
+layout. It is stubbed out to prevent accidental or malicious
+instant app termination. If you want to restart KiwiDesk use
+`KiwiDesk service restart` from a terminal or a keybinding
+via `KiwiDesk.exec`.
 
 ## Profiles & Monitors
 


### PR DESCRIPTION
Fixes #37. Follow-ups from the #5 review — hardening the exec pipeline's unbounded resource dimensions plus small observability/API-surface gaps.

## Changes

- **Non-blocking pipe drains.** `OutputCapture` uses `readabilityHandler` instead of parking two blocking `readToEnd` calls on the utility queue — no thread is ever held waiting for a child.
- **Bounded output.** stdout/stderr each capped at ~1 MB; beyond the cap the pipe is still drained (child never blocks) but data is discarded after a truncation marker.
- **Per-command timeout + watchdog.** Optional 3rd `exec(cmd, cb, timeout)` arg: SIGTERM after the interval, then a short grace for the normal EOF reap; if the child is still stuck (grandchild holding the pipe), a force-reap releases its bookkeeping and Lua callback ref. `reap` is idempotent, so the two completion paths reconcile safely.
- **Child quit policy.** Documented as fire-and-forget (hooks like `sketchybar --notify` should outlive app quit). `stop()` — which also runs on a mid-session AX-permission revoke — cancels armed watchdogs so a timeout can't SIGTERM a child after teardown.
- **`exec_running`** surfaced in `get_state`.
- **`os.exit`** neutralized alongside `os.execute`/`io.popen`.
- **`APIReference.luaOnly`** brings `exec`/`bind`/`on`/`define_mode`/`switch_mode` into the single source of truth. `help()` shows the full surface; did-you-mean (`suggestion`) stays dispatchable-only so a CLI/IPC typo never points at a Lua-only command.

## Notes

- `OutputCapture` split into its own file (ExecLauncher was over the 350-line ceiling).
- The force-reap synthesizes exit code `128+SIGTERM` (143) — the same code `/bin/sh` reports for a SIGTERM death.

## Tests
`ExecTests`: os.exit neutralized, 1 MB truncation, timeout terminate+reap, timeout with early-exiting child (single callback), `exec_running` count, luaOnly-in-help, luaOnly parity (each name is a real KiwiDesk function), did-you-mean excludes luaOnly.

## Verify
`swift build`, `swift test` (561), `scripts/lint.sh`, `swift build -c release` — all green.

Reviewed by `code-reviewer` + `architect-reviewer` (initial pass then focused fix-range re-review); all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)