### PR TITLE
refactor(core): unify deferred settle tasks under a keyed owner

### DIFF
--- a/Sources/KiwiDeskCore/App/DeferredTasks.swift
+++ b/Sources/KiwiDeskCore/App/DeferredTasks.swift
@@ -36,6 +36,9 @@ final class DeferredTasks {
     /// or cancelled first. Cancellation is checked once, after
     /// the sleep: `body` is synchronous main-actor code, so a
     /// cancel cannot interleave with it once it has started.
+    /// `body` is retained until it fires or is cancelled, so
+    /// capture the core weakly (see the type doc) — a strong
+    /// capture would pin it for the pending delay.
     func schedule(
         _ key: Key,
         after delay: Duration,
@@ -56,6 +59,10 @@ final class DeferredTasks {
 
     /// The task currently stored for a key — lets tests pin the
     /// cancel-and-replace claims (identity + `isCancelled`).
+    /// Not a pending-check: a fired body leaves its *finished*
+    /// task in the slot (bounded — one per key — and inert), so
+    /// this stays non-nil after firing; only `cancel`/`cancelAll`
+    /// clear the slot.
     func task(for key: Key) -> Task<Void, Never>? {
         tasks[key]
     }

--- a/Sources/KiwiDeskCore/App/DeferredTasks.swift
+++ b/Sources/KiwiDeskCore/App/DeferredTasks.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Owns KiwiCore's deferred one-shot settle tasks, keyed so a
+/// reschedule self-cancels the prior run and teardown can cancel
+/// everything at once instead of hand-listing fields (#49) — the
+/// hand-kept cancel list is how a missing cancel slipped through
+/// review once already (#48).
+///
+/// Only the store/cancel/sleep protocol lives here; the settle
+/// bodies stay closures at the call sites because their delays,
+/// guard predicates, and post-work genuinely differ (AGENTS.md
+/// §2.4). Bodies run on the main actor and should capture the
+/// core weakly, as the call sites do.
+@MainActor
+final class DeferredTasks {
+    /// One slot per deferred job; scheduling a key replaces
+    /// (cancels) whatever that key was still waiting on.
+    enum Key: Hashable {
+        /// Deferred switch to a hidden window's virtual space
+        /// (`scheduleFocusFollow`).
+        case focusFollow
+        /// One-shot startup sweep re-tracking windows the cold
+        /// AX scan missed (`scheduleStartupSweep`).
+        case startupSweep
+        /// One-shot layout re-assert after a virtual-space
+        /// switch (`scheduleSpaceSettle`).
+        case spaceSettle
+        /// Layout + focus re-assert after a native desktop
+        /// switch (`settleAfterNativeSwitch`).
+        case nativeSpaceSettle
+    }
+
+    private var tasks: [Key: Task<Void, Never>] = [:]
+
+    /// Runs `body` after `delay` unless the key is rescheduled
+    /// or cancelled first. Cancellation is checked once, after
+    /// the sleep: `body` is synchronous main-actor code, so a
+    /// cancel cannot interleave with it once it has started.
+    func schedule(
+        _ key: Key,
+        after delay: Duration,
+        _ body: @escaping @MainActor () -> Void
+    ) {
+        tasks[key]?.cancel()
+        tasks[key] = Task { @MainActor in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            body()
+        }
+    }
+
+    func cancel(_ key: Key) {
+        tasks[key]?.cancel()
+        tasks[key] = nil
+    }
+
+    /// The task currently stored for a key — lets tests pin the
+    /// cancel-and-replace claims (identity + `isCancelled`).
+    func task(for key: Key) -> Task<Void, Never>? {
+        tasks[key]
+    }
+
+    /// Cancels every pending task — the one call teardown makes,
+    /// so `stop()` cannot forget a newly added key.
+    func cancelAll() {
+        for task in tasks.values { task.cancel() }
+        tasks.removeAll()
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Lifecycle.swift
@@ -45,11 +45,9 @@ extension KiwiCore {
     /// only now be resolvable to its space.
     private func scheduleStartupSweep() {
         let landed = state.workspaces.activeSpace
-        pendingStartupSweep?.cancel()
-        pendingStartupSweep = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(1))
-            guard !Task.isCancelled, let self,
-                self.eventLoop.isRunning
+        deferred.schedule(.startupSweep, after: .seconds(1)) {
+            [weak self] in
+            guard let self, self.eventLoop.isRunning
             else { return }
             self.eventLoop.reconcileAll()
             guard
@@ -79,9 +77,7 @@ extension KiwiCore {
         // armed timeout watchdogs — they must not SIGTERM a
         // child after teardown (a start() may reuse the launcher).
         exec.cancelWatchdogs()
-        pendingFocusFollow?.cancel()
-        pendingStartupSweep?.cancel()
-        pendingSpaceSettle?.cancel()
+        deferred.cancelAll()
         mouse.stop()
         eventLoop.stop()
         sleepWake.stop()

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -25,18 +25,11 @@ public final class KiwiCore {
     /// animations to settle (see restoreStackZOrder).
     var pendingZOrderRestore = false
 
-    /// Deferred switch to a hidden window's virtual space
-    /// (see scheduleFocusFollow).
-    var pendingFocusFollow: Task<Void, Never>?
-
-    /// One-shot re-assertion of a virtual space's layout shortly
-    /// after a switch, catching windows whose single frame-set a
-    /// slow/background app dropped (see scheduleSpaceSettle).
-    var pendingSpaceSettle: Task<Void, Never>?
-
-    /// One-shot startup sweep re-tracking windows the cold
-    /// AX scan missed (see start()).
-    var pendingStartupSweep: Task<Void, Never>?
+    /// The deferred one-shot settle tasks (focus follow, startup
+    /// sweep, space settles), keyed so `stop()` cancels them all
+    /// without a hand-kept list (#49). Bodies live at the
+    /// `schedule*` call sites.
+    let deferred = DeferredTasks()
 
     /// Native desktop we are currently on (Mission Control
     /// number), and the virtual space each desktop showed
@@ -223,7 +216,7 @@ public final class KiwiCore {
         case .windowCreated(let window):
             // A brand-new window supersedes a pending follow
             // of a hidden window (see above).
-            pendingFocusFollow?.cancel()
+            deferred.cancel(.focusFollow)
             newlyCreatedWindow = window.id
             emitWindowCreated(window)
         case .windowMoved(let id, let frame):

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -18,10 +18,11 @@ extension KiwiCore {
         guard
             Date().timeIntervalSince(lastNativeSwitch) > 1
         else { return }
-        pendingFocusFollow?.cancel()
-        pendingFocusFollow = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(250))
-            guard !Task.isCancelled, let self else { return }
+        deferred.schedule(
+            .focusFollow,
+            after: .milliseconds(250)
+        ) { [weak self] in
+            guard let self else { return }
             guard let window = self.state.windows[id],
                 NSWorkspace.shared.frontmostApplication?
                     .processIdentifier == window.pid,
@@ -119,10 +120,11 @@ extension KiwiCore {
     /// re-issue only the windows still at the stash corner rather
     /// than lengthening or repeating this timer.
     func scheduleSpaceSettle(_ target: SpaceID) {
-        pendingSpaceSettle?.cancel()
-        pendingSpaceSettle = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(300))
-            guard !Task.isCancelled, let self,
+        deferred.schedule(
+            .spaceSettle,
+            after: .milliseconds(300)
+        ) { [weak self] in
+            guard let self,
                 self.state.workspaces.activeSpace == target,
                 // A native desktop switch in this window runs its
                 // own retile + settle and is still re-tracking

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+NativeSpaces.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+NativeSpaces.swift
@@ -75,10 +75,16 @@ extension KiwiCore {
     /// windows over the next few hundred ms; afterwards,
     /// re-assert the layout (stashing included) and hand
     /// focus to the restored space — the OS may have focused
-    /// a stashed window during the transition.
+    /// a stashed window during the transition. Keyed (#49):
+    /// rapid switches keep only the latest settle — a stale
+    /// task either no-op'd on the `lastNativeSpace` guard or
+    /// (switch away and back inside the delay) fired an early
+    /// settle mid-reconcile — and `stop()` can now cancel it.
     private func settleAfterNativeSwitch(_ number: Int?) {
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(600))
+        deferred.schedule(
+            .nativeSpaceSettle,
+            after: .milliseconds(600)
+        ) { [weak self] in
             guard let self, self.lastNativeSpace == number
             else { return }
             self.retile(animated: false, force: true)

--- a/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
+++ b/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
@@ -109,7 +109,7 @@ struct DeferredTasksTests {
         let owner = DeferredTasks()
         var fired = false
         owner.schedule(.spaceSettle, after: .milliseconds(5)) {}
-        owner.cancelAll()
+        owner.cancel(.spaceSettle)
         owner.schedule(.spaceSettle, after: .milliseconds(5)) {
             fired = true
         }

--- a/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
+++ b/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+            "kiwidesk-deferred-tests-\(UUID().uuidString)"
+        )
+    return KiwiCore(configDirectory: directory)
+}
+
+/// The keyed owner of KiwiCore's one-shot settle tasks (#49).
+/// Tests await the stored task handles instead of sleeping
+/// fixed buffers, so they stay deterministic.
+@MainActor
+struct DeferredTasksTests {
+    @Test("A scheduled body fires after its delay")
+    func schedulesAndFires() async {
+        let owner = DeferredTasks()
+        var fired = false
+        owner.schedule(.spaceSettle, after: .milliseconds(5)) {
+            fired = true
+        }
+        await owner.task(for: .spaceSettle)?.value
+        #expect(fired)
+    }
+
+    @Test("Rescheduling a key cancels and replaces the prior")
+    func reschedulingReplacesThePrior() async {
+        let owner = DeferredTasks()
+        var winner = 0
+        owner.schedule(.spaceSettle, after: .milliseconds(5)) {
+            winner = 1
+        }
+        let first = owner.task(for: .spaceSettle)
+        owner.schedule(.spaceSettle, after: .milliseconds(5)) {
+            winner = 2
+        }
+        let second = owner.task(for: .spaceSettle)
+        #expect(first?.isCancelled == true)
+        #expect(second != first)
+        await first?.value
+        await second?.value
+        #expect(winner == 2)
+    }
+
+    @Test("cancel(_:) prevents the body and clears the slot")
+    func cancelPreventsTheBody() async {
+        let owner = DeferredTasks()
+        var fired = false
+        owner.schedule(.focusFollow, after: .milliseconds(5)) {
+            fired = true
+        }
+        let task = owner.task(for: .focusFollow)
+        owner.cancel(.focusFollow)
+        await task?.value
+        #expect(!fired)
+        #expect(owner.task(for: .focusFollow) == nil)
+    }
+
+    @Test("Keys are independent slots")
+    func keysAreIndependent() async {
+        let owner = DeferredTasks()
+        var focusFired = false
+        var sweepFired = false
+        owner.schedule(.focusFollow, after: .milliseconds(5)) {
+            focusFired = true
+        }
+        owner.schedule(.startupSweep, after: .milliseconds(5)) {
+            sweepFired = true
+        }
+        let cancelled = owner.task(for: .focusFollow)
+        owner.cancel(.focusFollow)
+        await cancelled?.value
+        await owner.task(for: .startupSweep)?.value
+        #expect(!focusFired)
+        #expect(sweepFired)
+    }
+
+    @Test("cancelAll sweeps every pending key")
+    func cancelAllSweepsEveryKey() async {
+        let owner = DeferredTasks()
+        var fired = false
+        let body: @MainActor () -> Void = { fired = true }
+        let keys: [DeferredTasks.Key] = [
+            .focusFollow, .startupSweep,
+            .spaceSettle, .nativeSpaceSettle,
+        ]
+        for key in keys {
+            owner.schedule(key, after: .milliseconds(5), body)
+        }
+        let pending = keys.compactMap { owner.task(for: $0) }
+        #expect(pending.count == keys.count)
+        owner.cancelAll()
+        for task in pending {
+            await task.value
+        }
+        #expect(!fired)
+        for key in keys {
+            #expect(owner.task(for: key) == nil)
+        }
+    }
+
+    @Test("A cancelled key can be rescheduled afterwards")
+    func cancelledKeyReschedules() async {
+        let owner = DeferredTasks()
+        var fired = false
+        owner.schedule(.spaceSettle, after: .milliseconds(5)) {}
+        owner.cancelAll()
+        owner.schedule(.spaceSettle, after: .milliseconds(5)) {
+            fired = true
+        }
+        await owner.task(for: .spaceSettle)?.value
+        #expect(fired)
+    }
+
+    @Test("stop() cancels a pending settle via cancelAll")
+    func stopCancelsPendingSettles() {
+        let core = makeCore()
+        core.execute(
+            "focus_virtual_space",
+            args: [.string("2")]
+        )
+        let settle = core.deferred.task(for: .spaceSettle)
+        #expect(settle != nil)
+        core.stop()
+        #expect(settle?.isCancelled == true)
+        #expect(core.deferred.task(for: .spaceSettle) == nil)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/MoveToSpaceTests.swift
+++ b/Tests/KiwiDeskCoreTests/MoveToSpaceTests.swift
@@ -302,7 +302,7 @@ struct MoveToSpaceTests {
             "focus_virtual_space",
             args: [.string("2")]
         )
-        let first = core.pendingSpaceSettle
+        let first = core.deferred.task(for: .spaceSettle)
         #expect(first != nil)
         core.execute(
             "focus_virtual_space",
@@ -310,9 +310,10 @@ struct MoveToSpaceTests {
         )
         // The prior settle is cancelled AND a fresh one scheduled
         // for the new target — not merely cancelled.
+        let second = core.deferred.task(for: .spaceSettle)
         #expect(first?.isCancelled == true)
-        #expect(core.pendingSpaceSettle != nil)
-        #expect(core.pendingSpaceSettle != first)
+        #expect(second != nil)
+        #expect(second != first)
     }
 
     @Test("Moving to the current space re-stamps focus safely")


### PR DESCRIPTION
## Description

Extracts the keyed deferred-task owner proposed in #49. `KiwiCore`
held three hand-managed one-shot `Task<Void, Never>?` fields
(`pendingFocusFollow`, `pendingStartupSweep`, `pendingSpaceSettle`)
plus an unstored fire-and-forget task in `settleAfterNativeSwitch`,
each repeating the same store / self-cancel / sleep / `isCancelled`
protocol — and `stop()` cancelled them via a hand-kept list, which
is exactly how a missing cancel slipped through review once (#48).

`DeferredTasks` (new, `App/`, 80 lines) now owns that protocol
behind `schedule(_ key:, after:, _ body:)` / `cancel(_:)` /
`cancelAll()`. The four settle bodies stay closures at their call
sites with their genuinely different delays, guards, and post-work
(AGENTS.md §2.4, as the issue prescribed). `stop()` calls
`cancelAll()`, so teardown cannot forget a newly added key.
`pendingZOrderRestore` deliberately stays a flag — it is driven by
the animation-ended callback, not a timer.

Two behavior improvements fall out for the native-switch settle:

- **Latent teardown bug fixed:** the old unstored task was outside
  `stop()`'s hand-kept cancel list entirely; since the core object
  outlives `stop()`, a pending settle could `retile` + focus after
  teardown. It is now cancelled with everything else.
- **Rapid A→B→A switches debounce to the last switch:** the stale
  A-task previously re-matched the `lastNativeSpace` guard and
  fired an early settle mid-reconcile; keyed rescheduling keeps
  only the latest settle (documented at the call site).

## Related Issue(s)

Closes #49

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/` (n/a — no
  user-visible behavior change)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## How I verified

Internal refactor with no user-visible surface: verified via the
full gate (debug build, 576 tests, lint, release build) before
each commit. New `DeferredTasksTests` suite (7 tests) pins
fire-after-delay, cancel-and-replace on reschedule, per-key
independence, `cancelAll`, reschedule-after-cancel, and
`stop() → cancelAll()`; tests await the stored task handles
instead of sleeping fixed buffers, so they are deterministic.
`MoveToSpaceTests` ported to the new accessor with its original
assertions intact.

## Notes for Reviewer

AGENTS.md §3 review completed: `code-reviewer` and
`architect-reviewer` ran in parallel on the diff; **both returned
no major findings**. Low-severity advisories were addressed in
998b0e6 (document that `task(for:)` may return a finished task;
note that bodies are retained until they fire, capture the core
weakly; test-name/API mismatch). Dismissed as accepted:
finished-task slot retention (bounded, one per key, inert),
temp-dir cleanup in tests (existing suite convention), Key doc
comments naming call-site functions (useful cross-reference).

The issue gated this on "when a 5th deferred task appears";
tackled now by request — and the latent native-settle teardown
bug it surfaced suggests that was the right call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)