### PR TITLE
fix(gui): settings clickability affordance, click-away focus commit (#93), live sidebar language

### DIFF
--- a/Sources/KiwiDesk/Settings/ClickAwayResignsFocus.swift
+++ b/Sources/KiwiDesk/Settings/ClickAwayResignsFocus.swift
@@ -1,0 +1,29 @@
+import AppKit
+import SwiftUI
+
+/// A transparent background layer that resigns the key window's
+/// first responder on click (#93). Several settings fields
+/// (`StepperRow`, `ColorSwatch`'s hex field, `SpaceNameField`)
+/// use `@FocusState` and commit on focus loss — but on macOS,
+/// clicking empty/non-focusable space does NOT resign a
+/// `TextField`'s first responder the way it does on iOS, so a
+/// typed value can stick uncommitted until Return or clicking
+/// another field.
+///
+/// Meant to sit BEHIND real content in a `ZStack`, never as a
+/// gesture on the whole container: SwiftUI hit-tests top-down,
+/// so any actual control (button, picker, field) drawn on top
+/// still claims its own click first, and only genuinely empty
+/// area falls through to this layer's tap. `Color.clear` still
+/// participates in hit-testing via `.contentShape`, so it needs
+/// no visible fill to catch the click.
+struct ClickAwayResignsFocus: View {
+    var body: some View {
+        Color.clear
+            .contentShape(Rectangle())
+            .onTapGesture {
+                NSApp.keyWindow?.makeFirstResponder(nil)
+            }
+            .accessibilityHidden(true)
+    }
+}

--- a/Sources/KiwiDesk/Settings/ClickAwayResignsFocus.swift
+++ b/Sources/KiwiDesk/Settings/ClickAwayResignsFocus.swift
@@ -1,29 +1,77 @@
 import AppKit
 import SwiftUI
 
-/// A transparent background layer that resigns the key window's
-/// first responder on click (#93). Several settings fields
-/// (`StepperRow`, `ColorSwatch`'s hex field, `SpaceNameField`)
-/// use `@FocusState` and commit on focus loss — but on macOS,
-/// clicking empty/non-focusable space does NOT resign a
-/// `TextField`'s first responder the way it does on iOS, so a
-/// typed value can stick uncommitted until Return or clicking
-/// another field.
+/// Resigns the settings window's first responder when the user
+/// clicks outside the currently-edited text field (#93).
 ///
-/// Meant to sit BEHIND real content in a `ZStack`, never as a
-/// gesture on the whole container: SwiftUI hit-tests top-down,
-/// so any actual control (button, picker, field) drawn on top
-/// still claims its own click first, and only genuinely empty
-/// area falls through to this layer's tap. `Color.clear` still
-/// participates in hit-testing via `.contentShape`, so it needs
-/// no visible fill to catch the click.
-struct ClickAwayResignsFocus: View {
-    var body: some View {
-        Color.clear
-            .contentShape(Rectangle())
-            .onTapGesture {
-                NSApp.keyWindow?.makeFirstResponder(nil)
-            }
-            .accessibilityHidden(true)
+/// Several settings fields (`StepperRow`, `ColorSwatch`'s hex
+/// field, `SpaceNameField`) use `@FocusState` and commit on focus
+/// loss — but on macOS, clicking empty/non-focusable space does
+/// NOT resign a `TextField`'s first responder the way it does on
+/// iOS, so a typed value can stick uncommitted until Return or a
+/// click into another field.
+///
+/// A transparent tap layer can't fix this: the section
+/// `ScrollView`s and every control claim the mouse-down before it
+/// reaches a sibling behind them. So this installs a window-scoped
+/// `NSEvent` local monitor, independent of SwiftUI hit-testing: on
+/// a left mouse-down, if a field editor holds focus and the click
+/// landed outside it, resign — which fires each field's
+/// commit-on-focus-loss path.
+struct ClickAwayResignsFocus: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        FocusResignMonitorView()
     }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+/// Owns a left-mouse-down monitor scoped to its own window, torn
+/// down when the view leaves the window or is deallocated. Never
+/// intercepts clicks itself (`hitTest` returns nil).
+private final class FocusResignMonitorView: NSView {
+    private var monitor: Any?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        removeMonitor()
+        guard let window else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown]
+        ) { [weak window] event in
+            guard let window, event.window === window else {
+                return event
+            }
+            Self.resignIfClickOutsideEditor(window, event)
+            return event
+        }
+    }
+
+    /// Keep editing when the click lands inside the focused field
+    /// editor; otherwise resign so the field commits. A no-op
+    /// unless a text field editor currently holds focus, so plain
+    /// clicks never disturb button/menu behaviour.
+    private static func resignIfClickOutsideEditor(
+        _ window: NSWindow,
+        _ event: NSEvent
+    ) {
+        guard let editor = window.firstResponder as? NSTextView
+        else { return }
+        let hit = window.contentView?.hitTest(
+            event.locationInWindow
+        )
+        if let hit, hit.isDescendant(of: editor) { return }
+        window.makeFirstResponder(nil)
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    private func removeMonitor() {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+            self.monitor = nil
+        }
+    }
+
+    deinit { removeMonitor() }
 }

--- a/Sources/KiwiDesk/Settings/ClickAwayResignsFocus.swift
+++ b/Sources/KiwiDesk/Settings/ClickAwayResignsFocus.swift
@@ -26,9 +26,13 @@ struct ClickAwayResignsFocus: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
-/// Owns a left-mouse-down monitor scoped to its own window, torn
-/// down when the view leaves the window or is deallocated. Never
-/// intercepts clicks itself (`hitTest` returns nil).
+/// Owns a left-mouse-down monitor scoped to its own window. The
+/// monitor is torn down (and re-installed) in `viewDidMoveToWindow`
+/// whenever the view's window changes — including leaving the
+/// window (`window == nil`), which is the teardown path — so no
+/// `deinit` is needed (a nonisolated `deinit` can't touch the
+/// `@MainActor` monitor state anyway). Never intercepts clicks
+/// itself (`hitTest` returns nil).
 private final class FocusResignMonitorView: NSView {
     private var monitor: Any?
 
@@ -72,6 +76,4 @@ private final class FocusResignMonitorView: NSView {
             self.monitor = nil
         }
     }
-
-    deinit { removeMonitor() }
 }

--- a/Sources/KiwiDesk/Settings/ProfileHeader.swift
+++ b/Sources/KiwiDesk/Settings/ProfileHeader.swift
@@ -73,6 +73,7 @@ struct ProfileHeaderBar: View {
                 Image(systemName: "xmark.circle")
             }
             .buttonStyle(.borderless)
+            .hoverHighlight(cornerRadius: 4, padding: 2)
             .help(L("profile_header.dismiss", "Dismiss"))
         }
     }

--- a/Sources/KiwiDesk/Settings/Sections/AppRuleRow.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRuleRow.swift
@@ -107,7 +107,9 @@ struct AppRuleRow: View {
                 }
             }
         } label: {
-            Text(model.config.appRules[app]?.raw ?? automatic)
+            menuLabel(
+                model.config.appRules[app]?.raw ?? automatic
+            )
         }
         .menuStyle(.borderlessButton)
         .fixedSize()
@@ -137,10 +139,22 @@ struct AppRuleRow: View {
                 editingTitles = true
             }
         } label: {
-            Text(floatLabel)
+            menuLabel(floatLabel)
         }
         .menuStyle(.borderlessButton)
         .fixedSize()
+    }
+
+    /// The borderless-menu signature (`ProfileEditTargetMenu`):
+    /// a trailing chevron on the label so a bare-text menu
+    /// still reads as "this opens a menu".
+    private func menuLabel(_ text: String) -> some View {
+        HStack(spacing: 4) {
+            Text(text)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
     }
 
     private var titledLabel: String {

--- a/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
@@ -79,6 +79,7 @@ struct AppRulesSection: View {
                     systemImage: "plus"
                 )
             }
+            .buttonStyle(.bordered)
             .disabled(newApp.trimmed.isEmpty)
             Spacer()
         }

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
@@ -140,6 +140,13 @@ struct ProfilesSection: View {
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
                     Text(summary.name)
+                        // Bonus discovery path (low-risk): a
+                        // double-click on the name opens the
+                        // same rename popover as the pencil,
+                        // which stays the primary visible cue.
+                        .onTapGesture(count: 2) {
+                            beginRename(summary.name)
+                        }
                     renameButton(summary.name)
                     if summary.name == model.activeProfile {
                         BadgeChip(
@@ -207,18 +214,23 @@ struct ProfilesSection: View {
     /// Rename is a pencil right beside the profile name (in
     /// front of the badges), opening a popover. The rename is
     /// immediate (file + native-Space bindings follow), like
-    /// Delete and make default.
+    /// Delete and make default. Unlike the other icon-only
+    /// borderless buttons, the pencil stays persistently visible
+    /// (a soft always-on background circle, matching
+    /// `hoverHighlight`'s hover value at rest) rather than
+    /// hover-only — it is the primary discovery path for
+    /// renaming, so it must not require finding it first.
     private func renameButton(_ name: String) -> some View {
         Button {
-            renameDraft = name
-            renaming = name
+            beginRename(name)
         } label: {
             Image(systemName: "pencil")
-                .imageScale(.small)
+                .imageScale(.medium)
         }
         .buttonStyle(.borderless)
+        .frame(width: 22, height: 22)
+        .hoverHighlight(cornerRadius: 11, padding: 0)
         .help(L("profiles.rename.help", "Rename profile"))
-        .linkHover()
         .popover(
             isPresented: Binding(
                 get: { renaming == name },
@@ -257,6 +269,11 @@ struct ProfilesSection: View {
                 && $0.caseInsensitiveCompare(old)
                     != .orderedSame
         }
+    }
+
+    private func beginRename(_ name: String) {
+        renameDraft = name
+        renaming = name
     }
 
     private func commitRename(of old: String) {

--- a/Sources/KiwiDesk/Settings/Sections/SpaceAssignmentChip.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpaceAssignmentChip.swift
@@ -51,6 +51,7 @@ struct SpaceAssignmentChip: View {
                         .font(.system(size: 9))
                 }
                 .buttonStyle(.borderless)
+                .hoverHighlight(cornerRadius: 4, padding: 2)
                 .help(
                     L(
                         "monitors.orphan_pin.help",

--- a/Sources/KiwiDesk/Settings/SettingsRows.swift
+++ b/Sources/KiwiDesk/Settings/SettingsRows.swift
@@ -205,3 +205,53 @@ struct PlacementPicker: View {
         L("placement.new_window", "New window")
     }
 }
+
+/// Hover-driven background chip for icon-only borderless
+/// buttons that otherwise show no cue until pressed — the
+/// `ColorSwatch` recipe, generalized: a `RoundedRectangle` fill
+/// that lifts from a faint rest state to a stronger one on
+/// `.onHover`. Buttons never change the cursor (AGENTS.md); this
+/// is chrome only, no `pointingHandCursor()`.
+private struct HoverChip: ViewModifier {
+    @State private var hovering = false
+    var restOpacity: Double
+    var hoverOpacity: Double
+    var cornerRadius: CGFloat
+    var padding: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .padding(padding)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(
+                        Color.primary.opacity(
+                            hovering ? hoverOpacity : restOpacity
+                        )
+                    )
+            )
+            .onHover { hovering = $0 }
+    }
+}
+
+extension View {
+    /// Wraps an icon-only borderless control in a hover
+    /// background chip (0.06 at rest → 0.12 on hover, matching
+    /// `ColorSwatch.swatchButton`), so it reads as clickable
+    /// before the pointer commits to a press.
+    func hoverHighlight(
+        restOpacity: Double = 0.06,
+        hoverOpacity: Double = 0.12,
+        cornerRadius: CGFloat = 6,
+        padding: CGFloat = 4
+    ) -> some View {
+        modifier(
+            HoverChip(
+                restOpacity: restOpacity,
+                hoverOpacity: hoverOpacity,
+                cornerRadius: cornerRadius,
+                padding: padding
+            )
+        )
+    }
+}

--- a/Sources/KiwiDesk/Settings/SettingsSidebar.swift
+++ b/Sources/KiwiDesk/Settings/SettingsSidebar.swift
@@ -11,6 +11,11 @@ struct SettingsSidebar: View {
     let editingStoredProfile: Bool
     /// Swaps the identity mark to the golden variant on dark.
     @Environment(\.colorScheme) private var colorScheme
+    /// Subscribes the sidebar to live language changes: without
+    /// it, section headers and row titles (`L(...)` /
+    /// `destination.title`) only refresh when `selection` changes
+    /// (a section switch), not on the language switch itself.
+    @EnvironmentObject private var localization: LocalizationManager
 
     var body: some View {
         List(selection: $selection) {

--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -81,7 +81,15 @@ struct SettingsView: View {
                 title: selection.title,
                 showsProfileContext: selection.showsProfileContext
             )
-            content()
+            // `content()` stacks on top of the resign-on-click
+            // background (#93): SwiftUI hit-tests top-down, so
+            // any real control inside `content()` still claims
+            // the click first — only genuinely empty area falls
+            // through to the background tap.
+            ZStack {
+                ClickAwayResignsFocus()
+                content()
+            }
             Divider()
             SettingsFooter(model: model)
         }

--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -81,11 +81,11 @@ struct SettingsView: View {
                 title: selection.title,
                 showsProfileContext: selection.showsProfileContext
             )
-            // `content()` stacks on top of the resign-on-click
-            // background (#93): SwiftUI hit-tests top-down, so
-            // any real control inside `content()` still claims
-            // the click first — only genuinely empty area falls
-            // through to the background tap.
+            // `ClickAwayResignsFocus` installs a window-scoped
+            // mouse-down monitor (#93) that commits an edited
+            // field when the click lands outside it. It's a
+            // zero-size, hit-test-transparent probe, so the ZStack
+            // order is incidental — it never intercepts clicks.
             ZStack {
                 ClickAwayResignsFocus()
                 content()

--- a/Sources/KiwiDesk/Settings/Tabs/AppRuleControls.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppRuleControls.swift
@@ -39,7 +39,7 @@ struct AppSelector: View {
                     name = ""
                 }
             } label: {
-                Text(
+                menuLabel(
                     name.isEmpty
                         ? L("shortcuts.choose_app", "Choose app…")
                         : name
@@ -48,6 +48,18 @@ struct AppSelector: View {
             }
             .controlSize(.large)
         }
+    }
+}
+
+/// The borderless-menu signature (`ProfileEditTargetMenu`): a
+/// trailing chevron on the label so a bare-text menu still reads
+/// as "this opens a menu".
+private func menuLabel(_ text: String) -> some View {
+    HStack(spacing: 4) {
+        Text(text)
+        Image(systemName: "chevron.up.chevron.down")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
     }
 }
 
@@ -64,7 +76,7 @@ struct SpaceMenu: View {
                 Button(space.raw) { onPick(space) }
             }
         } label: {
-            Text(
+            menuLabel(
                 selected?.raw
                     ?? L("space_menu.placeholder", "Space…")
             )

--- a/Sources/KiwiDesk/Settings/Tabs/ColorField.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/ColorField.swift
@@ -157,7 +157,6 @@ struct ColorSwatch: View {
                 )
         }
         .buttonStyle(.plain)
-        .pointingHandCursor()
         .onHover { hovering = $0 }
         .help(
             L(

--- a/Sources/KiwiDesk/Settings/Tabs/KeyRecorderField.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeyRecorderField.swift
@@ -76,6 +76,7 @@ struct KeyRecorderField: View {
                     }
                     .buttonStyle(.borderless)
                     .foregroundStyle(.secondary)
+                    .hoverHighlight(cornerRadius: 4, padding: 2)
                 }
             }
             if let rejection = liveRejection {
@@ -127,6 +128,14 @@ struct KeyRecorderField: View {
     /// the tint alone only recolors the border. Same
     /// accent-layer vocabulary as OverrideChrome's active rows.
     /// Negative padding keeps the layout footprint unchanged.
+    ///
+    /// Deliberately NOT a rounded pill like Save/Cancel
+    /// (`.borderedProminent`): this is a stateful input well —
+    /// System Settings' own Keyboard Shortcuts recorder reads
+    /// the same way — not a momentary action, so it must not
+    /// read as one. The at-rest tint below is a light nudge
+    /// toward "field", not a restructure: a touch tighter corner
+    /// radius plus a faint recessed fill (`.quaternary`).
     private var recordButton: some View {
         Button(action: toggle) {
             Text(label)
@@ -136,7 +145,11 @@ struct KeyRecorderField: View {
         .buttonStyle(.bordered)
         .tint(buttonTint)
         .background {
-            if recording {
+            if !recording {
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(.quaternary.opacity(0.5))
+                    .allowsHitTesting(false)
+            } else {
                 RoundedRectangle(cornerRadius: 6)
                     .fill(Color.accentColor.opacity(0.08))
                     .padding(-4)
@@ -180,34 +193,19 @@ struct KeyRecorderField: View {
     private func rejectionRow(
         _ rejection: RecorderRejection
     ) -> some View {
-        HStack(spacing: 6) {
-            Text(
-                L(
-                    "key_recorder.assigned_to",
-                    "Assigned to \u{201C}%1$@\u{201D}",
-                    rejection.holder
-                )
-            )
-            .foregroundStyle(.red)
-            Button(L("key_recorder.steal", "Steal")) {
+        KeyRecorderRejectionRow(
+            rejection: rejection,
+            onSteal: {
                 self.rejection = nil
                 rejection.steal()
-            }
-            Button(L("key_recorder.go_to", "Go to")) {
+            },
+            onGoTo: {
                 self.rejection = nil
                 coordinator.scrollTarget =
                     rejection.holderRowID
-            }
-            Button {
-                self.rejection = nil
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-            }
-            .buttonStyle(.borderless)
-            .foregroundStyle(.secondary)
-        }
-        .font(.caption)
-        .buttonStyle(.link)
+            },
+            onDismiss: { self.rejection = nil }
+        )
     }
 
     private var buttonTint: Color? {

--- a/Sources/KiwiDesk/Settings/Tabs/KeyRecorderRejectionRow.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeyRecorderRejectionRow.swift
@@ -1,0 +1,39 @@
+import KiwiDeskCore
+import SwiftUI
+
+/// The inline "Assigned to…" row `KeyRecorderField` shows when a
+/// lock-in collides with another KiwiDesk row (#34): Steal /
+/// Go to are link-styled (`.buttonStyle(.link)`), so they get
+/// the pointing-hand cursor explicitly — `.link` sets color but
+/// not the cursor. Split out of `KeyRecorderField` to keep that
+/// file under the line ceiling.
+struct KeyRecorderRejectionRow: View {
+    let rejection: RecorderRejection
+    let onSteal: () -> Void
+    let onGoTo: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(
+                L(
+                    "key_recorder.assigned_to",
+                    "Assigned to \u{201C}%1$@\u{201D}",
+                    rejection.holder
+                )
+            )
+            .foregroundStyle(.red)
+            Button(L("key_recorder.steal", "Steal"), action: onSteal)
+                .pointingHandCursor()
+            Button(L("key_recorder.go_to", "Go to"), action: onGoTo)
+                .pointingHandCursor()
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+        }
+        .font(.caption)
+        .buttonStyle(.link)
+    }
+}

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingAppSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingAppSection.swift
@@ -128,11 +128,19 @@ struct ApplicationsSection: View {
                 chooseBundle(binding)
             }
         } label: {
-            Text(
-                binding.wrappedValue.label.isEmpty
-                    ? L("shortcuts.choose_app", "Choose app…")
-                    : binding.wrappedValue.label
-            )
+            HStack(spacing: 4) {
+                Text(
+                    binding.wrappedValue.label.isEmpty
+                        ? L(
+                            "shortcuts.choose_app",
+                            "Choose app…"
+                        )
+                        : binding.wrappedValue.label
+                )
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
             .frame(minWidth: 160, alignment: .leading)
         }
         .frame(width: 200)


### PR DESCRIPTION
## Description

Settings-surface polish, all verified in-app by the maintainer:

- **Clickability affordance.** Bare-label borderless menus (App Rules space/float pickers, app selector, keybinding app-picker) now carry the app's `chevron.up.chevron.down` menu cue, so they read as menus instead of static captions. "Add app rule" gets `.buttonStyle(.bordered)` to match the other Add buttons. A reusable `hoverHighlight(...)` modifier (generalized from the ColorSwatch recipe) gives the icon buttons (clear ✕, dismiss, recorder clear) a hover cue; the rename pencil is now persistently visible with a bigger target + double-click-the-name. `.link`-styled buttons get the pointing hand; the color swatch drops its redundant one. The shortcut recorder is intentionally **not** rounded (it's a stateful input well, not a momentary action) — only a faint at-rest background.
- **#93 — fields keep focus / don't commit on click-away.** A window-scoped `NSEvent` mouse-down monitor (`ClickAwayResignsFocus`) resigns first responder when a click lands outside the focused field editor, firing each field's commit-on-focus-loss path — independent of SwiftUI hit-testing (a transparent-tap-layer approach could not work because ScrollViews/controls claim the click).
- **Live sidebar language.** `SettingsSidebar` now observes `LocalizationManager`, so its section headers and row titles update immediately on a language switch instead of lagging until a section change.

## Related Issue(s)

Closes #93

## Checklist

- [x] Run in the app to confirm it works (maintainer verified: click-away commit, hover cues, live language reload)
- [x] Commits follow Conventional Commits
- [x] New behavior tested where testable (pure logic); this batch is GUI chrome + AppKit interaction, verified interactively
- [x] Docs/comments match behavior (fixed a stale inline comment during review)
- [x] `swift build && swift test && ./scripts/lint.sh` passes (701 tests)
- [x] Release build passes: `swift build -c release` (warning-free — fixed an actor-isolation diagnostic in the monitor)
- [x] PR focused; commits keep the three concerns (affordance / #93 / sidebar i18n) separable

## How I verified

- Full gate green: `swift build`, `swift test` (701), `scripts/lint.sh` (incl. `extract-keys --check`), `swift build -c release`.
- Maintainer ran the app: confirmed click-away now commits + clears focus everywhere (incl. inside scrollable sections), menus read as clickable, and the sidebar reloads language live.
- Reviewed by `code-reviewer` + `architect-reviewer` (parallel) — no must-fix findings; the one actionable item (stale comment) and an actor-isolation warning are fixed in this branch.

## Notes for Reviewer

- The #93 monitor lifecycle: installed/removed in `viewDidMoveToWindow`, scoped by `event.window === window`; the settings window is a singleton so only one is ever live. No retain cycle (static handler + `[weak window]`), no `deinit` needed under strict concurrency.
- The borderless-menu chevron is hand-repeated across ~3-4 sites (small readable duplication per §2.4); promote to a shared `MenuChevronLabel` if a further site appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)