### PR TITLE
chore(scripts): add doc-writing subagents for wave 10

### DIFF
--- a/scripts/install-subagents.sh
+++ b/scripts/install-subagents.sh
@@ -15,8 +15,9 @@ mkdir -p "$CLAUDE_AGENTS_DIR"
 
 # KiwiDesk-relevant subagents (category/agent-name)
 AGENTS=(
-    "01-core-development/ui-designer" 
-    "01-core-development/websocket-engineer" 
+    "01-core-development/frontend-developer"
+    "01-core-development/ui-designer"
+    "01-core-development/websocket-engineer"
     "02-language-specialists/swift-expert"
     "02-language-specialists/cpp-pro"
     "03-infrastructure/devops-engineer"
@@ -24,7 +25,9 @@ AGENTS=(
     "04-quality-security/architect-reviewer"
     "06-developer-experience/git-workflow-manager"
     "06-developer-experience/documentation-engineer"
+    "06-developer-experience/readme-generator"
     "07-specialized-domains/api-documenter"
+    "07-specialized-domains/seo-specialist"
     "08-business-product/technical-writer"
     "09-meta-orchestration/codebase-orchestrator"
 )

--- a/scripts/install-subagents.sh
+++ b/scripts/install-subagents.sh
@@ -23,6 +23,9 @@ AGENTS=(
     "04-quality-security/code-reviewer"
     "04-quality-security/architect-reviewer"
     "06-developer-experience/git-workflow-manager"
+    "06-developer-experience/documentation-engineer"
+    "07-specialized-domains/api-documenter"
+    "08-business-product/technical-writer"
     "09-meta-orchestration/codebase-orchestrator"
 )
 


### PR DESCRIPTION
## Summary

Adds six subagents from the VoltAgent catalog to
`scripts/install-subagents.sh` for the Wave 10 docs + website
overhaul (#63 umbrella, sub-tasks #3 and #62):

**Docs writing:**
- `06-developer-experience/documentation-engineer`
- `07-specialized-domains/api-documenter`
- `08-business-product/technical-writer`

**Website (Astro + Starlight site, landing page, README):**
- `01-core-development/frontend-developer`
- `06-developer-experience/readme-generator`
- `07-specialized-domains/seo-specialist`

Installed and verified locally (15 subagents active, all fetches
succeed).

## Verification

- `swift build` ✅
- `swift test` ✅ (701 tests, 130 suites)
- `scripts/lint.sh` ✅ (pre-existing length warnings only)
- `swift build -c release` ✅

Part of Wave 10 prep (#27); the docs/site implementation follows
in separate PRs per the agreed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188TsGvxQe8d7qhb3g3TS9V