### PR TITLE
fix(profiles): reconcile gui.json space list with live state (#77)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
@@ -66,6 +66,11 @@ extension KiwiCore {
         // own override via apply(profile:) (#55 phase 6).
         if isGuiManaged {
             applyStructuredConfig()
+            // Seed GUI-only spaces before the active profile
+            // (below) or a monitor change ensures its own on
+            // top — a bare sidecar space would otherwise never
+            // enter live and would drop on reload (#77).
+            seedGuiSpaces()
         } else {
             applyConfigGlobals(from: fresh)
         }

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -101,7 +101,11 @@ extension KiwiCore {
         // `buildProfile` would recapture it and it would reappear
         // on reload (#77). Same reconcile as an explicit
         // `load_profile`; survivors are exactly the set ensured
-        // above, so the just-added extras are never pruned.
+        // above, so the just-added extras are never pruned. The
+        // sidecar half is closed by the caller — `persist`
+        // rewrites gui.json when the space list changed
+        // (`globalsChanged`) — so the cold-boot seed can't re-add
+        // the dropped space; this path needs no direct mirror.
         pruneSpaces(
             keeping: inList.union(extra),
             orderedBy: config.spaces,

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -95,6 +95,18 @@ extension KiwiCore {
         // same order `overwriteProfile` would — one order
         // representation across both save paths (#75/#55).
         state.workspaces.reorder(matching: config.spaces)
+        // A space the model no longer references anywhere (list,
+        // modes, pins, Main) was deleted in the Spaces tab — drop
+        // it from live too, forwarding any windows, or the next
+        // `buildProfile` would recapture it and it would reappear
+        // on reload (#77). Same reconcile as an explicit
+        // `load_profile`; survivors are exactly the set ensured
+        // above, so the just-added extras are never pruned.
+        pruneSpaces(
+            keeping: inList.union(extra),
+            orderedBy: config.spaces,
+            preferring: config.fallbackSpace
+        )
         for space in state.workspaces.allSpaces {
             state.workspaces.setMode(
                 space.id,
@@ -117,6 +129,46 @@ extension KiwiCore {
         // by ≤2 pt and visibly did nothing (#68).
         retile(force: true)
         emitSpaceChange()
+    }
+
+    /// Cold-boot story for GUI-only spaces (#77): seeds live from
+    /// the sidecar's `spaces` list so a space that lives *only* in
+    /// `gui.json` — no active profile, pin, window, or Lua
+    /// `set_mode` backs it — is present in live and survives the
+    /// next reload (`overlayLiveProfileState` reads live, not the
+    /// sidecar). Runs in `loadConfig` before the first
+    /// `handleMonitorChange` adopts a profile, which then ensures
+    /// its own spaces on top. Only *adds* (never sets modes or
+    /// removes), so a Lua-declared space keeps its mode and no
+    /// live-only space is dropped. Safe against resurrecting a
+    /// profile-pruned space because every authoritative prune
+    /// mirrors live back into the sidecar (`syncGuiSpacesToLive`),
+    /// so its `spaces` list is never stale.
+    func seedGuiSpaces() {
+        guard let config = guiConfigStore.load() else { return }
+        for space in config.spaces {
+            state.workspaces.ensureSpace(space)
+        }
+        state.workspaces.reorder(matching: config.spaces)
+    }
+
+    /// Mirrors the live space set back into `gui.json` after an
+    /// authoritative reconcile changed it (a `load_profile` or an
+    /// in-effect edit that pruned stale spaces), keeping the
+    /// sidecar a faithful copy of live so the cold-boot seed above
+    /// never re-injects a space a profile load dropped (#77).
+    /// GUI-managed only (no sidecar otherwise); writes the store
+    /// directly — NOT `saveGuiConfig`, which would reload the
+    /// config mid-command. A no-op when the list already matches.
+    func syncGuiSpacesToLive() {
+        guard isGuiManaged, var config = guiConfigStore.load()
+        else { return }
+        let live = SpaceID.deduplicated(
+            state.workspaces.allSpaces.map(\.id)
+        )
+        guard config.spaces != live else { return }
+        config.spaces = live
+        try? guiConfigStore.save(config)
     }
 
     /// Whether the GUI owns the configuration — the ownership

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
@@ -62,7 +62,8 @@ extension KiwiCore {
         // carries the chosen display order — while the
         // sidecar's list can be stale (e.g. right after
         // loading a profile whose order differs). A bare space
-        // only in `gui.json` drops — it wasn't seeded at boot.
+        // only in `gui.json` is seeded into live at boot
+        // (`seedGuiSpaces`, #77), so it is present here too.
         config.spaces = SpaceID.deduplicated(live)
         config.spacePins = spacePins
         config.mainSpaces = mainSpaces

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
@@ -55,6 +55,11 @@ extension KiwiCore {
                 orderedBy: profile.orderedSpaces,
                 preferring: profile.fallbackSpace
             )
+            // An authoritative reconcile just fixed the live space
+            // set — mirror it into the sidecar so the cold-boot
+            // seed can't re-inject a space this prune dropped
+            // (#77). No-op when not GUI-managed.
+            syncGuiSpacesToLive()
         }
         // Dense over all live spaces: a space a (hand-edited,
         // sparse) profile doesn't declare reverts to bsp
@@ -104,7 +109,12 @@ extension KiwiCore {
     /// first space of the new profile's displayed list. When
     /// both lists are empty (degenerate call) the guard skips
     /// pruning entirely.
-    private func pruneSpaces(
+    ///
+    /// `internal` (not `private`): the GUI save path
+    /// (`applyProfileScopedState`) reuses this same reconcile so a
+    /// Spaces-tab deletion drops the space from live too (#77),
+    /// not just profile loads.
+    func pruneSpaces(
         keeping survivors: Set<SpaceID>,
         orderedBy storedOrder: [SpaceID],
         preferring explicit: SpaceID? = nil

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
@@ -317,9 +317,15 @@ extension KiwiCore {
         if profiles.currentName == name,
             let fresh = try? profiles.read(name: name)
         {
-            // Explicit: an in-effect edit re-apply whose
-            // delta may sit inside the tolerance.
-            apply(profile: fresh, forceRetile: true)
+            // Explicit re-apply of an in-effect edit; prunes so a
+            // deleted space leaves live now, not at the next
+            // load_profile (#77). Bound branch below keeps
+            // monitor-change's no-prune-on-reconnect rule.
+            apply(
+                profile: fresh,
+                pruneStaleSpaces: true,
+                forceRetile: true
+            )
         } else {
             handleMonitorChange()
         }

--- a/Tests/KiwiDeskCoreTests/GuiSpaceReconcileTests.swift
+++ b/Tests/KiwiDeskCoreTests/GuiSpaceReconcileTests.swift
@@ -183,4 +183,79 @@ struct GuiSpaceReconcileTests {
         #expect(core.state.workspaces[SpaceID("1")] != nil)
         #expect(core.state.workspaces[SpaceID("2")] != nil)
     }
+
+    @Test("A load_profile prune mirrors the live set to gui.json")
+    func loadProfileMirrorsSidecar() throws {
+        let core = makeCore()
+        // GUI-managed: a sidecar exists (no foreign init.lua here).
+        try core.guiConfigStore.save(
+            config(spaces: [SpaceID("A"), SpaceID("B")])
+        )
+        core.state.workspaces.ensureSpace(SpaceID("A"))
+        core.state.workspaces.ensureSpace(SpaceID("B"))
+        try core.profiles.write(
+            Profile(
+                name: "solo",
+                monitorSets: [
+                    MonitorSet(
+                        monitors: ["m"],
+                        spaceMonitorMap: [:]
+                    )
+                ],
+                spaces: [SpaceID("A")],
+                spaceModes: [SpaceID("A"): .bsp],
+                settings: TilingSettings()
+            )
+        )
+        _ = core.execute("load_profile", args: [.string("solo")])
+        // "B" pruned from live and the sidecar now mirrors [A].
+        #expect(core.state.workspaces[SpaceID("B")] == nil)
+        let saved = try #require(core.guiConfigStore.load())
+        #expect(saved.spaces == [SpaceID("A")])
+    }
+
+    @Test("Deleting a space under one profile leaves others intact")
+    func deletionIsPerProfile() throws {
+        let core = makeCore()
+        let mon = [
+            MonitorSet(monitors: ["m"], spaceMonitorMap: [:])
+        ]
+        try core.profiles.write(
+            Profile(
+                name: "one",
+                monitorSets: mon,
+                spaces: [SpaceID("A"), SpaceID("B")],
+                spaceModes: [
+                    SpaceID("A"): .bsp,
+                    SpaceID("B"): .bsp,
+                ],
+                settings: TilingSettings()
+            )
+        )
+        let two = Profile(
+            name: "two",
+            monitorSets: mon,
+            spaces: [SpaceID("A"), SpaceID("C")],
+            spaceModes: [
+                SpaceID("A"): .bsp,
+                SpaceID("C"): .bsp,
+            ],
+            settings: TilingSettings()
+        )
+        try core.profiles.write(two)
+        // Activate "two" and delete the shared space "A" from it.
+        core.apply(
+            profile: two,
+            pruneStaleSpaces: true,
+            forceRetile: false
+        )
+        core.applyProfileScopedState(
+            from: config(spaces: [SpaceID("C")])
+        )
+        #expect(core.state.workspaces[SpaceID("A")] == nil)
+        // Profile "one" still declares "A" — each profile is its
+        // own file, so the delete never touches the other.
+        let reread = try core.profiles.read(name: "one")
+        #expect(reread.declaredSpaces.contains(SpaceID("A")))
+    }
 }

--- a/Tests/KiwiDeskCoreTests/GuiSpaceReconcileTests.swift
+++ b/Tests/KiwiDeskCoreTests/GuiSpaceReconcileTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    KiwiCore(
+        configDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "kiwi-gui-space-\(UUID().uuidString)"
+            )
+    )
+}
+
+/// A minimal GUI model listing `spaces` with default bsp modes —
+/// the shape the Spaces tab produces after add/delete edits.
+private func config(spaces: [SpaceID]) -> GuiConfig {
+    var config = GuiConfig()
+    config.spaces = spaces
+    var modes: [SpaceID: LayoutMode] = [:]
+    for space in spaces { modes[space] = .bsp }
+    config.spaceModes = modes
+    return config
+}
+
+/// The GUI save/boot half of space reconcile (#77): a Spaces-tab
+/// deletion drops the space from live, the sidecar mirrors live,
+/// and a bare sidecar space seeds into live at boot.
+@Suite("GUI space reconcile", .serialized)
+@MainActor
+struct GuiSpaceReconcileTests {
+    // MARK: - Spaces-tab delete (applyProfileScopedState)
+
+    @Test("Deleting a space prunes it from live; windows rehome")
+    func deletePrunesAndRehomes() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("2"))
+        core.state.workspaces.add(WindowID(7), to: SpaceID("3"))
+        // The model no longer lists "3" (deleted in the tab).
+        core.applyProfileScopedState(
+            from: config(spaces: [SpaceID("1"), SpaceID("2")])
+        )
+        #expect(core.state.workspaces[SpaceID("3")] == nil)
+        #expect(core.state.workspaces[SpaceID("1")] != nil)
+        #expect(core.state.workspaces[SpaceID("2")] != nil)
+        // Its window forwarded to the first listed space.
+        #expect(
+            core.state.workspaces.space(of: WindowID(7))
+                == SpaceID("1")
+        )
+    }
+
+    @Test("Listing every live space prunes nothing")
+    func keepAllPrunesNothing() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("2"))
+        core.applyProfileScopedState(
+            from: config(spaces: [SpaceID("1"), SpaceID("2")])
+        )
+        #expect(core.state.workspaces[SpaceID("1")] != nil)
+        #expect(core.state.workspaces[SpaceID("2")] != nil)
+    }
+
+    @Test("A space kept alive by a mode-only reference survives")
+    func modeReferenceKeepsSpace() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("2"))
+        // "2" isn't in the list but is referenced by a mode — it
+        // is an ensured survivor, not a deletion, so it stays.
+        var model = config(spaces: [SpaceID("1")])
+        model.spaceModes[SpaceID("2")] = .stack
+        core.applyProfileScopedState(from: model)
+        #expect(core.state.workspaces[SpaceID("2")] != nil)
+        #expect(
+            core.state.workspaces[SpaceID("2")]?.mode == .stack
+        )
+    }
+
+    @Test("An empty space list prunes nothing (degenerate guard)")
+    func emptyListPrunesNothing() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("2"))
+        core.applyProfileScopedState(from: config(spaces: []))
+        #expect(core.state.workspaces[SpaceID("1")] != nil)
+        #expect(core.state.workspaces[SpaceID("2")] != nil)
+    }
+
+    // MARK: - Cold-boot seed (seedGuiSpaces)
+
+    @Test("Boot seeds live from the sidecar's space list, in order")
+    func seedsSidecarSpaces() throws {
+        let core = makeCore()
+        try core.guiConfigStore.save(
+            config(spaces: [SpaceID("7"), SpaceID("8")])
+        )
+        core.seedGuiSpaces()
+        #expect(core.state.workspaces[SpaceID("7")] != nil)
+        #expect(core.state.workspaces[SpaceID("8")] != nil)
+        // Seeded ahead of the core's default space, in list order
+        // (a fresh StateCoordinator holds space "1").
+        let seeded = [SpaceID("7"), SpaceID("8")]
+        let ids = core.state.workspaces.allSpaces.map(\.id)
+        #expect(ids.filter { seeded.contains($0) } == seeded)
+    }
+
+    @Test("Seeding only adds — a live-only space is not dropped")
+    func seedKeepsLiveOnlySpace() throws {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("live"))
+        try core.guiConfigStore.save(
+            config(spaces: [SpaceID("7")])
+        )
+        core.seedGuiSpaces()
+        #expect(core.state.workspaces[SpaceID("live")] != nil)
+        #expect(core.state.workspaces[SpaceID("7")] != nil)
+    }
+
+    // MARK: - Sidecar mirror (syncGuiSpacesToLive)
+
+    @Test("Mirror writes the live space set into gui.json")
+    func mirrorsLiveIntoSidecar() throws {
+        let core = makeCore()
+        // GUI-managed = sidecar exists and no foreign init.lua
+        // (none is written in the temp dir here).
+        try core.guiConfigStore.save(config(spaces: [SpaceID("1")]))
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("2"))
+        core.syncGuiSpacesToLive()
+        let saved = try #require(core.guiConfigStore.load())
+        #expect(saved.spaces == [SpaceID("1"), SpaceID("2")])
+    }
+
+    @Test("Mirror is a no-op with no sidecar (not GUI-managed)")
+    func mirrorNoopWithoutSidecar() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        // No sidecar saved -> not GUI-managed -> nothing written.
+        core.syncGuiSpacesToLive()
+        #expect(core.guiConfigStore.load() == nil)
+    }
+
+    // MARK: - In-place edit prune (reapplyIfInEffect, #77 / #18)
+
+    @Test("An in-place edit prunes a space dropped in the session")
+    func inPlaceEditPrunes() throws {
+        let core = makeCore()
+        var start = GuiConfig()
+        start.spaces = [SpaceID("1"), SpaceID("2"), SpaceID("3")]
+        // Adopt a profile carrying all three spaces, live matches.
+        // A non-empty monitor set is required to round-trip
+        // through `profiles.save`/`read`.
+        let profile = Profile(
+            name: "edit",
+            monitorSets: [
+                MonitorSet(monitors: ["mon-a"], spaceMonitorMap: [:])
+            ],
+            spaces: start.spaces,
+            spaceModes: [
+                SpaceID("1"): .bsp,
+                SpaceID("2"): .bsp,
+                SpaceID("3"): .bsp,
+            ],
+            settings: TilingSettings()
+        )
+        try core.profiles.save(profile)
+        core.apply(
+            profile: profile,
+            pruneStaleSpaces: true,
+            forceRetile: false
+        )
+        // The edit session drops "3"; write it and hot-reload.
+        try core.overwriteProfile(
+            named: "edit",
+            with: config(spaces: [SpaceID("1"), SpaceID("2")])
+        )
+        core.reapplyIfInEffect("edit")
+        #expect(core.state.workspaces[SpaceID("3")] == nil)
+        #expect(core.state.workspaces[SpaceID("1")] != nil)
+        #expect(core.state.workspaces[SpaceID("2")] != nil)
+    }
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -111,6 +111,21 @@ reference would silently resurrect the space on the next
 profile load. App rules survive by design: they're global,
 and another profile may declare a space of the same name.
 
+**Live state is the single source of truth for which spaces
+exist; `gui.json` mirrors it, never the reverse.** A deletion
+prunes the space from live immediately (windows rehome to the
+fallback), not only when a later profile load happens to drop
+it — otherwise the next save re-captured it from live and it
+reappeared. The sidecar's `spaces` list is kept a faithful
+copy of live: every authoritative reconcile (a `load_profile`
+or an in-place edit that prunes) writes the live set back, so
+the list can never quietly drift. The one place `gui.json`
+seeds *into* live is cold boot — a space that lives only in
+the sidecar (no profile, pin, window, or `set_mode` backs it)
+is seeded so it survives the reload. That seed is safe against
+resurrecting a profile-pruned space precisely because the
+mirror keeps the list current. (#77)
+
 **Saved profiles lead; Presets demote once one exists.** On
 the Profiles tab, the built-in Presets top the list only
 while no profile is saved yet — they're a bootstrap tool,

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -117,14 +117,22 @@ prunes the space from live immediately (windows rehome to the
 fallback), not only when a later profile load happens to drop
 it — otherwise the next save re-captured it from live and it
 reappeared. The sidecar's `spaces` list is kept a faithful
-copy of live: every authoritative reconcile (a `load_profile`
-or an in-place edit that prunes) writes the live set back, so
-the list can never quietly drift. The one place `gui.json`
-seeds *into* live is cold boot — a space that lives only in
-the sidecar (no profile, pin, window, or `set_mode` backs it)
-is seeded so it survives the reload. That seed is safe against
+copy of live *as of the last authoritative reconcile*: every
+explicit prune — a `load_profile` (including a scripted
+Lua/CLI one) or an in-place edit — writes the live set back.
+Hardware-driven applies (monitor change, native-Space
+binding) deliberately don't prune or mirror (the
+no-shuffle-on-reconnect rule), so between such an event and
+the next reconcile the list may lag; the cold-boot seed and
+the next prune re-converge it. The one place `gui.json` seeds
+*into* live is cold boot — a space that lives only in the
+sidecar (no profile, pin, window, or `set_mode` backs it) is
+seeded so it survives the reload. That seed is safe against
 resurrecting a profile-pruned space precisely because the
-mirror keeps the list current. (#77)
+mirror keeps the list current. Deletion is per-profile:
+each profile is its own file, so removing a space from the
+active profile never touches another profile that still
+declares a space of the same name. (#77)
 
 **Saved profiles lead; Presets demote once one exists.** On
 the Profiles tab, the built-in Presets top the list only

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -134,9 +134,10 @@ To **add a space**, click the **+** button and enter a name
 
 To **rename**, click the space name in the list.
 
-To **delete**, right-click and pick Delete. Any windows in that
-space are reassigned to the fallback space when you load a profile
-that drops them (see Profiles section).
+To **delete**, right-click and pick Delete. The space is removed
+right away — any windows in it move to the fallback space (or the
+first space in the list when no fallback is set), and it stays gone
+across reloads and restarts.
 
 To **set a recognition icon** (optional), click the space name to
 edit it and pick an SF Symbol, emoji, or single character. The icon

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -123,6 +123,48 @@ To reset the app to what your `init.lua` declares, delete `gui.json`.
 Treat it like `init.lua` — do not import it from an untrusted source,
 since custom Lua in keybindings runs on every reload.
 
+## What Lives Where: Global vs Per-Profile
+
+Your configuration is split across two homes, and knowing which is
+which tells you the *blast radius* of any edit:
+
+- **`gui.json` (global)** — one file, shared by every profile.
+- **Each profile's JSON (per-profile)** — one file per saved
+  profile, applied only while that profile is active.
+
+**Global settings** live in `gui.json`; editing or deleting one
+changes it for **every** profile:
+
+- **Keyboard shortcuts** (the base set)
+- **App rules** (app → space assignment)
+- **Float rules** (apps that never tile)
+- **Native Space → profile bindings**
+
+**Per-profile settings** live in the profile's own JSON; editing
+one touches **only that profile** — another profile that declares
+a space of the same name is left untouched:
+
+- **Which spaces exist** and their order (the list you see is the
+  active profile's)
+- **Layout mode, gaps, and per-layout / per-space tuning**
+- **Space-to-monitor pins, the Main role, and the fallback space**
+
+This is why, when you **edit a stored profile without switching to
+it**, the App Rules and General sections disappear — they hold
+global state a profile edit never writes.
+
+**One hybrid — keyboard shortcuts.** The base set is global, but a
+profile can carry a *sparse override* that adds, changes, or
+removes specific bindings just for itself (see **Per-Profile
+Shortcut Overrides**). Everything else is squarely one or the
+other.
+
+A practical consequence: because app rules are global, an app maps
+to a single space name everywhere. To send an app to a given space
+across profiles, give that space the **same name** in each profile
+(e.g. keep a `comms` space and assign the app to it) — each profile
+can still lay that space out differently.
+
 ## Spaces
 
 The **Spaces** section (in the **Design** group) lists every virtual


### PR DESCRIPTION
Closes #77.

Makes **live state the single source of truth for which virtual spaces exist**, so the `gui.json` sidecar's `spaces` list can no longer silently diverge from it. Three drift sources, three fixes:

## The problems (all "the thing I just did didn't stick")

1. **Deleting a space in the Spaces tab was a no-op on the active profile.** `applyProfileScopedState` only ever *ensured* (added) spaces — never removed them — so `buildProfile` recaptured the deleted space from live and it reappeared on reload.
2. **The in-place active-profile edit (#18) didn't prune.** `reapplyIfInEffect` re-applied without pruning, so a space deleted in an edit session survived until the next full `load_profile`.
3. **A GUI-only space dropped across a restart.** Boot seeded no spaces from the sidecar (`profiles.currentName` isn't persisted), so a space that lived only in `gui.json` — no profile, pin, window, or `set_mode` behind it — vanished on the next reload.

## The fix

- **Prune on delete** — `applyProfileScopedState` now drops live spaces the model no longer references (list ∪ modes ∪ pins ∪ Main), reusing the existing, tested `pruneSpaces` reconcile and forwarding windows to the rehome target.
- **In-place edit is authoritative** — `reapplyIfInEffect` applies with `pruneStaleSpaces: true`.
- **Cold-boot seed + mirror** — `loadConfig` seeds live from the sidecar (`seedGuiSpaces`), and every authoritative prune mirrors the live set back into `gui.json` (`syncGuiSpacesToLive`). The sidecar is therefore a faithful copy of live *as of the last authoritative reconcile*, so the seed can never resurrect a profile-pruned space — the trap the issue called out.

Deletion stays **per-profile**: each profile is its own file, so removing a space under one profile never touches another profile that declares a same-named space.

Unblocks #92 (orphaned space-targeting shortcuts), which needs the authoritative live space set.

## Tests & docs

- New `GuiSpaceReconcileTests` (11 tests): delete-prune + rehome, mode-only survivors, empty-list guard, boot seed, add-only seed, sidecar mirror, in-place-edit prune, Lua/CLI `load_profile` mirror, and per-profile isolation.
- `docs/design-decisions.md` documents the "live is the single source of truth; gui.json mirrors it" invariant; `docs/user-guide.md` corrects the delete behavior.

## Verification

`swift build` · `swift test` (712 pass) · `scripts/lint.sh` · `swift build -c release` — all green.

Reviewed by `code-reviewer` + `architect-reviewer` (both clean, no blocking findings); their doc/comment/wording notes were folded into the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)