### PR TITLE
docs: accuracy corrections from code-verified review

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -58,6 +58,7 @@ KiwiDesk service restart
 | | `set_mouse_resize` | `layout\|snap_back` |
 | | `set_gap_global` | size |
 | | `set_gap_override` | space, size |
+| | `set_min_window_size` | pt (default 300) |
 | | `set_fallback_space` | space id ("" clears) — rehome target on profile switch |
 | | `set_space_icon` | space id, icon (SF Symbol\|emoji\|char; "" clears) |
 | | `get_state` | — (returns `{active_space, spaces, windows, monitor_count, native_space, exec_running}`) |
@@ -106,7 +107,7 @@ KiwiDesk service restart
 | | `bsp.set_new_window_placement` | placement¹ (default `after_focused`) |
 | Scrolling | `scroll.set_slot_size` | px, `"NN%"`, or `0` (auto) |
 | | `scroll.set_anchor` | `center`, or edge `left\|right` (`top\|bottom` vertical) |
-| | `scroll.set_speed` | ms |
+| | `scroll.set_orientation` | `horizontal\|vertical` |
 | | `scroll.set_new_window_placement` | placement¹ (default `after_focused`) |
 | Grid | `grid.set_type` | `dynamic\|rigid` |
 | | `grid.set_fill_empty_space` | true\|false |
@@ -116,6 +117,11 @@ KiwiDesk service restart
 | Spawn | `set_new_window_placement_override` | space id, placement¹ |
 
 ¹ placement: `first\|last\|before_focused\|after_focused`
+
+The table lists each layout global once. Every layout global
+has a per-space `_override` twin (e.g. `bsp.set_ratio_override`,
+`scroll.set_slot_size_override`) that takes a leading `space id,
+value` and shadows the global for that space only.
 
 `resize` adapts to the active layout: BSP adjusts the split
 ratio, Stack the master ratio, Scrolling the column width.
@@ -141,6 +147,17 @@ Events: `space_change`, `layout_change`, `focus_change`,
 `monitor_change`, `native_space_change`, `window_created`,
 `window_destroyed`, `window_minimized`,
 `window_moved_to_space`.
+
+`focus_change` data carries `window_id`, `app`, **and**
+`title` — but the Lua callback receives only `window_id, app`
+positionally, so the window title is available on the socket
+stream but not to a Lua handler:
+
+```json
+{"event": "focus_change",
+ "data": {"window_id": 4711, "app": "Ghostty",
+          "title": "~/src — zsh"}}
+```
 
 The window lifecycle events fire even when focus does not
 change, so bars can drop stale icons immediately:

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -33,6 +33,90 @@ them directly. **Saving never rewrites `init.lua`**: the file is
 yours alone, for event hooks and custom Lua. For the full GUI
 workflow, see the [user guide](user-guide.md).
 
+## Navigation & Movement
+
+The verbs you bind to shortcuts to move focus and windows
+around. Direction arguments are `"left"`, `"right"`, `"up"`,
+or `"down"`.
+
+### focus
+
+**Expects:** a direction (`"left"`, `"right"`, `"up"`, or
+`"down"`).
+
+**Does:** moves keyboard focus to the neighboring window in
+that direction, following the active layout's geometry. In
+monocle and scrolling layouts the axis cycles through the
+space's windows (see the layout's orientation).
+
+**Example:**
+
+```lua
+KiwiDesk.focus("left")
+```
+
+### swap
+
+**Expects:** a direction (`"left"`, `"right"`, `"up"`, or
+`"down"`).
+
+**Does:** swaps the focused window with its neighbor in that
+direction, reordering the flat window array — the two windows
+trade slots in the layout.
+
+**Example:**
+
+```lua
+KiwiDesk.swap("right")
+```
+
+### focus_virtual_space
+
+**Expects:** a space identifier (number or string).
+
+**Does:** switches to that virtual space, hiding the current
+space's tiled windows and revealing the target's. Aliased as
+`focus_space`.
+
+**Example:**
+
+```lua
+KiwiDesk.focus_virtual_space(2)
+KiwiDesk.focus_space("mail")   -- alias
+```
+
+### move_to_virtual_space
+
+**Expects:** a space identifier.
+
+**Does:** moves the focused window to that space **without
+following** it — you stay on the current space. The moved
+window becomes the target space's focused window, so the first
+time you switch there it is the window you land on. Aliased as
+`move_to_space`.
+
+**Example:**
+
+```lua
+KiwiDesk.move_to_virtual_space("mail")
+KiwiDesk.move_to_space(3)      -- alias
+```
+
+### move_to_virtual_space_and_follow
+
+**Expects:** a space identifier.
+
+**Does:** moves the focused window to that space **and**
+switches you there with it. Aliased as
+`move_to_space_and_follow`.
+
+**Example:**
+
+```lua
+KiwiDesk.move_to_virtual_space_and_follow("mail")
+KiwiDesk.move_to_space_and_follow(3)   -- alias
+```
+
 ## Layouts & Gaps
 
 ### set_mode
@@ -102,8 +186,9 @@ KiwiDesk.set_gap_override("editor", {
 
 **Expects:** a number (points).
 
-**Does:** windows below this width or height fall back to the
-Overlap Stack instead of shrinking further.
+**Does:** windows below this width or height
+[cascade](#when-windows-run-out-of-space) instead of shrinking
+further.
 
 **Example:**
 
@@ -135,9 +220,10 @@ space forward automatically. Floating windows — including
 picture-in-picture — are never stashed and stay visible across all
 virtual spaces.
 
-Sending a window elsewhere with `move_to_virtual_space` makes it
-that space's focused window, so the first time you switch there it
-is the window you land on — even without `_and_follow`.
+Sending a window elsewhere with
+[`move_to_virtual_space`](#move_to_virtual_space) makes it that
+space's focused window, so the first time you switch there it is
+the window you land on — even without `_and_follow`.
 
 **Minimizing** a window removes it from its space entirely.
 Restoring it from the Dock opens it in the virtual space you are
@@ -875,9 +961,11 @@ app_bar.set_group_badge_text_color("#FFFFFF")
 
 ### Per-Layout App Bar Overrides
 
-Each layout can override any individual bar field for itself.
-Unset fields inherit the global value. The available overrides are
-the same setters prefixed with the layout name:
+Each bar-hosting layout (monocle, scrolling) can override any
+individual bar field for itself. Only these two layouts show a
+bar, so only they expose `set_app_bar_*`. Unset fields inherit
+the global value. The available overrides are the same setters
+prefixed with the layout name:
 
 - `monocle.set_app_bar_enabled`, `monocle.set_app_bar_position`,
   `monocle.set_app_bar_thickness`, etc.
@@ -1255,42 +1343,6 @@ window's current state:
 KiwiDesk.bind("cmd+alt+f", function()
     local state = KiwiDesk.get_state()
     if not state.active_space then return end
-    -- Find the focused window
-    for _, window in ipairs(state.windows) do
-        local space = nil
-        for _, s in ipairs(state.spaces) do
-            if s.focused == window.id then
-                space = s.id
-                break
-            end
-        end
-        if space == state.active_space and
-           window.id == 
-           (function()
-               for _, s in ipairs(state.spaces) do
-                   if s.id == state.active_space then
-                       return s.focused
-                   end
-               end
-           end)()
-        then
-            if window.floating then
-                KiwiDesk.make_tiled()
-            else
-                KiwiDesk.make_floating()
-            end
-            break
-        end
-    end
-end)
-```
-
-A simpler approach using `get_state()` returned table structure:
-
-```lua
-KiwiDesk.bind("cmd+alt+f", function()
-    local state = KiwiDesk.get_state()
-    if not state.active_space then return end
     local active_space = state.active_space
     local focused_id = nil
     for _, space in ipairs(state.spaces) do
@@ -1362,7 +1414,8 @@ end)
 **Modifiers:** `cmd`/`command`, `alt`/`opt`/`option`,
 `ctrl`/`control`, `shift`.
 
-**Keys:** letters, digits, `left`, `right`, `up`, `down`, `space`,
+**Keys:** letters, digits, `left`, `right`, `up`, `down`,
+`home`, `end`, `pageup`, `pagedown`, `space`,
 `return`/`enter`, `tab`, `escape`/`esc`, `f1`–`f12`, and
 punctuation.
 
@@ -1376,8 +1429,8 @@ punctuation.
 - `equal`/`=`
 - `leftbracket`/`[`
 - `rightbracket`/`]`
-- `grave`/`` ` ``
-- `quote`/`'`
+- `grave`/`backtick`/`` ` ``
+- `quote`/`apostrophe`/`'`
 - `return`/`enter`
 - `delete`/`backspace`
 - `escape`/`esc`
@@ -1417,10 +1470,18 @@ end)
 
 **Does:** grows or shrinks the focused window. Only applies in bsp,
 stack, and scrolling layouts; a no-op in monocle, grid, and
-floating. In bsp and stack it nudges the split / master ratio, so
-there is no independent width and height today: the `axis` argument
-only scales the step by the screen's width or height — both axes
-move the same ratio. Prefer a single shrink/enlarge pair (#56).
+floating. What the `delta` actually adjusts depends on the layout:
+
+- **bsp / stack** — it nudges the split / master ratio, so there
+  is no independent width and height today: the `axis` argument
+  only scales the step by the screen's width or height, and both
+  axes move the same ratio.
+- **scrolling** — it adjusts the slot size in real points along
+  the layout's own scroll axis (columns for horizontal, rows for
+  vertical), regardless of which `axis` you pass — the `x`/`y`
+  argument does not steer it.
+
+Prefer a single shrink/enlarge pair (#56).
 
 **Example:**
 
@@ -2104,7 +2165,8 @@ KiwiDesk.debug_log("hello from init.lua")
 **Does:** returns a table with the current window and space state.
 Fields: `active_space` (current space id or `nil`), `spaces` (array of
 space objects), `windows` (array of window objects), `monitor_count`,
-`native_space`.
+`native_space`, `exec_running` (count of `KiwiDesk.exec` children
+still running).
 
 Each space object has: `id`, `mode`, `windows` (array of window ids),
 `focused` (focused window id or `nil`).

--- a/docs/recipes/misc.md
+++ b/docs/recipes/misc.md
@@ -32,8 +32,9 @@ Query state on demand:
 
 The event stream is useful for durable external daemons, shell
 functions, or tools that run in a different sandbox than
-KiwiDesk. Each event has a `type` (e.g., `"space_change"`) and
-a `data` object with fields matching the Lua callback arguments
+KiwiDesk. Each event has an `event` field (e.g.,
+`"space_change"`) and a `data` object with fields matching the
+Lua callback arguments
 (e.g., `space_id`, `mode`).
 
 ## Hammerspoon

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -23,8 +23,8 @@ shows a two-group sidebar on the left:
 
 At the top you'll see the app name and a banner showing which
 profile is loaded and letting you edit a saved profile without
-switching to it. At the bottom, a three-button footer holds Save,
-Revert, and Save a Copy options.
+switching to it. At the bottom, a stable three-slot footer holds
+Revert, Save a Copy As…, and Save.
 
 ### Permission & First Run
 
@@ -339,17 +339,25 @@ create a variant of a profile without loading it first.
 
 ### Saving
 
-Three buttons appear in the footer:
+The footer always holds the same three slots, clustered at the
+trailing edge — **Revert**, **Save a Copy As…**, and **Save**.
+Only the primary **Save**'s label and target change with
+context; there is no separate fourth button:
 
-- **Save** (default, when an active profile exists) — persists edits to
-  the currently loaded profile and adds/refreshes the connected monitor
-  set. Greyed out if the connected screen count differs from the
-  profile's count ("this profile is for 2 screens").
-- **Save a Copy As…** — creates a new profile from the current state.
-  The new profile covers only the connected monitors. Names are
-  suffixed `_1`, `_2`, … when taken.
-- **Save as New Profile…** (when using a transient layout or
-  built-in Standard) — creates a real profile from scratch.
+- **Revert** — discards pending edits and reloads the target's
+  stored state.
+- **Save a Copy As…** — creates a new profile from the current
+  state. The new profile covers only the connected monitors.
+  Names are suffixed `_1`, `_2`, … when taken.
+- **Save** — persists edits to the current target. When an
+  active profile exists it writes to that profile and
+  adds/refreshes the connected monitor set; it is greyed out if
+  the connected screen count differs from the profile's count
+  ("this profile is for 2 screens"). When you are on a transient
+  layout or a built-in Standard, the same slot instead reads
+  **Save as New Profile…** and creates a real profile from
+  scratch. The banner's profile picker names the edit target
+  authoritatively.
 
 After saving, if a global setting changed (keybindings, app/float
 rules, or native Space bindings), `gui.json` is rewritten. Tiling-only
@@ -484,9 +492,10 @@ persistent ⚠️.
 **Modifiers**: `cmd`/`command`, `alt`/`opt`/`option`,
 `ctrl`/`control`, `shift`.
 
-**Keys**: letters (a–z), digits (0–9), arrows, `space`, `return`,
-`tab`, `escape`, `f1`–`f12`, and punctuation. Punctuation can be
-entered as the symbol or a word name:
+**Keys**: letters (a–z), digits (0–9), arrows, `home`, `end`,
+`pageup`, `pagedown`, `space`, `return`, `tab`, `escape`,
+`f1`–`f12`, and punctuation. Punctuation can be entered as the
+symbol or a word name:
 - `;` or `semicolon`
 - `,` or `comma`
 - `.` or `period`
@@ -496,8 +505,8 @@ entered as the symbol or a word name:
 - `=` or `equal`
 - `[` or `leftbracket`
 - `]` or `rightbracket`
-- `` ` `` or `grave`
-- `'` or `quote`
+- `` ` `` or `grave` / `backtick`
+- `'` or `quote` / `apostrophe`
 
 A combo is one set of modifiers + exactly one key. Multi-key chords
 like `cmd+j+k` are not supported — use modal modes instead.


### PR DESCRIPTION
Fixes factual errors and fills gaps found in a fresh, code-verified review of the reorganized docs (every claim checked against `Sources/KiwiDeskCore`).

**High (accuracy):**
- `recipes/misc.md`: event JSON key is `event`, not `type`.
- `lua-reference.md`: new **Navigation & Movement** section (focus/swap/focus_virtual_space/move_to_virtual_space[_and_follow] + aliases, which had no reference entry); corrected `resize` (scrolling adjusts slot size in points, not just ratio scaling).
- `cli.md`: add `set_min_window_size` (was missing from 'every command').
- `lua-reference.md` + `user-guide.md`: add bindable keys `home`/`end`/`pageup`/`pagedown` + `apostrophe`/`backtick` aliases.

**Medium (consistency):** app-bar overrides scoped to bar-hosting layouts; `focus_change` `title` field; `scroll.set_orientation` in CLI; dropped stale duplicate `scroll.set_speed` row; `exec_running` in get_state; 'Overlap Stack' → 'cascade'; Save-footer aligned to the canonical 3-slot model; convoluted floating example removed.

Verified the GUI-language `UserDefaults` key (`"language"`) already matched the source — no change needed there. Lint green; no new overlong lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188TsGvxQe8d7qhb3g3TS9V