### PR TITLE
docs(config): relax profile-ownership guardrail to behavior-vs-routing

### DIFF
--- a/.claude/rules/profiles.md
+++ b/.claude/rules/profiles.md
@@ -10,10 +10,16 @@ The binding rules live in **AGENTS.md §5** (canonical) — read them
 before editing this subsystem. The ones this code trips over most,
 as a checklist (rationale is in §5, not restated here):
 
-- Profiles own **tiling only** — a new profile-serialized setting
-  goes *inside* `TilingSettings` (the `gap.override` precedent).
-  One designed exception (#55): the sparse keybinding override in
-  `Profile.modes` — the only non-tiling field; never add another.
+- Profiles own **tiling, plus sparse _behavior_ overrides** — tiling
+  state goes *inside* `TilingSettings` (the `gap.override`
+  precedent); beyond it, a profile may sparsely override a global
+  *behavior* setting (keybindings via `Profile.modes` today; app
+  rules planned, #109), but **never** one that routes/selects the
+  profile (`profile_bindings`) or lives outside config ownership
+  (GUI language in `UserDefaults`). Each override is base + sparse
+  diff with a tombstone for removal, templated on `KeyModeOverride`
+  and parity-tested — not a generic primitive until a real second
+  flat-map client exists (see §5 / [parity-tests.md](parity-tests.md)).
 - `ProfileManager` mutators are `internal`; go through a `KiwiCore`
   facade. `read(name:)` loads for edit; `save()` **adopts** — an
   edit-without-activating path is a separate, non-adopting write.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,14 +252,26 @@ Keep this list updated whenever a recurring mistake is found.
   ceiling repeatedly bit large test files. Break suites into
   focused files before they grow; per-file private helpers are the
   convention and small duplication across suites is fine.
-- **Profiles own tiling only.** A profile serializes tiling state,
-  not keybindings or app rules. Profile-serialized settings belong
-  *inside* `TilingSettings` so they ride the config split for free
-  (see `gap.override`). One designed exception (#55): the sparse
-  per-profile keybinding tier lives in `Profile.modes`
-  (`KeyModeOverride`) — it is an override onto the base `gui.json`
-  modes, not a second home for keybindings, and it must stay the
-  only non-tiling field. `ProfileManager` mutators are `internal` by
+- **Profiles own tiling, plus sparse behavior overrides.** A
+  profile serializes tiling state — that belongs *inside*
+  `TilingSettings` so it rides the config split for free (see
+  `gap.override`). Beyond tiling, a profile may carry a **sparse
+  override of a global _behavior_ setting** — one that shapes how
+  the workspace behaves *while the profile is active* (keybindings
+  today, via `Profile.modes` / `KeyModeOverride`; app rules
+  planned, #109). It may **never** override a setting that *routes
+  or selects* the profile itself (`profile_bindings`, the
+  native-Space→profile map) or that lives outside config ownership
+  (the GUI language pref, which persists in `UserDefaults`) — a
+  profile that could rewrite what selects it is a self-reference
+  hazard. Every override is the base overlaid with a sparse diff
+  (absent = inherit; an explicit tombstone expresses removal),
+  never a second home for the setting. Add each one deliberately —
+  templated on `KeyModeOverride`'s seam and guarded by a round-trip
+  + resolve parity test — NOT via a generic override primitive
+  until a real second flat-map client exists (one client removes no
+  drift; see `.claude/rules/parity-tests.md`).
+  `ProfileManager` mutators are `internal` by
   design — mutate through a `KiwiCore` facade, never re-publicize
   them. `read(name:)` is the public load-for-edit primitive
   (path-traversal guarded, touches no state); `save()` **adopts**

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -132,6 +132,25 @@ draggable profile chips duplicated the dropdown while adding
 a chip palette row and drop-target styling — a second
 interaction model with zero extra capability. (#7)
 
+**Profiles may override *behavior* settings, never *routing*
+ones.** A profile owns tiling, and may also carry a sparse
+override of a global setting that shapes how the workspace
+*behaves while the profile is active* — keybindings today
+(`Profile.modes`), app rules next (#109). It may never
+override a setting that *selects or routes* the profile
+itself: the native-Space→profile bindings decide *which*
+profile loads, so a profile owning part of that map would be
+a self-reference (load A → A rebinds Desktop 2 → B → …). The
+GUI language is a second hard exclusion for a different
+reason — it lives in `UserDefaults`, outside config ownership
+entirely, and must never touch a sidecar. Every override is
+the base overlaid with a sparse diff (absent inherits; a
+tombstone removes), never a second home for the setting. Each
+new one is added deliberately and parity-tested, templated on
+the keybinding override's seam — not folded into a generic
+primitive, which stays unjustified until a real second
+flat-map client exists (one client removes no duplication).
+
 ## Icons
 
 **A curated, keyword-tagged icon catalog — because macOS has


### PR DESCRIPTION
Prerequisite for #109 (per-profile app→space rules). **Docs/guardrail only — no code change.**

## What & why

AGENTS.md §5 currently says the per-profile keybinding override "must stay the **only** non-tiling field; never add another." That absolute wording actively blocks #109. This reframes it into a **principle with a hard boundary**, so future per-profile overrides have a clear yes/no test:

> Profiles own tiling, **and** may carry a *sparse override of a global **behavior** setting* — one that shapes how the workspace behaves *while the profile is active* (keybindings today; app rules next, #109). They may **never** override a setting that:
> - **routes/selects the profile itself** — the native-Space→profile bindings decide *which* profile loads, so a profile owning part of that map is a self-reference hazard (load A → A rebinds Desktop 2 → B → …); or
> - **lives outside config ownership** — the GUI language pref persists in `UserDefaults` and must never touch a sidecar.
>
> Every override is the base overlaid with a sparse diff (absent = inherit; a tombstone removes), never a second home. Each is added deliberately and parity-tested, templated on `KeyModeOverride`'s seam — **not** a generic override primitive until a real second flat-map client exists (one client removes no drift).

## Background

This came out of a two-subagent investigation (fact-map + architecture assessment) into whether to (a) fold float rules into app rules and (b) build a generic `[Key: Value?]` sparse-override primitive now. Conclusions, both confirmed independently:
- **Don't fold float** — the storage split is load-bearing (app→one space vs float's N `App:Title` patterns; orthogonal lifetimes; different engine consumers).
- **Generic is premature** — it would have exactly one permanent client (keybindings are nested + tombstone-free by design; float is set-shaped; `spaceModes` has no base tier), so it removes zero drift and violates `.claude/rules/parity-tests.md`.

The concrete feature that applies this principle is tracked in **#109**.

## Files

- `AGENTS.md` §5 — the canonical guardrail bullet.
- `.claude/rules/profiles.md` — the checklist mirror.
- `docs/design-decisions.md` — a new note on the behavior-vs-routing line and the two carve-outs.

Lint green; no Swift touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)