### PR TITLE
docs: minor nitpicks (binary path, six-vs-seven layouts, mode phrasing)

### DIFF
--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -38,9 +38,9 @@ timeout, and output capture.
 > **Binary path note:** KiwiDesk is not yet on PATH. Until
 > Homebrew symlinks it at version 1.0, either use the absolute
 > path to your built binary (e.g.,
-> `~/.build/release/KiwiDesk`) or symlink it yourself. The
+> `~/path/to/KiwiDesk/.build/release/KiwiDesk`) or symlink it yourself. The
 > recipes below assume you've stored the path in a variable
-> like `KIWIDESK=~/.build/release/KiwiDesk`.
+> like `KIWIDESK=~/path/to/KiwiDesk/.build/release/KiwiDesk`.
 
 ## Recipe pages
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -414,9 +414,11 @@ mode (see [Per-Profile Shortcut Overrides](#per-profile-shortcut-overrides)).
 
 ### Built-in Standards & Presets
 
-KiwiDesk ships seven built-in layouts — Standards for 1, 2, or 3
-screens that resolve silently when no saved profile matches, and
-Presets you can apply to spin up a starting point.
+KiwiDesk ships seven built-in **profiles** — Standards for 1, 2, or
+3 screens that resolve silently when no saved profile matches, and
+Presets you can apply to spin up a starting point. (These are whole
+profiles — not to be confused with the six layout *modes* like bsp
+or stack.)
 
 **1 Screen:**
 
@@ -483,8 +485,8 @@ you do not need a rule for them.
 
 The **Shortcuts** section (in the **System** group) binds keyboard
 combos to actions. Every shortcut lives in a **mode** — normally the
-**default** mode where every binding fires, plus optional modal modes
-(vim-style) where only one mode's bindings are active at a time.
+**default** mode (active at startup), plus optional modal modes
+(vim-style); only the active mode's bindings fire at a time.
 
 ### Recording a Shortcut
 


### PR DESCRIPTION
Small clarity fixes from the docs review's LOW findings:
- `recipes/index.md`: binary-path example aligned to the repo-relative form the recipes actually use.
- `user-guide.md`: 'seven built-in layouts' → 'seven built-in profiles' (disambiguated from the six layout modes); tightened the default-mode sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188TsGvxQe8d7qhb3g3TS9V