### PR TITLE
feat(layout): configurable global resize step (resize.step, #58)

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -183,7 +183,10 @@ final class SettingsModel: ObservableObject {
             recovered: core.recoverKeybindings(),
             into: &updated
         )
-        KeybindingImportClassifier.classify(&updated)
+        KeybindingImportClassifier.classify(
+            &updated,
+            recoverResizeStep: true
+        )
         config = updated
     }
 

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog.swift
@@ -37,13 +37,6 @@ enum KeybindingCatalog {
         }
     }
 
-    /// The fixed step a Grow/Shrink preset nudges the layout by, in
-    /// points. The catalog authors one magnitude, so import
-    /// classification only upgrades a recovered `resize` that used
-    /// this exact delta (like every preset, the Lua must match
-    /// byte-for-byte); other magnitudes stay Custom.
-    static let resizeStep = 50
-
     /// The four directional focus rows (#68 §3.6.1 Focus).
     static let focusDirections: [NavCommand] = directions.map {
         dir,
@@ -144,8 +137,10 @@ enum KeybindingCatalog {
     }
 
     /// Navigation grouped for the import classifier (#4): the
-    /// same commands the sections render, so a recovered row
-    /// matches byte-for-byte.
+    /// commands the sections render, so a recovered row matches
+    /// byte-for-byte. Grow/Shrink is deliberately absent — its
+    /// magnitude is configurable (#58), so import matches it by
+    /// *shape* via `resizeShape(from:)`, not from this map.
     static func navigationGroups(
         spaces: [SpaceID]
     ) -> [NavGroup] {
@@ -156,39 +151,67 @@ enum KeybindingCatalog {
             ),
             NavGroup(
                 title: "Window Management",
-                commands: resizeAndFloat + swapDirections
-                    + moveToSpace(spaces)
+                commands: swapDirections + moveToSpace(spaces)
             ),
         ]
     }
 
     /// Window-size and float presets (Size & Float, §3.6.1).
     /// Enlarge/Shrink nudge the single bsp split / stack master
-    /// ratio by `resizeStep` — there is no independent
-    /// width/height today, so this is one pair on the `"x"`
-    /// axis, not four (true 2-axis resize is deferred, #56; a
-    /// configurable step is #58 — both land in this group).
-    /// Resize is a no-op in monocle/grid/floating; the section
-    /// caption states this and the docs echo it.
-    static let resizeAndFloat: [NavCommand] = [
-        NavCommand(
-            label: "Shrink",
-            lua: "KiwiDesk.resize(\"x\", -\(resizeStep))",
-            displayLabel: { L("keybinding.shrink", "Shrink") }
-        ),
-        NavCommand(
-            label: "Enlarge",
-            lua: "KiwiDesk.resize(\"x\", \(resizeStep))",
-            displayLabel: { L("keybinding.enlarge", "Enlarge") }
-        ),
-        NavCommand(
-            label: "Make floating",
-            lua: "KiwiDesk.make_floating()",
-            displayLabel: {
-                L("keybinding.make_floating", "Make floating")
-            }
-        ),
-    ]
+    /// ratio by `step` points — the configurable global
+    /// `resize.step` (#58), passed in by the caller from live
+    /// settings. There is no independent width/height today, so
+    /// this is one pair on the `"x"` axis, not four (true 2-axis
+    /// resize is deferred, #56). Resize is a no-op in
+    /// monocle/grid/floating; the section caption states this and
+    /// the docs echo it.
+    static func resizeAndFloat(step: Int) -> [NavCommand] {
+        [
+            NavCommand(
+                label: "Shrink",
+                lua: "KiwiDesk.resize(\"x\", -\(step))",
+                displayLabel: { L("keybinding.shrink", "Shrink") }
+            ),
+            NavCommand(
+                label: "Enlarge",
+                lua: "KiwiDesk.resize(\"x\", \(step))",
+                displayLabel: {
+                    L("keybinding.enlarge", "Enlarge")
+                }
+            ),
+            NavCommand(
+                label: "Make floating",
+                lua: "KiwiDesk.make_floating()",
+                displayLabel: {
+                    L("keybinding.make_floating", "Make floating")
+                }
+            ),
+        ]
+    }
+
+    /// The Grow/Shrink magnitude inside a `resize("x", ±N)` row of
+    /// ANY step, plus its canonical label — the inverse of
+    /// `resizeAndFloat`'s authoring, used by import classification
+    /// (#58). A shape match (not byte-for-byte) so a config whose
+    /// step differs from the current one still lands in Size &
+    /// Float, and its magnitude is read back into `resize.step`.
+    /// Nil unless `lua` is exactly a single-axis `"x"` resize with
+    /// a non-zero integer delta.
+    static func resizeShape(
+        from lua: String
+    ) -> (label: String, step: Int)? {
+        let prefix = "KiwiDesk.resize(\"x\", "
+        let suffix = ")"
+        guard lua.hasPrefix(prefix), lua.hasSuffix(suffix)
+        else { return nil }
+        let inner = lua.dropFirst(prefix.count)
+            .dropLast(suffix.count)
+        guard let value = Int(inner), value != 0 else {
+            return nil
+        }
+        let label = value < 0 ? "Shrink" : "Enlarge"
+        return (label, abs(value))
+    }
 
     /// A space id as a quoted, escaped Lua string argument.
     static func spaceArg(_ space: SpaceID) -> String {

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingImportClassifier.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingImportClassifier.swift
@@ -12,7 +12,17 @@ enum KeybindingImportClassifier {
     /// rebuilding the navigation and change-mode commands the
     /// keybindings tab would generate from the config's own
     /// spaces and mode names.
-    static func classify(_ config: inout GuiConfig) {
+    /// `recoverResizeStep` reads a recovered Grow/Shrink magnitude
+    /// back into `resize.step` (#58) — pass it ONLY on an explicit
+    /// import, where the pulled-in bindings are the source of
+    /// truth. A plain load-for-edit leaves it `false`: there
+    /// `resize.step` is already authoritative (from tiler/profile
+    /// settings), so a magnitude baked into a stray `.custom` row
+    /// must not overwrite it (#58 review).
+    static func classify(
+        _ config: inout GuiConfig,
+        recoverResizeStep: Bool = false
+    ) {
         let navigation = navigationLabels(for: config)
         var recoveredStep: Int?
         for mode in config.modes.indices {
@@ -25,11 +35,10 @@ enum KeybindingImportClassifier {
                 }
             }
         }
-        // Read a recovered Grow/Shrink magnitude back into the
-        // step, so an imported config's own resize size drives
-        // the setting (#58). Left untouched when no resize row is
-        // present, so an import without one keeps the default.
-        if let recoveredStep {
+        // Grow and Shrink carry the same magnitude, so the last
+        // recovered row wins harmlessly; untouched when the import
+        // has no resize row (keeps the default).
+        if recoverResizeStep, let recoveredStep {
             config.settings.resizeStep = CGFloat(recoveredStep)
         }
     }

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingImportClassifier.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingImportClassifier.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import KiwiDeskCore
 
 /// Upgrades imported `.custom` keybinding rows to `.navigation`
@@ -13,13 +14,23 @@ enum KeybindingImportClassifier {
     /// spaces and mode names.
     static func classify(_ config: inout GuiConfig) {
         let navigation = navigationLabels(for: config)
+        var recoveredStep: Int?
         for mode in config.modes.indices {
             for row in config.modes[mode].bindings.indices {
-                reclassify(
+                if let step = reclassify(
                     &config.modes[mode].bindings[row],
                     navigation: navigation
-                )
+                ) {
+                    recoveredStep = step
+                }
             }
+        }
+        // Read a recovered Grow/Shrink magnitude back into the
+        // step, so an imported config's own resize size drives
+        // the setting (#58). Left untouched when no resize row is
+        // present, so an import without one keeps the default.
+        if let recoveredStep {
+            config.settings.resizeStep = CGFloat(recoveredStep)
         }
     }
 
@@ -44,11 +55,25 @@ enum KeybindingImportClassifier {
         return map
     }
 
+    /// Reclassifies one `.custom` row, returning a recovered
+    /// Grow/Shrink magnitude when the row is a resize of any step
+    /// (so `classify` can read it back into `resize.step`, #58).
+    /// Resize is checked first — before the exact-match map — so
+    /// a magnitude differing from the current step still upgrades
+    /// out of Custom.
+    @discardableResult
     private static func reclassify(
         _ binding: inout KeyBinding,
         navigation: [String: String]
-    ) {
-        guard binding.kind == .custom else { return }
+    ) -> Int? {
+        guard binding.kind == .custom else { return nil }
+        if let shape = KeybindingCatalog.resizeShape(
+            from: binding.lua
+        ) {
+            binding.kind = .navigation
+            binding.label = shape.label
+            return shape.step
+        }
         if let label = navigation[binding.lua] {
             binding.kind = .navigation
             binding.label = label
@@ -58,5 +83,6 @@ enum KeybindingImportClassifier {
             binding.kind = .application
             binding.label = app
         }
+        return nil
     }
 }

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingSections.swift
@@ -107,7 +107,11 @@ struct SizeFloatSection: View {
         SettingsSection(
             L("shortcuts.section.size_float", "Size & Float")
         ) {
-            ForEach(KeybindingCatalog.resizeAndFloat) {
+            ForEach(
+                KeybindingCatalog.resizeAndFloat(
+                    step: Int(model.config.settings.resizeStep)
+                )
+            ) {
                 command in
                 NavRow(
                     model: model,

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -32,6 +32,7 @@ public enum APIReference {
             ("set_gap_global", "set_gap_global"),
             ("set_gap_override", "set_gap_override"),
             ("set_min_window_size", "set_min_window_size"),
+            ("set_resize_step", "set_resize_step"),
             ("set_fallback_space", "set_fallback_space"),
             ("set_space_icon", "set_space_icon"),
             (

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
@@ -35,6 +35,8 @@ extension KiwiCore {
             return setGaps(command, args)
         case "set_min_window_size":
             return setMinWindowSize(args)
+        case "set_resize_step":
+            return setResizeStep(args)
         case "help", "list_commands":
             return .ok(
                 .array(

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
@@ -77,7 +77,11 @@ extension KiwiCore {
         guard let step = args.first?.numberValue else {
             return .fail("expected step")
         }
-        tiler.settings.resizeStep = CGFloat(step)
+        // Whole points ≥ 1: the catalog authors an integer Lua
+        // literal, so store what that path can represent — a
+        // fractional or non-positive step would truncate silently
+        // or author a no-op/inverted resize (#58 review).
+        tiler.settings.resizeStep = CGFloat(max(1, Int(step.rounded())))
         // No retile (unlike set_min_window_size): the step is
         // only consulted when the catalog authors a Grow/Shrink
         // binding and on import read-back — never by layout

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
@@ -70,4 +70,18 @@ extension KiwiCore {
         retile(force: true)
         return .ok()
     }
+
+    func setResizeStep(
+        _ args: [JSONValue]
+    ) -> CommandResponse {
+        guard let step = args.first?.numberValue else {
+            return .fail("expected step")
+        }
+        tiler.settings.resizeStep = CGFloat(step)
+        // No retile (unlike set_min_window_size): the step is
+        // only consulted when the catalog authors a Grow/Shrink
+        // binding and on import read-back — never by layout
+        // math — so it can't move a window (#58).
+        return .ok()
+    }
 }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
@@ -74,14 +74,18 @@ extension KiwiCore {
     func setResizeStep(
         _ args: [JSONValue]
     ) -> CommandResponse {
-        guard let step = args.first?.numberValue else {
+        guard let raw = args.first?.numberValue, raw.isFinite
+        else {
             return .fail("expected step")
         }
-        // Whole points ≥ 1: the catalog authors an integer Lua
-        // literal, so store what that path can represent — a
-        // fractional or non-positive step would truncate silently
-        // or author a no-op/inverted resize (#58 review).
-        tiler.settings.resizeStep = CGFloat(max(1, Int(step.rounded())))
+        // Whole points in a sane range: the catalog funnels this
+        // through `Int(...)` when it authors the Lua literal, so
+        // an unbounded or non-finite arg must never reach it
+        // (`Int(1e300)` / `Int(.nan)` trap); a fractional or
+        // non-positive step would author a no-op/inverted resize
+        // (#58 review).
+        let step = min(max(raw.rounded(), 1), 10_000)
+        tiler.settings.resizeStep = CGFloat(step)
         // No retile (unlike set_min_window_size): the step is
         // only consulted when the catalog authors a Grow/Shrink
         // binding and on import read-back — never by layout

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
@@ -13,6 +13,11 @@ public struct TilingSettings: Sendable, Equatable, Codable {
     /// `gap.override[space_id]` beats the global gaps.
     public var gapsOverride: [SpaceID: Gaps] = [:]
     public var minWindowSize: CGFloat = 300
+    /// Global magnitude (points) each Grow/Shrink keybinding
+    /// nudges the layout by (`resize.step`, #58). The catalog
+    /// authors `resize("x", ±step)` from this; import reads a
+    /// recovered magnitude back into it.
+    public var resizeStep: CGFloat = 50
     public var bsp = BspParams()
     public var stack = StackParams()
     public var scrolling = ScrollingParams()
@@ -57,11 +62,16 @@ public struct TilingSettings: Sendable, Equatable, Codable {
         case placementOverride =
             "new_window_placement_override"
         case mouseResize = "mouse_resize"
+        case resize
         case space
     }
 
     private enum SpaceKeys: String, CodingKey {
         case icon
+    }
+
+    private enum ResizeKeys: String, CodingKey {
+        case step
     }
 
     private enum DragKeys: String, CodingKey {
@@ -121,6 +131,22 @@ public struct TilingSettings: Sendable, Equatable, Codable {
         try decodeLayout(from: container)
         try decodeDrag(from: container)
         try decodeSpace(from: container)
+        try decodeResize(from: container)
+    }
+
+    private mutating func decodeResize(
+        from container: Container
+    ) throws {
+        guard container.contains(.resize) else { return }
+        let resize = try container.nestedContainer(
+            keyedBy: ResizeKeys.self,
+            forKey: .resize
+        )
+        resizeStep =
+            try resize.decodeIfPresent(
+                CGFloat.self,
+                forKey: .step
+            ) ?? 50
     }
 
     private mutating func decodeSpace(
@@ -265,5 +291,10 @@ public struct TilingSettings: Sendable, Equatable, Codable {
             forKey: .space
         )
         try space.encode(spaceIcons, forKey: .icon)
+        var resize = container.nestedContainer(
+            keyedBy: ResizeKeys.self,
+            forKey: .resize
+        )
+        try resize.encode(resizeStep, forKey: .step)
     }
 }

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
@@ -13,10 +13,11 @@ public struct TilingSettings: Sendable, Equatable, Codable {
     /// `gap.override[space_id]` beats the global gaps.
     public var gapsOverride: [SpaceID: Gaps] = [:]
     public var minWindowSize: CGFloat = 300
-    /// Global magnitude (points) each Grow/Shrink keybinding
-    /// nudges the layout by (`resize.step`, #58). The catalog
-    /// authors `resize("x", ±step)` from this; import reads a
-    /// recovered magnitude back into it.
+    /// Global magnitude (points) the catalog *authors* Grow/Shrink
+    /// keybindings with (`resize.step`, #58): it emits
+    /// `resize("x", ±step)`, and import reads a recovered magnitude
+    /// back into it. Layout math never reads this — the bound
+    /// row's own literal delta drives an actual resize.
     public var resizeStep: CGFloat = 50
     public var bsp = BspParams()
     public var stack = StackParams()

--- a/Tests/KiwiDeskCoreTests/ResizeStepCommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/ResizeStepCommandTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    KiwiCore(
+        configDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "kiwi-resize-\(UUID().uuidString)"
+            )
+    )
+}
+
+/// `set_resize_step` stores a whole point count in a sane range,
+/// so the catalog's integer authoring can always represent it and
+/// no argument can trap the `Int` funnel (#58 review).
+@MainActor
+struct ResizeStepCommandTests {
+    @Test("Stores a whole step as given")
+    func storesStep() {
+        let core = makeCore()
+        _ = core.execute("set_resize_step", args: [.number(75)])
+        #expect(core.tiler.settings.resizeStep == 75)
+    }
+
+    @Test("Rounds a fractional step to whole points")
+    func roundsFractional() {
+        let core = makeCore()
+        _ = core.execute(
+            "set_resize_step",
+            args: [.number(50.5)]
+        )
+        #expect(core.tiler.settings.resizeStep == 51)
+    }
+
+    @Test("Clamps a non-positive step up to 1")
+    func clampsNonPositive() {
+        let core = makeCore()
+        _ = core.execute("set_resize_step", args: [.number(0)])
+        #expect(core.tiler.settings.resizeStep == 1)
+        _ = core.execute("set_resize_step", args: [.number(-9)])
+        #expect(core.tiler.settings.resizeStep == 1)
+    }
+
+    @Test("Caps an enormous step instead of trapping the Int")
+    func capsHugeStep() {
+        let core = makeCore()
+        _ = core.execute(
+            "set_resize_step",
+            args: [.number(1e300)]
+        )
+        #expect(core.tiler.settings.resizeStep == 10_000)
+    }
+
+    @Test("Rejects a non-finite step, keeping the prior value")
+    func rejectsNonFinite() {
+        let core = makeCore()
+        _ = core.execute("set_resize_step", args: [.number(75)])
+        _ = core.execute(
+            "set_resize_step",
+            args: [.number(.infinity)]
+        )
+        #expect(core.tiler.settings.resizeStep == 75)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
+++ b/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
@@ -29,13 +29,16 @@ struct SettingsCodingTests {
             Set(root.keys) == [
                 "animations", "app_bar", "drag", "gap", "layout",
                 "min_window_size", "mouse_resize",
-                "new_window_placement_override", "space",
+                "new_window_placement_override", "resize", "space",
             ]
         )
         // `set_space_icon` → `space.icon[space_id]` (#68).
         let space = try object(root["space"])
         let icons = try object(space["icon"])
         #expect(icons["2"] as? String == "globe")
+        // `set_resize_step` → `resize.step` (#58).
+        let resize = try object(root["resize"])
+        #expect(resize["step"] as? Double == 50)
         #expect(root["mouse_resize"] as? String == "layout")
         // Toggles (issue #11) and duration knobs (issue #51).
         // Keys mirror the Lua names per the one-vocabulary rule.
@@ -121,6 +124,7 @@ struct SettingsCodingTests {
         settings.stack.masterCount = 2
         settings.grid.rows = 4
         settings.minWindowSize = 200
+        settings.resizeStep = 75
         settings.dragGhost.enabled = false
         settings.dragDropZone.fillColor = "#11223344"
         settings.dragCornerRadius = 22

--- a/Tests/KiwiDeskGuiTests/KeybindingLocalizationTests.swift
+++ b/Tests/KiwiDeskGuiTests/KeybindingLocalizationTests.swift
@@ -33,7 +33,7 @@ struct KeybindingLocalizationTests {
         reset()
         LocalizationManager.shared.select("de")
         defer { reset() }
-        let shrink = KeybindingCatalog.resizeAndFloat[0]
+        let shrink = KeybindingCatalog.resizeAndFloat(step: 50)[0]
         #expect(shrink.label == "Shrink")
         #expect(shrink.resolvedLabel == "Verkleinern")
     }

--- a/Tests/KiwiDeskGuiTests/ResizeStepImportTests.swift
+++ b/Tests/KiwiDeskGuiTests/ResizeStepImportTests.swift
@@ -14,15 +14,19 @@ struct ResizeStepImportTests {
         KeyBinding(combo: "alt+h", lua: lua, kind: .custom)
     }
 
-    private func config(lua: String) -> GuiConfig {
+    private func config(luas: [String]) -> GuiConfig {
         var config = GuiConfig()
         config.modes = [
             KeyMode(
                 name: KeyMode.defaultName,
-                bindings: [customRow(lua)]
+                bindings: luas.map(customRow)
             )
         ]
         return config
+    }
+
+    private func config(lua: String) -> GuiConfig {
+        config(luas: [lua])
     }
 
     @Test("The catalog authors Grow/Shrink from the given step")
@@ -35,6 +39,7 @@ struct ResizeStepImportTests {
     @Test("A non-default resize magnitude still classifies")
     func nonDefaultMagnitudeClassifies() {
         var config = config(lua: "KiwiDesk.resize(\"x\", -75)")
+        // Classification is not gated (only the step read-back is).
         KeybindingImportClassifier.classify(&config)
         let row = config.modes[0].bindings[0]
         // Old code demoted any non-±50 resize to Custom; now the
@@ -47,15 +52,47 @@ struct ResizeStepImportTests {
     func importReadsStepBack() {
         var config = config(lua: "KiwiDesk.resize(\"x\", 120)")
         #expect(config.settings.resizeStep == 50)
-        KeybindingImportClassifier.classify(&config)
+        KeybindingImportClassifier.classify(
+            &config,
+            recoverResizeStep: true
+        )
         #expect(config.settings.resizeStep == 120)
         #expect(config.modes[0].bindings[0].label == "Enlarge")
+    }
+
+    @Test("A Shrink+Enlarge pair recovers one agreed magnitude")
+    func pairRecoversStep() {
+        var config = config(luas: [
+            "KiwiDesk.resize(\"x\", -90)",
+            "KiwiDesk.resize(\"x\", 90)",
+        ])
+        KeybindingImportClassifier.classify(
+            &config,
+            recoverResizeStep: true
+        )
+        #expect(config.settings.resizeStep == 90)
+        #expect(config.modes[0].bindings[0].label == "Shrink")
+        #expect(config.modes[0].bindings[1].label == "Enlarge")
+    }
+
+    @Test("A load-for-edit never overwrites the step")
+    func loadForEditKeepsStep() {
+        // Without `recoverResizeStep`, a resize row still
+        // classifies but must not clobber the authoritative
+        // setting (#58 review).
+        var config = config(lua: "KiwiDesk.resize(\"x\", 120)")
+        KeybindingImportClassifier.classify(&config)
+        #expect(config.settings.resizeStep == 50)
+        #expect(config.modes[0].bindings[0].kind == .navigation)
     }
 
     @Test("No resize row leaves the step at its default")
     func noResizeRowKeepsDefault() {
         var config = config(lua: "KiwiDesk.focus(\"left\")")
-        KeybindingImportClassifier.classify(&config)
+        KeybindingImportClassifier.classify(
+            &config,
+            recoverResizeStep: true
+        )
         #expect(config.settings.resizeStep == 50)
     }
 

--- a/Tests/KiwiDeskGuiTests/ResizeStepImportTests.swift
+++ b/Tests/KiwiDeskGuiTests/ResizeStepImportTests.swift
@@ -1,0 +1,82 @@
+import KiwiDeskCore
+import Testing
+
+@testable import KiwiDesk
+
+/// The configurable resize step's GUI seam (#58): the catalog
+/// authors `resize("x", ±step)` from the live setting, and import
+/// classification matches a resize row of ANY magnitude by shape
+/// (not the old byte-for-byte ±50), reading that magnitude back
+/// into `resize.step`.
+@MainActor
+struct ResizeStepImportTests {
+    private func customRow(_ lua: String) -> KeyBinding {
+        KeyBinding(combo: "alt+h", lua: lua, kind: .custom)
+    }
+
+    private func config(lua: String) -> GuiConfig {
+        var config = GuiConfig()
+        config.modes = [
+            KeyMode(
+                name: KeyMode.defaultName,
+                bindings: [customRow(lua)]
+            )
+        ]
+        return config
+    }
+
+    @Test("The catalog authors Grow/Shrink from the given step")
+    func catalogAuthorsFromStep() {
+        let rows = KeybindingCatalog.resizeAndFloat(step: 75)
+        #expect(rows[0].lua == "KiwiDesk.resize(\"x\", -75)")
+        #expect(rows[1].lua == "KiwiDesk.resize(\"x\", 75)")
+    }
+
+    @Test("A non-default resize magnitude still classifies")
+    func nonDefaultMagnitudeClassifies() {
+        var config = config(lua: "KiwiDesk.resize(\"x\", -75)")
+        KeybindingImportClassifier.classify(&config)
+        let row = config.modes[0].bindings[0]
+        // Old code demoted any non-±50 resize to Custom; now the
+        // shape match upgrades it and keeps the canonical label.
+        #expect(row.kind == .navigation)
+        #expect(row.label == "Shrink")
+    }
+
+    @Test("Import reads the resize magnitude back into the step")
+    func importReadsStepBack() {
+        var config = config(lua: "KiwiDesk.resize(\"x\", 120)")
+        #expect(config.settings.resizeStep == 50)
+        KeybindingImportClassifier.classify(&config)
+        #expect(config.settings.resizeStep == 120)
+        #expect(config.modes[0].bindings[0].label == "Enlarge")
+    }
+
+    @Test("No resize row leaves the step at its default")
+    func noResizeRowKeepsDefault() {
+        var config = config(lua: "KiwiDesk.focus(\"left\")")
+        KeybindingImportClassifier.classify(&config)
+        #expect(config.settings.resizeStep == 50)
+    }
+
+    @Test("A non-resize or malformed row is not a resize shape")
+    func shapeRejectsNonResize() {
+        #expect(
+            KeybindingCatalog.resizeShape(
+                from: "KiwiDesk.focus(\"left\")"
+            ) == nil
+        )
+        // A zero delta is not a Grow or a Shrink.
+        #expect(
+            KeybindingCatalog.resizeShape(
+                from: "KiwiDesk.resize(\"x\", 0)"
+            ) == nil
+        )
+        // The y axis isn't authored yet (2-axis is #56).
+        #expect(
+            KeybindingCatalog.resizeShape(
+                from: "KiwiDesk.resize(\"y\", 50)"
+            ) == nil
+        )
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,6 +59,7 @@ KiwiDesk service restart
 | | `set_gap_global` | size |
 | | `set_gap_override` | space, size |
 | | `set_min_window_size` | pt (default 300) |
+| | `set_resize_step` | pt (default 50) — Grow/Shrink magnitude |
 | | `set_fallback_space` | space id ("" clears) — rehome target on profile switch |
 | | `set_space_icon` | space id, icon (SF Symbol\|emoji\|char; "" clears) |
 | | `get_state` | — (returns `{active_space, spaces, windows, monitor_count, native_space, exec_running}`) |

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -497,7 +497,14 @@ The color mark is reserved as the `.icns` master for when an
 
 - **Onboarding** is a separate follow-up pass (shares only
   the branding glyph). (#68 §5.9)
-- **Configurable resize step** (#58) and **2-axis resize**
-  (#56) have a reserved slot in Shortcuts ▸ Size & Float;
-  the design there is additive so their arrival won't
-  re-layout the section.
+- **Configurable resize step** (#58): the `resize.step` setting,
+  `set_resize_step` command, and import shape-match have landed;
+  the **in-GUI step control** (a slider in Shortcuts ▸ Size &
+  Float) and the **live-rewrite of already-bound rows** are
+  deferred to the redesign, whose reserved slot is additive so
+  their arrival won't re-layout the section. Until then the
+  setting is authoritative only at *authoring* time — it sizes
+  newly-authored Grow/Shrink bindings and is recovered from
+  bindings on import, but changing it does not rewrite existing
+  bound rows (their literal keeps firing). **2-axis resize**
+  (#56) extends the same slot to per-axis steps.

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -196,6 +196,24 @@ further.
 KiwiDesk.set_min_window_size(300)
 ```
 
+### set_resize_step
+
+**Expects:** a number (points).
+
+**Does:** sets the global magnitude the **Grow** / **Shrink**
+keybindings nudge the layout by (default 50). The Shortcuts
+catalog authors those bindings as `resize("x", ±step)` from this
+value, and importing a config reads a recovered magnitude back
+into it. Does not move any window on its own — it only sizes the
+Grow/Shrink presets — so it takes effect the next time such a
+binding fires.
+
+**Example:**
+
+```lua
+KiwiDesk.set_resize_step(75)
+```
+
 ### Space Identity
 
 Spaces are identified by **strings or numbers** — `1` and `"1"`


### PR DESCRIPTION
Closes #58.

Makes the Grow/Shrink keybinding magnitude a configurable global tiling setting, instead of a hardcoded ±50.

## What

- **Core:** `TilingSettings.resizeStep` (JSON `resize.step`, nested under `resize` per the one-vocabulary rule, pinned by `SettingsCodingTests`) + Lua/CLI command `KiwiDesk.set_resize_step(N)`. No retile — the step is authoring metadata for Grow/Shrink, never consumed by layout math (the bound row's own literal drives a resize). The command rounds/clamps to whole points in `[1, 10000]` and rejects non-finite input.
- **Catalog reference:** the Grow/Shrink presets now author `resize("x", ±step)` from the live setting (`resizeAndFloat(step:)`); the Shortcuts section passes it through, so newly-authored rows use the configured magnitude.
- **Import:** classification matches a resize row by *shape* (`resize("x", ±N)`, any N) instead of the old byte-for-byte ±50 that demoted other magnitudes to Custom, and — on an explicit import only — reads the recovered magnitude back into `resize.step`.

## Scope & the deferred half

Per the design discussion, this is the **setting + command + catalog-reference + import** slice. Deferred to the #68 Settings redesign (whose reserved slot is additive):
- the **in-GUI step control** (a slider in Shortcuts ▸ Size & Float), and
- **live-rewrite of already-bound rows** when the step changes.

**Known interim gap** (flagged in review, documented in `design-decisions.md`): until the redesign lands, the setting is authoritative only at *authoring* time — it sizes newly-authored bindings and is recovered from bindings on import, but changing it via `set_resize_step` does **not** rewrite existing bound rows (their literal keeps firing). The import read-back is gated to the explicit import path so a plain load-for-edit never clobbers an authoritative `resize.step`.

Down-payment on #56 (per-axis steps extend the same setting).

## Tests & docs

- `ResizeStepImportTests` (catalog authoring, shape-match, read-back gate, Shrink+Enlarge pair, load-for-edit no-clobber) and `ResizeStepCommandTests` (round / clamp / cap / non-finite-reject).
- `SettingsCodingTests` pins `resize.step`; `docs/lua-reference.md` + `docs/cli.md` document `set_resize_step`.

## Verification

`swift build` · `swift test` (724) · `scripts/lint.sh` · `swift build -c release` — all green.

Reviewed by `code-reviewer` + `architect-reviewer` (no blocking findings); their read-back-clobber, truncation, and overflow notes were folded into the follow-up commits, with a focused re-review confirming the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)