### PR TITLE
feat(lua): typo guard on namespace tables + visible config issues

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
@@ -36,23 +36,23 @@ extension KiwiCore {
         registerLuaAPI(on: fresh)
 
         ensureDefaultConfig()
-        // Arm the typo-guard recorder for the chunk run: a
-        // guarded unknown call is non-fatal, so it must land
+        // Typo-guard hits are recorded only for the chunk run:
+        // a guarded unknown call is non-fatal, so it must land
         // here as an issue to stay visible (#39).
-        typoIssues = []
-        if case .failure(let error) = fresh.runFile(
-            configURL
-        ) {
-            onLog("init.lua error: \(error)")
-            issues.append(
-                ConfigIssue(
-                    source: "init.lua",
-                    message: "\(error)"
+        let typos = recordingTypoIssues {
+            if case .failure(let error) = fresh.runFile(
+                configURL
+            ) {
+                onLog("init.lua error: \(error)")
+                issues.append(
+                    ConfigIssue(
+                        source: "init.lua",
+                        message: "\(error)"
+                    )
                 )
-            )
+            }
         }
-        issues.append(contentsOf: typoIssues ?? [])
-        typoIssues = nil
+        issues.append(contentsOf: typos)
         // A sidecar that exists but no longer decodes means
         // the visual editor (and the structured loader) can't
         // see the user's rules — half-loaded, must be visible.

--- a/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
@@ -36,6 +36,10 @@ extension KiwiCore {
         registerLuaAPI(on: fresh)
 
         ensureDefaultConfig()
+        // Arm the typo-guard recorder for the chunk run: a
+        // guarded unknown call is non-fatal, so it must land
+        // here as an issue to stay visible (#39).
+        typoIssues = []
         if case .failure(let error) = fresh.runFile(
             configURL
         ) {
@@ -47,6 +51,8 @@ extension KiwiCore {
                 )
             )
         }
+        issues.append(contentsOf: typoIssues ?? [])
+        typoIssues = nil
         // A sidecar that exists but no longer decodes means
         // the visual editor (and the structured loader) can't
         // see the user's rules — half-loaded, must be visible.

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -73,6 +73,11 @@ public final class KiwiCore {
     /// gui.json) — kept so profile mutations can refresh the
     /// profile half without losing these.
     var configLoadIssues: [ConfigIssue] = []
+    /// Typo-guard hits from the init.lua chunk currently
+    /// running (#39). Non-nil only while `loadConfig` executes
+    /// the chunk; nil gates runtime hits (a typo inside a
+    /// keybinding closure) to log-only.
+    var typoIssues: [ConfigIssue]?
     /// Fired whenever `configIssues` changes (including back
     /// to empty, so the badge clears itself).
     public var onConfigIssuesChange:

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -74,9 +74,9 @@ public final class KiwiCore {
     /// profile half without losing these.
     var configLoadIssues: [ConfigIssue] = []
     /// Typo-guard hits from the init.lua chunk currently
-    /// running (#39). Non-nil only while `loadConfig` executes
-    /// the chunk; nil gates runtime hits (a typo inside a
-    /// keybinding closure) to log-only.
+    /// running (#39). Armed exclusively by
+    /// `recordingTypoIssues`; nil gates runtime hits (a typo
+    /// inside a keybinding closure) to log-only.
     var typoIssues: [ConfigIssue]?
     /// Fired whenever `configIssues` changes (including back
     /// to empty, so the badge clears itself).

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -67,7 +67,11 @@ public enum APIReference {
             ),
         ]
 
-    /// Layout sub-APIs exposed as global Lua tables.
+    /// Layout sub-APIs exposed as global Lua tables. Keys must
+    /// be fresh, valid Lua identifiers: they are interpolated
+    /// bare into the typo-guard install chunk, and a name
+    /// colliding with a stdlib global (`table`, `os`, …) would
+    /// reuse — and metatable — that table.
     public static let namespaces: [String: [String]] = [
         "animations": [
             "set_duration", "set_scroll_speed",

--- a/Sources/KiwiDeskCore/Lua/KiwiCore+LuaAPI.swift
+++ b/Sources/KiwiDeskCore/Lua/KiwiCore+LuaAPI.swift
@@ -48,7 +48,7 @@ extension KiwiCore {
         registerEventAPI(on: lua)
         registerKeybindingAPI(on: lua)
         registerExecAPI(on: lua)
-        installTypoGuard(on: lua)
+        installTypoGuards(on: lua)
     }
 
     /// `KiwiDesk.bind`, `define_mode`, and `switch_mode`
@@ -126,26 +126,6 @@ extension KiwiCore {
             return nil
         }
         return opts["icon"]?.stringValue
-    }
-
-    /// A metatable on the KiwiDesk table turns typo'd calls
-    /// ("attempt to call a nil value") into a helpful log
-    /// line pointing at KiwiDesk.help().
-    private func installTypoGuard(on lua: LuaInterpreter) {
-        lua.run(
-            """
-            setmetatable(KiwiDesk, {
-                __index = function(_, key)
-                    return function()
-                        KiwiDesk.debug_log(
-                            "unknown KiwiDesk function '"
-                            .. tostring(key)
-                            .. "' — see KiwiDesk.help()")
-                    end
-                end,
-            })
-            """
-        )
     }
 
     private func register(

--- a/Sources/KiwiDeskCore/Lua/KiwiCore+TypoGuard.swift
+++ b/Sources/KiwiDeskCore/Lua/KiwiCore+TypoGuard.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Typo guards (#39): a metatable on the `KiwiDesk` table and
+/// on every layout namespace table (`bsp`, `scroll`, …) turns
+/// an unknown call into a logged did-you-mean hint instead of
+/// the hard "attempt to call a nil value" error that would
+/// abort the rest of init.lua.
+///
+/// Non-fatal must not mean invisible (the original #39 bug was
+/// a typo whose only trace was a buried log line): during a
+/// config load every guard hit is also recorded as a
+/// `ConfigIssue`, so it reaches the menu-bar badge and the
+/// Config Issues window. Outside a load — a typo inside a
+/// keybinding or event closure — the hit only logs; a stale
+/// "config error" badge for a runtime slip would mislead.
+extension KiwiCore {
+    /// Installs the guard on `KiwiDesk` and every
+    /// `APIReference.namespaces` table. Must run at the end of
+    /// `registerLuaAPI` so all guarded tables already exist.
+    func installTypoGuards(on lua: LuaInterpreter) {
+        // Internal reporter, `__`-prefixed: absent from
+        // `APIReference`, so `help()` and did-you-mean can
+        // never surface (or suggest) it.
+        lua.register("__report_unknown") { [weak self] args in
+            guard let self,
+                let table = args.first?.stringValue,
+                let key = args.dropFirst().first?.stringValue
+            else { return .none }
+            self.reportUnknownCall(table: table, key: key)
+            return .none
+        }
+        let tables =
+            ["KiwiDesk"] + APIReference.namespaces.keys.sorted()
+        let installs = tables.map {
+            "setmetatable(\($0), guard(\"\($0)\"))"
+        }.joined(separator: "\n")
+        lua.run(
+            """
+            local function guard(name)
+                return {
+                    __index = function(_, key)
+                        return function()
+                            KiwiDesk.__report_unknown(
+                                name, tostring(key))
+                        end
+                    end,
+                }
+            end
+            \(installs)
+            """
+        )
+    }
+
+    /// Logs the did-you-mean hint; during a config load (see
+    /// `typoIssues` in KiwiCore) additionally records the typo
+    /// as a ConfigIssue, deduped so a typo'd call inside a
+    /// loop reports once.
+    private func reportUnknownCall(table: String, key: String) {
+        let qualified =
+            table == "KiwiDesk" ? key : "\(table).\(key)"
+        let hint =
+            APIReference.suggestion(for: qualified)
+            .map { " — did you mean '\($0)'?" } ?? ""
+        onLog(
+            "unknown \(table) function '\(key)'\(hint)"
+                + " — see KiwiDesk.help()"
+        )
+        guard typoIssues != nil else { return }
+        let issue = ConfigIssue(
+            source: "init.lua",
+            message: "unknown call '\(qualified)'\(hint)"
+        )
+        if typoIssues?.contains(issue) == false {
+            typoIssues?.append(issue)
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/Lua/KiwiCore+TypoGuard.swift
+++ b/Sources/KiwiDeskCore/Lua/KiwiCore+TypoGuard.swift
@@ -60,6 +60,10 @@ extension KiwiCore {
     /// Runs `body` with typo-guard ConfigIssue recording armed
     /// and returns what it captured. The only way to arm the
     /// buffer — the `defer` makes a forgotten drain impossible.
+    /// Not reentrant (a nested call would un-arm the outer
+    /// scope); `loadConfig` is the single caller, and a
+    /// reentrant `loadConfig` is already impossible because
+    /// `reload_config` defers via `Task`.
     func recordingTypoIssues(
         _ body: () -> Void
     ) -> [ConfigIssue] {

--- a/Sources/KiwiDeskCore/Lua/KiwiCore+TypoGuard.swift
+++ b/Sources/KiwiDeskCore/Lua/KiwiCore+TypoGuard.swift
@@ -18,9 +18,9 @@ extension KiwiCore {
     /// `APIReference.namespaces` table. Must run at the end of
     /// `registerLuaAPI` so all guarded tables already exist.
     func installTypoGuards(on lua: LuaInterpreter) {
-        // Internal reporter, `__`-prefixed: absent from
-        // `APIReference`, so `help()` and did-you-mean can
-        // never surface (or suggest) it.
+        // The reporter is registered only to be captured as an
+        // upvalue below; the chunk removes the table entry, so
+        // user Lua can neither call, spoof, nor break it.
         lua.register("__report_unknown") { [weak self] args in
             guard let self,
                 let table = args.first?.stringValue,
@@ -34,14 +34,15 @@ extension KiwiCore {
         let installs = tables.map {
             "setmetatable(\($0), guard(\"\($0)\"))"
         }.joined(separator: "\n")
-        lua.run(
+        let result = lua.run(
             """
+            local report = KiwiDesk.__report_unknown
+            KiwiDesk.__report_unknown = nil
             local function guard(name)
                 return {
                     __index = function(_, key)
                         return function()
-                            KiwiDesk.__report_unknown(
-                                name, tostring(key))
+                            report(name, tostring(key))
                         end
                     end,
                 }
@@ -49,6 +50,23 @@ extension KiwiCore {
             \(installs)
             """
         )
+        // A failed install would silently revert typos to hard
+        // chunk-aborting errors — the exact #39 failure mode.
+        if case .failure(let error) = result {
+            onLog("typo guard install failed: \(error)")
+        }
+    }
+
+    /// Runs `body` with typo-guard ConfigIssue recording armed
+    /// and returns what it captured. The only way to arm the
+    /// buffer — the `defer` makes a forgotten drain impossible.
+    func recordingTypoIssues(
+        _ body: () -> Void
+    ) -> [ConfigIssue] {
+        typoIssues = []
+        defer { typoIssues = nil }
+        body()
+        return typoIssues ?? []
     }
 
     /// Logs the did-you-mean hint; during a config load (see

--- a/Tests/KiwiDeskCoreTests/TypoGuardTests.swift
+++ b/Tests/KiwiDeskCoreTests/TypoGuardTests.swift
@@ -151,6 +151,22 @@ struct TypoGuardTests {
         }
     }
 
+    @Test("Namespace keys never shadow a Lua stdlib global")
+    func namespaceKeysAreFresh() {
+        // The guard-install chunk metatables each namespace
+        // table by name; a key colliding with a stdlib global
+        // would reuse — and metatable — that library table.
+        let stdlib: Set<String> = [
+            "_G", "coroutine", "debug", "io", "math", "os",
+            "package", "string", "table", "utf8",
+        ]
+        #expect(
+            stdlib.isDisjoint(
+                with: APIReference.namespaces.keys
+            )
+        )
+    }
+
     @Test("Namespaced typos get a did-you-mean suggestion")
     func namespacedSuggestion() {
         #expect(

--- a/Tests/KiwiDeskCoreTests/TypoGuardTests.swift
+++ b/Tests/KiwiDeskCoreTests/TypoGuardTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+// The namespace typo guard (#39): an unknown call on KiwiDesk
+// or a layout namespace table logs a did-you-mean and keeps
+// the rest of init.lua running; during a config load the hit
+// also surfaces as a ConfigIssue so it cannot go unnoticed.
+
+@MainActor
+private func makeCore(config: String? = nil) -> KiwiCore {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+            "kiwi-typo-\(UUID().uuidString)"
+        )
+    let core = KiwiCore(configDirectory: directory)
+    if let config {
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        try? config.write(
+            to: core.configURL,
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+    return core
+}
+
+@Suite("Namespace typo guard (#39)", .serialized)
+@MainActor
+struct TypoGuardTests {
+    @Test("A namespace typo logs and the config keeps running")
+    func nonFatal() {
+        let core = makeCore(
+            config: """
+                scroll.set_width(1550)
+                marker = 42
+                """
+        )
+        var logs: [String] = []
+        core.onLog = { logs.append($0) }
+        core.loadConfig()
+        #expect(core.lua?.global("marker") == .number(42))
+        #expect(
+            logs.contains {
+                $0.contains("set_width")
+                    && $0.contains("KiwiDesk.help()")
+            }
+        )
+    }
+
+    @Test("A load-time namespace typo becomes a ConfigIssue")
+    func loadIssue() {
+        let core = makeCore(config: "scroll.set_width(1)")
+        core.loadConfig()
+        #expect(
+            core.configIssues.contains {
+                $0.source == "init.lua"
+                    && $0.message.contains(
+                        "scroll.set_width"
+                    )
+            }
+        )
+    }
+
+    @Test("A top-level typo during load is an issue too")
+    func topLevelLoadIssue() {
+        let core = makeCore(
+            config: """
+                KiwiDesk.focsu("left")
+                marker = 1
+                """
+        )
+        core.loadConfig()
+        #expect(core.lua?.global("marker") == .number(1))
+        #expect(
+            core.configIssues.contains {
+                $0.message.contains("focsu")
+                    && $0.message.contains("focus")
+            }
+        )
+    }
+
+    @Test("One typo in a loop dedupes to a single issue")
+    func dedupe() {
+        let core = makeCore(
+            config: """
+                for i = 1, 3 do
+                    scroll.set_width(i)
+                end
+                """
+        )
+        core.loadConfig()
+        #expect(core.configIssues.count == 1)
+    }
+
+    @Test("A runtime typo logs but records no ConfigIssue")
+    func runtimeHitOnlyLogs() {
+        let core = makeCore()
+        var logs: [String] = []
+        core.onLog = { logs.append($0) }
+        core.loadConfig()
+        #expect(core.configIssues.isEmpty)
+        let result = core.lua?.run("scroll.set_width(1)")
+        let succeeded: Bool =
+            if case .success = result { true } else { false }
+        #expect(succeeded)
+        #expect(logs.contains { $0.contains("set_width") })
+        #expect(core.configIssues.isEmpty)
+    }
+
+    @Test("A reload clears a fixed typo's issue")
+    func issueClearsOnReload() throws {
+        let core = makeCore(config: "scroll.set_width(1)")
+        core.loadConfig()
+        #expect(!core.configIssues.isEmpty)
+        try "scroll.set_slot_size(1550)".write(
+            to: core.configURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        core.loadConfig()
+        #expect(core.configIssues.isEmpty)
+    }
+
+    @Test("Namespaced typos get a did-you-mean suggestion")
+    func namespacedSuggestion() {
+        #expect(
+            APIReference.suggestion(
+                for: "scroll.set_slot_sze"
+            ) == "scroll.set_slot_size"
+        )
+        #expect(
+            APIReference.suggestion(
+                for: "stack.set_master_ratoi"
+            ) == "stack.set_master_ratio"
+        )
+    }
+}

--- a/Tests/KiwiDeskCoreTests/TypoGuardTests.swift
+++ b/Tests/KiwiDeskCoreTests/TypoGuardTests.swift
@@ -126,6 +126,31 @@ struct TypoGuardTests {
         #expect(core.configIssues.isEmpty)
     }
 
+    @Test("Every namespace table is guarded")
+    func allNamespacesGuarded() {
+        // One typo per namespace: proves the install chunk
+        // compiled and every table got its guard — a broken
+        // install would abort at the first call instead.
+        let tables = APIReference.namespaces.keys.sorted()
+        let core = makeCore(
+            config:
+                tables
+                .map { "\($0).no_such_fn_xyz(1)" }
+                .joined(separator: "\n")
+        )
+        core.loadConfig()
+        for table in tables {
+            #expect(
+                core.configIssues.contains {
+                    $0.message.contains(
+                        "\(table).no_such_fn_xyz"
+                    )
+                },
+                "unguarded namespace: \(table)"
+            )
+        }
+    }
+
     @Test("Namespaced typos get a did-you-mean suggestion")
     func namespacedSuggestion() {
         #expect(

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -474,6 +474,16 @@ reachable without opening Settings. Profile issues also
 refresh on save/delete, so repairing one clears its badge
 immediately. (#68 §3.7, #39/#31 own the validation cores)
 
+**A typo is non-fatal, but never invisible.** An unknown call
+on `KiwiDesk` or a layout namespace table is a guarded no-op
+(logged with a did-you-mean), so one wrong name can no longer
+abort init.lua and silently kill every keybinding below it.
+The flip side — non-fatal would mean *unnoticed* — is closed
+by recording each load-time hit as a config issue feeding the
+badge and window above. Runtime hits (a typo inside a
+keybinding closure) only log; a persistent "config error"
+badge for a transient slip would mislead. (#39)
+
 **The quick menu is for daily driving.** Header row naming
 the live profile, a Switch Profile submenu (`load_profile`
 finally has a quick path), Config Issues… only while

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -16,13 +16,20 @@ It is created with a commented starter template on first launch
 and re-read on `KiwiDesk reload_config`. The embedded
 interpreter is **Lua 5.5** with the full standard library.
 
-Two safety rails apply to all Lua code:
+Three safety rails apply to all Lua code:
 
 - Any single call into the VM is aborted after **500 ms** —
   an accidental `while true do end` cannot freeze KiwiDesk.
 - A callback (event handler or keybinding) that errors or
   times out is **disabled** and logged; everything else keeps
   working until the next `reload_config`.
+- A typo'd function name on `KiwiDesk` or a layout table
+  (`scroll.set_width(…)` instead of
+  `scroll.set_slot_size(…)`) does **not** abort the config:
+  the call becomes a no-op that logs a did-you-mean hint,
+  and everything below it still runs. During a config load
+  the typo is also reported in the menu bar's **Config
+  Issues** window, so it cannot pass silently.
 
 ## Settings app vs init.lua
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -652,6 +652,13 @@ Check the Shortcuts section for a ⚠️ conflict marker. Verify the combo
 is not reserved by macOS. If you hand-edited, reload with
 `KiwiDesk reload_config`.
 
+**Typo in init.lua?**  
+A misspelled function name (e.g. `scroll.set_width` instead of
+`scroll.set_slot_size`) doesn't abort the config: the call is
+skipped with a did-you-mean hint and the rest of the file still
+runs. Every typo the load hits is listed under menu bar › Config
+Issues… — if the error badge is showing, check there first.
+
 **Windows aren't tiling?**  
 Ensure the space has a layout mode other than Floating set in Layout
 Defaults. Check that the app is not in float_rules. If using a


### PR DESCRIPTION
## Description

A single wrong name on a layout namespace table
(`scroll.set_width` instead of `scroll.set_slot_size`) used to
raise a hard Lua error that aborted the rest of init.lua — every
keybinding, rule, and event handler below it silently never ran,
with only a buried NSLog line as diagnostic.

This change makes such typos non-fatal **and** impossible to
miss:

- The `KiwiDesk`-table typo guard is extended to every
  `APIReference.namespaces` table (`bsp`, `stack`, `scroll`,
  `grid`, `monocle`, `app_bar`, `animations`, `drag`) via a
  shared reporter captured as a chunk upvalue (zero Lua-visible
  internal surface). An unknown call logs a did-you-mean
  (`APIReference.suggestion` already handles qualified names)
  and the chunk keeps running.
- Because non-fatal must not mean invisible, every guard hit
  during `loadConfig` is recorded as a `ConfigIssue` (deduped
  per call name, arm/drain lexically scoped in
  `recordingTypoIssues`) and reaches the existing #68 menu-bar
  badge + Config Issues window. Runtime hits (a typo inside a
  keybinding closure) stay log-only.
- Guard coverage is derived from `APIReference.namespaces` — the
  same data that drives registration — and proven by a
  per-namespace test; namespace keys are pinned as fresh, valid
  Lua identifiers (doc comment + stdlib-disjointness test).

## Related Issue(s)

Closes #39

## Checklist

- [x] I understand what this change does and have verified it
  (see "How I verified" below)
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested (9 tests in TypoGuardTests)
- [x] User-facing changes are documented in `docs/`
  (lua-reference safety rails, user-guide troubleshooting,
  design-decisions)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
  (733 tests, 134 suites)
- [x] Release build passes: `swift build -c release`
- [x] PR is focused

## How I verified

Core-level end-to-end via tests: `loadConfig` with a typo'd
namespace call runs the rest of the config (marker global set),
publishes the typo as a `ConfigIssue` (the same
`configLoadIssues → refreshConfigIssues` pipeline that drives
the badge/window — that #68 surface is reused unchanged), dedupes
loop hits, clears on reload after the fix, and stays log-only for
runtime hits. Every namespace is exercised by
`allNamespacesGuarded`. No GUI code was touched, so no separate
in-app pass beyond the existing #68 surface.

Two-agent review (code-reviewer + architect-reviewer) ran on the
feature commit, plus a sequential focused re-review of the fix
batch — final verdict both sides: no major findings.

## Notes for Reviewer

CI is expected red (no Actions budget); the local verify gate
runs the identical commands and passed on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)