### PR TITLE
feat(commands): focus-aware BSP keyboard resize direction (#122)

### DIFF
--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
@@ -59,7 +59,11 @@ extension KiwiCore {
     }
 
     /// Per-axis BSP resize (#56): "x" moves the side-by-side
-    /// splits, "y" the stacked splits — independent knobs.
+    /// splits, "y" the stacked splits — independent knobs. The
+    /// delta's sign follows the FOCUSED window (#122): a slot
+    /// in the second (right/bottom) region grows when the
+    /// shared ratio DROPS, so +delta always grows the focused
+    /// region — mouse-path parity (`MouseResize.translate`).
     private func resizeBsp(
         axis: String,
         delta: Double,
@@ -67,20 +71,48 @@ extension KiwiCore {
         space: Space
     ) -> CommandResponse {
         let bsp = tiler.settings.resolvedBsp(for: space.id)
+        let signed =
+            bspFocusSign(axis: axis, space: space)
+            * delta
         if axis == "x" {
-            let value = bsp.splitRatioH + delta / span
+            let value = bsp.splitRatioH + signed / span
             tiler.settings.setSplitRatioH(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )
         } else {
-            let value = bsp.splitRatioV + delta / span
+            let value = bsp.splitRatioV + signed / span
             tiler.settings.setSplitRatioV(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )
         }
         return .ok()
+    }
+
+    /// Which way the shared BSP ratio must move so "grow"
+    /// grows the FOCUSED window: +1 when its calculated slot
+    /// sits in the first (left/top) half of the screen, -1 in
+    /// the second — the same midpoint rule the mouse path
+    /// infers a drag's side from. Unknown focus (none, or
+    /// floating — no slot) keeps +1, the first-region
+    /// direction (the pre-#122 behavior).
+    private func bspFocusSign(
+        axis: String,
+        space: Space
+    ) -> Double {
+        guard let focused = space.focused,
+            let slot = tiler.calculatedFrames(
+                state: state
+            )[focused],
+            let screen = NSScreen.main
+                ?? NSScreen.screens.first
+        else { return 1 }
+        let bounds = GeometryUtils.axVisibleFrame(of: screen)
+        if axis == "x" {
+            return slot.midX <= bounds.midX ? 1 : -1
+        }
+        return slot.midY <= bounds.midY ? 1 : -1
     }
 
     /// Focus-aware stack resize (#67). "x" moves the

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
@@ -91,12 +91,13 @@ extension KiwiCore {
     }
 
     /// Which way the shared BSP ratio must move so "grow"
-    /// grows the FOCUSED window: +1 when its calculated slot
-    /// sits in the first (left/top) half of the screen, -1 in
-    /// the second — the same midpoint rule the mouse path
-    /// infers a drag's side from. Unknown focus (none, or
-    /// floating — no slot) keeps +1, the first-region
-    /// direction (the pre-#122 behavior).
+    /// grows the FOCUSED window — the mouse path's side rule,
+    /// via the shared authority (`MouseResize.bspSide`).
+    /// Unknown focus (none, or floating — no slot) keeps +1,
+    /// the first-region direction (the pre-#122 behavior).
+    /// Assumes `space` IS the active space: the slot lookup
+    /// resolves the active space's frames only, so any other
+    /// space silently gets the +1 fallback.
     private func bspFocusSign(
         axis: String,
         space: Space
@@ -108,11 +109,15 @@ extension KiwiCore {
             let screen = NSScreen.main
                 ?? NSScreen.screens.first
         else { return 1 }
-        let bounds = GeometryUtils.axVisibleFrame(of: screen)
-        if axis == "x" {
-            return slot.midX <= bounds.midX ? 1 : -1
-        }
-        return slot.midY <= bounds.midY ? 1 : -1
+        return Double(
+            MouseResize.bspSide(
+                slot: slot,
+                bounds: GeometryUtils.axVisibleFrame(
+                    of: screen
+                ),
+                horizontal: axis == "x"
+            )
+        )
     }
 
     /// Focus-aware stack resize (#67). "x" moves the

--- a/Sources/KiwiDeskCore/Tiling/MouseResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/MouseResize.swift
@@ -116,6 +116,23 @@ public enum MouseResize {
             && !inner.contains(point)
     }
 
+    /// The side of the first BSP split a slot sits on, as the
+    /// direction the shared ratio must move for that slot's
+    /// region to GROW: +1 first (left/top), -1 second. The
+    /// midpoint rule is a heuristic (deep slots under extreme
+    /// ratios can misread), so the mouse and keyboard paths
+    /// (#122) share this one authority — never re-derive the
+    /// comparison.
+    public static func bspSide(
+        slot: CGRect,
+        bounds: CGRect,
+        horizontal: Bool
+    ) -> CGFloat {
+        horizontal
+            ? (slot.midX <= bounds.midX ? 1 : -1)
+            : (slot.midY <= bounds.midY ? 1 : -1)
+    }
+
     /// The layout change a resize gesture asks for, or nil
     /// when the layout has no parameter for that axis (the
     /// window snaps back).
@@ -137,13 +154,19 @@ public enum MouseResize {
         switch mode {
         case .bsp:
             if abs(dw) >= abs(dh), abs(dw) > threshold {
-                let side: CGFloat =
-                    slot.midX <= bounds.midX ? 1 : -1
+                let side = bspSide(
+                    slot: slot,
+                    bounds: bounds,
+                    horizontal: true
+                )
                 return .bspRatioH(side * dw / bounds.width)
             }
             if abs(dh) > threshold {
-                let side: CGFloat =
-                    slot.midY <= bounds.midY ? 1 : -1
+                let side = bspSide(
+                    slot: slot,
+                    bounds: bounds,
+                    horizontal: false
+                )
                 return .bspRatioV(side * dh / bounds.height)
             }
             return nil

--- a/Tests/KiwiDeskCoreTests/BspFocusResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/BspFocusResizeTests.swift
@@ -1,0 +1,130 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Focus-aware BSP resize direction (#122): `resize` flips the
+/// delta's sign from the focused window's calculated slot, so
+/// "grow" grows the focused window's region — the keyboard path
+/// finally matches the mouse path's side inference.
+@Suite("BSP focus-aware resize (#122)", .serialized)
+@MainActor
+struct BspFocusResizeTests {
+    private func makeCore() -> KiwiCore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "kiwidesk-tests-\(UUID().uuidString)"
+            )
+        return KiwiCore(configDirectory: dir)
+    }
+
+    /// BSP space under the ALTERNATING strategy, so the split
+    /// orientation per depth is fixed regardless of the host
+    /// screen's shape. BSP's `.afterFocused` placement keeps
+    /// creation order: [1, 2] — w1 the left region, w2 the
+    /// right; a third window splits the right region
+    /// vertically — w2 top, w3 bottom. Creation focuses the
+    /// last window, so tests set focus explicitly.
+    private func bspSpace(_ core: KiwiCore, count: Int = 2) {
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("bsp")]
+        )
+        core.execute(
+            "bsp.set_strategy",
+            args: [.string("alternating")]
+        )
+        for index in 1...count {
+            core.state.apply(
+                .windowCreated(
+                    ManagedWindow(
+                        id: WindowID(UInt32(index)),
+                        pid: 1,
+                        appName: "A"
+                    )
+                )
+            )
+        }
+    }
+
+    @Test("x with the left window focused raises the H ratio")
+    func leftFocusGrowsLeft() {
+        let core = makeCore()
+        bspSpace(core)
+        core.state.apply(.windowFocused(WindowID(1)))
+        let before = core.tiler.settings.bsp.splitRatioH
+        core.execute("resize", args: [.string("x"), .number(200)])
+        #expect(core.tiler.settings.bsp.splitRatioH > before)
+    }
+
+    @Test("x with the right window focused lowers the H ratio")
+    func rightFocusGrowsRight() {
+        let core = makeCore()
+        bspSpace(core)
+        core.state.apply(.windowFocused(WindowID(2)))
+        let before = core.tiler.settings.bsp.splitRatioH
+        core.execute("resize", args: [.string("x"), .number(200)])
+        // +delta grows the FOCUSED window: the right region
+        // widens, so the shared H ratio drops (#122).
+        #expect(core.tiler.settings.bsp.splitRatioH < before)
+    }
+
+    @Test("y with the top window focused raises the V ratio")
+    func topFocusGrowsTop() {
+        let core = makeCore()
+        bspSpace(core, count: 3)
+        // [1, 2, 3]: w1 left; the right region stacks w2 over
+        // w3 (alternating → vertical at depth 1).
+        core.state.apply(.windowFocused(WindowID(2)))
+        let before = core.tiler.settings.bsp.splitRatioV
+        core.execute("resize", args: [.string("y"), .number(200)])
+        #expect(core.tiler.settings.bsp.splitRatioV > before)
+    }
+
+    @Test("y with the bottom window focused lowers the V ratio")
+    func bottomFocusGrowsBottom() {
+        let core = makeCore()
+        bspSpace(core, count: 3)
+        core.state.apply(.windowFocused(WindowID(3)))
+        let before = core.tiler.settings.bsp.splitRatioV
+        core.execute("resize", args: [.string("y"), .number(200)])
+        #expect(core.tiler.settings.bsp.splitRatioV < before)
+    }
+
+    @Test("x with a floating focused window keeps first-region")
+    func floatingFocusKeepsDirection() {
+        let core = makeCore()
+        bspSpace(core)
+        // The focused (right) window floats out of the tiled
+        // set: no slot to infer a side from, so the pre-#122
+        // first-region direction must survive — even though a
+        // tiled w2 would have flipped the sign.
+        core.state.apply(.windowFocused(WindowID(2)))
+        core.state.setFloating(WindowID(2), true)
+        let before = core.tiler.settings.bsp.splitRatioH
+        core.execute("resize", args: [.string("x"), .number(200)])
+        #expect(core.tiler.settings.bsp.splitRatioH > before)
+    }
+
+    @Test("right focus writes the space's own override (#17)")
+    func focusSignHitsOverride() {
+        let core = makeCore()
+        bspSpace(core)
+        core.execute(
+            "bsp.set_ratio_h_override",
+            args: [.string("1"), .number(0.5)]
+        )
+        core.state.apply(.windowFocused(WindowID(2)))
+        let globalBefore = core.tiler.settings.bsp.splitRatioH
+        core.execute("resize", args: [.string("x"), .number(200)])
+        let over =
+            core.tiler.settings.bsp.override[SpaceID("1")]
+        // The flipped sign still lands on the override, and
+        // the shared global stays put.
+        #expect((over?.splitRatioH ?? 1) < 0.5)
+        #expect(
+            core.tiler.settings.bsp.splitRatioH == globalBefore
+        )
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,10 +127,12 @@ value` and shadows the global for that space only.
 
 `resize` adapts to the active layout and is per-axis (#56): in
 BSP, `x` moves the side-by-side split ratio and `y` the stacked
-one, independently. Stack is focus-aware (#67): `x` moves the
-master/stack split in the direction that grows the *focused*
-window, `y` grows the focused window's vertical share of its
-column (session-scoped weights, reset on relaunch). Scrolling
+one, independently, each in the direction that grows the
+*focused* window's region (#122). Stack is focus-aware too
+(#67): `x` moves the master/stack split in the direction that
+grows the *focused* window, `y` grows the focused window's
+vertical share of its column (session-scoped weights, reset on
+relaunch). Scrolling
 resizes the slot along its own scroll axis for either `x` or
 `y`. monocle, grid, and floating reply "not supported".
 

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1535,6 +1535,13 @@ floating. What the `delta` actually adjusts depends on the layout:
 - **bsp** — per-axis (#56): `"x"` nudges the side-by-side split
   ratio (`bsp.set_ratio_h`), `"y"` the stacked one
   (`bsp.set_ratio_v`) — genuinely independent width and height.
+  Focus-aware in direction (#122): a positive delta grows the
+  *focused* window's region, so with a right/bottom window
+  focused it lowers the shared ratio — the same side rule a
+  mouse drag of that window's edge uses. All same-orientation
+  splits still share the one ratio; with no usable focus (no
+  focused window, or a floating one) the delta moves the
+  left/top region, as before.
 - **stack** — focus-aware (#67). `"x"` moves the master/stack
   split *in the direction that grows the focused window*: with
   a master focused, a positive delta raises the master ratio;


### PR DESCRIPTION
## Description

BSP keyboard `resize("x"|"y", delta)` now flips the delta's
sign from the focused window's calculated slot, so a positive
delta always grows the FOCUSED window's region — previously it
always grew the first (left/top) region, so with the right-hand
window focused, "Grow width" shrank it.

- Side inference is the mouse path's midpoint rule, now shared
  as one authority: `MouseResize.bspSide(slot:bounds:horizontal:)`
  is consumed by both `translate` (mouse) and the new
  `bspFocusSign` (keyboard) — no re-derived boundary comparison
  (#67 precedent).
- Unknown focus (none, or floating — no slot) keeps the old
  first-region direction.
- Sign only, per the issue: per-node ratios stay rejected
  (flat-array guardrail). All same-orientation splits still
  share one ratio; "grow" just means "grow *my* region".
- New `BspFocusResizeTests` (6 tests, alternating strategy so
  split orientation is screen-shape independent), mirroring
  `StackFocusResizeTests`. Docs: `lua-reference.md` + `cli.md`.

## Related Issue(s)

Closes #122. Backlog: #71 (Lane C). Completes the #56/#67
focus-awareness story for BSP.

## Checklist

- [ ] I understand what this change does and have run it in
  the app to confirm it works as intended (manual pass pending —
  same as the #56/#67 flow, please verify grow/shrink with
  right/bottom windows focused)
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
  (802 tests)
- [x] Release build passes: `swift build -c release`
- [x] PR is focused

## How I verified

Full local gate (debug build, 802 tests, lint incl.
extract-keys --check, release build). Command-level tests pin:
left/right focus flips the H-ratio direction, top/bottom focus
flips the V-ratio direction, floating focus falls back to the
old direction, and the flipped sign still writes the space's
own override (#17). Manual in-app pass: left for review (CI is
red by design — no Actions budget; the local gate is the gate).

## Notes for Reviewer

Two-agent review (code-reviewer + architect-reviewer) ran clean
of majors; the one actionable finding (extract the side rule as
a shared pure static) is the second commit. Known, intended
limitation inherited from mouse parity: at deeply nested splits
under extreme ratios the midpoint heuristic can misread the
side — identical to dragging with the mouse, so both paths stay
in lockstep via `bspSide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)