### PR TITLE
feat(config): normalize untrusted mode lists on decode (#31)

### DIFF
--- a/Sources/KiwiDeskCore/App/ConfigIssues.swift
+++ b/Sources/KiwiDeskCore/App/ConfigIssues.swift
@@ -3,8 +3,12 @@ import Foundation
 /// One config-load or profile-validation problem, surfaced to
 /// the GUI's error badge and Config Issues panel (#68). This is
 /// the *surface* only — the typo-guard and validation cores
-/// stay with #39/#31; anything they learn to detect lands here
-/// as another issue.
+/// stay with #39/#31. Lua typo hits land here (#39); the #31
+/// mode-list normalization is currently SILENT (it runs inside
+/// pure `Codable`, out of the reporter's reach) — surfacing a
+/// "was normalized" issue from a post-decode seam
+/// (`profileConfigIssues()` / `configLoadIssues`) is a
+/// follow-up candidate, not a promise this file already keeps.
 public struct ConfigIssue: Sendable, Equatable, Identifiable {
     /// The offending file, as the user knows it
     /// (`init.lua`, `gui.json`, `<profile>.json`).

--- a/Sources/KiwiDeskCore/Config/GuiConfig.swift
+++ b/Sources/KiwiDeskCore/Config/GuiConfig.swift
@@ -162,12 +162,17 @@ public struct GuiConfig: Codable, Equatable, Sendable {
             ) ?? []
         profileBindings =
             try decodeProfileBindings(from: container)
-        modes =
-            try container.decodeIfPresent(
+        // Normalized like the spaces below: a hand-edited
+        // sidecar can carry duplicate mode names or an icon on
+        // the default mode (#31) — cleaned here so invalid
+        // entries never reach the loader or the GUI. Empty
+        // input falls back to [KeyMode.defaultMode] as before.
+        modes = KeyMode.normalized(
+            full: try container.decodeIfPresent(
                 [KeyMode].self,
                 forKey: .modes
-            ) ?? [KeyMode.defaultMode]
-        if modes.isEmpty { modes = [KeyMode.defaultMode] }
+            ) ?? []
+        )
         dropEmptyNamedSpaces()
     }
 

--- a/Sources/KiwiDeskCore/Config/KeyModeNormalization.swift
+++ b/Sources/KiwiDeskCore/Config/KeyModeNormalization.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Decode-time normalization for untrusted mode lists (#31).
+///
+/// `[KeyMode]` enters from hand-editable JSON at exactly two
+/// sites — `GuiConfig.modes` (the `gui.json` sidecar) and
+/// `KeyModeOverride` (a profile's sparse `"modes"` override).
+/// A hand-edited file can carry duplicate mode names, an icon
+/// on the default mode, or empty names; every GUI entry point
+/// blocks these, so decode is the one untrusted boundary.
+///
+/// Both `init(from:)` contexts are pure `Codable` — the
+/// config-issue reporter is unreachable from there — so invalid
+/// input is normalized silently and predictably instead of
+/// rejected. Re-saving persists the normalized form; that is
+/// the migration (AGENTS.md §5, pre-release). ONE shared helper
+/// serves both sites so the rules cannot drift apart.
+extension KeyMode {
+    /// Normalizes a FULL mode list (`GuiConfig.modes`):
+    /// `sanitized`, plus the always-present default mode is
+    /// guaranteed to exist and sit first (the documented list
+    /// convention; the GUI and the structured loader assume a
+    /// default mode is available). Empty input therefore falls
+    /// back to `[KeyMode.defaultMode]` — the pre-#31 behavior.
+    public static func normalized(
+        full modes: [KeyMode]
+    ) -> [KeyMode] {
+        var result = sanitized(modes)
+        if let at = result.firstIndex(where: { $0.isDefault }) {
+            if at != 0 {
+                result.insert(result.remove(at: at), at: 0)
+            }
+        } else {
+            result.insert(.defaultMode, at: 0)
+        }
+        return result
+    }
+
+    /// Normalizes a SPARSE override list (`KeyModeOverride`):
+    /// `sanitized` only. A sparse list must NEVER gain a
+    /// default entry — a missing mode means "inherit the base"
+    /// (O4 soft), and order is preserved as stored.
+    public static func normalized(
+        sparse modes: [KeyMode]
+    ) -> [KeyMode] {
+        sanitized(modes)
+    }
+
+    /// The shared core, applied by both flavors:
+    /// - drops modes with an empty name (never addressable —
+    ///   the GUI cannot create, select, or delete them);
+    /// - drops later duplicates of a name (first occurrence
+    ///   wins; mode identity is the name, so a second entry
+    ///   would be unreachable and could shadow-edit the first);
+    /// - strips an icon from the default mode (its menu bar
+    ///   icon is fixed; this replaces #15's debug-only writer
+    ///   assert with unconditional normalization).
+    private static func sanitized(
+        _ modes: [KeyMode]
+    ) -> [KeyMode] {
+        var seen: Set<String> = []
+        var result: [KeyMode] = []
+        for var mode in modes {
+            guard !mode.name.isEmpty else { continue }
+            guard seen.insert(mode.name).inserted else {
+                continue
+            }
+            if mode.isDefault { mode.icon = nil }
+            result.append(mode)
+        }
+        return result
+    }
+}

--- a/Sources/KiwiDeskCore/Config/KeyModeNormalization.swift
+++ b/Sources/KiwiDeskCore/Config/KeyModeNormalization.swift
@@ -47,21 +47,28 @@ extension KeyMode {
     }
 
     /// The shared core, applied by both flavors:
-    /// - drops modes with an empty name (never addressable —
-    ///   the GUI cannot create, select, or delete them);
-    /// - drops later duplicates of a name (first occurrence
+    /// - drops modes with an empty or whitespace-only name
+    ///   (never addressable — the GUI trims names and cannot
+    ///   create, select, or delete blank ones);
+    /// - drops later duplicates of a name (FIRST occurrence
     ///   wins; mode identity is the name, so a second entry
-    ///   would be unreachable and could shadow-edit the first);
+    ///   would be unreachable and could shadow-edit the first.
+    ///   Deliberately unlike combos WITHIN a mode, which are
+    ///   last-wins at registration — see StructuredConfig);
     /// - strips an icon from the default mode (its menu bar
-    ///   icon is fixed; this replaces #15's debug-only writer
-    ///   assert with unconditional normalization).
+    ///   icon is fixed; this succeeds the #28 debug-only
+    ///   writer assert, gone with the generated-init.lua
+    ///   writer in #55, as unconditional normalization).
     private static func sanitized(
         _ modes: [KeyMode]
     ) -> [KeyMode] {
         var seen: Set<String> = []
         var result: [KeyMode] = []
         for var mode in modes {
-            guard !mode.name.isEmpty else { continue }
+            let name = mode.name.trimmingCharacters(
+                in: .whitespaces
+            )
+            guard !name.isEmpty else { continue }
             guard seen.insert(mode.name).inserted else {
                 continue
             }

--- a/Sources/KiwiDeskCore/Config/KeyModeOverride.swift
+++ b/Sources/KiwiDeskCore/Config/KeyModeOverride.swift
@@ -48,7 +48,10 @@ public struct KeyModeOverride: Sendable, Equatable {
         onto base: [KeyMode]
     ) -> [KeyMode] {
         guard !isEmpty else { return base }
-        // Index override modes by name for O(n) lookup.
+        // Index override modes by name for O(n) lookup. The
+        // assignment is last-wins, but duplicate names cannot
+        // reach here: decode sanitizes them FIRST-wins
+        // (`KeyMode.normalized`), and `diff` keys by name.
         var overrideByName: [String: KeyMode] = [:]
         for mode in modes {
             overrideByName[mode.name] = mode

--- a/Sources/KiwiDeskCore/Config/KeyModeOverride.swift
+++ b/Sources/KiwiDeskCore/Config/KeyModeOverride.swift
@@ -168,9 +168,15 @@ extension KeyModeOverride: Codable {
     /// Transparent to [KeyMode]: encode/decode as a bare JSON
     /// array, matching the `GuiConfig.modes` shape so both
     /// surfaces share one vocabulary (AGENTS.md §5).
+    /// Decoded input is untrusted (hand-edited profile JSON,
+    /// #31): duplicate names and a default-mode icon are
+    /// normalized away. Sparse flavor — a default entry is
+    /// never inserted (absence means inherit).
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        modes = try container.decode([KeyMode].self)
+        modes = KeyMode.normalized(
+            sparse: try container.decode([KeyMode].self)
+        )
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Tests/KiwiDeskCoreTests/ModeNormalizationTests.swift
+++ b/Tests/KiwiDeskCoreTests/ModeNormalizationTests.swift
@@ -106,6 +106,30 @@ struct ModeNormalizationTests {
         #expect(result[0].bindings.first?.combo == "alt+h")
     }
 
+    @Test("Whitespace-only names are dropped like empty ones")
+    func whitespaceNamesDropped() {
+        let result = KeyMode.normalized(full: [
+            mode("default"),
+            mode("  ", combo: "alt+z"),
+        ])
+        #expect(result.map(\.name) == ["default"])
+    }
+
+    @Test("Composite: later default dropped, first moved front")
+    func duplicateDefaultNotFirstComposite() {
+        // The review's worst case in one input: the FIRST
+        // default wins (keeps alt+h, later bindings are
+        // dropped with their entry), then moves to the front.
+        let result = KeyMode.normalized(full: [
+            mode("resize", combo: "alt+r"),
+            mode("default", combo: "alt+h"),
+            mode("default", icon: "gear", combo: "alt+z"),
+        ])
+        #expect(result.map(\.name) == ["default", "resize"])
+        #expect(result[0].bindings.map(\.combo) == ["alt+h"])
+        #expect(result[0].icon == nil)
+    }
+
     // MARK: - Sparse flavor (KeyModeOverride)
 
     @Test("Sparse: no default entry is inserted")

--- a/Tests/KiwiDeskCoreTests/ModeNormalizationTests.swift
+++ b/Tests/KiwiDeskCoreTests/ModeNormalizationTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Decode-time normalization of untrusted mode lists (#31):
+/// duplicate names, a default-mode icon, and empty names are
+/// cleaned predictably at the two JSON boundaries —
+/// `GuiConfig.modes` (full list) and `KeyModeOverride`
+/// (sparse override). One shared helper serves both.
+@Suite("Mode list normalization (#31)")
+struct ModeNormalizationTests {
+
+    private func mode(
+        _ name: String,
+        icon: String? = nil,
+        combo: String? = nil
+    ) -> KeyMode {
+        KeyMode(
+            name: name,
+            icon: icon,
+            bindings: combo.map {
+                [KeyBinding(combo: $0, lua: "-- noop")]
+            } ?? []
+        )
+    }
+
+    // MARK: - Shared core (via the full flavor)
+
+    @Test("Duplicate mode names: first occurrence wins")
+    func duplicateNamesFirstWins() {
+        let result = KeyMode.normalized(full: [
+            mode("default"),
+            mode("resize", combo: "alt+r"),
+            mode("resize", combo: "alt+x"),
+        ])
+        #expect(result.map(\.name) == ["default", "resize"])
+        #expect(result[1].bindings.first?.combo == "alt+r")
+    }
+
+    @Test("Second 'default' entry is dropped, its icon lost")
+    func duplicateDefaultDropped() {
+        let result = KeyMode.normalized(full: [
+            mode("default", combo: "alt+h"),
+            mode("default", icon: "gear"),
+        ])
+        #expect(result.count == 1)
+        #expect(result[0].isDefault)
+        #expect(result[0].icon == nil)
+        #expect(result[0].bindings.first?.combo == "alt+h")
+    }
+
+    @Test("Icon on the default mode is stripped")
+    func defaultIconStripped() {
+        let result = KeyMode.normalized(full: [
+            mode("default", icon: "gear"),
+            mode("resize", icon: "arrow.left.and.right"),
+        ])
+        #expect(result[0].icon == nil)
+        // Non-default modes keep their icon untouched.
+        #expect(result[1].icon == "arrow.left.and.right")
+    }
+
+    @Test("Empty-named modes are dropped")
+    func emptyNamesDropped() {
+        let result = KeyMode.normalized(full: [
+            mode("default"),
+            mode("", combo: "alt+z"),
+        ])
+        #expect(result.map(\.name) == ["default"])
+    }
+
+    @Test("Valid input passes through untouched")
+    func validInputUntouched() {
+        let modes = [
+            mode("default", combo: "alt+h"),
+            mode("resize", icon: "📐", combo: "alt+r"),
+        ]
+        #expect(KeyMode.normalized(full: modes) == modes)
+        #expect(KeyMode.normalized(sparse: modes) == modes)
+    }
+
+    // MARK: - Full flavor (GuiConfig.modes)
+
+    @Test("Empty list falls back to [KeyMode.defaultMode]")
+    func emptyFallsBackToDefault() {
+        let result = KeyMode.normalized(full: [])
+        #expect(result == [KeyMode.defaultMode])
+    }
+
+    @Test("Missing default mode is inserted first")
+    func missingDefaultInserted() {
+        let result = KeyMode.normalized(full: [
+            mode("resize", combo: "alt+r")
+        ])
+        #expect(result.map(\.name) == ["default", "resize"])
+    }
+
+    @Test("A default mode not first is moved to the front")
+    func defaultMovedToFront() {
+        let result = KeyMode.normalized(full: [
+            mode("resize", combo: "alt+r"),
+            mode("default", combo: "alt+h"),
+        ])
+        #expect(result.map(\.name) == ["default", "resize"])
+        #expect(result[0].bindings.first?.combo == "alt+h")
+    }
+
+    // MARK: - Sparse flavor (KeyModeOverride)
+
+    @Test("Sparse: no default entry is inserted")
+    func sparseInsertsNoDefault() {
+        let result = KeyMode.normalized(sparse: [
+            mode("resize", combo: "alt+r")
+        ])
+        #expect(result.map(\.name) == ["resize"])
+        #expect(KeyMode.normalized(sparse: []).isEmpty)
+    }
+
+    @Test("Sparse: duplicates dropped, default icon stripped")
+    func sparseSanitizes() {
+        let result = KeyMode.normalized(sparse: [
+            mode("resize", combo: "alt+r"),
+            mode("default", icon: "gear"),
+            mode("resize", combo: "alt+x"),
+        ])
+        // Order preserved as stored — never reordered.
+        #expect(result.map(\.name) == ["resize", "default"])
+        #expect(result[0].bindings.first?.combo == "alt+r")
+        #expect(result[1].icon == nil)
+    }
+}
+
+/// The normalization applied at the real decode boundaries:
+/// hand-edited JSON through `GuiConfig` and `KeyModeOverride`.
+@Suite("Mode normalization at the decode boundaries (#31)")
+struct ModeNormalizationDecodeTests {
+
+    @Test("GuiConfig decode normalizes a hand-edited sidecar")
+    func guiConfigDecodeNormalizes() throws {
+        let json = """
+            {"modes":[
+              {"name":"resize","bindings":[]},
+              {"name":"default","icon":"gear","bindings":[]},
+              {"name":"resize","bindings":[]},
+              {"name":"","bindings":[]}
+            ]}
+            """
+        let config = try JSONDecoder().decode(
+            GuiConfig.self,
+            from: Data(json.utf8)
+        )
+        #expect(
+            config.modes.map(\.name) == ["default", "resize"]
+        )
+        #expect(config.modes[0].icon == nil)
+    }
+
+    @Test("GuiConfig decode: empty modes fall back to default")
+    func guiConfigEmptyModesFallBack() throws {
+        for json in ["{}", "{\"modes\":[]}"] {
+            let config = try JSONDecoder().decode(
+                GuiConfig.self,
+                from: Data(json.utf8)
+            )
+            #expect(config.modes == [KeyMode.defaultMode])
+        }
+    }
+
+    @Test("GuiConfig round-trip stays normalized")
+    func guiConfigRoundTripStaysNormalized() throws {
+        let json = """
+            {"modes":[
+              {"name":"default","icon":"gear","bindings":[]},
+              {"name":"default","bindings":[]}
+            ]}
+            """
+        let first = try JSONDecoder().decode(
+            GuiConfig.self,
+            from: Data(json.utf8)
+        )
+        let data = try JSONEncoder().encode(first)
+        let second = try JSONDecoder().decode(
+            GuiConfig.self,
+            from: data
+        )
+        #expect(second.modes == first.modes)
+        #expect(second.modes == [KeyMode.defaultMode])
+    }
+
+    @Test("KeyModeOverride decode normalizes, stays sparse")
+    func overrideDecodeNormalizes() throws {
+        let json = """
+            [
+              {"name":"resize","bindings":[]},
+              {"name":"resize","icon":"x","bindings":[]},
+              {"name":"default","icon":"gear","bindings":[]}
+            ]
+            """
+        let over = try JSONDecoder().decode(
+            KeyModeOverride.self,
+            from: Data(json.utf8)
+        )
+        #expect(
+            over.modes.map(\.name) == ["resize", "default"]
+        )
+        #expect(over.modes[1].icon == nil)
+        // Resolving onto a base never gives default an icon.
+        let resolved = over.resolved(
+            onto: [KeyMode.defaultMode]
+        )
+        let def = resolved.first { $0.isDefault }
+        #expect(def?.icon == nil)
+    }
+}

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1604,6 +1604,13 @@ The override is **sparse and soft by design**:
   The same applies to a base mode's menu bar icon — a profile
   can *change* it, but clearing it just reverts to the base
   icon.
+- A hand-edited `"modes"` list (in `gui.json` or a profile) is
+  normalized on load: empty-named modes are dropped, a
+  duplicated mode name keeps only its first entry, and an icon
+  on the `default` mode is removed (its menu bar indicator is
+  fixed). In `gui.json` the `default` mode additionally always
+  exists and sits first; a profile's sparse override never
+  gains one (a mode it omits is inherited).
 - Keybindings live in ONE home: the structured config (gui.json +
   profiles) when GUI-managed, or your `init.lua` otherwise —
   never merged. Hand-written binds that evade the managed-

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -121,6 +121,13 @@ Each field:
     - **`kind`**: classification ("navigation", "application", or "custom").
     - **`label`**: display name for the row.
 
+If you hand-edit the `modes` list, it is normalized on load:
+modes with an empty name are dropped, a duplicated mode name
+keeps only its first entry, the `default` mode always exists and
+sits first, and an `icon` on the default mode is removed (its
+menu bar indicator is fixed). The cleanup is silent; the next
+Save persists the normalized list.
+
 To reset the app to what your `init.lua` declares, delete `gui.json`.
 Treat it like `init.lua` — do not import it from an untrusted source,
 since custom Lua in keybindings runs on every reload.


### PR DESCRIPTION
## Description

Hand-edited `gui.json` / profile JSON could carry duplicate
mode names, a second `default` entry, an icon on the default
mode, or blank names — all reaching downstream intact (#31; the
old #28 guard was a debug-only writer assert, gone with the
generated-init.lua writer in #55).

Decode is the one untrusted boundary (every GUI entry point
already blocks these states), so both JSON entry sites now
normalize there, via ONE shared core:

- `KeyMode.normalized(full:)` — `GuiConfig.modes`: drops
  blank/whitespace names, first-occurrence-wins dedupe, strips
  the default mode's icon, and guarantees exactly one default
  at index 0 (inserting `KeyMode.defaultMode` when absent).
  Empty input keeps the pre-#31 `[KeyMode.defaultMode]`
  fallback.
- `KeyMode.normalized(sparse:)` — `KeyModeOverride`: sanitize
  only. A sparse override must never gain a default entry
  (absent = inherit) and is never reordered.

Normalization is silent and predictable — decode runs in pure
`Codable`, out of the ConfigIssues reporter's reach; re-saving
persists the normalized form (pre-release: that IS the
migration). 16 new tests; docs in `user-guide.md` +
`lua-reference.md` where hand-editing is discussed.

## Related Issue(s)

Closes #31.  Backlog: #71.

## Checklist

- [ ] I understand what this change does and have run it in
  the app to confirm it works as intended (manual pass: hand-
  edit gui.json with a duplicate mode and reload)
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
  (812 tests)
- [x] Release build passes: `swift build -c release`
- [x] PR is focused

## How I verified

Full local gate. Tests pin: first-wins dedupe (incl. the
composite duplicate-default-with-bindings worst case),
default-icon strip on both flavors, whitespace-name drop,
default inserted/moved-to-front (full only), sparse never
gains a default / never reorders, decode-boundary behavior for
both files, and round-trip fixpoint. Also pinned: a stripped
override default icon cannot resurface through
`resolved(onto:)`.

## Notes for Reviewer

Two-agent review clean of majors; fixes from the round are the
second commit. **One follow-up needs your sign-off before I
file it** (per our publishing rule): surface a "file was
normalized" ConfigIssue from a post-decode seam
(`profileConfigIssues()` / `configLoadIssues` — no Codable
plumbing). The ConfigIssues charter comment now marks it as a
candidate, not a promise. Say the word and I'll open the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)