### PR TITLE
feat(commands): keyboard resize for the focused floating window

### DIFF
--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
@@ -17,6 +17,19 @@ extension KiwiCore {
         guard let space = activeSpace else {
             return .fail("no active space")
         }
+        // A floating focused window resizes ITSELF, in every
+        // layout mode — it does not participate in the layout,
+        // so the ratio paths below (and their unknown-focus
+        // fallbacks) never see a floating focus.
+        if let focused = space.focused,
+            state.windows[focused]?.isFloating == true
+        {
+            return resizeFloating(
+                focused,
+                axis: axis,
+                delta: delta
+            )
+        }
         let span =
             axis == "x"
             ? Double(NSScreen.main?.visibleFrame.width ?? 1920)

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
@@ -59,7 +59,11 @@ extension KiwiCore {
     }
 
     /// Per-axis BSP resize (#56): "x" moves the side-by-side
-    /// splits, "y" the stacked splits — independent knobs.
+    /// splits, "y" the stacked splits — independent knobs. The
+    /// delta's sign follows the FOCUSED window (#122): a slot
+    /// in the second (right/bottom) region grows when the
+    /// shared ratio DROPS, so +delta always grows the focused
+    /// region — mouse-path parity (`MouseResize.translate`).
     private func resizeBsp(
         axis: String,
         delta: Double,
@@ -67,20 +71,48 @@ extension KiwiCore {
         space: Space
     ) -> CommandResponse {
         let bsp = tiler.settings.resolvedBsp(for: space.id)
+        let signed =
+            bspFocusSign(axis: axis, space: space)
+            * delta
         if axis == "x" {
-            let value = bsp.splitRatioH + delta / span
+            let value = bsp.splitRatioH + signed / span
             tiler.settings.setSplitRatioH(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )
         } else {
-            let value = bsp.splitRatioV + delta / span
+            let value = bsp.splitRatioV + signed / span
             tiler.settings.setSplitRatioV(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )
         }
         return .ok()
+    }
+
+    /// Which way the shared BSP ratio must move so "grow"
+    /// grows the FOCUSED window: +1 when its calculated slot
+    /// sits in the first (left/top) half of the screen, -1 in
+    /// the second — the same midpoint rule the mouse path
+    /// infers a drag's side from. Unknown focus (none, or
+    /// floating — no slot) keeps +1, the first-region
+    /// direction (the pre-#122 behavior).
+    private func bspFocusSign(
+        axis: String,
+        space: Space
+    ) -> Double {
+        guard let focused = space.focused,
+            let slot = tiler.calculatedFrames(
+                state: state
+            )[focused],
+            let screen = NSScreen.main
+                ?? NSScreen.screens.first
+        else { return 1 }
+        let bounds = GeometryUtils.axVisibleFrame(of: screen)
+        if axis == "x" {
+            return slot.midX <= bounds.midX ? 1 : -1
+        }
+        return slot.midY <= bounds.midY ? 1 : -1
     }
 
     /// Focus-aware stack resize (#67). "x" moves the

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
@@ -91,12 +91,13 @@ extension KiwiCore {
     }
 
     /// Which way the shared BSP ratio must move so "grow"
-    /// grows the FOCUSED window: +1 when its calculated slot
-    /// sits in the first (left/top) half of the screen, -1 in
-    /// the second — the same midpoint rule the mouse path
-    /// infers a drag's side from. Unknown focus (none, or
-    /// floating — no slot) keeps +1, the first-region
-    /// direction (the pre-#122 behavior).
+    /// grows the FOCUSED window — the mouse path's side rule,
+    /// via the shared authority (`MouseResize.bspSide`).
+    /// Unknown focus (none, or floating — no slot) keeps +1,
+    /// the first-region direction (the pre-#122 behavior).
+    /// Assumes `space` IS the active space: the slot lookup
+    /// resolves the active space's frames only, so any other
+    /// space silently gets the +1 fallback.
     private func bspFocusSign(
         axis: String,
         space: Space
@@ -108,11 +109,15 @@ extension KiwiCore {
             let screen = NSScreen.main
                 ?? NSScreen.screens.first
         else { return 1 }
-        let bounds = GeometryUtils.axVisibleFrame(of: screen)
-        if axis == "x" {
-            return slot.midX <= bounds.midX ? 1 : -1
-        }
-        return slot.midY <= bounds.midY ? 1 : -1
+        return Double(
+            MouseResize.bspSide(
+                slot: slot,
+                bounds: GeometryUtils.axVisibleFrame(
+                    of: screen
+                ),
+                horizontal: axis == "x"
+            )
+        )
     }
 
     /// Focus-aware stack resize (#67). "x" moves the

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeFloating.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeFloating.swift
@@ -1,4 +1,4 @@
-import AppKit
+import CoreGraphics
 import Foundation
 
 /// The floating half of the `resize` command, split out of
@@ -7,11 +7,12 @@ import Foundation
 extension KiwiCore {
     /// Direct resize of a floating focused window: "x" widens
     /// by the delta, "y" heightens (negative shrinks), origin
-    /// kept, floored at `min_window_size` (never below 1 pt,
-    /// `FloatResize`). Applies through the tiler's frame
-    /// pipeline — animated per `animations.on_window_resize`,
-    /// echo-tracked either way — and skips the layout retile:
-    /// no tiled window moved.
+    /// kept, floored at `min_window_size` — capped at the
+    /// current size, so a sub-floor window never grows on a
+    /// shrink (`FloatResize`). Applies through the tiler's
+    /// shared frame policy (`applyFrame`) — animated per
+    /// `animations.on_window_resize`, echo-tracked either way —
+    /// and skips the layout retile: no tiled window moved.
     func resizeFloating(
         _ id: WindowID,
         axis: String,
@@ -26,19 +27,12 @@ extension KiwiCore {
             delta: delta,
             minSize: tiler.settings.minWindowSize
         )
-        if tiler.settings.animations.onWindowResize,
-            let screen = NSScreen.main
-                ?? NSScreen.screens.first
-        {
-            tiler.animation.animate(
-                window: id,
-                on: screen,
-                from: window.frame,
-                to: target
-            )
-        } else {
-            tiler.setFrame(id, target)
-        }
+        tiler.applyFrame(
+            id,
+            from: window.frame,
+            to: target,
+            animated: tiler.settings.animations.onWindowResize
+        )
         return .ok()
     }
 }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeFloating.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeFloating.swift
@@ -1,0 +1,44 @@
+import AppKit
+import Foundation
+
+/// The floating half of the `resize` command, split out of
+/// `KiwiCore+Resize` for file size: a floating focused window
+/// resizes ITSELF — the per-layout ratio paths never see it.
+extension KiwiCore {
+    /// Direct resize of a floating focused window: "x" widens
+    /// by the delta, "y" heightens (negative shrinks), origin
+    /// kept, floored at `min_window_size` (never below 1 pt,
+    /// `FloatResize`). Applies through the tiler's frame
+    /// pipeline — animated per `animations.on_window_resize`,
+    /// echo-tracked either way — and skips the layout retile:
+    /// no tiled window moved.
+    func resizeFloating(
+        _ id: WindowID,
+        axis: String,
+        delta: Double
+    ) -> CommandResponse {
+        guard let window = state.windows[id] else {
+            return .fail("unknown window")
+        }
+        let target = FloatResize.resized(
+            window.frame,
+            horizontal: axis == "x",
+            delta: delta,
+            minSize: tiler.settings.minWindowSize
+        )
+        if tiler.settings.animations.onWindowResize,
+            let screen = NSScreen.main
+                ?? NSScreen.screens.first
+        {
+            tiler.animation.animate(
+                window: id,
+                on: screen,
+                from: window.frame,
+                to: target
+            )
+        } else {
+            tiler.setFrame(id, target)
+        }
+        return .ok()
+    }
+}

--- a/Sources/KiwiDeskCore/Tiling/FloatResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/FloatResize.swift
@@ -17,7 +17,11 @@ public enum FloatResize {
     /// The frame after growing along one axis by `delta`
     /// (negative shrinks), anchored at its origin — the
     /// top-left corner stays put, like a mouse drag of the
-    /// bottom/right edge.
+    /// bottom/right edge. The floor never exceeds the CURRENT
+    /// size: a window already below `min_window_size` (floats
+    /// are never layout-clamped, so that state is reachable)
+    /// stays put on a shrink instead of jumping UP to the
+    /// floor, and a grow grows by exactly `delta` (review).
     public static func resized(
         _ frame: CGRect,
         horizontal: Bool,
@@ -28,12 +32,12 @@ public enum FloatResize {
         if horizontal {
             result.size.width = max(
                 frame.width + delta,
-                shrinkFloor(minSize: minSize)
+                min(shrinkFloor(minSize: minSize), frame.width)
             )
         } else {
             result.size.height = max(
                 frame.height + delta,
-                shrinkFloor(minSize: minSize)
+                min(shrinkFloor(minSize: minSize), frame.height)
             )
         }
         return result

--- a/Sources/KiwiDeskCore/Tiling/FloatResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/FloatResize.swift
@@ -6,8 +6,10 @@ import CoreGraphics
 /// the layout it does not participate in.
 public enum FloatResize {
     /// The size a shrink stops at: `min_window_size` when set,
-    /// never below 1 pt — AppKit rejects zero/negative frames,
-    /// and a vanished window could not be grown back.
+    /// never below 1 pt — AppKit rejects zero/negative frames.
+    /// `resized` caps this at the CURRENT size, so the floor
+    /// never *lifts* a frame; growing back works from any size
+    /// regardless.
     public static func shrinkFloor(
         minSize: CGFloat
     ) -> CGFloat {

--- a/Sources/KiwiDeskCore/Tiling/FloatResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/FloatResize.swift
@@ -1,0 +1,41 @@
+import CoreGraphics
+
+/// Pure frame math for keyboard-resizing a FLOATING window:
+/// `resize` on a floating focused window grows or shrinks the
+/// window itself along the requested axis instead of nudging
+/// the layout it does not participate in.
+public enum FloatResize {
+    /// The size a shrink stops at: `min_window_size` when set,
+    /// never below 1 pt — AppKit rejects zero/negative frames,
+    /// and a vanished window could not be grown back.
+    public static func shrinkFloor(
+        minSize: CGFloat
+    ) -> CGFloat {
+        max(minSize, 1)
+    }
+
+    /// The frame after growing along one axis by `delta`
+    /// (negative shrinks), anchored at its origin — the
+    /// top-left corner stays put, like a mouse drag of the
+    /// bottom/right edge.
+    public static func resized(
+        _ frame: CGRect,
+        horizontal: Bool,
+        delta: CGFloat,
+        minSize: CGFloat
+    ) -> CGRect {
+        var result = frame
+        if horizontal {
+            result.size.width = max(
+                frame.width + delta,
+                shrinkFloor(minSize: minSize)
+            )
+        } else {
+            result.size.height = max(
+                frame.height + delta,
+                shrinkFloor(minSize: minSize)
+            )
+        }
+        return result
+    }
+}

--- a/Sources/KiwiDeskCore/Tiling/MouseResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/MouseResize.swift
@@ -116,6 +116,23 @@ public enum MouseResize {
             && !inner.contains(point)
     }
 
+    /// The side of the first BSP split a slot sits on, as the
+    /// direction the shared ratio must move for that slot's
+    /// region to GROW: +1 first (left/top), -1 second. The
+    /// midpoint rule is a heuristic (deep slots under extreme
+    /// ratios can misread), so the mouse and keyboard paths
+    /// (#122) share this one authority — never re-derive the
+    /// comparison.
+    public static func bspSide(
+        slot: CGRect,
+        bounds: CGRect,
+        horizontal: Bool
+    ) -> CGFloat {
+        horizontal
+            ? (slot.midX <= bounds.midX ? 1 : -1)
+            : (slot.midY <= bounds.midY ? 1 : -1)
+    }
+
     /// The layout change a resize gesture asks for, or nil
     /// when the layout has no parameter for that axis (the
     /// window snaps back).
@@ -137,13 +154,19 @@ public enum MouseResize {
         switch mode {
         case .bsp:
             if abs(dw) >= abs(dh), abs(dw) > threshold {
-                let side: CGFloat =
-                    slot.midX <= bounds.midX ? 1 : -1
+                let side = bspSide(
+                    slot: slot,
+                    bounds: bounds,
+                    horizontal: true
+                )
                 return .bspRatioH(side * dw / bounds.width)
             }
             if abs(dh) > threshold {
-                let side: CGFloat =
-                    slot.midY <= bounds.midY ? 1 : -1
+                let side = bspSide(
+                    slot: slot,
+                    bounds: bounds,
+                    horizontal: false
+                )
                 return .bspRatioV(side * dh / bounds.height)
             }
             return nil

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
@@ -130,24 +130,51 @@ public final class TilingEngine {
                 animation.cancel(window: id)
                 continue
             }
-            if animated {
-                animation.animate(
-                    window: id,
-                    on: screen,
-                    from: current,
-                    to: target,
-                    isNewWindow: id == newlyCreatedWindow
-                )
-            } else {
-                animation.cancel(window: id)
-                setFrame(id, target)
-            }
+            applyFrame(
+                id,
+                from: current,
+                to: target,
+                animated: animated,
+                isNewWindow: id == newlyCreatedWindow
+            )
         }
         stashInactive(
             state: state,
             fallback: screen,
             force: force
         )
+    }
+
+    /// Applies one frame through the shared animate-or-instant
+    /// policy: animated when asked (and a screen exists),
+    /// otherwise an instant, echo-tracked set with any
+    /// in-flight animation cancelled. The single authority for
+    /// this policy — `retile` and the floating keyboard resize
+    /// both route here; never copy the branch (a copy already
+    /// drifted once, dropping the cancel). The screen pick is
+    /// the pre-existing single-screen ceiling (plan item 8).
+    public func applyFrame(
+        _ id: WindowID,
+        from current: CGRect,
+        to target: CGRect,
+        animated: Bool,
+        isNewWindow: Bool = false
+    ) {
+        if animated,
+            let screen = NSScreen.main
+                ?? NSScreen.screens.first
+        {
+            animation.animate(
+                window: id,
+                on: screen,
+                from: current,
+                to: target,
+                isNewWindow: isNewWindow
+            )
+        } else {
+            animation.cancel(window: id)
+            setFrame(id, target)
+        }
     }
 
     // MARK: - Hiding inactive virtual spaces

--- a/Tests/KiwiDeskCoreTests/BspFocusResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/BspFocusResizeTests.swift
@@ -1,0 +1,130 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Focus-aware BSP resize direction (#122): `resize` flips the
+/// delta's sign from the focused window's calculated slot, so
+/// "grow" grows the focused window's region — the keyboard path
+/// finally matches the mouse path's side inference.
+@Suite("BSP focus-aware resize (#122)", .serialized)
+@MainActor
+struct BspFocusResizeTests {
+    private func makeCore() -> KiwiCore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "kiwidesk-tests-\(UUID().uuidString)"
+            )
+        return KiwiCore(configDirectory: dir)
+    }
+
+    /// BSP space under the ALTERNATING strategy, so the split
+    /// orientation per depth is fixed regardless of the host
+    /// screen's shape. BSP's `.afterFocused` placement keeps
+    /// creation order: [1, 2] — w1 the left region, w2 the
+    /// right; a third window splits the right region
+    /// vertically — w2 top, w3 bottom. Creation focuses the
+    /// last window, so tests set focus explicitly.
+    private func bspSpace(_ core: KiwiCore, count: Int = 2) {
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("bsp")]
+        )
+        core.execute(
+            "bsp.set_strategy",
+            args: [.string("alternating")]
+        )
+        for index in 1...count {
+            core.state.apply(
+                .windowCreated(
+                    ManagedWindow(
+                        id: WindowID(UInt32(index)),
+                        pid: 1,
+                        appName: "A"
+                    )
+                )
+            )
+        }
+    }
+
+    @Test("x with the left window focused raises the H ratio")
+    func leftFocusGrowsLeft() {
+        let core = makeCore()
+        bspSpace(core)
+        core.state.apply(.windowFocused(WindowID(1)))
+        let before = core.tiler.settings.bsp.splitRatioH
+        core.execute("resize", args: [.string("x"), .number(200)])
+        #expect(core.tiler.settings.bsp.splitRatioH > before)
+    }
+
+    @Test("x with the right window focused lowers the H ratio")
+    func rightFocusGrowsRight() {
+        let core = makeCore()
+        bspSpace(core)
+        core.state.apply(.windowFocused(WindowID(2)))
+        let before = core.tiler.settings.bsp.splitRatioH
+        core.execute("resize", args: [.string("x"), .number(200)])
+        // +delta grows the FOCUSED window: the right region
+        // widens, so the shared H ratio drops (#122).
+        #expect(core.tiler.settings.bsp.splitRatioH < before)
+    }
+
+    @Test("y with the top window focused raises the V ratio")
+    func topFocusGrowsTop() {
+        let core = makeCore()
+        bspSpace(core, count: 3)
+        // [1, 2, 3]: w1 left; the right region stacks w2 over
+        // w3 (alternating → vertical at depth 1).
+        core.state.apply(.windowFocused(WindowID(2)))
+        let before = core.tiler.settings.bsp.splitRatioV
+        core.execute("resize", args: [.string("y"), .number(200)])
+        #expect(core.tiler.settings.bsp.splitRatioV > before)
+    }
+
+    @Test("y with the bottom window focused lowers the V ratio")
+    func bottomFocusGrowsBottom() {
+        let core = makeCore()
+        bspSpace(core, count: 3)
+        core.state.apply(.windowFocused(WindowID(3)))
+        let before = core.tiler.settings.bsp.splitRatioV
+        core.execute("resize", args: [.string("y"), .number(200)])
+        #expect(core.tiler.settings.bsp.splitRatioV < before)
+    }
+
+    @Test("x with a floating focused window keeps first-region")
+    func floatingFocusKeepsDirection() {
+        let core = makeCore()
+        bspSpace(core)
+        // The focused (right) window floats out of the tiled
+        // set: no slot to infer a side from, so the pre-#122
+        // first-region direction must survive — even though a
+        // tiled w2 would have flipped the sign.
+        core.state.apply(.windowFocused(WindowID(2)))
+        core.state.setFloating(WindowID(2), true)
+        let before = core.tiler.settings.bsp.splitRatioH
+        core.execute("resize", args: [.string("x"), .number(200)])
+        #expect(core.tiler.settings.bsp.splitRatioH > before)
+    }
+
+    @Test("right focus writes the space's own override (#17)")
+    func focusSignHitsOverride() {
+        let core = makeCore()
+        bspSpace(core)
+        core.execute(
+            "bsp.set_ratio_h_override",
+            args: [.string("1"), .number(0.5)]
+        )
+        core.state.apply(.windowFocused(WindowID(2)))
+        let globalBefore = core.tiler.settings.bsp.splitRatioH
+        core.execute("resize", args: [.string("x"), .number(200)])
+        let over =
+            core.tiler.settings.bsp.override[SpaceID("1")]
+        // The flipped sign still lands on the override, and
+        // the shared global stays put.
+        #expect((over?.splitRatioH ?? 1) < 0.5)
+        #expect(
+            core.tiler.settings.bsp.splitRatioH == globalBefore
+        )
+    }
+}

--- a/Tests/KiwiDeskCoreTests/BspFocusResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/BspFocusResizeTests.swift
@@ -92,19 +92,21 @@ struct BspFocusResizeTests {
         #expect(core.tiler.settings.bsp.splitRatioV < before)
     }
 
-    @Test("x with a floating focused window keeps first-region")
-    func floatingFocusKeepsDirection() {
+    @Test("x with a floating focused window resizes the float")
+    func floatingFocusResizesTheFloat() {
         let core = makeCore()
         bspSpace(core)
-        // The focused (right) window floats out of the tiled
-        // set: no slot to infer a side from, so the pre-#122
-        // first-region direction must survive — even though a
-        // tiled w2 would have flipped the sign.
+        // A floating focused window resizes ITSELF — the
+        // shared ratio must not move, in either direction.
         core.state.apply(.windowFocused(WindowID(2)))
         core.state.setFloating(WindowID(2), true)
         let before = core.tiler.settings.bsp.splitRatioH
-        core.execute("resize", args: [.string("x"), .number(200)])
-        #expect(core.tiler.settings.bsp.splitRatioH > before)
+        let response = core.execute(
+            "resize",
+            args: [.string("x"), .number(200)]
+        )
+        #expect(response.isSuccess)
+        #expect(core.tiler.settings.bsp.splitRatioH == before)
     }
 
     @Test("right focus writes the space's own override (#17)")

--- a/Tests/KiwiDeskCoreTests/FloatResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatResizeTests.swift
@@ -1,0 +1,54 @@
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Pure frame math for the floating keyboard resize.
+@Suite("Float resize math")
+struct FloatResizeTests {
+    private let base = CGRect(
+        x: 40,
+        y: 60,
+        width: 500,
+        height: 400
+    )
+
+    @Test("x grows the width; origin and height keep")
+    func growsWidth() {
+        let result = FloatResize.resized(
+            base,
+            horizontal: true,
+            delta: 150,
+            minSize: 300
+        )
+        #expect(result.origin == base.origin)
+        #expect(result.width == 650)
+        #expect(result.height == 400)
+    }
+
+    @Test("y shrinks the height down to min_window_size")
+    func shrinkClampsAtMinSize() {
+        let result = FloatResize.resized(
+            base,
+            horizontal: false,
+            delta: -10_000,
+            minSize: 300
+        )
+        #expect(result.height == 300)
+        #expect(result.width == 500)
+    }
+
+    @Test("the floor never drops below 1 pt")
+    func floorNeverBelowOnePoint() {
+        // min_window_size accepts 0 today; a 0-size frame
+        // would be rejected by AppKit and could not be grown
+        // back, so the floor holds at 1 pt regardless.
+        let result = FloatResize.resized(
+            base,
+            horizontal: true,
+            delta: -10_000,
+            minSize: 0
+        )
+        #expect(result.width == 1)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/FloatResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatResizeTests.swift
@@ -67,9 +67,9 @@ struct FloatResizeTests {
 
     @Test("the floor never drops below 1 pt")
     func floorNeverBelowOnePoint() {
-        // min_window_size accepts 0 today; a 0-size frame
-        // would be rejected by AppKit and could not be grown
-        // back, so the floor holds at 1 pt regardless.
+        // min_window_size accepts 0 today; AppKit rejects
+        // 0-size frames, so a shrink from a normal size stops
+        // at 1 pt even with no configured minimum.
         let result = FloatResize.resized(
             base,
             horizontal: true,

--- a/Tests/KiwiDeskCoreTests/FloatResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatResizeTests.swift
@@ -38,6 +38,33 @@ struct FloatResizeTests {
         #expect(result.width == 500)
     }
 
+    @Test("a sub-floor window never grows on a shrink")
+    func subFloorShrinkStaysPut() {
+        // Floats are never layout-clamped, so a window below
+        // min_window_size is reachable; a shrink must stop
+        // where it is, not jump UP to the floor.
+        let small = CGRect(x: 0, y: 0, width: 100, height: 90)
+        let result = FloatResize.resized(
+            small,
+            horizontal: true,
+            delta: -10,
+            minSize: 300
+        )
+        #expect(result.width == 100)
+    }
+
+    @Test("a sub-floor window grows by exactly the delta")
+    func subFloorGrowGrowsExactly() {
+        let small = CGRect(x: 0, y: 0, width: 100, height: 90)
+        let result = FloatResize.resized(
+            small,
+            horizontal: false,
+            delta: 50,
+            minSize: 300
+        )
+        #expect(result.height == 140)
+    }
+
     @Test("the floor never drops below 1 pt")
     func floorNeverBelowOnePoint() {
         // min_window_size accepts 0 today; a 0-size frame

--- a/Tests/KiwiDeskCoreTests/FloatingResizeCommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatingResizeCommandTests.swift
@@ -53,6 +53,9 @@ struct FloatingResizeCommandTests {
         )
         core.state.apply(.windowFocused(WindowID(2)))
         core.state.setFloating(WindowID(2), true)
+        // Pin the routing: the animated branch must be taken
+        // even if the setting's default ever flips.
+        core.tiler.settings.animations.onWindowResize = true
         core.tiler.animation.isEnabled = false
         core.tiler.animation.apply = { id, frame, _ in
             applied(id, frame)
@@ -109,6 +112,22 @@ struct FloatingResizeCommandTests {
         )
         #expect(response.isSuccess)
         #expect(frames[WindowID(2)]?.height == 650)
+    }
+
+    @Test("animations off routes through the instant path")
+    func instantPathSucceeds() {
+        let core = makeCore()
+        var frames: [WindowID: CGRect] = [:]
+        floatingSetup(core, mode: "bsp") { frames[$0] = $1 }
+        core.tiler.settings.animations.onWindowResize = false
+        let response = core.execute(
+            "resize",
+            args: [.string("x"), .number(200)]
+        )
+        #expect(response.isSuccess)
+        // The instant path (cancel + setFrame) bypasses the
+        // animate hook entirely.
+        #expect(frames.isEmpty)
     }
 
     @Test("a tiled focus in the floating layout still fails")

--- a/Tests/KiwiDeskCoreTests/FloatingResizeCommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatingResizeCommandTests.swift
@@ -1,0 +1,139 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// `resize` on a floating focused window resizes the window
+/// itself — in every layout mode, including the floating
+/// layout, where tiled resize replies "not supported".
+@Suite("Floating keyboard resize", .serialized)
+@MainActor
+struct FloatingResizeCommandTests {
+    private func makeCore() -> KiwiCore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "kiwidesk-tests-\(UUID().uuidString)"
+            )
+        return KiwiCore(configDirectory: dir)
+    }
+
+    /// Two windows in the given mode; w2 focused, floating,
+    /// with a known frame. The animation engine is disabled so
+    /// `animate` applies the target synchronously through the
+    /// observable `apply` hook (the MoveToSpaceTests pattern).
+    private func floatingSetup(
+        _ core: KiwiCore,
+        mode: String,
+        applied:
+            @escaping @MainActor (
+                WindowID, CGRect
+            ) -> Void
+    ) {
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string(mode)]
+        )
+        for index in 1...2 {
+            core.state.apply(
+                .windowCreated(
+                    ManagedWindow(
+                        id: WindowID(UInt32(index)),
+                        pid: 1,
+                        appName: "A"
+                    )
+                )
+            )
+        }
+        core.state.apply(
+            .windowResized(
+                WindowID(2),
+                CGRect(x: 100, y: 100, width: 600, height: 500)
+            )
+        )
+        core.state.apply(.windowFocused(WindowID(2)))
+        core.state.setFloating(WindowID(2), true)
+        core.tiler.animation.isEnabled = false
+        core.tiler.animation.apply = { id, frame, _ in
+            applied(id, frame)
+        }
+    }
+
+    @Test("x widens the floating window; layout untouched")
+    func widensTheFloat() {
+        let core = makeCore()
+        var frames: [WindowID: CGRect] = [:]
+        floatingSetup(core, mode: "bsp") { frames[$0] = $1 }
+        let ratioBefore = core.tiler.settings.bsp.splitRatioH
+        let response = core.execute(
+            "resize",
+            args: [.string("x"), .number(200)]
+        )
+        #expect(response.isSuccess)
+        #expect(frames[WindowID(2)]?.width == 800)
+        #expect(frames[WindowID(2)]?.height == 500)
+        #expect(frames[WindowID(2)]?.origin.x == 100)
+        #expect(
+            core.tiler.settings.bsp.splitRatioH == ratioBefore
+        )
+    }
+
+    @Test("y shrink stops at min_window_size")
+    func shrinkFloorsAtMinSize() {
+        let core = makeCore()
+        var frames: [WindowID: CGRect] = [:]
+        floatingSetup(core, mode: "stack") { frames[$0] = $1 }
+        core.execute(
+            "set_min_window_size",
+            args: [.number(300)]
+        )
+        let response = core.execute(
+            "resize",
+            args: [.string("y"), .number(-10_000)]
+        )
+        #expect(response.isSuccess)
+        #expect(frames[WindowID(2)]?.height == 300)
+        #expect(frames[WindowID(2)]?.width == 600)
+    }
+
+    @Test("works in the floating layout too")
+    func worksInFloatingLayout() {
+        let core = makeCore()
+        var frames: [WindowID: CGRect] = [:]
+        floatingSetup(core, mode: "floating") {
+            frames[$0] = $1
+        }
+        let response = core.execute(
+            "resize",
+            args: [.string("y"), .number(150)]
+        )
+        #expect(response.isSuccess)
+        #expect(frames[WindowID(2)]?.height == 650)
+    }
+
+    @Test("a tiled focus in the floating layout still fails")
+    func tiledFocusInFloatingLayoutStillFails() {
+        let core = makeCore()
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("floating")]
+        )
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(
+                    id: WindowID(1),
+                    pid: 1,
+                    appName: "A"
+                )
+            )
+        )
+        // Created (and auto-focused) but never flagged
+        // floating: the tiled dispatch keeps rejecting the
+        // floating layout.
+        let response = core.execute(
+            "resize",
+            args: [.string("x"), .number(100)]
+        )
+        #expect(!response.isSuccess)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/StackFocusResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/StackFocusResizeTests.swift
@@ -122,17 +122,21 @@ struct StackFocusResizeTests {
         #expect(!response.isSuccess)
     }
 
-    @Test("x with a floating focused window keeps master-grow")
-    func unknownFocusKeepsMasterDirection() {
+    @Test("x with a floating focused window resizes the float")
+    func floatingFocusResizesTheFloat() {
         let core = makeCore()
         stackSpace(core)
-        // The focused window floats out of the tiled set: the
-        // pre-#67 master-grows direction must survive.
+        // A floating focused window resizes ITSELF — the
+        // master/stack ratio must not move.
         core.state.apply(.windowFocused(WindowID(1)))
         core.state.setFloating(WindowID(1), true)
         let before = core.tiler.settings.stack.masterRatio
-        core.execute("resize", args: [.string("x"), .number(500)])
-        #expect(core.tiler.settings.stack.masterRatio > before)
+        let response = core.execute(
+            "resize",
+            args: [.string("x"), .number(500)]
+        )
+        #expect(response.isSuccess)
+        #expect(core.tiler.settings.stack.masterRatio == before)
     }
 
     @Test("y works inside a multi-window master column")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,10 +127,12 @@ value` and shadows the global for that space only.
 
 `resize` adapts to the active layout and is per-axis (#56): in
 BSP, `x` moves the side-by-side split ratio and `y` the stacked
-one, independently. Stack is focus-aware (#67): `x` moves the
-master/stack split in the direction that grows the *focused*
-window, `y` grows the focused window's vertical share of its
-column (session-scoped weights, reset on relaunch). Scrolling
+one, independently, each in the direction that grows the
+*focused* window's region (#122). Stack is focus-aware too
+(#67): `x` moves the master/stack split in the direction that
+grows the *focused* window, `y` grows the focused window's
+vertical share of its column (session-scoped weights, reset on
+relaunch). Scrolling
 resizes the slot along its own scroll axis for either `x` or
 `y`. monocle, grid, and floating reply "not supported".
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -125,16 +125,18 @@ has a per-space `_override` twin (e.g. `bsp.set_ratio_h_override`,
 `scroll.set_slot_size_override`) that takes a leading `space id,
 value` and shadows the global for that space only.
 
-`resize` adapts to the active layout and is per-axis (#56): in
-BSP, `x` moves the side-by-side split ratio and `y` the stacked
-one, independently, each in the direction that grows the
-*focused* window's region (#122). Stack is focus-aware too
-(#67): `x` moves the master/stack split in the direction that
-grows the *focused* window, `y` grows the focused window's
-vertical share of its column (session-scoped weights, reset on
-relaunch). Scrolling
-resizes the slot along its own scroll axis for either `x` or
-`y`. monocle, grid, and floating reply "not supported".
+`resize` adapts to the active layout and is per-axis (#56). A
+floating focused window resizes itself directly in any mode
+(width for `x`, height for `y`, floored at `min_window_size`).
+For tiled windows: in BSP, `x` moves the side-by-side split
+ratio and `y` the stacked one, independently, each in the
+direction that grows the *focused* window's region (#122).
+Stack is focus-aware too (#67): `x` moves the master/stack
+split in the direction that grows the *focused* window, `y`
+grows the focused window's vertical share of its column
+(session-scoped weights, reset on relaunch). Scrolling resizes
+the slot along its own scroll axis for either `x` or `y`.
+monocle, grid, and floating reply "not supported".
 
 ## Event Stream
 

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1531,7 +1531,8 @@ end)
 **Does:** grows or shrinks the focused window. A **floating**
 focused window resizes itself directly, in every layout mode:
 `"x"` changes its width by the delta, `"y"` its height, top-left
-corner anchored, floored at `min_window_size`. Tiled windows
+corner anchored, floored at `min_window_size` (a window already
+smaller than that just shrinks no further). Tiled windows
 only resize in bsp, stack, and scrolling layouts (monocle, grid,
 and the floating layout report "not supported"); what the
 `delta` actually adjusts depends on the layout:

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1528,9 +1528,13 @@ end)
 - An axis: `"x"` or `"y"`.
 - A delta (points; positive = grow, negative = shrink).
 
-**Does:** grows or shrinks the focused window. Only applies in bsp,
-stack, and scrolling layouts; a no-op in monocle, grid, and
-floating. What the `delta` actually adjusts depends on the layout:
+**Does:** grows or shrinks the focused window. A **floating**
+focused window resizes itself directly, in every layout mode:
+`"x"` changes its width by the delta, `"y"` its height, top-left
+corner anchored, floored at `min_window_size`. Tiled windows
+only resize in bsp, stack, and scrolling layouts (monocle, grid,
+and the floating layout report "not supported"); what the
+`delta` actually adjusts depends on the layout:
 
 - **bsp** — per-axis (#56): `"x"` nudges the side-by-side split
   ratio (`bsp.set_ratio_h`), `"y"` the stacked one
@@ -1539,9 +1543,8 @@ floating. What the `delta` actually adjusts depends on the layout:
   *focused* window's region, so with a right/bottom window
   focused it lowers the shared ratio — the same side rule a
   mouse drag of that window's edge uses. All same-orientation
-  splits still share the one ratio; with no usable focus (no
-  focused window, or a floating one) the delta moves the
-  left/top region, as before.
+  splits still share the one ratio; with no focused window the
+  delta moves the left/top region, as before.
 - **stack** — focus-aware (#67). `"x"` moves the master/stack
   split *in the direction that grows the focused window*: with
   a master focused, a positive delta raises the master ratio;

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1535,6 +1535,13 @@ floating. What the `delta` actually adjusts depends on the layout:
 - **bsp** — per-axis (#56): `"x"` nudges the side-by-side split
   ratio (`bsp.set_ratio_h`), `"y"` the stacked one
   (`bsp.set_ratio_v`) — genuinely independent width and height.
+  Focus-aware in direction (#122): a positive delta grows the
+  *focused* window's region, so with a right/bottom window
+  focused it lowers the shared ratio — the same side rule a
+  mouse drag of that window's edge uses. All same-orientation
+  splits still share the one ratio; with no usable focus (no
+  focused window, or a floating one) the delta moves the
+  left/top region, as before.
 - **stack** — focus-aware (#67). `"x"` moves the master/stack
   split *in the direction that grows the focused window*: with
   a master focused, a positive delta raises the master ratio;


### PR DESCRIPTION
## Description

Re-opened copy of #127 (auto-closed when its stacked base
branch was deleted on the #124 merge; now based on `main`).

`resize("x"|"y", delta)` on a **floating** focused window now
resizes the window itself, in every layout mode (including the
floating layout): `x` changes width, `y` height, top-left
corner anchored, floored at `min_window_size` — capped at the
current size, so a window already below the floor just stops
shrinking (never jumps UP to it). Previously the delta fell
through to the layout-ratio fallbacks (bsp/stack) or failed.
The mouse could already resize floats; the keyboard now can too.

- Pure math: `Tiling/FloatResize.swift` (+ 1-pt hard floor).
- Apply goes through the new `TilingEngine.applyFrame` — now
  the SINGLE animate-or-instant frame policy (cancel + screen
  pick included), shared with `retile`; the review caught that
  the copied branch had already drifted (missing cancel).
- Deliberately replaces the #122/#67 floating-focus fallbacks
  (a hidden layout ratio moving on "grow" over a float was a
  category error); those tests now pin the new contract.
- No layout retile — no tiled window moved.

## Related Issue(s)

Requested by @hajiboy95 during the #122 pass (no tracking
issue — filing one was left to you). Backlog: #71 (Lane C).

## Checklist

- [ ] I understand what this change does and have run it in
  the app to confirm it works as intended (manual pass: float
  a window, Grow/Shrink both axes; try one smaller than
  min_window_size)
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
  (812 tests)
- [x] Release build passes: `swift build -c release`
- [x] PR is focused (stacked so #122 stays reviewable alone)

## How I verified

Full local gate. Tests pin: width/height grow with origin
kept, shrink floors at min_window_size, sub-floor windows
never grow on a shrink and grow by exactly the delta, the
1-pt hard floor, animated-vs-instant routing (both branches),
works in the floating layout, tiled focus in the floating
layout still fails, and bsp/stack ratios stay untouched under
floating focus.

## Notes for Reviewer

Two-agent review + a focused re-review of the fix batch, all
clean of majors. Known, accepted limitation: very fast key
repeats under-accumulate slightly while an animation is in
flight (each step re-bases on the AX-echo frame). If Grow/
Shrink feels mushy on key-repeat in your manual pass, say so —
the fix is a small `AnimationEngine.targetFrame(for:)`
accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
