### PR TITLE
docs(design-decisions): BSP nested-resize pinning is accepted, by architecture

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -369,6 +369,33 @@ purpose: **BSP still cascades on an extreme stored ratio** — the
 same clamp principle should migrate there in a follow-up rather
 than ride the #44 fix. (#44)
 
+**BSP keyboard resize is focus-aware in *direction* only — and
+some nested windows cannot grow. Accepted, by architecture.**
+Since #122, `resize` infers its sign from the focused window's
+slot (the same screen-midpoint side rule a mouse drag uses,
+shared as one authority — `MouseResize.bspSide`), so "grow"
+grows the focused window's side instead of always the left/top
+region. What it deliberately does **not** do is give every
+window a growable boundary: all same-orientation splits still
+share the one per-space ratio (#56's settled trade — per-node
+ratios need a container tree, which the flat-array model
+forbids). Concretely: the inner window of a pair nested inside
+the second region has width `r·(1−r)·W`, which is *maximized*
+at the default ratio — no resize direction can widen it, and
+the visible effect of a grow press is its outer neighbor
+widening instead. The same is true when dragging that window's
+edge with the mouse; keyboard and mouse stay in lockstep,
+warts included. This is an **accepted limitation, not a bug to
+fix within BSP**: a smarter sign (derivative-based) was
+considered and rejected — it cannot help the pinned case and
+would split the just-unified mouse/keyboard rule. The real
+answer is the planned `track` layout (#128), where every
+window sits in exactly one track and every resize has one true
+target. A **floating** focused window is exempt from all of
+this: it resizes itself directly, in every mode (width for x,
+height for y, floored at `min_window_size`). (#122, #124,
+#129)
+
 **Orphaned space shortcuts are surfaced, never pruned.** A
 binding that targets a space by name outlives the space's
 presence in the current profile: it stays Carbon-registered


### PR DESCRIPTION
## Description

Records the finding from the #124 manual pass as a settled
decision in `docs/design-decisions.md`: with one shared ratio
per orientation, the inner window of a nested BSP pair sits at
`r·(1−r)·W` — maximized at the default ratio, so no resize
direction can grow it, keyboard or mouse alike. Explains why a
smarter (derivative) sign was rejected, points to the `track`
layout (#128) as the real fix, and notes the floating-window
exemption (#129).

First seeded entry for #130 (accepted-by-architecture
limitations as a first-class docs surface).

## Related Issue(s)

References #122, #124, #128, #129, #130.

## Checklist

- [x] Docs-only; verify gate run anyway (build, tests, lint,
  release build — all green)
- [x] Commits follow Conventional Commits format
- [x] No contradictions between code and docs
- [x] PR is focused

## Notes for Reviewer

Docs-only, one entry appended to the Shortcuts section after
the #44 entry, following the file's decision-entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)