### PR TITLE
chore(github): add issue templates for roadmaps and collectors

### DIFF
--- a/.github/ISSUE_TEMPLATE/collector.yml
+++ b/.github/ISSUE_TEMPLATE/collector.yml
@@ -1,0 +1,65 @@
+name: Collector (tracking)
+description: Themed collecting issue grouping related issues
+labels: ["roadmap"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A collector groups **related issues around one theme**
+        (a pipeline, a subsystem, a lane) so the roadmap stays
+        the wave sequence and this stays the themed backlog.
+        Keep checkboxes in sync when issues close — a stale
+        tracker is worse than none (see the #71 retrospective).
+
+        Conventions (see AGENTS.md §3–4): cluster = worktree =
+        branch = PR; parallelize across file-disjoint lanes,
+        serialize within a lane (same files → they conflict).
+
+  - type: textarea
+    id: theme
+    attributes:
+      label: Theme & scope
+      description: |
+        What binds these issues together, and which roadmap
+        wave owns the sequencing.
+      placeholder: |
+        The 1.0 release & distribution pipeline — Roadmap 2
+        (#XXX) Wave 14. Each link consumes the previous one's
+        artifact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tracked_issues
+    attributes:
+      label: Tracked issues
+      description: |
+        Task list in execution order. Note per-item ordering
+        constraints (→ chains, "do with/after", gates) inline.
+      placeholder: |
+        - [ ] #89 — .app bundle + .icns icon
+        - [ ] #32 — release workflow (needs #89's bundle)
+        - [ ] #105 — Homebrew cask (depends on #89 + #32)
+    validations:
+      required: true
+
+  - type: textarea
+    id: execution
+    attributes:
+      label: Execution notes
+      description: |
+        Lane structure: what serializes (shared files), what
+        can fan out, seams with other collectors/lanes.
+      placeholder: |
+        Sequential by nature — one lane, serialize within.
+        Seam: #117 edits site/ — coordinate with the site lane.
+
+  - type: textarea
+    id: relations
+    attributes:
+      label: Relations
+      description: |
+        Owning roadmap, sibling collectors, related issues that
+        are noted but not gated here.
+      placeholder: |
+        Roadmap: #XXX. Related, not gated here: #106.

--- a/.github/ISSUE_TEMPLATE/roadmap.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap.yml
@@ -1,0 +1,85 @@
+name: Roadmap
+description: Wave-sequenced execution plan across open issues
+labels: ["roadmap"]
+title: "Roadmap: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A roadmap owns the **wave sequence**: which issues run
+        in which order, what gates what, and what is deferred.
+        Themed sub-backlogs live in **collector** issues that
+        the roadmap links; small standalones may be hosted here
+        directly. Keep checkboxes in sync when issues close —
+        a stale tracker is worse than none.
+
+        Conventions (see AGENTS.md §3–4): cluster = worktree =
+        branch = PR; parallelize across file-disjoint lanes,
+        serialize within a lane; big architectural issues get
+        dedicated solo sessions and merge before fan-out.
+
+        Legend: 🟢 parallel-safe · 🔴 must serialize ·
+        🧠 big — dedicated single session · ⛔ blocked/deferred
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope & guiding rule
+      description: |
+        What this roadmap covers, its predecessor (if any), and
+        the one rule that drives the ordering.
+      placeholder: |
+        Successor to #27 (waves 1–10, closed). Guiding rule:
+        everything that adds or rewrites UI strings lands
+        before localization; release freezes the surface last.
+    validations:
+      required: true
+
+  - type: textarea
+    id: waves
+    attributes:
+      label: Waves
+      description: |
+        One section per wave, in execution order. Reference
+        collector issues for themed groups; list standalones
+        as task-list items with their legend marker.
+      placeholder: |
+        ### Wave N — Quick wins 🟢
+        Disjoint files, run as parallel lanes.
+        - [ ] #66 — scrolling focus-up bug
+        - [ ] #113 — docs-site build warnings
+
+        ### Wave N+1 — Feature tail
+        - [ ] #128 🧠 — track mode (solo)
+        - [ ] Settings-GUI lane → see collector #XXX
+    validations:
+      required: true
+
+  - type: textarea
+    id: merge_gates
+    attributes:
+      label: Merge gates
+      description: |
+        Land the left before starting the right, and why.
+      placeholder: |
+        | Merge first | Before starting | Why |
+        |---|---|---|
+        | #89 | #32 | workflow packages the bundle |
+
+  - type: textarea
+    id: deferred
+    attributes:
+      label: Deferred / icebox
+      description: |
+        Blocked or unscheduled issues, with the blocker named.
+      placeholder: |
+        - [ ] #25 — move window to native Space ⛔ SIP
+
+  - type: textarea
+    id: relations
+    attributes:
+      label: Relations
+      description: |
+        Predecessor roadmaps, linked collectors, plan/ docs.
+      placeholder: |
+        Predecessor: #27. Collectors: #XXX, #YYY, #ZZZ.


### PR DESCRIPTION
## Summary

Tracking issues have two recurring shapes in this repo — the
wave-sequenced **roadmap** (#27) and the themed **collector**
backlog (#71) — but both were free-form. This adds GitHub issue
forms for each so future trackers start with the settled
structure:

- **`roadmap.yml`** — scope & guiding rule, waves, merge-gates
  table, deferred/icebox, relations. Title-prefixed
  `Roadmap: `, auto-labels `roadmap`.
- **`collector.yml`** — theme & owning wave, tracked task list
  in execution order, lane/serialization notes, relations.
  Auto-labels `roadmap`.

Both embed the AGENTS.md execution conventions (cluster =
worktree = branch = PR; serialize within a lane) and a reminder
to keep checkboxes in sync with issue state — the drift that
made #71 go stale.

## Verification

- Both files parse as valid issue forms (YAML + block-type
  check) and respect the 79-char line limit.
- `scripts/lint.sh` green (`extract-keys --check` OK; no Swift
  touched, so builds are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)