### PR TITLE
docs(design-decisions): accepted-limitations reference (#130)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,22 @@ GUI lives in `Sources/KiwiDesk` (`Settings/`, `Settings/Tabs/`).
    decision is made or changed) — and `plan/` when the design
    itself shifts. Code and docs must never describe different
    behavior.
+   The marketing/docs **site (`site/`)** renders `docs/` through
+   a symlink, so doc *content* edits flow to it automatically —
+   never hand-copy a doc into `site/`. But the site is not fully
+   covered by that symlink: a **new doc page** needs a sidebar
+   entry in `site/astro.config.mjs`, and **site-only surfaces**
+   (the landing page, cross-page callouts) are updated in the
+   same change set when a feature warrants surfacing there —
+   e.g. a new layout mode (#128) adds its user-guide/reference
+   prose *and* whatever nav or callout makes it findable. Run
+   `npm run build` in `site/` when you touch either.
+   When a review or manual pass classifies a behavior as
+   **accepted-by-architecture**, it adds a row to the *Accepted
+   limitations* table in `docs/design-decisions.md` in the same
+   change set — the user-facing twin of the §5 guardrail rule
+   (OS-blocked-by-SIP items are a separate class there, with no
+   in-app escape hatch).
 6. **Review:** once a substantial change is finished, verified,
    and committed, spin up **both** `code-reviewer` and
    `architect-reviewer` on the diff since the last review point —

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -13,6 +13,51 @@ Settings redesign (#68, PR #88) unless noted; deeper rationale
 lives in the linked issues. Architecture and code guardrails
 live in `AGENTS.md`, not here.
 
+## Accepted limitations
+
+Some behaviors are *bugs by design* — accepted consequences of a
+settled architectural trade, not defects to fix. This table is the
+one place that says, for each: it's known, here's why it's
+accepted, here's the architectural root, and here's the real fix
+where one is planned. Every row links to its full reasoning
+elsewhere on this page (or to the issue that owns it).
+
+Convention: when a review or manual pass classifies a behavior as
+accepted-by-architecture, it adds a row here **in the same change
+set** — the user-facing twin of the `AGENTS.md` §5 guardrail rule.
+A row needs an architectural root and, where one exists, the
+planned escape hatch; it is not a wontfix dumping ground.
+
+| Behavior | Why it's accepted | Architectural root | Escape hatch / planned fix |
+|---|---|---|---|
+| In BSP, the inner window of a nested pair can't grow — a "grow" press (or edge-drag) widens its outer neighbor instead. | Its width `r·(1−r)·W` is already maximized at the default ratio, so no resize direction can widen it. | All same-orientation splits share the one per-space ratio; per-node ratios would need a container tree the flat-array model forbids (#56 trade). | The [`track` layout (#128)](https://github.com/hajiboy95/KiwiDesk/issues/128), where every window has one true resize target. See [BSP resize is focus-aware in *direction* only](#shortcuts). |
+| An extreme *stored* BSP ratio still collapses the space into the overlap cascade — even though the stack layout no longer does. | The stack's layout-time clamp hasn't been migrated to BSP yet; doing it as a follow-up rather than riding the #44 fix keeps that change scoped. | BSP has no effective-ratio clamp authority; the #44 fix (`StackLayout.effectiveRatioRange`) landed in the stack only. | Migrate the clamp principle to BSP (follow-up to [#44](https://github.com/hajiboy95/KiwiDesk/issues/44)). See [The stack cascade is a last resort](#shortcuts). |
+| Dragging a stack window's height with the mouse snaps back; only keyboard/CLI `resize("y")` actually moves the vertical share. | Vertical weights are a windowless keyboard/CLI concept; the mouse-drag seam has no window to anchor a weight against. | Per-window vertical weights are session-scoped and keyboard-only by design ([#67](https://github.com/hajiboy95/KiwiDesk/issues/67)). | Use keyboard/CLI `resize("y")`; the mouse asymmetry is deliberate. See [Stack resize is focus-aware](#shortcuts). |
+| Holding a key to resize a floating window under-accumulates while a slide/resize animation is still in flight. | Each step re-bases on the last AX-reported frame; mid-animation the AX echo lags, so rapid repeats read stale geometry. | Resize re-bases on live AX state, and AX echoes trail an in-flight animation. | Let the frame settle, or press again once the animation completes ([#129](https://github.com/hajiboy95/KiwiDesk/issues/129)). |
+| Animation and screen-selection heuristics assume a single screen; some multi-monitor edge cases aren't fully modeled yet. | These paths were scoped single-screen first; multi-monitor is a tracked frontier, not a regression. | Screen-pick and per-monitor animation heuristics are single-screen by construction. | Multi-monitor hardening (roadmap `plan/06_Roadmap.md`). |
+| At deep BSP splits under extreme ratios, the screen-midpoint side rule can misread which side a "grow" acts on. | Mouse parity is the spec: keyboard matches the mouse's midpoint reading exactly, warts included, so the two never diverge. | The sign is inferred from the focused window's screen-midpoint side (`MouseResize.bspSide`), shared with the mouse for parity. | The [`track` layout (#128)](https://github.com/hajiboy95/KiwiDesk/issues/128) gives each resize one true target; until then parity is intentional ([#122](https://github.com/hajiboy95/KiwiDesk/issues/122)). |
+
+### Blocked by macOS (SIP)
+
+A separate class: capabilities macOS forbids without disabling
+**System Integrity Protection**. KiwiDesk drives native Spaces
+through private SkyLight/CGS symbols resolved at runtime, and the
+few operations that *write* the native-Space arrangement are
+gated by SIP. KiwiDesk **never disables SIP or asks a user to** —
+a disabled-SIP requirement is a non-starter for a window manager
+(`AGENTS.md` §5), so these stay unimplemented rather than shipping
+a fragile fast path with no safe fallback. Unlike the table above,
+the root is the OS, not our architecture, and there is no in-app
+escape hatch — only Apple exposing a supported API. They are
+tracked, not abandoned:
+
+- **Move the focused window to another native Space**
+  ([#25](https://github.com/hajiboy95/KiwiDesk/issues/25)).
+- **Switch the visible native Space programmatically**
+  ([#26](https://github.com/hajiboy95/KiwiDesk/issues/26)).
+- **Restore windows across all native Spaces on quit**
+  ([#70](https://github.com/hajiboy95/KiwiDesk/issues/70)).
+
 ## Navigation & saving
 
 **Two-group sidebar, topic-named: "Design" vs "System".**

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -245,6 +245,13 @@ Expand each layout type to adjust its defaults:
   split direction (horizontal or vertical), and for rigid mode,
   column and row counts.
 
+> **A few resize behaviors are accepted limitations, not bugs.**
+> Some tiling quirks — e.g. the inner window of a nested BSP pair
+> not growing, or a stack window's *mouse* height-drag snapping
+> back — are settled architectural trades, each with a reason and,
+> where planned, a real fix. See
+> [Accepted limitations](design-decisions.md#accepted-limitations).
+
 ### Per-Space Overrides
 
 To tune the *same layout type differently in different spaces*, use

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -49,6 +49,12 @@ export default defineConfig({
           items: [
             { label: "Lua Reference", slug: "docs/lua-reference" },
             { label: "CLI & IPC", slug: "docs/cli" },
+            {
+              label: "Accepted Limitations",
+              // User-facing entry point into the table that lives
+              // in the (contributor-facing) Design Decisions page.
+              link: "/docs/design-decisions/#accepted-limitations",
+            },
           ],
         },
         {


### PR DESCRIPTION
## Summary

Closes #130. Gives `docs/design-decisions.md` a first-class **Accepted limitations** reference and surfaces it on the site + user guide.

- **`## Accepted limitations` table** — scannable *behavior / why accepted / architectural root / escape hatch*, seeded with the six known entries (BSP nested pinning, BSP extreme-ratio cascade, stack height mouse-drag snap-back, float-resize under-accumulation, single-screen ceiling, midpoint side-rule misread). Each row links to its full prose and issues.
- **`### Blocked by macOS (SIP)` subsection** — #25/#26/#70. A separate class: externally gated by SIP (we never disable it), no in-app escape hatch. Kept out of the table so its *root + escape hatch* contract stays meaningful, but under the same umbrella.
- **User-guide callout** — Layout Defaults links to the table (the site renders `docs/` via symlink, so the table is live automatically).
- **`AGENTS.md §3.5`** — codifies the convention (accepted-by-architecture → a row in the same change set) and extends the Document step to cover the docs **site**: content flows via the symlink, but new pages need a sidebar entry in `site/astro.config.mjs` and site-only surfaces need explicit updates (e.g. track mode #128).

## Verification

Docs-only — no Swift touched. `npm run build` in `site/` succeeds (15 pages, no new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)