### PR TITLE
chore(site): silence duplicate-id build warnings (#113)

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,7 +1,51 @@
 import { defineCollection } from "astro:content";
 import { docsLoader } from "@astrojs/starlight/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
+import type { Loader, LoaderContext } from "astro/loaders";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Astro 5's glob loader logs a spurious `Duplicate id` warning
+// whenever a build re-syncs a file whose contents changed since
+// the persisted data store was written: the "duplicate" it finds
+// is the entry's own stale store record, not a second file (the
+// docs/ symlink is innocent — a cold build is warning-free).
+// Astro 6 fixed this upstream by warning only when the stored
+// entry points at a *different* file that still exists. Until
+// the site is on Astro 6, replicate that check here and drop
+// the same-file false positive. Real duplicates (two files that
+// produce one id) still warn. Delete this wrapper when
+// upgrading Astro.
+const duplicateWarning = new RegExp(
+  '^Duplicate id "(.+)" found in (.+)\\. ' +
+    "Later items with the same id will overwrite earlier ones\\.$",
+);
+
+function withoutStaleResyncWarnings(loader: Loader): Loader {
+  return {
+    ...loader,
+    load(context: LoaderContext) {
+      const { logger, store, config } = context;
+      const root = fileURLToPath(config.root);
+      const quiet = Object.create(logger) as typeof logger;
+      quiet.warn = (message: string) => {
+        const match = duplicateWarning.exec(message);
+        // At warn time the store still holds the previous entry
+        // for this id; when it lives at the very file being
+        // warned about, this is a stale re-sync of that file,
+        // not a duplicate. Anything else passes through.
+        const owner = match && store.get(match[1])?.filePath;
+        if (owner && resolve(root, owner) === match[2]) return;
+        logger.warn(message);
+      };
+      return loader.load({ ...context, logger: quiet });
+    },
+  };
+}
 
 export const collections = {
-  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({
+    loader: withoutStaleResyncWarnings(docsLoader()),
+    schema: docsSchema(),
+  }),
 };


### PR DESCRIPTION
## Description

Silences the noisy `[WARN] [starlight-docs-loader] Duplicate id …`
lines the site build emitted on incremental rebuilds.

**Root cause (differs from the issue's theory).** The `docs/`
symlink is innocent — a cold build enumerates each file exactly
once and is warning-free. The warning is a false positive in
Astro 5's glob loader: an incremental build reuses the persisted
data store (`node_modules/.astro/data-store.json`); a file whose
contents changed since that store was written fails the digest
short-circuit, and the loader then finds its own stale record
under the same id and logs "Duplicate id" before overwriting it.
The five ids named in #113 are exactly the five docs edited during
PR #101. Astro 6 fixed this upstream by warning only when the
stored entry points at a *different* file that still exists;
Starlight 0.30 pins Astro 5, where no in-range update has the fix
(5.18.2 is current).

**Fix.** `site/src/content.config.ts` wraps Starlight's
`docsLoader` with a logger that replicates the Astro 6 check: a
"Duplicate id" warning whose stored entry lives at the very file
being warned about is a stale re-sync and is dropped; anything
else — a real duplicate id from two files, or an unrecognized
message shape — passes through unchanged (fail-open). The wrapper
is deletable once the site moves to Astro 6.

**Rejected alternative.** `astro build --force` clears the store
(silencing the false positive) but logs its own `[WARN] [content]
data store cleared (force)` on every build and loses the
warm-build signal for genuine duplicates.

## Related Issue(s)

Closes #113.

## Checklist

- [x] I understand what this change does and have run it to
  confirm it works as intended (see "How I verified")
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [ ] New behavior is tested (pure logic / layout code
  required) — n/a, site build config; verified by build runs
- [ ] User-facing changes are documented in `docs/` — n/a,
  build-output-only change
- [x] No contradictions between code and docs
- [ ] `swift build && swift test && ./scripts/lint.sh`
  passes — n/a, no Swift touched; `npm run build` is the gate
- [ ] Release build passes — n/a, no Swift touched
- [x] PR is focused; refactors separated from features

## How I verified

- Reproduced first: appended a newline to a shared doc, rebuilt →
  1 `Duplicate id` warning per edited file (0 on cold builds,
  confirming the symlink double-registration theory false).
- With the fix: edit-then-rebuild → **0 warnings**; cold and warm
  builds → 0 warnings of any kind.
- Page set unchanged: **15 pages built**, `dist/docs/{cli,
  lua-reference, design-decisions, user-guide, recipes,
  recipes/sketchybar, recipes/jankyborders, recipes/misc,
  translating}/index.html` plus the overview all present; Pagefind
  still indexes 10 pages.
- Guard against over-suppression: added a temporary
  `docs/cli/index.md` colliding with `docs/cli.md` → the genuine
  duplicate **still warns** with the fix in place.

## Notes for Reviewer

The filter keys on Astro's exact warning message; if Astro ever
rewords it the filter goes inert and warnings reappear (noise, not
breakage). At warn time the store still holds the previous entry
for the id, which is what makes the same-file comparison sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)