### PR TITLE
fix(layout): pin far-offscreen scrolling slots at a fixed sliver (#142)

### DIFF
--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
@@ -14,15 +14,26 @@ import CoreGraphics
 /// bar enabled its strip is carved out of the usable area
 /// first, so windows and bar never overlap.
 ///
-/// Vertical rows overflow only at the bottom: macOS refuses any
-/// window position above the top screen border, so a row
-/// scrolled past the top pins at the border — its upper strip
-/// peeks — instead of tucking above the screen (an accepted
-/// OS-blocked limitation, see docs/design-decisions.md). The
-/// viewport *offset* stays the ideal, unpinned value, so the
-/// up/down scroll math remains symmetric; only the materialized
-/// frames pin.
+/// macOS constrains what frames it will apply, so materialized
+/// frames pin while the viewport *offset* stays the ideal,
+/// unpinned value (keeping the up/down scroll math symmetric):
+/// a vertical row scrolled past the top pins at the border —
+/// its upper strip peeks — because nothing may go above the top
+/// screen edge (an accepted OS-blocked limitation, see
+/// docs/design-decisions.md); and a slot scrolled far past any
+/// other edge pins with an `edgePeek` sliver still visible,
+/// because macOS clamps fully offscreen frames to its own
+/// undocumented minimum anyway (#142) — pinning above that
+/// minimum keeps every target achievable.
 public struct ScrollingLayout: LayoutSystem {
+    /// Visible sliver of a slot scrolled far past a screen edge
+    /// (#142). macOS clamps fully offscreen frames to an
+    /// undocumented title-bar minimum (~32–40 pt observed);
+    /// sitting safely above it keeps every pinned target
+    /// achievable, so the retile tolerance can settle instead
+    /// of re-issuing unreachable frames forever.
+    static let edgePeek: CGFloat = 48
+
     public init() {}
 
     public func calculateGeometry(
@@ -217,18 +228,25 @@ public struct ScrollingLayout: LayoutSystem {
         stride: CGFloat,
         size: CGFloat
     ) -> [WindowID: CGRect] {
+        let along = horizontal ? area.width : area.height
         var result: [WindowID: CGRect] = [:]
         for (index, window) in windows.enumerated() {
             var lead = offset + CGFloat(index) * stride
-            // macOS silently rejects frames above the top
-            // screen border (WindowServer clamp; the SIP
-            // guardrail rules out private workarounds). Pin
-            // vertical up-overflow rows at the edge so targets
-            // stay achievable — otherwise every retile re-issues
-            // an impossible frame that the ±2pt tolerance can
-            // never absorb. The focused row is unaffected: the
-            // offset clamp keeps its lead in view (>= 0).
-            if !horizontal { lead = max(lead, 0) }
+            // Pin what macOS would refuse anyway (#139/#142):
+            // above the top border it applies nothing at all,
+            // and (almost) fully offscreen frames clamp to its
+            // own title-bar minimum. An unreachable target makes
+            // every retile re-issue the frame past the ±2pt
+            // tolerance, so far slots keep `edgePeek` visible at
+            // the trailing edge and (horizontal only) at the
+            // leading edge; the vertical top stays a hard wall
+            // at 0. The focused slot is never touched — the
+            // offset clamp keeps its lead in [0, along - size].
+            lead = min(lead, along - Self.edgePeek)
+            lead =
+                horizontal
+                ? max(lead, Self.edgePeek - size)
+                : max(lead, 0)
             result[window] =
                 horizontal
                 ? CGRect(

--- a/Tests/KiwiDeskCoreTests/ScrollingFocusSymmetryTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingFocusSymmetryTests.swift
@@ -30,26 +30,26 @@ private func makeContext(
     return context
 }
 
-/// Drives `calculateGeometry` like a real retile loop: each call
-/// carries the previous call's resulting offset forward as
+/// Drives the offset like a real retile loop: each call carries
+/// the previous call's resulting offset forward as
 /// `context.scrollOffset`, exactly as `KiwiCore.persistScrollOffset`
-/// does between retiles.
+/// does between retiles. Reads `viewportOffset` (the ideal,
+/// persisted value) rather than deriving it from a frame — far
+/// slots pin at the screen edges (#139/#142), so frames no
+/// longer expose the raw offset.
 private func offsets(
     anchor: ScrollingParams.Anchor,
     focusSequence: [WindowID]
 ) -> [CGFloat] {
-    let layout = ScrollingLayout()
     var previous: CGFloat?
     var result: [CGFloat] = []
     for focused in focusSequence {
         var context = makeContext(anchor: anchor, focused: focused)
         context.scrollOffset = previous
-        let frames = layout.calculateGeometry(
+        let offset = ScrollingLayout.viewportOffset(
             for: windows,
             in: context
         )
-        let offset =
-            frames[w1]!.minX - context.usable.minX
         result.append(offset)
         previous = offset
     }
@@ -117,11 +117,10 @@ struct ScrollingFocusSymmetryTests {
                 focused: focused
             )
             context.scrollOffset = previous
-            let frames = layout.calculateGeometry(
+            previous = ScrollingLayout.viewportOffset(
                 for: windows,
                 in: context
             )
-            previous = frames[w1]!.minX - context.usable.minX
         }
         let atEnd = try #require(previous)
 
@@ -134,7 +133,10 @@ struct ScrollingFocusSymmetryTests {
             for: windows,
             in: context
         )
-        let after = frames[w1]!.minX - context.usable.minX
+        let after = ScrollingLayout.viewportOffset(
+            for: windows,
+            in: context
+        )
         #expect(after > atEnd)
 
         // And the newly focused window must be fully in view.
@@ -157,7 +159,10 @@ struct ScrollingFocusSymmetryTests {
             for: windows,
             in: context
         )
-        let seed = seedFrames[w1]!.minX - context.usable.minX
+        let seed = ScrollingLayout.viewportOffset(
+            for: windows,
+            in: context
+        )
 
         // Precondition: w3 is already fully visible at the seed.
         let w3Seed = try #require(seedFrames[w3])
@@ -167,11 +172,10 @@ struct ScrollingFocusSymmetryTests {
         // Focusing it must not pan the viewport.
         context.focused = w3
         context.scrollOffset = seed
-        let frames = layout.calculateGeometry(
+        let offset = ScrollingLayout.viewportOffset(
             for: windows,
             in: context
         )
-        let offset = frames[w1]!.minX - context.usable.minX
         #expect(offset == seed)
     }
 }

--- a/Tests/KiwiDeskCoreTests/ScrollingLayoutTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingLayoutTests.swift
@@ -160,4 +160,85 @@ struct ScrollingLayoutTests {
             KiwiCore.scrollingRaiseOrder(windows, focusIndex: 10) == windows
         )
     }
+
+    /// 1000pt usable width, 400pt slots, no gap — the symmetry
+    /// suite's round-number geometry (#142 edge pins).
+    private func pinContext(focused: WindowID) -> LayoutContext {
+        var context = makeContext(
+            bounds: CGRect(x: 0, y: 0, width: 1020, height: 1080),
+            focused: focused
+        )
+        context.scrolling.appBar.enabled = false
+        context.scrolling.slotSize = .points(400)
+        context.gaps.inner.horizontal = 0
+        return context
+    }
+
+    @Test("Slots far past the left edge pin at a sliver (#142)")
+    func farLeftSlotsPin() throws {
+        var context = pinContext(focused: w5)
+        context.scrollOffset = -1000
+        let frames = layout.calculateGeometry(
+            for: [w1, w2, w3, w4, w5],
+            in: context
+        )
+        // w1/w2 are fully off-left ideally; both keep an
+        // edgePeek sliver so macOS can actually apply them.
+        let peek = ScrollingLayout.edgePeek
+        #expect(
+            try #require(frames[w1]).maxX
+                == context.usable.minX + peek
+        )
+        #expect(
+            try #require(frames[w2]).maxX
+                == context.usable.minX + peek
+        )
+        // The focused slot is untouched, fully visible.
+        let focused = try #require(frames[w5])
+        #expect(focused.maxX <= context.usable.maxX + 0.01)
+    }
+
+    @Test("Slots far past the right edge pin at a sliver (#142)")
+    func farRightSlotsPin() throws {
+        var context = pinContext(focused: w1)
+        context.scrollOffset = 0
+        let frames = layout.calculateGeometry(
+            for: [w1, w2, w3, w4, w5],
+            in: context
+        )
+        let peek = ScrollingLayout.edgePeek
+        #expect(
+            try #require(frames[w4]).minX
+                == context.usable.maxX - peek
+        )
+        #expect(
+            try #require(frames[w5]).minX
+                == context.usable.maxX - peek
+        )
+        // A merely partially visible slot is NOT pinned.
+        #expect(
+            try #require(frames[w3]).minX
+                == context.usable.minX + 800
+        )
+    }
+
+    @Test("viewportOffset matches frames when no pin engages")
+    func viewportOffsetFrameParity() throws {
+        // Guards the in-file mirror between `viewportOffset`
+        // and `calculateGeometry`: with three slots nothing
+        // scrolls far enough to pin, so the frame-derived
+        // offset must equal the ideal one exactly.
+        let context = pinContext(focused: w2)
+        let frames = layout.calculateGeometry(
+            for: [w1, w2, w3],
+            in: context
+        )
+        let ideal = ScrollingLayout.viewportOffset(
+            for: [w1, w2, w3],
+            in: context
+        )
+        let fromFrame =
+            try #require(frames[w1]).minX - context.usable.minX
+        #expect(fromFrame == ideal)
+    }
 }

--- a/Tests/KiwiDeskCoreTests/ScrollingVerticalTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingVerticalTests.swift
@@ -165,4 +165,29 @@ struct ScrollingVerticalTests {
         #expect(focused.minY >= context.usable.minY - 0.01)
         #expect(focused.maxY <= context.usable.maxY + 0.01)
     }
+
+    @Test("Rows far past the bottom pin at a sliver (#142)")
+    func farBottomRowsPin() throws {
+        // Focus at the top: the third row lies fully below the
+        // viewport ideally; it keeps an edgePeek sliver so the
+        // frame stays applicable (macOS clamps fully offscreen
+        // frames to its own minimum anyway).
+        var context = makeContext(focused: w1)
+        context.scrolling.orientation = .vertical
+        context.scrolling.appBar.enabled = false
+        context.scrolling.slotSize = .points(800)
+        context.scrollOffset = 0
+        let frames = layout.calculateGeometry(
+            for: [w1, w2, w3],
+            in: context
+        )
+        let third = try #require(frames[w3])
+        #expect(
+            third.minY
+                == context.usable.maxY - ScrollingLayout.edgePeek
+        )
+        // The partially visible second row is NOT pinned.
+        let second = try #require(frames[w2])
+        #expect(second.minY == context.usable.minY + 810)
+    }
 }

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -71,6 +71,10 @@ tracked, not abandoned:
   ([#139](https://github.com/hajiboy95/KiwiDesk/issues/139);
   the pin shipped with
   [#66](https://github.com/hajiboy95/KiwiDesk/issues/66)).
+  On the other edges KiwiDesk pins far-offscreen slots at its
+  own fixed sliver, safely above the OS minimum, for the same
+  achievable-target reason
+  ([#142](https://github.com/hajiboy95/KiwiDesk/issues/142)).
 
 All of these are collected in
 [#140](https://github.com/hajiboy95/KiwiDesk/issues/140).

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -526,7 +526,10 @@ any window above the top screen border, so a row scrolled past the
 top stays pinned at the border with its upper strip peeking behind
 the focused row, instead of tucking above the screen. See the
 [accepted limitations](design-decisions.md#accepted-limitations)
-table.
+table. On the other edges, a slot scrolled far offscreen keeps a
+small fixed sliver visible — macOS refuses fully offscreen
+placement, so KiwiDesk pins at a deterministic sliver instead of
+letting the OS clamp unpredictably.
 
 **Example:**
 


### PR DESCRIPTION
## Description

Far-offscreen scrolling slots now pin at a fixed 48pt sliver
(`ScrollingLayout.edgePeek`) instead of targeting frames macOS
can never apply — the WindowServer clamps (almost) fully
offscreen frames to its own undocumented ~32–40pt minimum, so
the old targets caused a frame re-issue on every retile (AX
churn). The vertical top border keeps its hard wall from #139.
Persisted offsets stay ideal/unpinned (the #66 invariant); the
symmetry tests now read `viewportOffset` directly, and the
parity test from the #66 architect review (observation O1)
guards the viewportOffset/frames mirror.

Decision + reversibility discussed in #142: pin constant sits
deliberately above the OS minimum; swapping to stash-style
hiding later is a contained change.

## Related Issue(s)

Fixes #142. Related: #66 (merged as #144), #139.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## How I verified

- The OS clamp this encodes was verified by live AX probes
  (fully offscreen asks on bottom/left/right all clamped back to
  a ~32–40pt sliver; partial overflow applied exactly).
- 841 tests / 152 suites green: new far-left/far-right/
  far-bottom pin tests, not-pinned-when-partially-visible
  assertions, and the viewportOffset↔frames parity test.
- Full verify gate incl. release build.

## Notes for Reviewer

Session wrap-up note: unlike #144 (two full §3 review rounds),
this small follow-up merged on the verify gate only, per repo
owner's token-budget call — flagged for an optional re-review
next session. CI remains billing-blocked; merged on the local
gate per repo owner's standing decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)