### PR TITLE
fix(layout): cap the scrolling edge peek at the slot size

### DIFF
--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
@@ -240,12 +240,17 @@ public struct ScrollingLayout: LayoutSystem {
             // tolerance, so far slots keep `edgePeek` visible at
             // the trailing edge and (horizontal only) at the
             // leading edge; the vertical top stays a hard wall
-            // at 0. The focused slot is never touched — the
-            // offset clamp keeps its lead in [0, along - size].
-            lead = min(lead, along - Self.edgePeek)
+            // at 0. The peek caps at the slot size: a slot
+            // smaller than `edgePeek` (possible via `.fraction`,
+            // whose 5% floor has no point minimum) pins fully
+            // visible instead of displacing already-visible
+            // slots — with the cap, the focused slot is provably
+            // never touched (its lead stays in [0, along-size]).
+            let peek = min(Self.edgePeek, size)
+            lead = min(lead, along - peek)
             lead =
                 horizontal
-                ? max(lead, Self.edgePeek - size)
+                ? max(lead, peek - size)
                 : max(lead, 0)
             result[window] =
                 horizontal

--- a/Tests/KiwiDeskCoreTests/ScrollingLayoutTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingLayoutTests.swift
@@ -193,9 +193,11 @@ struct ScrollingLayoutTests {
             try #require(frames[w2]).maxX
                 == context.usable.minX + peek
         )
-        // The focused slot is untouched, fully visible.
+        // The focused slot is untouched: exactly flush at the
+        // trailing edge (an inward displacement would still
+        // satisfy a <= check, so assert equality).
         let focused = try #require(frames[w5])
-        #expect(focused.maxX <= context.usable.maxX + 0.01)
+        #expect(focused.maxX == context.usable.maxX)
     }
 
     @Test("Slots far past the right edge pin at a sliver (#142)")
@@ -220,6 +222,32 @@ struct ScrollingLayoutTests {
             try #require(frames[w3]).minX
                 == context.usable.minX + 800
         )
+        // The focused slot sits exactly at the leading edge —
+        // a sign error in the leading floor would move it.
+        #expect(
+            try #require(frames[w1]).minX == context.usable.minX
+        )
+    }
+
+    @Test("A slot smaller than edgePeek never displaces focus")
+    func tinySlotsKeepFocusedAtEdge() throws {
+        // `.fraction` can resolve below `edgePeek` (its 5%
+        // floor has no point minimum): 5% of 880pt = 44pt. The
+        // peek caps at the slot size, so the trailing pin must
+        // not pull the fully visible focused slot inward.
+        let many = (1...20).map { WindowID(UInt32($0)) }
+        var context = makeContext(
+            bounds: CGRect(x: 0, y: 0, width: 900, height: 1080),
+            focused: many[19]
+        )
+        context.scrolling.appBar.enabled = false
+        context.scrolling.slotSize = .fraction(0.05)
+        let frames = layout.calculateGeometry(
+            for: many,
+            in: context
+        )
+        let focused = try #require(frames[many[19]])
+        #expect(abs(focused.maxX - context.usable.maxX) < 0.01)
     }
 
     @Test("viewportOffset matches frames when no pin engages")


### PR DESCRIPTION
## Description

Fix-forward from the post-merge two-agent review of #145
(code-reviewer F1/F2, architect O4): `min(edgePeek, size)` peek
cap so fractional slot sizes below 48pt can't make the edge pins
displace fully visible slots (including the focused one);
exact-equality test assertions; sub-edgePeek regression test.

## Related Issue(s)

Refs #142 (shipped in #145). Remaining review findings M1
(pinned-slot navigation collisions) and M2 (stashPeek churn) are
filed as their own issues — this PR is only the prescribed
two-line fix.

## Checklist

- [x] Commits follow Conventional Commits format
- [x] New behavior is tested
- [x] `swift build && swift test && ./scripts/lint.sh` passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused
- (No user-visible docs change: behavior only differs in a
  sub-48pt-slot config where the old behavior was the bug.)

## How I verified

842 tests / 152 suites green incl. the new regression test
(20 windows, 5% fraction slots = 44pt < edgePeek, focused slot
stays exactly flush at the trailing edge). Full gate incl.
release build.

## Notes for Reviewer

Reviewer-prescribed micro-fix (two lines + tests) from the #145
post-merge round; merged on the local gate (CI billing-blocked,
standing owner decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)