### PR TITLE
fix(layout): floating focus keeps the scrolling viewport put

### DIFF
--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
@@ -82,13 +82,16 @@ public struct ScrollingLayout: LayoutSystem {
 
     /// The row geometry shared by `calculateGeometry` and
     /// `viewportOffset`: slot size, stride, total row length, and
-    /// the focused slot's position along the scroll axis.
+    /// the focused slot's position along the scroll axis — nil
+    /// when the focused window has no slot in the row (a floating
+    /// window, or nothing focused), so the offset math knows there
+    /// is nothing to scroll into view (#141).
     struct Metrics {
         let along: CGFloat
         let size: CGFloat
         let stride: CGFloat
         let rowLength: CGFloat
-        let focusedPos: CGFloat
+        let focusedPos: CGFloat?
     }
 
     static func metrics(
@@ -109,16 +112,17 @@ public struct ScrollingLayout: LayoutSystem {
         let stride = size + gap
         let count = CGFloat(windows.count)
         let rowLength = count * size + (count - 1) * gap
-        let focusedIndex =
-            context.focused.flatMap {
-                windows.firstIndex(of: $0)
-            } ?? 0
+        let focusedIndex = context.focused.flatMap {
+            windows.firstIndex(of: $0)
+        }
         return Metrics(
             along: along,
             size: size,
             stride: stride,
             rowLength: rowLength,
-            focusedPos: CGFloat(focusedIndex) * stride
+            focusedPos: focusedIndex.map {
+                CGFloat($0) * stride
+            }
         )
     }
 
@@ -175,25 +179,39 @@ public struct ScrollingLayout: LayoutSystem {
         along: CGFloat,
         size: CGFloat,
         rowLength: CGFloat,
-        focusedPos: CGFloat
+        focusedPos: CGFloat?
     ) -> CGFloat {
-        // The range of offsets that keep the focused slot fully
-        // inside the viewport: sliding it any further would clip
-        // its leading or trailing edge.
-        let visibleMin = -focusedPos
-        let visibleMax = along - size - focusedPos
-
         var target: CGFloat
-        if let previous {
-            target = min(max(previous, visibleMin), visibleMax)
+        if let focusedPos {
+            // The range of offsets that keep the focused slot
+            // fully inside the viewport: sliding it any further
+            // would clip its leading or trailing edge.
+            let visibleMin = -focusedPos
+            let visibleMax = along - size - focusedPos
+            if let previous {
+                target = min(
+                    max(previous, visibleMin),
+                    visibleMax
+                )
+            } else {
+                target = anchorOffset(
+                    anchor: anchor,
+                    along: along,
+                    size: size,
+                    focusedPos: focusedPos
+                )
+                target = min(
+                    max(target, visibleMin),
+                    visibleMax
+                )
+            }
         } else {
-            target = anchorOffset(
-                anchor: anchor,
-                along: along,
-                size: size,
-                focusedPos: focusedPos
-            )
-            target = min(max(target, visibleMin), visibleMax)
+            // The focused window has no slot in the row (a
+            // floating window, or nothing focused): there is
+            // nothing to scroll into view, so the viewport
+            // stays put instead of snapping home (#141). A
+            // never-scrolled space rests at the row start.
+            target = previous ?? 0
         }
 
         // Boundary awareness: never reveal empty margin past the

--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
@@ -172,7 +172,9 @@ public struct ScrollingLayout: LayoutSystem {
     /// nil` (a space that has never scrolled, or just switched
     /// into scrolling mode) falls back to the anchor's preferred
     /// resting position instead, so the very first tile still
-    /// respects `scroll.set_anchor`.
+    /// respects `scroll.set_anchor` — unless `focusedPos` is
+    /// also nil (no slot to anchor on), which rests at the row
+    /// start.
     static func offset(
         anchor: ScrollingParams.Anchor,
         previous: CGFloat?,
@@ -210,7 +212,11 @@ public struct ScrollingLayout: LayoutSystem {
             // floating window, or nothing focused): there is
             // nothing to scroll into view, so the viewport
             // stays put instead of snapping home (#141). A
-            // never-scrolled space rests at the row start.
+            // never-scrolled space rests at the row start —
+            // deliberately consuming the anchor seed (the
+            // persist loop writes the 0 back): re-seeding on
+            // the next slotted focus isn't worth an optional
+            // return through the #66 loop for this niche.
             target = previous ?? 0
         }
 

--- a/Tests/KiwiDeskCoreTests/ScrollingFloatingFocusTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingFloatingFocusTests.swift
@@ -1,0 +1,127 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+private let w1 = WindowID(1)
+private let w2 = WindowID(2)
+private let w3 = WindowID(3)
+private let w9 = WindowID(9)
+
+private func makeContext(
+    focused: WindowID?,
+    scrollOffset: CGFloat?
+) -> LayoutContext {
+    var context = LayoutContext(
+        bounds: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+        gaps: .uniform(10),
+        focused: focused
+    )
+    context.scrollOffset = scrollOffset
+    context.scrolling.slotSize = .points(800)
+    return context
+}
+
+/// A focused window without a slot in the row — floating, or
+/// nothing focused at all — must not pan the viewport (#141):
+/// there is nothing to scroll into view, so the offset keeps
+/// its boundary-clamped previous value instead of snapping to
+/// the first slot.
+@Suite("Scrolling floating focus")
+struct ScrollingFloatingFocusTests {
+    @Test("A slotless focus keeps the scrolled offset")
+    func slotlessFocusKeepsOffset() {
+        // w9 is not in the row; pre-#141 the slot-0 fallback
+        // clamped this offset back to 0.
+        let offset = ScrollingLayout.viewportOffset(
+            for: [w1, w2, w3],
+            in: makeContext(focused: w9, scrollOffset: -300)
+        )
+        #expect(offset == -300)
+    }
+
+    @Test("No focus at all keeps the scrolled offset")
+    func nilFocusKeepsOffset() {
+        let offset = ScrollingLayout.viewportOffset(
+            for: [w1, w2, w3],
+            in: makeContext(focused: nil, scrollOffset: -300)
+        )
+        #expect(offset == -300)
+    }
+
+    @Test("A never-scrolled space rests at the row start")
+    func slotlessFocusFreshSpace() {
+        let offset = ScrollingLayout.viewportOffset(
+            for: [w1, w2, w3],
+            in: makeContext(focused: w9, scrollOffset: nil)
+        )
+        #expect(offset == 0)
+    }
+
+    @Test("The kept offset still respects the row boundary")
+    func slotlessFocusBoundaryClamp() {
+        // Way past the end of a 3-slot row: the boundary clamp
+        // still applies, only the scroll-into-view clamp is
+        // skipped.
+        let offset = ScrollingLayout.viewportOffset(
+            for: [w1, w2, w3],
+            in: makeContext(focused: w9, scrollOffset: -9000)
+        )
+        let context = makeContext(focused: w9, scrollOffset: nil)
+        let area = context.scrolling.windowFrame(
+            in: context.usable,
+            inner: context.gaps.inner,
+            global: context.appBarStyle
+        )
+        let rowLength = 3 * CGFloat(800) + 2 * 10
+        #expect(offset == area.width - rowLength)
+    }
+
+    @Test("Focusing a floating window does not pan home")
+    @MainActor
+    func floatingFocusEndToEnd() {
+        guard NSScreen.main != nil else { return }
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "kiwidesk-tests-\(UUID().uuidString)"
+            )
+        let core = KiwiCore(configDirectory: directory)
+        for id in 1...5 {
+            core.state.apply(
+                .windowCreated(
+                    ManagedWindow(
+                        id: WindowID(UInt32(id)),
+                        pid: pid_t(id),
+                        appName: "App\(id)"
+                    )
+                )
+            )
+        }
+        let space = core.state.workspaces.space(of: w1)!
+        core.execute(
+            "set_mode",
+            args: [.string(space.raw), .string("scrolling")]
+        )
+        core.execute(
+            "scroll.set_slot_size",
+            args: [.number(800)]
+        )
+        // Scroll far, then back to w2: the offset rests at
+        // w2's left-visible edge — scrolled, but well inside
+        // the boundary of the row even after one slot floats
+        // out of it, so only the #141 bug could move it.
+        core.state.workspaces.focus(WindowID(5), in: space)
+        core.retile(animated: false)
+        core.state.workspaces.focus(w2, in: space)
+        core.retile(animated: false)
+        let scrolled = core.activeSpace?.scrollOffset
+        #expect(scrolled != nil && scrolled! < 0)
+        core.execute("make_floating")
+        core.retile(animated: false)
+        // Pre-#141 the slot-0 fallback panned the viewport
+        // home and persisted 0 — the tiled row visibly jumped.
+        #expect(core.activeSpace?.scrollOffset == scrolled)
+    }
+}

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -511,7 +511,9 @@ symmetrically: an off-screen window is revealed by panning toward
 it, and a window that is already fully visible does not move the
 viewport. The anchor decides where a freshly scrolled window comes
 to rest (centered, or against the leading/trailing edge) when the
-viewport had to move to reveal it.
+viewport had to move to reveal it. Focusing a *floating* window
+leaves the viewport where it is — a floating window has no slot
+in the row, so there is nothing to scroll into view.
 
 **Example:**
 


### PR DESCRIPTION
## Description

In a scrolling space scrolled away from the start, focusing a
*floating* window snapped the viewport home and persisted that
position: `ScrollingLayout.metrics()` fell back to
`focusedIndex = 0` when the focused window had no slot in the
row, so the visibility clamp scroll-into-viewed slot 0.

`Metrics.focusedPos` is now optional (nil when the focused
window has no slot — floating, or nothing focused), and
`offset()` skips the scroll-into-view clamp for a slotless
focus: the viewport keeps its previous offset with only the
boundary clamp applied. A never-scrolled space still rests at
the row start. The layout observes only the geometric fact
`focused ∉ windows` — floating-ness stays in Tiling, per the
pure-layout rule.

## Related Issue(s)

Closes #141. Follow-up filed from review: #155 (pre-existing:
the single-tiled-window short-circuit destroys a scrolled
offset through the same symptom class).

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## How I verified

- Full verify gate green: debug build, 865 tests (5 new in
  `ScrollingFloatingFocusTests`), lint, release build; site
  builds.
- The unit tests discriminate the bug (pre-fix, the slot-0
  fallback clamps the scrolled offsets back to 0 and each
  fails); the end-to-end test reproduces the issue's repro:
  scroll away, float the focused window, retile — the
  persisted offset must not move.
- CI is billing-blocked; merging on the green local gate per
  owner decision.

## Notes for Reviewer

Full AGENTS.md §3 round ran in parallel: architect-reviewer —
no must-fix/should-fix (modeling, layering, #66/#142
invariants, and stash-reversibility all confirmed; two
consider items folded in: seed-consumption comment + doc
sentence). code-reviewer — no must-fix (the adjacent
pre-existing single-window offset destruction is filed as
#155 per its own recommendation; doc-contract nit fixed).
Fix batch was comments/docs only → no re-review round per §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BArny3cz3zkmjWnV4iL5fF