### PR TITLE
fix(tiling): lift the stash peek above the OS visibility floor

### DIFF
--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
@@ -27,12 +27,13 @@ import CoreGraphics
 /// minimum keeps every target achievable.
 public struct ScrollingLayout: LayoutSystem {
     /// Visible sliver of a slot scrolled far past a screen edge
-    /// (#142). macOS clamps fully offscreen frames to an
-    /// undocumented title-bar minimum (~32–40 pt observed);
-    /// sitting safely above it keeps every pinned target
-    /// achievable, so the retile tolerance can settle instead
-    /// of re-issuing unreachable frames forever.
-    static let edgePeek: CGFloat = 48
+    /// (#142): the WindowServer's clamp floor plus a margin
+    /// (see `GeometryUtils.osVisibilityFloor`). Sitting safely
+    /// above the floor keeps every pinned target achievable,
+    /// so the retile tolerance can settle instead of
+    /// re-issuing unreachable frames forever.
+    static let edgePeek: CGFloat =
+        GeometryUtils.osVisibilityFloor + 8
 
     public init() {}
 

--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
@@ -27,13 +27,14 @@ import CoreGraphics
 /// minimum keeps every target achievable.
 public struct ScrollingLayout: LayoutSystem {
     /// Visible sliver of a slot scrolled far past a screen edge
-    /// (#142): the WindowServer's clamp floor plus a margin
-    /// (see `GeometryUtils.osVisibilityFloor`). Sitting safely
+    /// (#142): the WindowServer's clamp floor plus this
+    /// sliver's own margin (see
+    /// `WindowServerFacts.visibilityFloor`). Sitting safely
     /// above the floor keeps every pinned target achievable,
     /// so the retile tolerance can settle instead of
     /// re-issuing unreachable frames forever.
     static let edgePeek: CGFloat =
-        GeometryUtils.osVisibilityFloor + 8
+        WindowServerFacts.visibilityFloor + 8
 
     public init() {}
 

--- a/Sources/KiwiDeskCore/Models/WindowServerFacts.swift
+++ b/Sources/KiwiDeskCore/Models/WindowServerFacts.swift
@@ -1,0 +1,22 @@
+import CoreGraphics
+
+/// Empirical WindowServer placement facts, probed against the
+/// live OS. Shared value types so both `Layouts` (pure math)
+/// and `Tiling` (the engine) can consume them without a
+/// dependency edge between the two.
+public enum WindowServerFacts {
+    /// The WindowServer's offscreen-visibility floor: an
+    /// (almost) fully offscreen frame is clamped back until
+    /// roughly this much of it stays visible. Probed
+    /// 2026-07-10 (#148): ~32 pt on bottom/diagonal asks,
+    /// ~40 pt on left/right; partial overflow above the floor
+    /// applies exactly; nothing may go above the top border
+    /// at all (#139). An ask below the floor is unreachable —
+    /// the OS lifts it, the ±2 pt retile tolerance never
+    /// passes, and every retile re-issues the frame (#142,
+    /// #148). Any deliberate offscreen sliver must derive
+    /// from this value plus its own per-intent margin (the
+    /// derived slivers may diverge), so the next probe
+    /// updates exactly one site.
+    public static let visibilityFloor: CGFloat = 40
+}

--- a/Sources/KiwiDeskCore/Tiling/GeometryUtils.swift
+++ b/Sources/KiwiDeskCore/Tiling/GeometryUtils.swift
@@ -8,6 +8,20 @@ import CoreGraphics
 /// BOTTOM-left origin. KiwiDesk works in AX coordinates
 /// everywhere; NSScreen values are flipped at the boundary.
 public enum GeometryUtils {
+    /// The WindowServer's own offscreen-visibility floor: an
+    /// (almost) fully offscreen frame is clamped back until
+    /// roughly this much of it stays visible. Probed
+    /// 2026-07-10 (#148): ~32 pt on bottom/diagonal asks,
+    /// ~40 pt on left/right; partial overflow above the floor
+    /// applies exactly; nothing may go above the top border
+    /// at all (#139). An ask below the floor is unreachable —
+    /// the OS lifts it, the ±2 pt retile tolerance never
+    /// passes, and every retile re-issues the frame (#142,
+    /// #148). Any deliberate offscreen sliver must derive
+    /// from this value (floor + margin), so the next probe
+    /// updates exactly one site.
+    public static let osVisibilityFloor: CGFloat = 40
+
     /// Flips a rect between Cocoa and AX coordinate systems.
     /// The operation is its own inverse.
     public static func flip(

--- a/Sources/KiwiDeskCore/Tiling/GeometryUtils.swift
+++ b/Sources/KiwiDeskCore/Tiling/GeometryUtils.swift
@@ -8,20 +8,6 @@ import CoreGraphics
 /// BOTTOM-left origin. KiwiDesk works in AX coordinates
 /// everywhere; NSScreen values are flipped at the boundary.
 public enum GeometryUtils {
-    /// The WindowServer's own offscreen-visibility floor: an
-    /// (almost) fully offscreen frame is clamped back until
-    /// roughly this much of it stays visible. Probed
-    /// 2026-07-10 (#148): ~32 pt on bottom/diagonal asks,
-    /// ~40 pt on left/right; partial overflow above the floor
-    /// applies exactly; nothing may go above the top border
-    /// at all (#139). An ask below the floor is unreachable —
-    /// the OS lifts it, the ±2 pt retile tolerance never
-    /// passes, and every retile re-issues the frame (#142,
-    /// #148). Any deliberate offscreen sliver must derive
-    /// from this value (floor + margin), so the next probe
-    /// updates exactly one site.
-    public static let osVisibilityFloor: CGFloat = 40
-
     /// Flips a rect between Cocoa and AX coordinate systems.
     /// The operation is its own inverse.
     public static func flip(

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
@@ -195,8 +195,8 @@ public final class TilingEngine {
     // MARK: - Hiding inactive virtual spaces
 
     /// Visible sliver of stashed windows: the WindowServer's
-    /// clamp floor plus a margin (see
-    /// `GeometryUtils.osVisibilityFloor`). An ask below the
+    /// clamp floor plus this sliver's own margin (see
+    /// `WindowServerFacts.visibilityFloor`). An ask below the
     /// floor (the old 8 pt) was unreachable — the OS lifted it
     /// to ~32 pt, the ±2 pt tolerance never passed, and
     /// `stashInactive` re-issued a frame for every
@@ -205,7 +205,7 @@ public final class TilingEngine {
     /// windows settle; the visible change is marginal (the OS
     /// already showed ~32–40 pt).
     nonisolated static let stashPeek: CGFloat =
-        GeometryUtils.osVisibilityFloor + 8
+        WindowServerFacts.visibilityFloor + 8
 
     /// Where a hidden window parks: the bottom-right corner
     /// of its screen, AeroSpace style (only the top-left

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
@@ -194,12 +194,18 @@ public final class TilingEngine {
 
     // MARK: - Hiding inactive virtual spaces
 
-    /// Visible sliver of stashed windows: macOS rejects fully
-    /// offscreen frames — the WindowServer clamps any ask up to
-    /// its own title-bar-sliver minimum (~32–40 pt, empirically)
-    /// — so this many points stay on screen *by intent*; the OS
-    /// keeps somewhat more.
-    nonisolated static let stashPeek: CGFloat = 8
+    /// Visible sliver of stashed windows: the WindowServer's
+    /// clamp floor plus a margin (see
+    /// `GeometryUtils.osVisibilityFloor`). An ask below the
+    /// floor (the old 8 pt) was unreachable — the OS lifted it
+    /// to ~32 pt, the ±2 pt tolerance never passed, and
+    /// `stashInactive` re-issued a frame for every
+    /// inactive-space window on every retile (#148). At
+    /// floor + margin the target is achievable, so stashed
+    /// windows settle; the visible change is marginal (the OS
+    /// already showed ~32–40 pt).
+    nonisolated static let stashPeek: CGFloat =
+        GeometryUtils.osVisibilityFloor + 8
 
     /// Where a hidden window parks: the bottom-right corner
     /// of its screen, AeroSpace style (only the top-left

--- a/Tests/KiwiDeskCoreTests/OsVisibilityFloorTests.swift
+++ b/Tests/KiwiDeskCoreTests/OsVisibilityFloorTests.swift
@@ -1,0 +1,37 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The WindowServer clamps (almost) fully offscreen frames
+/// back to its own visibility floor (#148, probed): any
+/// deliberate sliver asked below it is unreachable, the ±2 pt
+/// retile tolerance never passes, and every retile re-issues
+/// the frame. Both slivers must sit at or above the shared
+/// floor constant so the next probe updates one site.
+@Suite("OS visibility floor")
+struct OsVisibilityFloorTests {
+    @Test("The stash peek is an achievable ask")
+    func stashPeekAboveFloor() {
+        #expect(
+            TilingEngine.stashPeek
+                >= GeometryUtils.osVisibilityFloor
+        )
+    }
+
+    @Test("The scrolling edge peek is an achievable ask")
+    func edgePeekAboveFloor() {
+        #expect(
+            ScrollingLayout.edgePeek
+                >= GeometryUtils.osVisibilityFloor
+        )
+    }
+
+    @Test("The floor itself matches the probed range")
+    func floorMatchesProbe() {
+        // 32–40 pt observed across edges; the constant is the
+        // max, so every edge's ask clears its clamp.
+        #expect(GeometryUtils.osVisibilityFloor == 40)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/OsVisibilityFloorTests.swift
+++ b/Tests/KiwiDeskCoreTests/OsVisibilityFloorTests.swift
@@ -8,15 +8,16 @@ import Testing
 /// back to its own visibility floor (#148, probed): any
 /// deliberate sliver asked below it is unreachable, the ±2 pt
 /// retile tolerance never passes, and every retile re-issues
-/// the frame. Both slivers must sit at or above the shared
-/// floor constant so the next probe updates one site.
+/// the frame. Both slivers must sit strictly above the shared
+/// floor constant — the floor is approximate, the margin
+/// absorbs that — so the next probe updates one site.
 @Suite("OS visibility floor")
 struct OsVisibilityFloorTests {
     @Test("The stash peek is an achievable ask")
     func stashPeekAboveFloor() {
         #expect(
             TilingEngine.stashPeek
-                >= GeometryUtils.osVisibilityFloor
+                > WindowServerFacts.visibilityFloor
         )
     }
 
@@ -24,14 +25,16 @@ struct OsVisibilityFloorTests {
     func edgePeekAboveFloor() {
         #expect(
             ScrollingLayout.edgePeek
-                >= GeometryUtils.osVisibilityFloor
+                > WindowServerFacts.visibilityFloor
         )
     }
 
-    @Test("The floor itself matches the probed range")
-    func floorMatchesProbe() {
-        // 32–40 pt observed across edges; the constant is the
-        // max, so every edge's ask clears its clamp.
-        #expect(GeometryUtils.osVisibilityFloor == 40)
+    @Test("The floor stays in the plausible probe band")
+    func floorSanityBand() {
+        // Not a pin — a re-probe after a macOS update is
+        // expected to edit the constant (one site). This only
+        // catches a fat-fingered edit.
+        let floor = WindowServerFacts.visibilityFloor
+        #expect(floor > 0 && floor < 100)
     }
 }

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -75,7 +75,10 @@ tracked, not abandoned:
   On the other edges KiwiDesk pins far-offscreen slots at its
   own fixed sliver, safely above the OS minimum, for the same
   achievable-target reason
-  ([#142](https://github.com/hajiboy95/KiwiDesk/issues/142)).
+  ([#142](https://github.com/hajiboy95/KiwiDesk/issues/142));
+  stashed inactive-space windows park at the same
+  floor-derived sliver
+  ([#148](https://github.com/hajiboy95/KiwiDesk/issues/148)).
 
 All of these are collected in
 [#140](https://github.com/hajiboy95/KiwiDesk/issues/140).


### PR DESCRIPTION
## Description

`TilingEngine.stashPeek = 8` asked for an 8pt-visible stash
frame, but the WindowServer lifts any ask below its own
visibility floor (probed: ~32pt bottom/diagonal, ~40pt
left/right). Every stash target was unreachable, the ±2pt
retile tolerance never passed, and `stashInactive` re-issued a
frame for every inactive-space window on every retile — the
churn class #142 fixed for scrolling slots, pre-existing in
the stash path.

The probed OS fact now lives in one documented constant,
`WindowServerFacts.visibilityFloor` (40) in `Models` — a leaf
both `Layouts` and `Tiling` may depend on without a dependency
edge between them. Both deliberate slivers derive from it plus
their own per-intent margin: `ScrollingLayout.edgePeek` stays
48 (zero behavior change) and `stashPeek` lifts 8 → 48, making
stash targets achievable so stashed windows settle. Visible
change is marginal — the OS already showed ~32–40pt. A guard
suite pins both derivations strictly above the floor.

## Related Issue(s)

Closes #148.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build passes: `swift build -c release`
- [x] PR is focused; refactors separated from features

## How I verified

- Full verify gate green: debug build, 868 tests (3 new in
  `OsVisibilityFloorTests`), lint, release build; site builds.
- The probe data backing the floor value was gathered live
  against the WindowServer earlier in this work stream (#145
  session) and is documented on the constant with date and
  per-edge values.
- All peek references are symbolic (checked tree-wide) — the
  existing `NativeSpaceTests` stash-frame assertions track the
  lift automatically.
- CI is billing-blocked; merging on the green local gate per
  owner decision.

## Notes for Reviewer

Full AGENTS.md §3 round ran in parallel: code-reviewer — no
must-fix/should-fix (knock-on audit of drag detection,
focus-follow, restore paths all clean). architect-reviewer —
no must-fix; two should-fixes applied in the second commit
(constant moved from `Tiling/GeometryUtils` to
`Models/WindowServerFacts` to remove the first
Layouts → Tiling dependency edge; the `== 40` change-detector
test replaced with strict derivation guards + a sanity band so
a re-probe stays a one-site edit). The unnamed per-site `+ 8`
margins are deliberate per the architect (naming a shared
margin would encode coupling the design disclaims). Fix batch
was a mechanical relocation specified by the reviewer → no
re-review round per §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BArny3cz3zkmjWnV4iL5fF