### PR TITLE
build(agents): load a caveman-compressed AGENTS.md brief

### DIFF
--- a/.claude/AGENTS.brief.md
+++ b/.claude/AGENTS.brief.md
@@ -1,0 +1,145 @@
+<!-- GENERATED from AGENTS.md by scripts/build-agent-brief.sh
+     DO NOT EDIT. Regenerate after editing AGENTS.md.
+     source-sha256: 5e3bb8b3e1d54215904607f87e0c6e7c22456dd1d7e8d3a8a6778925700aac77 -->
+
+# KiwiDesk — Agent & Contributor Guidelines
+
+Binding rules for human devs and AI agents on this repo. Read before touching code.
+
+This file canonical source. Claude Code loads caveman-compressed brief from it (`.claude/AGENTS.brief.md`, built by `scripts/build-agent-brief.sh`) to save per-session context; regenerate brief when you edit this file. Other agents (Cursor, Codex) and humans read this file direct.
+
+---
+
+## 1. Project Overview
+
+KiwiDesk = tiling window manager for macOS (Swift, SwiftUI, Lua). Manages windows in **flat, one-dimensional array per space** — never hierarchical trees. Layout algorithms = pure functions over that array.
+
+```mermaid
+graph TD
+    A[UI / SwiftUI App] <-->|Settings & Profiles| B[App Core / Swift]
+    B <-->|Bridge| C[Lua Engine / VM]
+    B -->|Calls| D[OS Layer / Private APIs & AX]
+```
+
+Module layout (SwiftPM targets):
+
+| Target | Path | Responsibility |
+|---|---|---|
+| `KiwiDeskCore` | `Sources/KiwiDeskCore` | State, events, OS bridge |
+| `KiwiDesk` | `Sources/KiwiDesk` | Executable, menu bar, GUI |
+| `KiwiDeskCoreTests` | `Tests/KiwiDeskCoreTests` | Unit tests |
+
+Swift core stays strictly separate from SwiftUI GUI and (later) Lua VM.
+
+Subsystem map (`Sources/KiwiDeskCore/*`) — directory-level, not file list; grep within subsystem for specifics:
+
+| Dir | Responsibility |
+|---|---|
+| `State` | Flat `[WindowID]`-per-space window state |
+| `Tiling` | Place windows from state into layouts |
+| `Layouts` | Pure layout algorithms over flat array |
+| `Commands` | Command dispatch (`set_*` verbs) |
+| `Config` | Decode Lua/profile config into settings |
+| `Profiles` | Profile JSON load/save & defaults |
+| `Lua` | Lua VM bridge, watchdog, registry refs |
+| `AX` | Accessibility bridge & `AXObserver` callbacks |
+| `OS` | Private SkyLight/CGS symbols via `dlsym`, AX fallback |
+| `Keys` | Carbon hotkey registration |
+| `Events` | Event listening / mouse drag taps |
+| `Animation` | Per-monitor `DisplayLink` animation |
+| `IPC` | CLI / external command IPC |
+| `Bar` | sketchybar integration |
+| `Power` | Power / display-state handling |
+| `Permissions` | AX / permission prompts |
+| `App` | Core bootstrap & wiring |
+| `Models` | Shared value types |
+| `Service` | Long-running service glue |
+
+GUI lives in `Sources/KiwiDesk` (`Settings/`, `Settings/Tabs/`).
+
+## 2. Code Rules
+
+1. **File size:** target **100–250 lines** per Swift file. Hard ceiling: **350 lines** (only cohesive, perf-critical logic). Split before growing past ceiling.
+2. **Line length:** max **79 characters** per line. Enforced by pre-commit hook and CI (`scripts/lint.sh`).
+3. **Single Responsibility:** one class/struct = one job (event listening, layout math, IPC — never mixed).
+4. **DRY vs. readability:** extract shared helpers (`AXHelper`, `GeometryUtils`) instead of duplicating, but prefer small readable duplication over deep protocol hierarchy or heavy generics. Keep code flat.
+5. **Formatting:** `swift format` with repo `.swift-format` config owns all style (whitespace, commas, braces). SwiftLint (SPM build plugin, `.swiftlint.yml`) owns semantic rules (force casts, complexity, file length), warns direct in Xcode during builds. Never enable SwiftLint style rule that fights swift-format. Run `scripts/lint.sh` before commit.
+6. **Concurrency:** AppKit/AX interaction is `@MainActor`. Pure state and layout code stays actor-free and unit-testable.
+
+## 3. Workflow: Refine → Plan → Act → Verify
+
+1. **Refine:** read relevant code and specs before proposing changes; clarify ambiguity first.
+2. **Plan:** for features and major fixes, write short plan (files to change, API surface, tests) before implementing.
+3. **Act:** implement step by step; keep commits focused.
+4. **Verify:** `swift build && swift test && scripts/lint.sh` for fast inner loop. **Release build** (`swift build -c
+   release`) must also pass before any commit or PR — enables optimizer and stricter concurrency diagnostics (e.g. non-Sendable captures in `@Sendable` closures) that debug build silently misses.
+5. **Document:** any user-visible behavior change updates matching docs in same change set — `docs/lua-reference.md` (Lua config & behavior, *expects → does → example* form), `docs/user-guide.md` (Settings app & GUI flows), `docs/cli.md` (commands, events, IPC), `docs/recipes/` (integration recipes), `docs/design-decisions.md` (when settled product/UX decision made or changed) — and `plan/` when design itself shifts. Code and docs never describe different behavior.
+   Marketing/docs **site (`site/`)** renders `docs/` through symlink, so doc *content* edits flow to it auto — never hand-copy doc into `site/`. But site not fully covered by symlink: **new doc page** needs sidebar entry in `site/astro.config.mjs`, and **site-only surfaces** (landing page, cross-page callouts) updated in same change set when feature warrants surfacing there — e.g. new layout mode (#128) adds user-guide/reference prose *and* whatever nav or callout makes it findable. Run `npm run build` in `site/` when you touch either.
+   When review or manual pass classifies behavior as **accepted-by-architecture**, add row to *Accepted limitations* table in `docs/design-decisions.md` in same change set — user-facing twin of §5 guardrail rule (OS-blocked-by-SIP items = separate class there, no in-app escape hatch).
+6. **Review:** once substantial change finished, verified, committed, spin up **both** `code-reviewer` and `architect-reviewer` on diff since last review point — branch merge base with `main`, or last reviewed commit / PR if one exists. Address or consciously dismiss findings before opening PR. (See §4 subagent delegation.)
+
+   Sequencing: first round runs both agents **in parallel** — diff finished, perspectives independent, serializing only costs time. When fix batch itself substantial (new abstractions, behavioral gates — not comment or guard tweaks), run focused re-review of **only fix range**, this time **sequentially**: `code-reviewer` first (fixes correct?), then `architect-reviewer` (do seams the fixes introduced hold up?). Alternate rounds until one returns no major findings. Brief each re-review with what fixes claim to do, so it verifies claims instead of re-reviewing feature.
+
+### Branching & Pull Requests
+
+Branch from `main` with name matching Conventional Commit type: `feat/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`, `ci/`, `perf/`, etc., then short kebab-case description (e.g., `feat/scrolling-snap-mode`). One focused change per branch; separate refactors from features.
+
+When opening issue or PR, use GitHub [issue templates](.github/ISSUE_TEMPLATE/) and [PR template](.github/pull_request_template.md). Reference related issues in commit messages or PR descriptions via `fixes #123` syntax.
+
+### Commit messages (Angular / Conventional Commits)
+
+Format: `type(scope): subject` — imperative, lower-case subject, no trailing period. Body (optional) explains why, wrapped at 72 columns.
+
+- Types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`.
+- Scope = touched area, e.g. `animation`, `tiling`, `layout`, `commands`, `lua`, `ax`, `profiles`, `docs`. Omit when change repo-wide.
+- Examples:
+  - `feat(layout): add stack.set_overflow_style`
+  - `fix(tiling): defer z-order restore until animations settle`
+  - `perf(animation): apply position-only frames per app`
+
+## 4. Tooling
+
+- Shared automation lives in visible `/scripts/` dir (never hidden in dot-folders): lint, git hooks, localization scripts.
+- Install hooks once per clone: `./scripts/install-hooks.sh`.
+- Fetch and install workspace subagents and skills: `./scripts/install-subagents.sh`.
+- (Optional, per-developer) install `caveman` skill to compress agent output — not build dependency; needs Node `>= 18` (installer checks): `npx -y github:JuliusBrussee/caveman --non-interactive`. `--non-interactive` avoids hang when piped; append flags to scope it, e.g. `--only claude`, `--minimal`, `--uninstall`.
+- Regenerate compressed agent brief after editing this file: `./scripts/build-agent-brief.sh` (needs caveman + `claude` CLI or `ANTHROPIC_API_KEY`). `scripts/lint.sh` runs `scripts/check-agent-brief.sh`, which only warns (never blocks) if brief stale — so editing this file needs no caveman install; brief drifts until someone rebuilds it.
+
+### Subagent delegation (AI agents)
+
+When subagents available, spin off proactively — no need to wait for user ask — but only where payoff clear. Subagent starts with zero conversation context, so delegate work not depending on it:
+
+- **Broad fan-out searches** across many files or naming conventions where only conclusion matters (`Explore`).
+- **Independent review passes** on finished substantial change (`code-reviewer`, `architect-reviewer`).
+- **Parallel, isolated implementation work** (e.g. separate worktree) that would otherwise serialize.
+
+Stay inline for anything small, sequential, or dependent on conversation context: cold agent re-deriving what session already knows costs more than it saves.
+- CI (`.github/workflows/ci.yml`) builds, lints, tests on every push and on PRs targeting `main`. Red build blocks merge.
+
+## 5. Guardrails (Known Pitfalls)
+
+Keep list updated when recurring mistake found.
+
+- **Pre-release, single user: no backward-compat shims.** Nothing publicly released, so nothing external depends on current command names, Lua/CLI verbs, event names, or file formats. Rename and restructure freely; do **not** add compat aliases, deprecation layers, or migration scripts — re-saving or re-editing config is the migration (#42 renamed space commands outright instead of keeping `*_virtual_space` aliases; profile JSON likewise needs none). Revisit at first public release — until then, back-compat = wasted complexity.
+- **One vocabulary across Lua and profile JSON.** Profile JSON key = Lua command name with `set_` verb stripped, snake_case, grouped by namespace: `set_gap_override` → `gap.override`, `bsp.set_ratio` → `layout.bsp.ratio`, `stack.set_master_ratio` → `layout.stack.master_ratio`. Multi-part element names nest further when element is configurable unit: `drag.set_ghost_fill_color` → `drag.ghost.fill_color`. Groups singular (`gap`, `layout`, `drag`); never invent synonyms or plurals. When adding setting, pick Lua name first and derive JSON key from it via `CodingKeys` (Swift property names may differ internally). `SettingsCodingTests` pins this shape.
+- **Never disable SIP or ask users to.** Private SkyLight/CGS symbols resolved at runtime via `dlsym` (`SkyLight.swift`), never linked with `@_silgen_name` — linked symbol that disappears in macOS update would crash app at launch, while failed lookup returns nil and caller falls back to public Accessibility API (`AXUIElement`). Every private fast path must have such fallback.
+- **Lua watchdog cannot interrupt blocking C calls.** Runaway-script guard = instruction-count hook; code blocking inside C (`system()`, pipe reads) executes zero VM instructions and freezes main thread forever. Never add API that blocks in C on main thread — external commands always go through `ExecLauncher`. Lua registry refs (`luaL_ref`) VM-specific and their slots reused: never deliver ref into different interpreter than one that minted it (capture owning `LuaInterpreter` weakly, as `KiwiCore+ExecAPI` does).
+- **AX calls slow and can block.** Never call AX APIs inside tight loops or layout math; snapshot state first.
+- **Electron/WebKit apps answer AX queries lazily** (100–300 ms). `AXEnhancedUserInterface` set to `true` on managed apps to keep their AX tree warm; do not remove without replacement.
+- **Windows live in flat `[WindowID]` per space.** Do not introduce tree/container structures into state or layout code.
+- **Space identifiers are strings** and case-sensitive; numeric strings and integers equivalent (`"1"` == `1`).
+- **Hotkeys use Carbon API** (`RegisterEventHotKey`), not CGEventTap — avoids Input Monitoring permission. Event taps only for mouse drag tracking.
+- **One `DisplayLink` per monitor** (mixed refresh rates). Never drive animations from single global timer.
+- **`AXObserver` callbacks arrive on run loop thread** that registered them; keep observer registration on main thread.
+- **SwiftUI cursor changes use `NSCursor.set()`, never push/pop.** View removed under pointer (link that deletes itself, row rebuilt by rename) never delivers balancing `onHover(false)`, and hover interleaved with drag gesture pops wrong entry — cursor stack cannot balance. Bit the spaces drag handle and link-hover modifier.
+- **Keep SwiftUI `body` a shallow container.** Long modifier chain with conditional `background`/`overlay` closures or `+`-concatenated string literals inside one `body` expression can exceed type-checker budget — and failure machine-dependent: compiles locally but dies on slower CI runner ("unable to type-check this expression in reasonable time"), so local verify gate does not catch it. Extract chained subviews into private computed properties / funcs and hoist concatenated strings into constants. Bit `KeyRecorderField`.
+- **Split test suites early.** 79-char limit and 350-line ceiling repeatedly bit large test files. Break suites into focused files before they grow; per-file private helpers = convention and small duplication across suites fine.
+- **Profiles own tiling, plus sparse behavior overrides.** Profile serializes tiling state — belongs *inside* `TilingSettings` so it rides config split for free (see `gap.override`). Beyond tiling, profile may carry **sparse override of global _behavior_ setting** — one shaping how workspace behaves *while profile active* (keybindings today, via `Profile.modes` / `KeyModeOverride`; app rules planned, #109). May **never** override setting that *routes or selects* the profile itself (`profile_bindings`, native-Space→profile map) or that lives outside config ownership (GUI language pref, persists in `UserDefaults`) — profile that could rewrite what selects it = self-reference hazard. Every override = base overlaid with sparse diff (absent = inherit; explicit tombstone expresses removal), never second home for setting. Add each deliberately — templated on `KeyModeOverride`'s seam and guarded by round-trip + resolve parity test — NOT via generic override primitive until real second flat-map client exists (one client removes no drift; see `.claude/rules/parity-tests.md`). `ProfileManager` mutators `internal` by design — mutate through `KiwiCore` facade, never re-publicize them. `read(name:)` = public load-for-edit primitive (path-traversal guarded, touches no state); `save()` **adopts** (sets `currentName`, clears dirty), so edit-without-activating path must be separate non-adopting write — never overload `save()`. GUI-vs-Lua ownership predicate centralized in `KiwiCore.isGuiManaged` (`KiwiCore+GuiConfig.swift`); refine that one predicate, never add second. Pre-release (single user): profile JSON needs no migration scripts — re-saving is migration.
+- **Explicit settings applies must `retile(force: true)`.** Engine "already there" tolerance (±2 pt per edge) exists to absorb AX-echo lag and app-side clamping; un-forced retile after config edit lets it swallow small changes entirely (1 pt gap edit visibly did nothing). Config-apply entry points (`applyProfileScopedState`, `set_gap_*`, `set_min_window_size`, `set_mode`, and whole `layoutCommand` dispatch — every retile triggered by explicit `set_*` from Lua/CLI) force; event-driven retiles stay un-forced so echo lag can't wobble windows. Profile applies classify themselves: `apply(profile:)` / `apply(composed:)` take **required** `forceRetile`, so every new caller must choose — explicit paths (`load_profile`, in-effect edit re-apply, post-reload re-apply, preset apply) force; monitor-change and native-space-binding applies stay un-forced.
+- **Resolve before layout, and merge per-field first.** Settings that layer (global → layout → space) merge field-by-field, cross-field clamps applied *last* on already-merged values (`AppBarStyle.resolved…` pattern). Resolution runs before layout math so layout functions stay pure over flat array.
+- **Guard hand-mirrored field lists with forget-proof parity test.** Some patterns repeat struct's field list across sites — global ↔ optional-override mirror (`AppBarStyle` ↔ `LayoutAppBar`), dual apply switch (`AppBarCommandSetting`), manual sparse `Codable`. Small readable duplication fine (§2.4), but past **two** mirrors of same field list, drift risk (add field, forget one site → silent data loss) outweighs clarity. Before adding third, weigh whether duplication still pays; if it ships, **must** carry parity test — and prefer one discovering fields by reflection / shared `CodingKeys` over hand-enumerated list, so guard itself cannot silently rot (hand-listed parity test = one more place to forget). Reflection net catches missing *property*, not forgotten `resolved()` / `encode` line — back it with round-trip + resolve-every-field test for those. Reach for generic/keypath merge only when it removes drift, not just `resolved()` lines — sparse `Codable` stays per-field either way, so generics rarely buy down real risk and fight §2.4.
+- **`Resources/Locales/*.json` generated/translation-owned (issue #9).** Every GUI string routes through `L("key", "English")` (`KiwiDeskCore/Localization/
+  LocalizationManager.swift`); English = source of truth, inlined at call site, with per-key fallback when locale omits key. Value interpolated into sentence (name, count) MUST go through `L(key, english, args...)` overload with POSITIONAL `%1$@`/`%1$d` specifiers, never `+`-concatenated fragments — translation can't reorder pieces stitched together in Swift, and many languages need to. `en.json` regenerated wholesale by `scripts/extract-keys` (scans both `Sources/KiwiDesk` and `Sources/
+  KiwiDeskCore`, ignores `//`/`///` comments so doc-comment example call site can't leak phantom key) from real call sites — never hand-edit it, and AI agents must not hand-edit any `Resources/Locales/*.json` file: use `scripts/extract-keys
+  <locale>` / `scripts/merge-keys <locale>` to translate, `scripts/rename-key <old> <new>` to rename key without losing translations, and `scripts/extract-keys --prune` to drop orphaned ones (see `docs/translating.md`). Because same English text can be authored at two different call sites for one key, `extract-keys` fails loud on any such drift (mismatched English for same key) rather than silently picking one; `extract-keys --check` (run unconditionally by `scripts/lint.sh` — part of verify gate, CI, and `scripts/pre-commit` when Swift or locale file staged) additionally hard-fails if `en.json` stale or if any shipped `<locale>.json` doesn't decode as flat `{string: string}` map (broken file would otherwise make `LocaleCatalog` soft-fail to `[:]` and silently revert that locale to English); orphan key (in locale file, absent from code) only warns — clean up with `extract-keys
+  --prune`. All backed by Swift tests (`LocalizationDriftGuardTests`, `LocalizationOrphanTests`, `RenameKeyTests`) so regression in tooling itself covered by `swift test`, not just by running script. GUI language pick persists in `UserDefaults` (`LocalizationPreference`), never `gui.json` — documented as side-effect-free and must never create sidecar or flip `KiwiCore.isGuiManaged`.

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ plan/
 .claude/*
 !.claude/skills/
 !.claude/rules/
+!.claude/AGENTS.brief.md
 .agents/skills/
 
 # macOS specific

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,13 @@
 Binding rules for human developers and AI agents working on this
 repository. Read this file before modifying any code.
 
+This file is the canonical source. Claude Code loads a
+caveman-compressed brief generated from it
+(`.claude/AGENTS.brief.md`, built by
+`scripts/build-agent-brief.sh`) to save per-session context;
+regenerate that brief whenever you edit this file. Other agents
+(Cursor, Codex) and humans read this file directly.
+
 ---
 
 ## 1. Project Overview
@@ -177,6 +184,18 @@ no trailing period. Body (optional) explains the why, wrapped at
 - Install hooks once per clone: `./scripts/install-hooks.sh`.
 - Fetch and install workspace subagents and skills:
   `./scripts/install-subagents.sh`.
+- (Optional, per-developer) install the `caveman` skill to
+  compress agent output — not a build dependency; needs Node
+  `>= 18` (the installer checks):
+  `npx -y github:JuliusBrussee/caveman --non-interactive`.
+  `--non-interactive` avoids a hang when piped; append flags to
+  scope it, e.g. `--only claude`, `--minimal`, `--uninstall`.
+- Regenerate the compressed agent brief after editing this file:
+  `./scripts/build-agent-brief.sh` (needs caveman + a `claude`
+  CLI or `ANTHROPIC_API_KEY`). `scripts/lint.sh` runs
+  `scripts/check-agent-brief.sh`, which only warns (never blocks)
+  if the brief is stale — so editing this file needs no caveman
+  install; the brief just drifts until someone rebuilds it.
 
 ### Subagent delegation (AI agents)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,14 @@
 
 The canonical agent & contributor guidelines for this repository
 live in **AGENTS.md** (the single source of truth, shared across
-tools). Claude Code imports it below — read it before modifying
-any code.
+tools) — read it before modifying any code.
 
-@AGENTS.md
+To cut per-session context, Claude Code loads a caveman-compressed
+brief generated from AGENTS.md, not the full file. The brief is a
+derived artifact: regenerate it with
+`./scripts/build-agent-brief.sh` after editing AGENTS.md
+(`scripts/lint.sh` prints a warning — never blocks — if it goes
+stale), and never hand-edit it. Read AGENTS.md itself for the
+authoritative, uncompressed text.
+
+@.claude/AGENTS.brief.md

--- a/scripts/build-agent-brief.sh
+++ b/scripts/build-agent-brief.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Regenerates .claude/AGENTS.brief.md — a caveman-compressed copy of
+# AGENTS.md that CLAUDE.md loads instead of the full file, to cut the
+# per-session context Claude Code ingests. AGENTS.md stays the
+# canonical, human-readable source; the brief is a DERIVED artifact and
+# must never be hand-edited (scripts/check-agent-brief.sh enforces it).
+#
+# Requires the caveman skill (see AGENTS.md §4) plus either
+# ANTHROPIC_API_KEY or a signed-in `claude` CLI — compression is an LLM
+# pass, so output is not byte-reproducible. The freshness guard pins
+# the SOURCE hash, not the compressed text, so any faithful run passes.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/AGENTS.md"
+OUT="$ROOT/.claude/AGENTS.brief.md"
+
+sha256() {
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        sha256sum "$1" | awk '{print $1}'
+    fi
+}
+
+[ -f "$SRC" ] || { echo "ERROR: $SRC missing" >&2; exit 1; }
+
+# Locate the caveman-compress skill across known install roots.
+CAVE=""
+for base in "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" "$HOME/.claude"; do
+    cand="$base/plugins/marketplaces/caveman/skills/caveman-compress"
+    if [ -d "$cand" ]; then CAVE="$cand"; break; fi
+done
+if [ -z "$CAVE" ]; then
+    echo "ERROR: caveman-compress not found. Install caveman first" >&2
+    echo "  (see AGENTS.md §4)." >&2
+    exit 1
+fi
+
+sha="$(sha256 "$SRC")"
+
+# Compress a scratch copy — caveman rewrites in place and drops a
+# .original.md backup, so keep AGENTS.md itself untouched.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cp "$SRC" "$tmp/AGENTS.md"
+( cd "$CAVE" && python3 -m scripts "$tmp/AGENTS.md" )
+
+mkdir -p "$(dirname "$OUT")"
+{
+    echo "<!-- GENERATED from AGENTS.md by scripts/build-agent-brief.sh"
+    echo "     DO NOT EDIT. Regenerate after editing AGENTS.md."
+    echo "     source-sha256: $sha -->"
+    echo
+    cat "$tmp/AGENTS.md"
+} >"$OUT"
+
+echo "Wrote $OUT (source-sha256 $sha)"

--- a/scripts/check-agent-brief.sh
+++ b/scripts/check-agent-brief.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Freshness reminder for .claude/AGENTS.brief.md (the caveman-compressed
+# AGENTS.md that CLAUDE.md loads). WARN-ONLY: never blocks a commit or
+# CI — it only prints a reminder when the brief is missing or its
+# recorded source-sha256 no longer matches AGENTS.md (i.e. AGENTS.md was
+# edited without regenerating the brief). Run by scripts/lint.sh and the
+# pre-commit hook. Regenerate with scripts/build-agent-brief.sh.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/AGENTS.md"
+OUT="$ROOT/.claude/AGENTS.brief.md"
+
+sha256() {
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        sha256sum "$1" | awk '{print $1}'
+    fi
+}
+
+if [ ! -f "$OUT" ]; then
+    echo "WARNING: $OUT missing;" \
+        "run scripts/build-agent-brief.sh" >&2
+    exit 0
+fi
+
+want="$(sha256 "$SRC")"
+have="$(grep -m1 'source-sha256:' "$OUT" | awk '{print $2}')"
+
+if [ "$want" != "$have" ]; then
+    echo "WARNING: .claude/AGENTS.brief.md is stale" \
+        "(AGENTS.md changed since it was built)." >&2
+    echo "  Regenerate: scripts/build-agent-brief.sh" >&2
+    exit 0
+fi
+
+echo "agent-brief OK (source-sha256 $want)"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -64,6 +64,11 @@ if ! python3 "$ROOT/scripts/extract-keys" --check; then
     STATUS=1
 fi
 
+# Agent-brief freshness reminder (warn-only, never fails lint): the
+# caveman-compressed AGENTS.md that CLAUDE.md loads should be
+# regenerated when AGENTS.md changes.
+"$ROOT/scripts/check-agent-brief.sh" || true
+
 if [ "$STATUS" -eq 0 ]; then
     echo "Lint OK"
 fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -41,4 +41,13 @@ elif [ "${#STAGED_LOCALES[@]}" -gt 0 ]; then
     fi
 fi
 
+# AGENTS.md (or the brief) edited without a staged Swift file? Then
+# lint.sh — which runs the brief freshness reminder — did not fire
+# above, so run that reminder directly (warn-only, never blocks).
+if [ "${#STAGED_SWIFT[@]}" -eq 0 ] \
+    && git diff --cached --name-only --diff-filter=ACM \
+        | grep -qE '^(AGENTS\.md|\.claude/AGENTS\.brief\.md)$'; then
+    "$ROOT/scripts/check-agent-brief.sh" || true
+fi
+
 exit $STATUS


### PR DESCRIPTION
## What

`CLAUDE.md` now imports `.claude/AGENTS.brief.md` — a
caveman-compressed copy of `AGENTS.md` (~65% fewer lines, 144 vs
~410) — to cut the per-session context Claude Code ingests.
`AGENTS.md` stays the **canonical, human-readable** source and keeps
its `§1–§5` anchors intact, so the ~30 cross-references across
`.claude/rules/*`, `docs/*`, `.github/*`, `.swiftlint.yml`,
`CONTRIBUTING.md`, `README.md` are untouched. Cursor/Codex and humans
still read `AGENTS.md` directly.

## How

- `scripts/build-agent-brief.sh` — regenerates the brief (needs
  caveman + a `claude` CLI or `ANTHROPIC_API_KEY`). Compression is an
  LLM pass, so output isn't byte-reproducible.
- `scripts/check-agent-brief.sh` — pins the source `sha256` in the
  brief header and **warns, never blocks**, via `lint.sh` /
  pre-commit when `AGENTS.md` changed without a rebuild. So editing
  `AGENTS.md` needs **no** caveman install; the brief just drifts
  until someone rebuilds it.
- `.gitignore` — un-ignores `.claude/AGENTS.brief.md`.
- `AGENTS.md` §4 — documents the caveman install one-liner + the
  regen step.

## Scope

Docs + scripts + one generated artifact. **No Swift touched** — build
and tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)