### PR TITLE
feat(commands): make_auto — clear the manual float override

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
@@ -104,6 +104,10 @@ extension KiwiCore {
         // recheckFloat only emits on changed verdicts, so an
         // unchanged config costs one quiet pass. No-op before
         // the event loop starts (startup load: no observers).
+        // This makes loadConfig emit events MID-LOAD: its
+        // non-reentrancy now also depends on every mutation
+        // verb reachable from a bus callback staying deferred
+        // (reload_config's Task, see KiwiCore+TypoGuard).
         eventLoop.reconcileAll()
         retile()
         // Lua-declared tiling is only the base state: the

--- a/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
@@ -95,6 +95,16 @@ extension KiwiCore {
         } else {
             applyConfigGlobals(from: fresh)
         }
+        // The float rules just changed hands: re-sync every
+        // app so `detectedFloating` reflects the NEW rules.
+        // Without this, verdicts stay stale until an unrelated
+        // AX event — user-visible since `make_auto` (#164)
+        // re-applies the cached verdict, and a rule edit +
+        // reload + make_auto would restore the pre-edit state.
+        // recheckFloat only emits on changed verdicts, so an
+        // unchanged config costs one quiet pass. No-op before
+        // the event loop starts (startup load: no observers).
+        eventLoop.reconcileAll()
         retile()
         // Lua-declared tiling is only the base state: the
         // active profile (or transient Standard) owns tiling

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -19,6 +19,7 @@ public enum APIReference {
             ("move_to_space_and_follow", "move_to_space_and_follow"),
             ("make_floating", "make_floating"),
             ("make_tiled", "make_tiled"),
+            ("make_auto", "make_auto"),
             ("resize", "resize"),
             ("pull_or_spawn", "pull_or_spawn"),
             ("spawn_new", "spawn_new"),

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
@@ -232,6 +232,11 @@ extension KiwiCore {
     /// re-applying the event loop's cached verdict. Without a
     /// cached verdict (untracked window) the current state
     /// stands until the next detection pass.
+    ///
+    /// Feeds the fold directly instead of `KiwiCore.handle`
+    /// (like `setFocusedFloating`): commands own their retile.
+    /// If `handle` ever grows a `windowFloatChanged` side
+    /// effect (bus emit), mirror it here.
     private func setFocusedAuto() -> CommandResponse {
         guard let focused = activeSpace?.focused else {
             return .fail("no focused window")

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
@@ -23,6 +23,8 @@ extension KiwiCore {
             return setFocusedFloating(true)
         case "make_tiled":
             return setFocusedFloating(false)
+        case "make_auto":
+            return setFocusedAuto()
         case "resize":
             return resize(args)
         case "pull_or_spawn":
@@ -221,6 +223,30 @@ extension KiwiCore {
             return .fail("no focused window")
         }
         state.setFloating(focused, floating)
+        retile()
+        return .ok()
+    }
+
+    /// `make_auto` (#164): clears the focused window's manual
+    /// float override and returns it to detection control by
+    /// re-applying the event loop's cached verdict. Without a
+    /// cached verdict (untracked window) the current state
+    /// stands until the next detection pass.
+    private func setFocusedAuto() -> CommandResponse {
+        guard let focused = activeSpace?.focused else {
+            return .fail("no focused window")
+        }
+        state.clearFloatOverride(focused)
+        if let detected = eventLoop.detectionVerdict(
+            for: focused
+        ) {
+            state.apply(
+                .windowFloatChanged(
+                    focused,
+                    isFloating: detected
+                )
+            )
+        }
         retile()
         return .ok()
     }

--- a/Sources/KiwiDeskCore/Events/EventLoop.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop.swift
@@ -13,6 +13,10 @@ public final class EventLoop {
     public var onEvent: @MainActor (KiwiEvent) -> Void = { _ in }
 
     /// User float rules from the Lua config (`float_rules`).
+    /// Assigning does NOT resync `detectedFloating`: rules
+    /// change hands inside loadConfig's reset→reassign
+    /// transaction, so any new assignment site outside it must
+    /// follow with `reconcileAll()` or a scoped recheck (#164).
     public var floatRules = FloatRules()
 
     var observers: [pid_t: AXApplicationObserver] = [:]

--- a/Sources/KiwiDeskCore/Events/EventLoop.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop.swift
@@ -68,6 +68,15 @@ public final class EventLoop {
         ignorePending = []
     }
 
+    /// Last float-detection verdict of a tracked window —
+    /// what `make_auto` returns a window to when the manual
+    /// override is cleared (#164). Nil for untracked windows.
+    public func detectionVerdict(
+        for id: WindowID
+    ) -> Bool? {
+        detectedFloating[id]
+    }
+
     /// AX element of a tracked window, if still known. Used to
     /// apply geometry (animations, wake restore) to windows.
     public func element(for id: WindowID) -> AXUIElement? {

--- a/Sources/KiwiDeskCore/State/StateCoordinator.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator.swift
@@ -98,6 +98,17 @@ public struct StateCoordinator: Sendable {
         manualFloatOverrides[id] = floating
     }
 
+    /// Returns a window to detection control (`make_auto`):
+    /// clears its manual override and the close/reopen memory
+    /// of its identity, so detection verdicts apply again and
+    /// nothing resurrects the old intent on reopen (#164).
+    public mutating func clearFloatOverride(_ id: WindowID) {
+        manualFloatOverrides[id] = nil
+        if let window = windows[id] {
+            rememberedFloating[WindowIdentity(of: window)] = nil
+        }
+    }
+
     public mutating func apply(_ event: KiwiEvent) {
         switch event {
         case .appLaunched:

--- a/Tests/KiwiDeskCoreTests/FloatPersistenceTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatPersistenceTests.swift
@@ -187,6 +187,25 @@ struct FloatPersistenceTests {
         state.apply(.windowCreated(makeWindow(9)))
         #expect(state.windows[WindowID(9)]?.isFloating == false)
     }
+
+    @Test("Clearing the override returns detection control")
+    func clearRestoresDetection() {
+        var state = StateCoordinator()
+        state.apply(.windowCreated(makeWindow(1)))
+        state.setFloating(WindowID(1), true)
+        state.clearFloatOverride(WindowID(1))
+        // Detection verdicts apply again ...
+        state.apply(
+            .windowFloatChanged(WindowID(1), isFloating: false)
+        )
+        #expect(state.windows[WindowID(1)]?.isFloating == false)
+        // ... and reopen restores nothing (#164).
+        state.apply(
+            .windowDestroyed(WindowID(1), wasMinimized: false)
+        )
+        state.apply(.windowCreated(makeWindow(2)))
+        #expect(state.windows[WindowID(2)]?.isFloating == false)
+    }
 }
 
 /// The titled-rule gate for the title-change recheck (#160).

--- a/Tests/KiwiDeskCoreTests/MakeAutoCommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/MakeAutoCommandTests.swift
@@ -68,6 +68,20 @@ struct MakeAutoCommandTests {
         )
     }
 
+    @Test("make_auto re-applies the cached detection verdict")
+    func reappliesCachedVerdict() {
+        let core = makeCore()
+        addWindow(core, 1)
+        #expect(core.execute("make_floating").isSuccess)
+        // Seed what the event loop would have cached at track
+        // time: detection said "tiled".
+        core.eventLoop.detectedFloating[WindowID(1)] = false
+        #expect(core.execute("make_auto").isSuccess)
+        #expect(
+            core.state.windows[WindowID(1)]?.isFloating == false
+        )
+    }
+
     @Test("make_auto without a focused window fails")
     func failsWithoutFocus() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/MakeAutoCommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/MakeAutoCommandTests.swift
@@ -1,0 +1,85 @@
+import AppKit
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The `make_auto` command (#164): the escape hatch back to
+/// detection-controlled float state.
+@Suite("make_auto command", .serialized)
+@MainActor
+struct MakeAutoCommandTests {
+    private func makeCore() -> KiwiCore {
+        KiwiCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-auto-\(UUID().uuidString)"
+                )
+        )
+    }
+
+    private func addWindow(
+        _ core: KiwiCore,
+        _ raw: UInt32
+    ) {
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(
+                    id: WindowID(raw),
+                    pid: 1,
+                    appName: "App\(raw)"
+                )
+            )
+        )
+    }
+
+    @Test("make_auto clears a manual float override")
+    func clearsOverride() {
+        let core = makeCore()
+        addWindow(core, 1)
+        #expect(core.execute("make_floating").isSuccess)
+        #expect(
+            core.state.windows[WindowID(1)]?.isFloating == true
+        )
+        #expect(core.execute("make_auto").isSuccess)
+        // No cached detection verdict in tests (no AX): the
+        // current state stands, but detection applies again.
+        core.state.apply(
+            .windowFloatChanged(WindowID(1), isFloating: false)
+        )
+        #expect(
+            core.state.windows[WindowID(1)]?.isFloating == false
+        )
+    }
+
+    @Test("make_auto forgets the close/reopen intent")
+    func forgetsReopenIntent() {
+        let core = makeCore()
+        addWindow(core, 1)
+        #expect(core.execute("make_floating").isSuccess)
+        #expect(core.execute("make_auto").isSuccess)
+        core.state.apply(
+            .windowDestroyed(WindowID(1), wasMinimized: false)
+        )
+        addWindow(core, 2)
+        #expect(
+            core.state.windows[WindowID(2)]?.isFloating == false
+        )
+    }
+
+    @Test("make_auto without a focused window fails")
+    func failsWithoutFocus() {
+        let core = makeCore()
+        #expect(!core.execute("make_auto").isSuccess)
+    }
+
+    @Test("make_auto is listed in the API reference")
+    func listedInReference() {
+        #expect(
+            APIReference.commands.contains {
+                $0.command == "make_auto"
+            }
+        )
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,6 +51,7 @@ KiwiDesk service restart
 | | `move_to_space_and_follow` | space id |
 | Window | `make_floating` | — |
 | | `make_tiled` | — |
+| | `make_auto` | — |
 | | `resize` | `x\|y`, delta (px) |
 | Launch | `pull_or_spawn` | app name |
 | | `spawn_new` | app name |

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1422,6 +1422,25 @@ survives the window closing and reopening.
 KiwiDesk.make_tiled()
 ```
 
+### make_auto
+
+**Expects:** nothing.
+
+**Does:** clears the focused window's manual override — the
+third state of the float tri-state (floating-manual /
+tiled-manual / auto). The window returns to detection control:
+`float_rules` and the built-in dialog/panel detection apply
+again, including future rule edits, and nothing restores the
+old manual intent when the window closes and reopens. Use it
+when a window "sticks" floating or tiled after a
+`make_floating`/`make_tiled` you no longer want.
+
+**Example:**
+
+```lua
+KiwiDesk.make_auto()
+```
+
 ### Example: toggle floating
 
 There is no built-in toggle; use `get_state()` to check the focused

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1430,9 +1430,12 @@ KiwiDesk.make_tiled()
 third state of the float tri-state (floating-manual /
 tiled-manual / auto). The window returns to detection control:
 `float_rules` and the built-in dialog/panel detection apply
-again, including future rule edits, and nothing restores the
-old manual intent when the window closes and reopens. Use it
-when a window "sticks" floating or tiled after a
+again, including future rule edits, and the close/reopen
+memory of the window's current identity is forgotten. (A
+remembered intent stored under an *older* title can still
+resurface after a reopen — run `make_auto` again once the
+window shows the wrong state and it is purged for good.) Use
+it when a window "sticks" floating or tiled after a
 `make_floating`/`make_tiled` you no longer want.
 
 **Example:**


### PR DESCRIPTION
## Summary

Adds `make_auto` (#164) — the escape hatch back to
detection-controlled float state, completing the tri-state
(floating-manual / tiled-manual / auto) that #163's manual-wins
semantics made necessary.

- `StateCoordinator.clearFloatOverride`: clears the focused
  window's manual override *and* its remembered close/reopen
  identity.
- `KiwiCore.setFocusedAuto`: clear → re-apply the event loop's
  cached detection verdict through the state fold (reusing the
  override guard) → retile. Untracked windows keep their current
  state until the next detection pass.
- `EventLoop.detectionVerdict(for:)`: read-only access to the
  cached verdict.
- `loadConfig` now runs `reconcileAll()` after applying float
  rules, so `detectedFloating` reflects post-edit rules — without
  it, "edit rule → reload → make_auto" restored the pre-edit
  verdict (architect finding; also fixes the pre-existing rule-edit
  lag for auto-state windows).
- Docs: lua-reference `make_auto` section (with the drifted-title
  resurrect hedge), cli.md row, APIReference entry. No GUI
  strings — no localization coupling.

Partner decision recorded on #109: profile switches will re-run
detection only where the rule verdict changed; this verb is the
window-scoped escape hatch and ships first.

## Review

Two-agent review + sequential re-review of both fix batches; all
rounds ended clean. Notable verifications: mid-load event emission
is ordering-safe (corrective forced profile re-apply runs last,
unconditional), `reload_config`'s Task deferral prevents
reentrancy, reconcile cost is user-paced. Advisory contracts
pinned as comments (floatRules assignment does not resync;
mid-load emission leans on deferred mutation verbs).

Future note for the per-profile float-rules follow-up (not #109
itself): loadConfig's reconcile runs before profile resolution;
once profiles carry float rules, the reconcile must move after
resolution (or the profile apply owns its scoped recheck) to
avoid a float→tile→float double pass on reload.

## Verification

- `swift build`, `swift test` (904 tests, 161 suites),
  `scripts/lint.sh`, `swift build -c release` — all green.
- `site/ npm run build` green (docs touched).
- CI red repo-wide from the Actions billing quota; merged with
  admin override per maintainer instruction.

fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuTcJrJNVqbSbrbmszPnVU
