### PR TITLE
fix(events): never manage KiwiDesk's own windows (#174)

### DIFF
--- a/Sources/KiwiDeskCore/Events/EventLoop+Apps.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop+Apps.swift
@@ -155,6 +155,15 @@ extension EventLoop {
 
     /// Attaches AX observation to a regular (Dock-visible) app.
     func attach(app: NSRunningApplication) {
+        // Never observe KiwiDesk's own process (#174): opening
+        // Settings flips the app to `.regular`, which would
+        // otherwise pass the gate below and tile the Settings
+        // window. Guarding here means no self-observer, so
+        // `reconcile`'s `observers[pid] != nil` check keeps
+        // self out of every downstream path too.
+        guard !Self.isOwnProcess(app.processIdentifier) else {
+            return
+        }
         guard app.activationPolicy == .regular else { return }
         let pid = app.processIdentifier
         guard observers[pid] == nil else { return }

--- a/Sources/KiwiDeskCore/Events/EventLoop.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop.swift
@@ -108,11 +108,27 @@ public final class EventLoop {
 
     // MARK: - Window tracking
 
+    /// KiwiDesk's own windows (the Settings window and any
+    /// panels/overlays it creates) must never be managed —
+    /// tiling or even floating its own UI is wrong. Opening
+    /// Settings promotes the app to `.regular`
+    /// (`activateAsRegular`), which otherwise slips past the
+    /// `attach` activation-policy gate and tiles the Settings
+    /// window, so a retile raises a tiled peer over it and
+    /// steals focus on restore (#174). Keyed on the process, so
+    /// it is policy-independent and covers every self-window.
+    nonisolated static func isOwnProcess(_ pid: pid_t) -> Bool {
+        pid == getpid()
+    }
+
     func track(
         _ element: AXUIElement,
         pid: pid_t,
         appName: String
     ) {
+        // Never manage KiwiDesk's own windows (#174) — the
+        // universal funnel guard, backing the `attach` gate.
+        guard !Self.isOwnProcess(pid) else { return }
         guard AXHelper.role(of: element) == kAXWindowRole,
             !AXHelper.isMinimized(element),
             var window = AXHelper.snapshot(

--- a/Tests/KiwiDeskCoreTests/SelfWindowExclusionTests.swift
+++ b/Tests/KiwiDeskCoreTests/SelfWindowExclusionTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// KiwiDesk must never manage its own windows (#174): opening
+/// the Settings window promotes the app to `.regular`, which
+/// otherwise slips past the `attach` activation-policy gate and
+/// tiles the Settings window, stealing focus on restore. The
+/// `attach` and `track` guards both key off `isOwnProcess`.
+@Suite("Self-window exclusion (#174)")
+struct SelfWindowExclusionTests {
+    @Test("The current process is recognized as self")
+    func ownProcessIsSelf() {
+        #expect(EventLoop.isOwnProcess(getpid()))
+    }
+
+    @Test("Other processes are not self")
+    func otherProcessesNotSelf() {
+        // launchd (pid 1) is never KiwiDesk; nor is any pid
+        // other than our own.
+        #expect(!EventLoop.isOwnProcess(1))
+        #expect(!EventLoop.isOwnProcess(getpid() &+ 1))
+    }
+}

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1551,6 +1551,10 @@ float automatically, no rule needed.
 assignment, no window events. KiwiDesk simply pretends it does not
 exist.
 
+**KiwiDesk's own windows** (the Settings window and any panels it
+shows) are likewise never managed — never tiled, floated, or
+tracked. This is unconditional and not a rule you configure.
+
 **Example:**
 
 ```lua


### PR DESCRIPTION
## Summary

Fixes #174 — the Settings window loses focus to a tiled window behind it on restore, because KiwiDesk was **managing its own Settings window as a tiled window**.

Root cause: no self-exclusion anywhere. KiwiDesk was hidden from itself only by accident of running `.accessory`; opening Settings promotes it to `.regular` (`activateAsRegular`), slipping past the `attach` activation-policy gate. The Settings window then classifies as a normal tiled window (`shouldFloat` false, `shouldIgnore` only matches Ghostty), joins the flat array, and a retile / z-order-restore raises a tiled peer over it.

## Fix

Exclude KiwiDesk's own process, keyed on `getpid()` (policy-independent, survives the `.regular` promotion):
- `EventLoop.attach` skips the own PID → no self-observer, so `reconcile`'s `observers[pid] != nil` gate keeps self out of every downstream path.
- `EventLoop.track` guards the same as the universal window-add funnel (defends future direct callers).
- Self-windows are **fully ignored** (no track/state/events), like the #21 Ghostty panel path — not floated (a floated window is still pinned to a space).

Orthogonal to the Ghostty quick-terminal workaround (per-window `appName == "Ghostty"` vs per-process `getpid()` — different mechanism, no shared state). AppBar/drag overlays are `NSPanel`s positioned directly, never AX-tracked, so unaffected.

## Verification

`swift build && swift test` (994) `&& scripts/lint.sh && swift build -c release` + `site npm run build` — all green. Code-reviewed clean (all entry paths sealed at the observer-creation source; no over-exclusion; Ghostty-independent; concurrency-sound). Docs: behavior noted in `lua-reference.md` (Window Rules).

Single commit → **squash-merge**. CI red is Actions billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)