### PR TITLE
fix(track): restore z-order in overflow cascades so title bars stay visible (#193)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
@@ -137,6 +137,11 @@ extension KiwiCore {
         }
         if TilingEngine.shouldRetile(after: event) {
             retile(newlyCreatedWindow: newlyCreatedWindow)
+            // A structural change in a track space (spawn, close)
+            // can push a window into an overflow cascade; fix the
+            // pile's z-order once it settles (#193, self-gated on
+            // track + actual overflow).
+            scheduleTrackZOrderRestoreIfOverflowing()
         }
         // Closing or minimizing the focused window hands focus
         // to the space's fallback (state picked one; this raise

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+NavigateCommand.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+NavigateCommand.swift
@@ -124,12 +124,15 @@ extension KiwiCore {
                 animated: tiler.settings.animations.onWindowSwap
             )
             // A scrolling swap can push a window into an edge pile
-            // whose stacking then goes stale (#150); a stack swap
+            // whose stacking then goes stale (#150); a track swap
+            // that fell through to the geometric search can
+            // scramble a track's overflow pile (#193); a stack swap
             // that crosses the master boundary scrambles the
-            // cascade. `crossesStackBoundary` is stack-only, so
-            // the two are mutually exclusive.
+            // cascade. All three gates are mode-exclusive.
             if space.mode == .scrolling {
                 scheduleScrollingZOrderRestoreIfOverflowing()
+            } else if space.mode == .track {
+                scheduleTrackZOrderRestoreIfOverflowing()
             } else if crossedZones {
                 scheduleZOrderRestore()
             }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
@@ -109,6 +109,10 @@ extension KiwiCore {
         retile(
             animated: tiler.settings.animations.onWindowResize
         )
+        // Resizing a track past min_window_size flips it into an
+        // overflow cascade (or unflips one back); fix the pile's
+        // z-order once it settles (#193, self-gated).
+        scheduleTrackZOrderRestoreIfOverflowing()
         return response
     }
 

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+TrackNavigate.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+TrackNavigate.swift
@@ -118,6 +118,7 @@ extension KiwiCore {
             retile(
                 animated: tiler.settings.animations.onWindowSwap
             )
+            scheduleTrackZOrderRestoreIfOverflowing()
         } else {
             focusWindow(target)
         }
@@ -248,6 +249,7 @@ extension KiwiCore {
         retile(
             animated: tiler.settings.animations.onWindowSwap
         )
+        scheduleTrackZOrderRestoreIfOverflowing()
         return .ok()
     }
 

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+TrackSwap.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+TrackSwap.swift
@@ -81,6 +81,7 @@ extension KiwiCore {
         retile(
             animated: tiler.settings.animations.onWindowSwap
         )
+        scheduleTrackZOrderRestoreIfOverflowing()
         return .ok()
     }
 }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+ZOrder.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+ZOrder.swift
@@ -65,9 +65,62 @@ extension KiwiCore {
             restoreStackZOrder(space)
         case .scrolling:
             restoreScrollingZOrder(space)
+        case .track:
+            restoreTrackZOrder(space)
         default:
             break
         }
+    }
+
+    /// Track (#193): an overflow cascade piles windows — the
+    /// windows inside one track, or whole buried tracks — with
+    /// the title-bar offset. Array order IS the cascade order
+    /// everywhere in the track model (each pile is a contiguous
+    /// slice), so raising the tiled windows in that order puts
+    /// every pile's first window behind and its last in front,
+    /// keeping each title bar visible. The focused window is
+    /// re-raised last — the same override as the stack cascade.
+    private func restoreTrackZOrder(_ space: Space) {
+        let tiled = space.windows.filter {
+            state.windows[$0]?.isFloating == false
+        }
+        guard tiled.count > 1 else { return }
+        raiseSequentially(tiled, thenFocus: space.focused)
+    }
+
+    /// Schedules a track z-order restore, but only when the
+    /// layout actually cascades (the scrolling gate's twin,
+    /// #150): tracks that tile side by side don't overlap, so a
+    /// reorder scrambles no stacking and a needless re-raise
+    /// would flicker focus. Call *after* the reorder's retile.
+    func scheduleTrackZOrderRestoreIfOverflowing() {
+        guard let input = tiler.layoutInput(state: state),
+            input.space.mode == .track,
+            Self.framesCascade(
+                TrackLayout().calculateGeometry(
+                    for: input.tiled,
+                    in: input.context
+                )
+            )
+        else { return }
+        scheduleZOrderRestore()
+    }
+
+    /// Whether any two laid-out frames overlap — the signature
+    /// of an overflow cascade. Tiled tracks never overlap (the
+    /// inner gaps separate them), so this is false whenever the
+    /// space fits without piling. Pure math, unit-tested.
+    nonisolated static func framesCascade(
+        _ frames: [WindowID: CGRect]
+    ) -> Bool {
+        let rects = Array(frames.values)
+        for i in rects.indices {
+            for j in (i + 1)..<rects.count
+            where !rects[i].intersection(rects[j]).isEmpty {
+                return true
+            }
+        }
+        return false
     }
 
     /// Re-raises the stack zone top to bottom, so upper

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -214,5 +214,9 @@ extension KiwiCore {
         if crossedZones {
             scheduleZOrderRestore()
         }
+        // A drop that reorders an overflowing track scrambles its
+        // pile just like a keyboard track.swap (#193); crossedZones
+        // is stack-only, so the two are mutually exclusive.
+        scheduleTrackZOrderRestoreIfOverflowing()
     }
 }

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
@@ -81,6 +81,9 @@ extension KiwiCore {
         retile(
             animated: tiler.settings.animations.onWindowResize
         )
+        // A track resize can flip a track into/out of an overflow
+        // cascade — restack the pile once it settles (#193).
+        scheduleTrackZOrderRestoreIfOverflowing()
         focusWindow(id)
     }
 

--- a/Tests/KiwiDeskCoreTests/ZOrderScheduleTests.swift
+++ b/Tests/KiwiDeskCoreTests/ZOrderScheduleTests.swift
@@ -136,6 +136,51 @@ struct ZOrderScheduleTests {
         #expect(!core.pendingZOrderRestore)
     }
 
+    @Test("framesCascade: piled frames true, tiled tracks false")
+    func framesCascadePredicate() {
+        // Side-by-side tracks: inner gaps separate them.
+        #expect(
+            !KiwiCore.framesCascade([
+                WindowID(1): CGRect(x: 0, y: 0, width: 90, height: 200),
+                WindowID(2): CGRect(x: 100, y: 0, width: 90, height: 200),
+            ])
+        )
+        // An overflow cascade: title-bar offset overlaps.
+        #expect(
+            KiwiCore.framesCascade([
+                WindowID(1): CGRect(x: 0, y: 0, width: 200, height: 200),
+                WindowID(2): CGRect(x: 0, y: 40, width: 200, height: 200),
+            ])
+        )
+        // A lone window never cascades.
+        #expect(!KiwiCore.framesCascade([WindowID(1): .zero]))
+    }
+
+    @Test("A track swap in an overflowing track arms a restore")
+    func trackSwapSchedulesRestore() {
+        let core = makeCore()
+        let space = makeSpace(core, windows: 8)
+        setMode(core, space, "track")
+        // Cap the space to one track: all eight windows pile into
+        // it and cascade (cascade_all default), so a swap scrambles
+        // the stacking. Turn off swap-skips-cascade (#172) so the
+        // swap targets the in-pile neighbor instead of stepping
+        // past the whole pile.
+        _ = core.execute("track.set_count", args: [.number(1)])
+        _ = core.execute(
+            "set_swap_skips_cascade",
+            args: [.bool(false)]
+        )
+        core.state.workspaces.focus(WindowID(2), in: space)
+        guard startDummyPan(core) else { return }
+        #expect(
+            core.execute("swap", args: [.string("down")]).isSuccess
+        )
+        #expect(core.pendingZOrderRestore)
+        core.tiler.animation.cancelAll()
+        #expect(!core.pendingZOrderRestore)
+    }
+
     @Test("rowOverflows: long row overflows, short row fits")
     func rowOverflowsPredicate() {
         let settings = TilingSettings()


### PR DESCRIPTION
Fixes #193.

## Bug
In a track layout, when a track (or the track row) overflows and its windows cascade, the windows were **positioned** as a title-bar cascade but their **z-order was never corrected** — `runPendingZOrderRestore` handled only `.stack` and `.scrolling`. A window that spawned or moved into the overflow stayed raised (AX made it key), covering the windows below it and hiding their title bars.

## Fix
- **`restoreTrackZOrder`** (new `.track` case): raise the tiled windows in **array order** — which *is* the cascade order everywhere in the track model (each pile is a contiguous slice) — so every pile's first window sits behind and its last in front. One raise fixes both within-track and cross-track (buried-track) piles. Focus stays the override (re-raised last), like the stack cascade.
- **`scheduleTrackZOrderRestoreIfOverflowing`** (the scrolling gate's twin): arm only when the layout actually cascades, via a `framesCascade` overlap predicate — side-by-side tracks that fit pay nothing.
- **Armed after** every path that can scramble a track pile: `move_to_track`, `track.swap`, the in-track/geometric-fallback `swap`, the structural retile (spawn/close), and both resize paths (keyboard/CLI + mouse) and drag-drop. Rides the existing animation-settle deferral + serial AX-raise queue.

## Review
Two-agent review (code-reviewer + architect-reviewer): fix is **correct and architecturally sound** — faithful reuse of the stack/scrolling z-order seam; the array-order-is-cascade-order invariant is structurally enforced by the `OverlapStack`/`trackFrames` emit order. The architect's under-arming findings (resize, drag-drop, geometric-fallback) are addressed in the second commit.

## Verify
Debug build, **1045 tests** (2 new: `framesCascade` predicate + a track-overflow swap arming the deferred restore), lint, and release build all pass. CI red is the pre-existing GitHub Actions billing failure, not the branch.

Follow-up to the track lane (#185 / #187). Part of #136. Related: #192 (first-class overflow model) carries a breadcrumb that this restore relies on cascade emit order == array order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)