### PR TITLE
refactor(gui): migrate Behavior duration row to shared StepperRow

### DIFF
--- a/Sources/KiwiDesk/Settings/Sections/BehaviorSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BehaviorSection.swift
@@ -113,27 +113,16 @@ struct BehaviorSection: View {
     /// (`animations.duration`; `animations.set_duration` Lua)
     /// — paces exactly the four toggles above (#51).
     private var durationRow: some View {
-        let ms = model.config.settings.animations.durationMS
-        let durationLabel = L(
-            "behavior.animations.duration",
-            "Duration"
+        StepperRow(
+            label: L(
+                "behavior.animations.duration",
+                "Duration"
+            ),
+            value: $model.config.settings.animations
+                .durationMS,
+            in: 50...1000,
+            step: 10,
+            suffix: "ms"
         )
-        return HStack {
-            Text(durationLabel)
-            Spacer()
-            Stepper(
-                value: $model.config.settings.animations
-                    .durationMS,
-                in: 50...1000,
-                step: 10
-            ) {
-                Text("\(ms) ms")
-                    .frame(minWidth: 52, alignment: .trailing)
-                    .monospacedDigit()
-            }
-            .controlSize(.large)
-            .accessibilityLabel(durationLabel)
-            .accessibilityValue("\(ms) ms")
-        }
     }
 }

--- a/Sources/KiwiDesk/Settings/SettingsRows.swift
+++ b/Sources/KiwiDesk/Settings/SettingsRows.swift
@@ -153,7 +153,10 @@ struct StepperRow: View {
                 .labelsHidden()
                 .controlSize(.large)
                 .accessibilityLabel(label)
-                .accessibilityValue("\(value)")
+                .accessibilityValue(
+                    suffix.map { "\(value) \($0)" }
+                        ?? "\(value)"
+                )
         }
         // Keep the field in step with arrow taps / external
         // changes — but never while the user is mid-edit, or a


### PR DESCRIPTION
## Summary

Migrates the Behavior ▸ Animations duration row — the last
hand-rolled numeric row in Settings (bare `Stepper` with a
read-only trailing `Text`, no way to type a value) — to the
shared `StepperRow`, per the numeric-control rule (discrete
counts/durations get a typeable field).

- Range `50...1000`, step `10`, existing
  `behavior.animations.duration` label key, `ms` suffix — all
  preserved. **No new strings** (not localization-gated).
- Review finding folded in: `StepperRow` now includes its
  suffix in `accessibilityValue` (announces "200 ms", not
  "200"), preserving the old row's accessibility prose and
  improving every other suffixed `StepperRow` call site.

fixes #206

## Verification

- `swift build` ✅
- `swift test` — 1081 tests, 187 suites ✅
- `scripts/lint.sh` ✅
- `swift build -c release` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
