### PR TITLE
fix(site): correct English motto typo (richtiger → richer)

### DIFF
--- a/site/src/i18n/en.json
+++ b/site/src/i18n/en.json
@@ -62,7 +62,7 @@
   "footer_github": "GitHub",
   "footer_kofi": "Support on Ko-fi",
   "footer_org": "Kiwi Solutions",
-  "footer_tag": "Planting Kiwis for a richtiger world 🥝🥝🥝",
+  "footer_tag": "Planting Kiwis for a richer world 🥝🥝🥝",
   "guide_after": "After",
   "guide_back_home": "Back to home",
   "guide_before": "Before",


### PR DESCRIPTION
English footer motto: "Planting Kiwis for a **richer** world 🥝🥝🥝" (was "richtiger"). German unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)