### PR TITLE
feat(commands): toggle_floating — one verb to flip float ↔ tiled (#221)

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog+Resize.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog+Resize.swift
@@ -46,16 +46,30 @@ extension KeybindingCatalog {
                     )
                 }
             ),
-            makeFloating,
+            toggleFloating,
         ]
     }
 
-    /// The Make-floating row — step-independent, so unlike
-    /// Grow/Shrink it is a fixed command. A named single
-    /// authority because the import classifier matches it
-    /// directly (it is in no `navigationGroups` group and has
-    /// no shape rule); without that entry an imported
-    /// `make_floating()` binding demoted to Custom (#4/#91).
+    /// The Toggle-floating row — the one float verb offered as a
+    /// bindable preset (#221): flip the focused window between
+    /// floating and tiled. The explicit `make_floating` /
+    /// `make_tiled` / `make_auto` verbs stay Lua/CLI-only (the
+    /// power-user escape hatch), so only this appears in the GUI
+    /// list. Step-independent, so a fixed command like the old
+    /// Make-floating row it replaces.
+    static let toggleFloating = NavCommand(
+        label: "Toggle floating",
+        lua: "KiwiDesk.toggle_floating()",
+        displayLabel: {
+            L("keybinding.toggle_floating", "Toggle floating")
+        }
+    )
+
+    /// Classification-only anchor for a hand-written
+    /// `make_floating()` (#4/#91): not offered as a bindable
+    /// preset anymore (#221), but the import classifier still
+    /// matches it directly so an imported binding lands in Size &
+    /// Float with its proper label instead of demoting to Custom.
     static let makeFloating = NavCommand(
         label: "Make floating",
         lua: "KiwiDesk.make_floating()",

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingImportClassifier.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingImportClassifier.swift
@@ -61,12 +61,18 @@ enum KeybindingImportClassifier {
             let command = KeybindingCatalog.switchModeCommand(name)
             map[command.lua] = command.label
         }
-        // Step-independent Size & Float row: not in any
-        // navigation group and matched by no shape rule, so it
-        // needs its own entry or an imported `make_floating()`
-        // stays Custom (#91).
-        let float = KeybindingCatalog.makeFloating
-        map[float.lua] = float.label
+        // Step-independent Size & Float rows: not in any
+        // navigation group and matched by no shape rule, so each
+        // needs its own entry or an imported binding stays Custom
+        // (#91). `toggle_floating` is the bindable one (#221);
+        // `make_floating` is kept for recognition only so a
+        // hand-written one still classifies.
+        for command in [
+            KeybindingCatalog.toggleFloating,
+            KeybindingCatalog.makeFloating,
+        ] {
+            map[command.lua] = command.label
+        }
         return map
     }
 

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -20,6 +20,7 @@ public enum APIReference {
             ("make_floating", "make_floating"),
             ("make_tiled", "make_tiled"),
             ("make_auto", "make_auto"),
+            ("toggle_floating", "toggle_floating"),
             ("resize", "resize"),
             ("move_to_track", "move_to_track"),
             ("pull_or_spawn", "pull_or_spawn"),

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
@@ -25,6 +25,8 @@ extension KiwiCore {
             return setFocusedFloating(false)
         case "make_auto":
             return setFocusedAuto()
+        case "toggle_floating":
+            return toggleFocusedFloating()
         case "resize":
             return resize(args)
         case "move_to_track":
@@ -106,6 +108,22 @@ extension KiwiCore {
         state.setFloating(focused, floating)
         retile()
         return .ok()
+    }
+
+    /// `toggle_floating` (#221): flip the focused window between
+    /// floating and tiled in one verb. Reads the window's
+    /// *effective* state and writes the explicit opposite as a
+    /// manual override — like `make_floating`/`make_tiled`, it
+    /// never yields `auto` (that stays `make_auto`'s job), so the
+    /// #164 tri-state is preserved by construction.
+    private func toggleFocusedFloating() -> CommandResponse {
+        guard
+            let focused = activeSpace?.focused,
+            let window = state.windows[focused]
+        else {
+            return .fail("no focused window")
+        }
+        return setFocusedFloating(!window.isFloating)
     }
 
     /// `make_auto` (#164): clears the focused window's manual

--- a/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
+++ b/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
@@ -111,9 +111,9 @@ public enum DefaultKeybindings {
         rows.append(
             KeyBinding(
                 combo: "option+t",
-                lua: "KiwiDesk.make_floating()",
+                lua: "KiwiDesk.toggle_floating()",
                 kind: .navigation,
-                label: "Make floating"
+                label: "Toggle floating"
             )
         )
         return rows

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -199,6 +199,7 @@
   "keybinding.swap_dir": "Swap with window %1$@",
   "keybinding.swap_with_track": "Swap with %1$@ track",
   "keybinding.switch_to_mode": "Switch to %1$@",
+  "keybinding.toggle_floating": "Toggle floating",
   "layout.bsp.name": "Bsp",
   "layout.floating.name": "Floating",
   "layout.grid.name": "Grid",

--- a/Tests/KiwiDeskCoreTests/ToggleFloatingCommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/ToggleFloatingCommandTests.swift
@@ -1,0 +1,100 @@
+import AppKit
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The `toggle_floating` command (#221): one verb to flip the
+/// focused window between floating and tiled, reading its
+/// effective state and writing the explicit opposite — never
+/// `auto` (that stays `make_auto`'s job, #164).
+@Suite("toggle_floating command", .serialized)
+@MainActor
+struct ToggleFloatingCommandTests {
+    private func makeCore() -> KiwiCore {
+        KiwiCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-toggle-\(UUID().uuidString)"
+                )
+        )
+    }
+
+    private func addWindow(_ core: KiwiCore, _ raw: UInt32) {
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(
+                    id: WindowID(raw),
+                    pid: 1,
+                    appName: "App\(raw)"
+                )
+            )
+        )
+    }
+
+    private func isFloating(_ core: KiwiCore) -> Bool? {
+        core.state.windows[WindowID(1)]?.isFloating
+    }
+
+    @Test("a tiled window toggles to floating")
+    func tiledToFloating() {
+        let core = makeCore()
+        addWindow(core, 1)
+        #expect(isFloating(core) == false)
+        #expect(core.execute("toggle_floating").isSuccess)
+        #expect(isFloating(core) == true)
+    }
+
+    @Test("a floating window toggles to tiled")
+    func floatingToTiled() {
+        let core = makeCore()
+        addWindow(core, 1)
+        #expect(core.execute("make_floating").isSuccess)
+        #expect(isFloating(core) == true)
+        #expect(core.execute("toggle_floating").isSuccess)
+        #expect(isFloating(core) == false)
+    }
+
+    @Test("two toggles return to the original state")
+    func roundTrip() {
+        let core = makeCore()
+        addWindow(core, 1)
+        #expect(core.execute("toggle_floating").isSuccess)
+        #expect(core.execute("toggle_floating").isSuccess)
+        #expect(isFloating(core) == false)
+    }
+
+    /// A fresh window is detection-controlled (auto). Toggling it
+    /// must write an *explicit* override, not leave it auto —
+    /// proven here because `make_auto` + a re-detection verdict is
+    /// then required to move it back, exactly as after a
+    /// `make_floating`.
+    @Test("toggle writes an explicit override, not auto")
+    func writesExplicitOverride() {
+        let core = makeCore()
+        addWindow(core, 1)
+        #expect(core.execute("toggle_floating").isSuccess)
+        #expect(isFloating(core) == true)
+        // Detection alone can't move an explicitly-overridden
+        // window; only make_auto returns it to detection control.
+        core.eventLoop.detectedFloating[WindowID(1)] = false
+        #expect(core.execute("make_auto").isSuccess)
+        #expect(isFloating(core) == false)
+    }
+
+    @Test("toggle without a focused window fails")
+    func failsWithoutFocus() {
+        let core = makeCore()
+        #expect(!core.execute("toggle_floating").isSuccess)
+    }
+
+    @Test("toggle_floating is listed in the API reference")
+    func listedInReference() {
+        #expect(
+            APIReference.commands.contains {
+                $0.command == "toggle_floating"
+            }
+        )
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,7 @@ KiwiDesk service restart
 | Window | `make_floating` | — |
 | | `make_tiled` | — |
 | | `make_auto` | — |
+| | `toggle_floating` | — |
 | | `resize` | `x\|y`, delta (px) |
 | | `move_to_track` | `prev\|next` — move window to the adjacent track (track spaces) |
 | Launch | `pull_or_spawn` | app name |

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1909,37 +1909,25 @@ it when a window "sticks" floating or tiled after a
 KiwiDesk.make_auto()
 ```
 
-### Example: toggle floating
+### toggle_floating
 
-There is no built-in toggle; use `get_state()` to check the focused
-window's current state:
+**Expects:** nothing.
+
+**Does:** flips the focused window between floating and tiled in
+one verb — if it is effectively floating it becomes tiled, and
+vice versa. Like `make_floating`/`make_tiled`, it writes an
+explicit manual override (which survives close/reopen); it never
+produces the `auto` state, so `make_auto` stays the way back to
+detection control. This is the everyday float shortcut (bound to
+`option+t` by default and the only float verb offered in the
+Settings shortcut list); the explicit `make_*` verbs remain for
+scripts that need a specific direction.
 
 **Example:**
 
 ```lua
 KiwiDesk.bind("cmd+alt+f", function()
-    local state = KiwiDesk.get_state()
-    if not state.active_space then return end
-    local active_space = state.active_space
-    local focused_id = nil
-    for _, space in ipairs(state.spaces) do
-        if space.id == active_space then
-            focused_id = space.focused
-            break
-        end
-    end
-    if focused_id then
-        for _, window in ipairs(state.windows) do
-            if window.id == focused_id then
-                if window.floating then
-                    KiwiDesk.make_tiled()
-                else
-                    KiwiDesk.make_floating()
-                end
-                break
-            end
-        end
-    end
+    KiwiDesk.toggle_floating()
 end)
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -679,7 +679,7 @@ you can drive KiwiDesk before configuring anything:
 | Move to space 1–9 | `⌥⇧1` … `⌥⇧9` |
 | Shrink / Grow width | `⌥-` / `⌥=` |
 | Shrink / Grow height | `⌥⇧-` / `⌥⇧=` |
-| Make floating | `⌥T` |
+| Toggle floating | `⌥T` |
 
 The digits are display-order positions: `⌥3` targets the *third*
 space in your Spaces list, whatever its name. A row is generated


### PR DESCRIPTION
Bind "float this window" to a single shortcut instead of the two verbs (`make_floating` + `make_tiled`) it took before. The toggle reads the focused window's effective state and writes the explicit opposite override — it never yields `auto`, so the #164 tri-state is preserved by construction and `make_auto` stays the escape hatch.

## Changes
- New `toggle_floating` command (thin dispatch case reusing `setFocusedFloating`) + `APIReference` entry → callable from Lua, CLI, IPC.
- **Scope (user 2026-07-14):** it's the ONLY float verb offered in the GUI Shortcuts list. The Size & Float pickable row becomes Toggle floating; the default `⌥T` binding switches to it. The explicit `make_floating`/`make_tiled`/`make_auto` stay Lua/CLI-only (power-user escape hatch). `make_floating` is kept as a classification-only anchor so a hand-written `make_floating()` import still lands in Size & Float (#4/#91) instead of demoting to Custom; `toggle_floating` gets the same recognition.
- Docs: replaced the obsolete "no built-in toggle, roll your own with get_state()" lua-reference recipe with a real `toggle_floating` verb entry; cli.md table; user-guide default-shortcut row.

## Tests
`ToggleFloatingCommandTests` (6): tiled→float, float→tiled, round-trip, explicit-override-not-auto (via make_auto), no-focus fail, API-reference listing.

## Review
Two-agent review (parallel round 1), both **approve**, no blockers. Noted (no action now): the "pickable ⊆ classifiable" catalog invariant is unguarded across two files — fine at two float entries, add a reflection parity guard before a third step-independent Size & Float preset. German for the new key rides #135.

## Verify gate
`swift build && swift test` (1128) `&& scripts/lint.sh` (492 keys) + release + `site` — all green.

fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)