### PR TITLE
fix(menu-bar): status icon invisible when a profile fails to decode

### DIFF
--- a/Sources/KiwiDesk/ConfigIssuesWindow.swift
+++ b/Sources/KiwiDesk/ConfigIssuesWindow.swift
@@ -123,7 +123,7 @@ struct ConfigIssuesView: View {
                 "Parts of the configuration could not be "
                     + "loaded."
             ),
-            systemImage: "doc.badge.exclamationmark"
+            systemImage: "exclamationmark.triangle.fill"
         )
         .font(.headline)
     }

--- a/Sources/KiwiDesk/StatusItemController.swift
+++ b/Sources/KiwiDesk/StatusItemController.swift
@@ -74,54 +74,76 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private func render() {
         guard let button = item.button else { return }
         if warning {
-            button.image = NSImage(
-                systemSymbolName:
-                    "exclamationmark.triangle.fill",
-                accessibilityDescription: L(
+            // Permission failure keeps the loud triangle; config
+            // error uses a distinct, softer circle so the two are
+            // never confused in the always-on glyph (§3.7).
+            setStatusSymbol(
+                "exclamationmark.triangle.fill",
+                on: button,
+                a11y: L(
                     "menu.status.warning.a11y",
                     "KiwiDesk (permission required)"
+                ),
+                tooltip: L(
+                    "menu.status.warning.tooltip",
+                    "KiwiDesk needs Accessibility permission. "
+                        + "Window management is paused."
                 )
-            )
-            button.title = ""
-            button.toolTip = L(
-                "menu.status.warning.tooltip",
-                "KiwiDesk needs Accessibility permission. "
-                    + "Window management is paused."
             )
             return
         }
         if configError {
-            button.image = NSImage(
-                systemSymbolName:
-                    "doc.badge.exclamationmark",
-                accessibilityDescription: L(
+            setStatusSymbol(
+                "exclamationmark.circle.fill",
+                on: button,
+                a11y: L(
                     "menu.status.config_error.a11y",
                     "KiwiDesk (config issues)"
+                ),
+                tooltip: L(
+                    "menu.status.config_error.tooltip",
+                    "Parts of the configuration could not be "
+                        + "loaded — open Config Issues for details."
                 )
-            )
-            button.title = ""
-            button.toolTip = L(
-                "menu.status.config_error.tooltip",
-                "Parts of the configuration could not be "
-                    + "loaded — open Config Issues for details."
             )
             return
         }
         button.toolTip = L("menu.status.tooltip", "KiwiDesk")
         if let modeIcon, !modeIcon.isEmpty {
             applyModeIcon(modeIcon, to: button)
-        } else {
+        } else if let icon = BrandAssets.menuBarIcon
+            ?? symbol("rectangle.3.group")
+        {
+            button.image = icon
             button.title = ""
-            button.image =
-                BrandAssets.menuBarIcon
-                ?? NSImage(
-                    systemSymbolName: "rectangle.3.group",
-                    accessibilityDescription: L(
-                        "menu.status.a11y",
-                        "KiwiDesk"
-                    )
-                )
+        } else {
+            // Last-ditch: never leave the slot blank.
+            button.image = nil
+            button.title = L("menu.status.a11y", "KiwiDesk")
         }
+    }
+
+    /// Sets the status button to the SF Symbol `name`, or — if
+    /// that symbol doesn't resolve on this macOS version — a
+    /// visible text fallback, so the menu bar item is never blank.
+    /// A nil image with an empty title leaves an
+    /// invisible-but-clickable slot that reads as a broken app
+    /// (an invalid symbol name — `doc.badge.exclamationmark`,
+    /// which does not exist — once did exactly that).
+    private func setStatusSymbol(
+        _ name: String,
+        on button: NSStatusBarButton,
+        a11y: String,
+        tooltip: String
+    ) {
+        let image = NSImage(
+            systemSymbolName: name,
+            accessibilityDescription: a11y
+        )
+        image?.isTemplate = true
+        button.image = image
+        button.title = image == nil ? "⚠︎" : ""
+        button.toolTip = tooltip
     }
 
     /// A mode icon is either an SF Symbol name or a flat
@@ -167,7 +189,10 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 keyEquivalent: ""
             )
             issues.target = self
-            issues.image = symbol("doc.badge.exclamationmark")
+            // A warning triangle makes the entry unmissable in
+            // the quick menu; safe from the §3.7 status-glyph
+            // distinction here because the row is text-labeled.
+            issues.image = symbol("exclamationmark.triangle.fill")
             menu.addItem(issues)
             menu.addItem(.separator())
         }


### PR DESCRIPTION
## The bug
When a saved profile no longer decodes (e.g. it carries an old vocabulary token after the #228 rename — `"position":"top"`), the menu bar status-item glyph became **invisible**. The menu still opened and showed its "Config Issues" entry, so the config-error state was correctly active — the icon just drew nothing.

## Root cause
The `configError` branch of `StatusItemController.render()` set:
```swift
button.image = NSImage(systemSymbolName: "doc.badge.exclamationmark", …) // ← nil, not a real SF Symbol
button.title = ""
```
`doc.badge.exclamationmark` is **not a valid SF Symbol name** (verified: `NSImage(systemSymbolName:)` returns nil). With a nil image *and* an empty title, the status item is invisible-but-clickable — reads as a broken app.

## Fix
- **Valid glyph:** config-error → `exclamationmark.circle.fill` (a softer circle, kept distinct from the permission warning's `exclamationmark.triangle.fill` per §3.7 "the two causes are never confused").
- **Never-blank guarantee:** `render()`'s warning/config branches go through a `setStatusSymbol` helper that falls back to a visible `⚠︎` text title if any symbol fails to resolve; the standard path falls back to a text title too. So an invalid symbol name can never blank the slot again — the robustness the reporter asked for, independent of migration (pre-release, a corrupt profile is expected, but it must not nuke the menu bar icon).
- **More obvious Config Issues entry:** the quick-menu "Config Issues…" row → `exclamationmark.triangle.fill` (unmissable; safe here since the row is text-labeled). Same glyph fix for the Config Issues window header (also used the dead symbol).

## Verification
- `doc.badge.exclamationmark` → nil; `exclamationmark.circle.fill` / `exclamationmark.triangle.fill` → resolve (checked via `NSImage(systemSymbolName:)`).
- Verify gate green: build, `swift test` (1129), lint, release build.
- No migration added — the corrupt profile still surfaces as a config issue (re-saving repairs it); this only ensures the icon degrades gracefully.

Rebuild and the icon shows the config-error circle (with a tooltip); the quick menu's Config Issues row now leads with a warning triangle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)