### PR TITLE
docs(gui): codify preview alignment convention (standalone vs paired)

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/GapsDiagram.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/GapsDiagram.swift
@@ -29,6 +29,13 @@ enum GapPreviewScale {
 /// so per-edge asymmetry renders honestly as uneven margins.
 /// It teaches the outer/inner vocabulary; it is deliberately
 /// not a layout preview.
+///
+/// Left-aligned beside its legend (not centered like a
+/// `SchematicCanvas`): this preview is **paired with the exact
+/// controls in its card**, so it lines up flush with them as one
+/// stack rather than reading as a standalone figure (see
+/// design-decisions "Preview alignment splits on
+/// standalone-vs-paired").
 struct GapsDiagram: View {
     let outer: Gaps.Outer
     let inner: Gaps.Inner

--- a/Sources/KiwiDesk/Settings/Tabs/LayoutSchematicCanvas.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/LayoutSchematicCanvas.swift
@@ -36,6 +36,14 @@ struct SchematicArrow: View {
 /// A single-frame schematic: one mini-screen plus a caption,
 /// centred as a self-contained tile. Size defaults to the family
 /// 140×96 but a mode may grow it (Scrolling draws a monitor).
+///
+/// Centered on purpose (the `.frame(maxWidth:.infinity)` with no
+/// alignment): this is a **standalone illustration** — nothing is
+/// edited on it and no control column shares its row, so it reads
+/// as a figure, not a row (see design-decisions "Preview
+/// alignment splits on standalone-vs-paired"). A preview that
+/// *does* sit beside its controls (GapsDiagram, the Drag columns)
+/// is left-aligned instead.
 struct SchematicCanvas<Content: View>: View {
     var width: CGFloat = LayoutSchematic.canvasWidth
     var height: CGFloat = LayoutSchematic.canvasHeight

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -836,6 +836,29 @@ corner-radius and
 border-width previews now remap the full slider range instead
 of hard-capping halfway (the `AppBarPreviewStrip` fix).
 
+**Preview alignment splits on standalone-vs-paired, not by
+tab.** (ui-designer consult 2026-07-14.) A settings preview is
+aligned one of two ways, and which one is decided by whether
+controls sit right next to it — never by which tab it's on:
+
+- **Standalone illustration** (a Layout schematic, the App Bar
+  mock strip) — centered in its card with a caption below.
+  Nothing is edited *on* it and no control column shares its
+  row, so there is no leading edge to line up against; it reads
+  as a figure, the way macOS System Settings centers a
+  wallpaper thumbnail or screen-saver preview over its label.
+- **Preview paired with the exact controls in the same card**
+  (the Gaps diagram + its outer/inner legend, the Drag Ghost /
+  Drop-zone columns) — left-aligned, flush with the control
+  rows it drives, so preview and controls read as one stack
+  (the accent-swatch / Displays-arrangement pattern).
+
+So Layout schematics and the App Bar strip are *both* centered
+(they are the same kind of thing); Gaps and Drag are left —
+that apparent Layout-vs-Appearance inconsistency is really this
+one correct rule. A new preview picks its bucket by asking "are
+its controls right here beside it," not by copying its tab.
+
 ## App Bar
 
 **App Bar position is axis-relative by design.** (#228.) The


### PR DESCRIPTION
Records the settled ui-designer ruling (2026-07-14) that a settings preview's alignment splits on **standalone-vs-paired**, not by tab:

- **Standalone illustration** (Layout schematic, App Bar strip) → centered, caption below.
- **Preview paired with the controls in its card** (Gaps diagram, Drag columns) → left-aligned flush with them.

So Layout schematics and the App Bar strip are both centered (same kind of thing); Gaps and Drag are left — the apparent Layout-vs-Appearance inconsistency is really this one correct rule. Adds the design-decisions.md note + naming comments on `SchematicCanvas` and `GapsDiagram`. **No behavior change** (docs + comments only).

Gate: build ✅ · lint ✅ · release ✅ · site ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)