### PR TITLE
feat(gui): app-bar override colors share Global's 2-column grid (#2)

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsMetrics.swift
+++ b/Sources/KiwiDesk/Settings/SettingsMetrics.swift
@@ -59,6 +59,21 @@ enum SettingsMetrics {
     /// second column) — don't "fix" them onto `labelColumn`.
     static let colorLabelColumn: CGFloat = 140
 
+    /// The label column for a color swatch inside an
+    /// `OverrideChrome` row (#2). An override color cell is a
+    /// half-width grid cell that also spends ~34 pt on the
+    /// leading checkbox (`overrideRowInset` + `checkboxWidth` +
+    /// inset) before the swatch and hex field, so the label is
+    /// deliberately narrower than Global's ungated
+    /// `colorLabelColumn` (140) to keep the cell inside half the
+    /// pane — not to align the swatch onto Global's axis (that
+    /// would need ~106 pt). 80 pt fits the English labels;
+    /// longer locales (e.g. German "Gruppen-Badge") truncate
+    /// with `lineLimit(1)` rather than wrap, and the same field
+    /// still shows full at 140 pt in Global's grid — an
+    /// asymmetry the half-width cell forces, tracked on #135.
+    static let overrideColorLabelColumn: CGFloat = 80
+
     /// The inline hex `TextField` beside each color swatch.
     /// Fixed (not auto-sizing) so the two-column color grid in
     /// `AppBarSections` keeps stable cell widths as values

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
@@ -162,84 +162,99 @@ struct LayoutAppBarSection: View {
     }
 }
 
-/// The color override rows, split out to stay within the view
-/// builder's child limit.
+/// The color override rows, in `AppBarColorGrid` so they read
+/// as the same 2-column grid as Global's colors (#2). Field
+/// order mirrors the global editor exactly — the inline trio
+/// (Box, Active box, Highlight) first, then the rest of the
+/// palette — so a field keeps the same reading order in both
+/// editors. (Column positions match only for the inline trio:
+/// Global splits its colors into two grids — inline three plus
+/// seven advanced behind a disclosure — while these ten flow as
+/// one continuous grid, so the seven advanced fields land in
+/// different columns.) Two `Group`s of five keep each under the
+/// view builder's child limit; `Group` is transparent to the
+/// grid, so the ten rows flow as ten cells.
 struct LayoutAppBarColorOverrides: View {
     @Binding var bar: LayoutAppBar
     let global: AppBarStyle
 
     var body: some View {
-        Group {
-            OverrideColorRow(
-                label: L("app_bar.color.text", "Text"),
-                value: $bar.textColor,
-                global: global.textColor
-            )
-            OverrideColorRow(
-                label: L("app_bar.color.box", "Box"),
-                value: $bar.boxColor,
-                global: global.boxColor
-            )
-            OverrideColorRow(
-                label: L(
-                    "app_bar.color.active_text",
-                    "Active text"
-                ),
-                value: $bar.activeTextColor,
-                global: global.activeTextColor
-            )
-            OverrideColorRow(
-                label: L(
-                    "app_bar.color.active_box",
-                    "Active box"
-                ),
-                value: $bar.activeBoxColor,
-                global: global.activeBoxColor
-            )
-            OverrideColorRow(
-                label: L("app_bar.color.highlight", "Highlight"),
-                value: $bar.highlightColor,
-                global: global.highlightColor
-            )
-            OverrideColorRow(
-                label: L("app_bar.color.hover", "Hover"),
-                value: $bar.hoverColor,
-                global: global.hoverColor
-            )
-        }
-        Group {
-            OverrideColorRow(
-                label: L(
-                    "app_bar.color.hover_text",
-                    "Hover text"
-                ),
-                value: $bar.hoverTextColor,
-                global: global.hoverTextColor
-            )
-            OverrideColorRow(
-                label: L(
-                    "app_bar.color.background",
-                    "Background"
-                ),
-                value: $bar.backgroundColor,
-                global: global.backgroundColor
-            )
-            OverrideColorRow(
-                label: L(
-                    "app_bar.color.group_badge",
-                    "Group badge"
-                ),
-                value: $bar.groupBadgeColor,
-                global: global.groupBadgeColor
-            )
-            OverrideColorRow(
-                label: L(
-                    "app_bar.color.badge_text",
-                    "Badge text"
-                ),
-                value: $bar.groupBadgeTextColor,
-                global: global.groupBadgeTextColor
-            )
+        AppBarColorGrid {
+            Group {
+                OverrideColorRow(
+                    label: L("app_bar.color.box", "Box"),
+                    value: $bar.boxColor,
+                    global: global.boxColor
+                )
+                OverrideColorRow(
+                    label: L(
+                        "app_bar.color.active_box",
+                        "Active box"
+                    ),
+                    value: $bar.activeBoxColor,
+                    global: global.activeBoxColor
+                )
+                OverrideColorRow(
+                    label: L(
+                        "app_bar.color.highlight",
+                        "Highlight"
+                    ),
+                    value: $bar.highlightColor,
+                    global: global.highlightColor
+                )
+                OverrideColorRow(
+                    label: L("app_bar.color.text", "Text"),
+                    value: $bar.textColor,
+                    global: global.textColor
+                )
+                OverrideColorRow(
+                    label: L(
+                        "app_bar.color.active_text",
+                        "Active text"
+                    ),
+                    value: $bar.activeTextColor,
+                    global: global.activeTextColor
+                )
+            }
+            Group {
+                OverrideColorRow(
+                    label: L("app_bar.color.hover", "Hover"),
+                    value: $bar.hoverColor,
+                    global: global.hoverColor
+                )
+                OverrideColorRow(
+                    label: L(
+                        "app_bar.color.hover_text",
+                        "Hover text"
+                    ),
+                    value: $bar.hoverTextColor,
+                    global: global.hoverTextColor
+                )
+                OverrideColorRow(
+                    label: L(
+                        "app_bar.color.background",
+                        "Background"
+                    ),
+                    value: $bar.backgroundColor,
+                    global: global.backgroundColor
+                )
+                OverrideColorRow(
+                    label: L(
+                        "app_bar.color.group_badge",
+                        "Group badge"
+                    ),
+                    value: $bar.groupBadgeColor,
+                    global: global.groupBadgeColor
+                )
+                OverrideColorRow(
+                    label: L(
+                        "app_bar.color.badge_text",
+                        "Badge text"
+                    ),
+                    value: $bar.groupBadgeTextColor,
+                    global: global.groupBadgeTextColor
+                )
+            }
         }
     }
 }

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarOverrideControls.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarOverrideControls.swift
@@ -183,11 +183,22 @@ struct OverrideColorRow: View {
     let label: String
     @Binding var value: String?
     let global: String
+    /// Defaults to the narrowed grid column (#2): every caller
+    /// is a cell in `AppBarColorGrid`, and the override checkbox
+    /// already eats the prefix `colorLabelColumn` would leave for
+    /// the swatch. `HexColorField` reads its own `labelWidth`,
+    /// not `OverrideChrome`'s `settingsLabelColumn`, so it must
+    /// be passed here rather than via the environment — the
+    /// `settingsLabelColumn` the chrome sets for its other row
+    /// types is inert for a color cell.
+    var labelWidth: CGFloat =
+        SettingsMetrics.overrideColorLabelColumn
 
     var body: some View {
         OverrideChrome(isOn: overrideToggle($value, global: global)) {
             HexColorField(
                 label: label,
+                labelWidth: labelWidth,
                 hex: overrideValue($value, global: global)
             )
         }

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
@@ -1,6 +1,30 @@
 import KiwiDeskCore
 import SwiftUI
 
+/// The 2-column swatch grid the App Bar color runs share:
+/// Global's colors and each layout's per-layout overrides (#2)
+/// both wrap their `HexColorField`s in this so the two read as
+/// one grid rather than a grid up top and a stacked list below.
+/// Flexible columns, so both grids span the pane's full width
+/// identically; a row's own label width sets where the swatch
+/// sits inside its (equal-width) cell.
+struct AppBarColorGrid<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(), alignment: .leading),
+                GridItem(.flexible(), alignment: .leading),
+            ],
+            alignment: .leading,
+            spacing: 8
+        ) {
+            content
+        }
+    }
+}
+
 // The App Bar sections are hosted by AppBarSection (#229, its
 // own sidebar destination): the global look shared by every
 // layout's bar, then a per-layout section for each layout that
@@ -36,9 +60,9 @@ struct GlobalAppBarSection: View {
         SettingsSection(
             L("app_bar.global_colors.title", "Global colors")
         ) {
-            colorGrid { inlineColors }
+            AppBarColorGrid { inlineColors }
             DisclosureGroup(isExpanded: $advancedColorsExpanded) {
-                colorGrid { advancedColors }
+                AppBarColorGrid { advancedColors }
                     .padding(.top, 8)
             } label: {
                 Text(
@@ -49,22 +73,6 @@ struct GlobalAppBarSection: View {
                 )
                 .font(.subheadline)
             }
-        }
-    }
-
-    /// The 2-column swatch grid both color runs share.
-    private func colorGrid<C: View>(
-        @ViewBuilder _ content: () -> C
-    ) -> some View {
-        LazyVGrid(
-            columns: [
-                GridItem(.flexible(), alignment: .leading),
-                GridItem(.flexible(), alignment: .leading),
-            ],
-            alignment: .leading,
-            spacing: 8
-        ) {
-            content()
         }
     }
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -470,7 +470,10 @@ make scrolling show segment style while monocle stays pills. When
 you open a layout's **Overrides**, a compact chip leads the rows:
 color swatches of the layout's *resolved* bar (global overlaid with
 its overrides) and a count of how many fields differ — a quick read
-on whether the layout diverges, without a second full preview.
+on whether the layout diverges, without a second full preview. The
+color overrides sit in the same 2-column grid as Global's colors,
+in the same field order; a leading checkbox on each cell unlocks
+that field.
 
 ## Behavior
 


### PR DESCRIPTION
## What

Per-layout app-bar color overrides (Monocle/Scrolling) now render in the same 2-column swatch grid Global's colors use, instead of a stacked list under the "Overrides" disclosure. Fixes #2.

## Changes

- Extract a shared `AppBarColorGrid`; Global colors and the layout overrides both wrap their `HexColorField`s in it, so both span the pane identically and the fields read in the same order.
- Reorder the override rows to match the global editor's field order (Box, Active box, Highlight first, then the rest).
- Add `SettingsMetrics.overrideColorLabelColumn` (80 pt) + an `OverrideColorRow.labelWidth` seam feeding `HexColorField`: an override color cell is a half-width grid cell that also spends ~34 pt on the leading checkbox, so the label is narrower than Global's ungated 140 pt to keep the cell inside half the pane. `HexColorField` reads its own `labelWidth`, not `OverrideChrome`'s `settingsLabelColumn`, so it is passed explicitly.

No new accordion — the overrides keep their single "Overrides" disclosure and dim/inherited chrome (#68 §3.4). No model or key changes; field labels unchanged.

## Known limitation

Column positions coincide only for the inline trio: Global splits its colors into two grids (inline 3 + advanced 7 behind a disclosure) while the overrides flow as one grid of 10, so the field *order* matches, not the column of every field. Longer locales (German "Gruppen-Badge") truncate the 80 pt override label via `lineLimit(1)` while Global shows it full at 140 pt — an asymmetry the half-width cell forces; tracked on #135.

## Review

code-reviewer + architect-reviewer run in parallel on the commit — no correctness bugs. Findings were comment/doc accuracy (the "same grid position" overstatement, the metric's axis-alignment/German rationale) and are folded into this commit. `AppBarColorGrid` home + the 80-vs-140 asymmetry consciously accepted.

## Verify

`swift build` + `swift test` (1140) + `scripts/lint.sh` + `swift build -c release` + `site/ npm run build` (15 pages) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)