### PR TITLE
refactor(gui): unify auto-toggle-gates-slider into AutoGatedGroup (#233)

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
@@ -154,7 +154,7 @@ struct LayoutAppBarSection: View {
             unit: "%"
         )
         .modifier(
-            AppBarGreyOut(
+            GreyOut(
                 active: bar.resolved(with: global)
                     .tabBackground != .boxed
             )

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarOverrideControls.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarOverrideControls.swift
@@ -17,21 +17,6 @@ enum AppBarAuto {
     }
 }
 
-/// The #171 "grey, don't hide" treatment: a control that has no
-/// effect in the current mode stays visible but disabled and
-/// dimmed, with an optional explanatory tooltip.
-struct AppBarGreyOut: ViewModifier {
-    let active: Bool
-    var help: String = ""
-
-    func body(content: Content) -> some View {
-        content
-            .disabled(active)
-            .opacity(active ? 0.5 : 1)
-            .help(active ? help : "")
-    }
-}
-
 /// The Position/Tab-background/Active-indicator/Content dropdown
 /// labels are
 /// data (an array of value/label pairs shared by the global and
@@ -150,10 +135,11 @@ struct OverrideSliderRow: View {
 }
 
 /// An override slider whose 0 = auto sentinel is exposed as an
-/// Auto toggle (#228 §3), mirroring the global editor. While the
-/// row overrides the field, the Auto toggle rides above the
-/// slider and greys it when auto; restoring turns auto off with a
-/// sensible non-zero size.
+/// Auto toggle (#228 §3), mirroring the global editor. A thin
+/// wrapper over `AutoGatedGroup` inside the override chrome: the
+/// shared component binds the Auto toggle above the slider and
+/// greys it when auto; restoring turns auto off with a sensible
+/// non-zero size (#233 — the pattern's origin site).
 struct OverrideAutoSliderRow: View {
     let label: String
     let autoLabel: String
@@ -164,23 +150,17 @@ struct OverrideAutoSliderRow: View {
 
     var body: some View {
         OverrideChrome(isOn: overrideToggle($value, global: global)) {
-            VStack(alignment: .leading, spacing: 4) {
-                Toggle(
-                    autoLabel,
-                    isOn: AppBarAuto.binding(
-                        overrideValue($value, global: global),
-                        restore: restore
-                    )
+            AutoGatedGroup(
+                title: autoLabel,
+                isOn: AppBarAuto.binding(
+                    overrideValue($value, global: global),
+                    restore: restore
                 )
+            ) {
                 PtSlider(
                     label: label,
                     value: overrideValue($value, global: global),
                     range: range
-                )
-                .modifier(
-                    AppBarGreyOut(
-                        active: (value ?? global) == 0
-                    )
                 )
             }
         }

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
@@ -120,53 +120,43 @@ struct GlobalAppBarSection: View {
         )
     }
 
-    // Ordered thickness → the two Auto-gated size pairs (each
-    // toggle bound directly above the slider it controls, the
-    // Apple-native pattern) → a divider → corner roundness (gated
-    // by a different switch, Tab background). "Auto" size/font is a
-    // GUI face on the model's 0 = auto sentinel: the toggle greys
-    // its slider and stores 0; turning it off restores a sensible
-    // non-zero value (#171 grey-out).
+    // Ordered thickness → the two Auto-gated size pairs
+    // (`AutoGatedGroup`: the toggle bound directly above the slider
+    // it owns) → a divider → corner roundness (gated by a different
+    // switch, Tab background). "Auto" size/font is a GUI face on the
+    // model's 0 = auto sentinel: the toggle greys its slider and
+    // stores 0; turning it off restores a sensible non-zero value
+    // (#171 grey-out).
     @ViewBuilder private var appearance: some View {
         PtSlider(
             label: L("app_bar.thickness", "Thickness"),
             value: $style.thickness,
             range: 8...80
         )
-        VStack(alignment: .leading, spacing: 4) {
-            Toggle(
-                L("app_bar.item_size.auto", "Auto item size"),
-                isOn: AppBarAuto.binding(
-                    $style.itemSize,
-                    restore: 120
-                )
-            )
+        AutoGatedGroup(
+            title: L("app_bar.item_size.auto", "Auto item size"),
+            isOn: AppBarAuto.binding($style.itemSize, restore: 120)
+        ) {
             PtSlider(
                 label: L("app_bar.item_size", "Item size"),
                 value: $style.itemSize,
                 range: 0...200
             )
-            .modifier(AppBarGreyOut(active: style.itemSize == 0))
         }
         PtSlider(
             label: L("app_bar.item_gap", "Item gap"),
             value: $style.itemGap,
             range: 0...40
         )
-        VStack(alignment: .leading, spacing: 4) {
-            Toggle(
-                L("app_bar.font_size.auto", "Auto font size"),
-                isOn: AppBarAuto.binding(
-                    $style.fontSize,
-                    restore: 14
-                )
-            )
+        AutoGatedGroup(
+            title: L("app_bar.font_size.auto", "Auto font size"),
+            isOn: AppBarAuto.binding($style.fontSize, restore: 14)
+        ) {
             PtSlider(
                 label: L("app_bar.font_size", "Font size"),
                 value: $style.fontSize,
                 range: 0...32
             )
-            .modifier(AppBarGreyOut(active: style.fontSize == 0))
         }
         Divider()
         // Roundness only shapes a Boxed tab; grey it for Plain —
@@ -178,7 +168,7 @@ struct GlobalAppBarSection: View {
             unit: "%"
         )
         .modifier(
-            AppBarGreyOut(
+            GreyOut(
                 active: style.tabBackground != .boxed,
                 help: L(
                     "app_bar.corner_roundness.boxed_only",

--- a/Sources/KiwiDesk/Settings/Tabs/AutoGatedGroup.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AutoGatedGroup.swift
@@ -1,0 +1,60 @@
+import KiwiDeskCore
+import SwiftUI
+
+/// A toggle that gates the control(s) directly below it. One
+/// `VStack` binds the switch above what it owns, so flipping it on
+/// reads as "this switch controls what's under it" — the
+/// Apple-native grouping (AGENTS §2.7). On greys the manual
+/// control(s) via the #171 "grey, don't hide" treatment
+/// (`GreyOut`): they stay visible but disabled and dimmed, never
+/// removed.
+///
+/// Shared by the App Bar Auto item/font-size pairs (the toggle is
+/// the `0 = auto` sentinel exposed through `AppBarAuto.binding`)
+/// and the Grid Auto-size block (a plain `autoSize` bool gating
+/// the Columns/Rows steppers). Before this component those three
+/// spelled the same interaction three ways, with different visual
+/// binding strengths, purely by which feature wave wrote them
+/// (#233).
+struct AutoGatedGroup<Gated: View>: View {
+    let title: String
+    @Binding var isOn: Bool
+    /// Optional one-line caption naming where the automatic value
+    /// comes from when the gated control can't show it itself
+    /// (Grid: the screen plus the minimum window size). Omitted
+    /// where the gated slider already teaches its own automatic
+    /// behaviour (the App Bar sizes), keeping the caption's job to
+    /// "name a source the control can't" rather than gloss "why".
+    var caption: String? = nil
+    @ViewBuilder let gated: Gated
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(title, isOn: $isOn)
+            if let caption {
+                Text(caption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            gated
+                .modifier(GreyOut(active: isOn))
+        }
+    }
+}
+
+/// The #171 "grey, don't hide" treatment: a control that has no
+/// effect in the current mode stays visible but disabled and
+/// dimmed, with an optional explanatory tooltip. Generic (not
+/// App-Bar-specific) — `AutoGatedGroup`, the App Bar roundness
+/// gate, and the per-layout override all share it.
+struct GreyOut: ViewModifier {
+    let active: Bool
+    var help: String = ""
+
+    func body(content: Content) -> some View {
+        content
+            .disabled(active)
+            .opacity(active ? 0.5 : 1)
+            .help(active ? help : "")
+    }
+}

--- a/Sources/KiwiDesk/Settings/Tabs/GridEditor.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/GridEditor.swift
@@ -79,44 +79,42 @@ struct GridEditor: View {
             .disabled(
                 model.config.settings.grid.type == .rigid
             )
-            gridAutoSize
-            StepperRow(
-                label: L("scroll_grid.columns", "Columns"),
-                value: grid.columns,
-                in: 1...10
-            )
-            .disabled(model.config.settings.grid.autoSize)
-            StepperRow(
-                label: L("scroll_grid.rows", "Rows"),
-                value: grid.rows,
-                in: 1...10
-            )
-            .disabled(model.config.settings.grid.autoSize)
+            Divider()
+            // Auto-size + its dimensions read as a distinct block
+            // from the grid-fill behaviour above, mirroring the
+            // Divider BSP/Stack put before their own such content.
+            gridDimensions
             Divider()
             PlacementPicker(placement: grid.newWindowPlacement)
         }
     }
 
-    /// The auto-size toggle with its caption. A behavior modifier
-    /// like Fill empty space / Wrap focus — not a mode switch —
-    /// so it reads as a plain toggle; when on it greys the
-    /// Columns/Rows steppers below (the screen supplies the dims).
-    private var gridAutoSize: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Toggle(
-                L("scroll_grid.auto_size", "Auto-size grid"),
-                isOn: grid.autoSize
+    /// The Auto-size toggle gating the Columns/Rows steppers, via
+    /// the shared `AutoGatedGroup` (#233). A behaviour modifier
+    /// like Fill empty space / Wrap focus — not a mode switch — so
+    /// it reads as a plain toggle; on, it greys the steppers
+    /// (visible but disabled, #171), the screen supplying the dims.
+    private var gridDimensions: some View {
+        AutoGatedGroup(
+            title: L("scroll_grid.auto_size", "Auto-size grid"),
+            isOn: grid.autoSize,
+            caption: L(
+                "scroll_grid.auto_size_caption",
+                "Fits as many columns and rows as the "
+                    + "screen allows, using the minimum "
+                    + "window size above."
             )
-            Text(
-                L(
-                    "scroll_grid.auto_size_caption",
-                    "Fits as many columns and rows as the "
-                        + "screen allows, using the minimum "
-                        + "window size above."
-                )
+        ) {
+            StepperRow(
+                label: L("scroll_grid.columns", "Columns"),
+                value: grid.columns,
+                in: 1...10
             )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            StepperRow(
+                label: L("scroll_grid.rows", "Rows"),
+                value: grid.rows,
+                in: 1...10
+            )
         }
     }
 }


### PR DESCRIPTION
Closes #233.

The "a toggle exposes a `0 = auto` sentinel (or a plain bool) and greys the control it gates" interaction was implemented **three ways** — App Bar global editor, per-layout override row, Grid Auto-size — with different visual binding strengths purely by which feature wave wrote them. This extracts one shared `AutoGatedGroup`.

## Change
- **`AutoGatedGroup`** (new): the toggle (+ optional caption) bound directly above its gated control(s) in one `VStack`, greying them via the shared #171 grey-out. A user gets the same "this toggle owns what's below it" signal everywhere.
- **Global App Bar** Auto item/font size and **`OverrideAutoSliderRow`** now call it (the override row becomes a thin wrapper — the pattern's origin site).
- **`GridEditor`** pulls the Columns/Rows steppers *inside* the gated group, so they now grey (dim **+** disable) instead of only disabling, and read as owned by Auto-size. Adds a `Divider()` before the auto-size + dimensions block, matching BSP/Stack's separation of different-register content.
- **Renamed `AppBarGreyOut` → `GreyOut`** and hoisted it beside `AutoGatedGroup`: it was always the generic #171 treatment (its own doc said so), and a generic component + the Grid editor now depend on it, so the `AppBar` prefix was a misnomer. Also drops `AppBarOverrideControls.swift` back under the size ceiling (336→321). `AppBarAuto` keeps its name (the sentinel is genuinely App-Bar-only).

## Decisions
- **Caption stays per-site.** Grid keeps its "screen + minimum window size" caption (names a source the steppers can't show); the App Bar sizes stay caption-less (the slider teaches its own auto behaviour; §2.7 defers per-control "why" to #94). No new `L()` keys, no de-drift.
- **Grid steppers now dim** (were only disabled) — the intended #171 unification.

## Review
Two-agent review (code-reviewer + architect-reviewer, parallel). code-reviewer verified the binding equivalence is exact across all three sites (no behavioral regression). Both flagged the dead `greyHelp` param (dropped) and architect flagged the `AppBarGreyOut` misnomer (renamed + hoisted). Grid caption phrasing (low-sev) dismissed — it already names both sources.

## Verify
`swift build` · `swift test` (1145) · `scripts/lint.sh` (extract-keys OK, no new keys) · `swift build -c release` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)