### PR TITLE
fix(monocle): default wrap_focus off, matching scrolling/track (#257)

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/LayoutHelp.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/LayoutHelp.swift
@@ -53,16 +53,16 @@ enum LayoutHelp {
         )
     }
 
-    /// Wrap-focus for the linear layouts (Scrolling, Track),
-    /// where it defaults off. Monocle shares the concept but
-    /// flips the default, so it gets its own scoped text below.
+    /// Wrap-focus, shared by all three array-order layouts
+    /// (Scrolling, Track, Monocle) — one string since they now
+    /// share the default (off, #257).
     ///
     /// Key deviates from the usual `<label-key>.help` derivation:
     /// the wrap-focus *label* is itself split across pre-existing
     /// keys (`scroll_grid.wrap_focus` for Scrolling/Monocle,
     /// `track.wrap_focus` for Track, from #168), so no single
-    /// label key yields one help key. These live under a neutral
-    /// `layout_params.wrap_focus.*` home instead — unlike
+    /// label key yields one help key. It lives under a neutral
+    /// `layout_params.wrap_focus.help` home instead — unlike
     /// `trackOverflow`, whose label key `layout_params.overflow`
     /// does derive cleanly.
     @MainActor static var wrapFocus: String {
@@ -71,18 +71,6 @@ enum LayoutHelp {
             "When on, moving focus past the last window wraps "
                 + "around to the first, and past the first back "
                 + "to the last, instead of stopping at the end."
-        )
-    }
-
-    /// Monocle's wrap-focus: same behaviour, but on by default
-    /// (a carousel), so the text leads with that.
-    @MainActor static var wrapFocusMonocle: String {
-        L(
-            "layout_params.wrap_focus.monocle.help",
-            "On by default: monocle is a carousel, so moving "
-                + "focus past the last window returns to the "
-                + "first (and the reverse). Turn it off to stop "
-                + "focus at the first and last window."
         )
     }
 

--- a/Sources/KiwiDesk/Settings/Tabs/MonocleEditor.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/MonocleEditor.swift
@@ -38,14 +38,13 @@ struct MonocleEditor: View {
                 ]
             )
             Divider()
-            // Monocle is a carousel, so this defaults on (unlike
-            // the linear scrolling/track wrap). Off = focus stops
-            // at the first/last window. Reuses the shared
-            // "Wrap focus" string.
+            // Off by default, same as scrolling/track (#257) —
+            // one wrap default across the array-order layouts, so
+            // it reuses the shared "Wrap focus" string and help.
             ToggleRow(
                 label: L("scroll_grid.wrap_focus", "Wrap focus"),
                 isOn: $model.config.settings.monocle.wrapFocus,
-                help: LayoutHelp.wrapFocusMonocle
+                help: LayoutHelp.wrapFocus
             )
             Divider()
             PlacementPicker(

--- a/Sources/KiwiDeskCore/Layouts/MonocleParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/MonocleParams.swift
@@ -17,12 +17,13 @@ public struct MonocleParams: Sendable, Equatable, AppBarHosting {
 
     public var orientation: Orientation = .horizontal
     /// Whether the focus cycle wraps past the ends (#168). Unlike
-    /// scrolling/track (linear, default off), monocle is a
-    /// carousel that has always wrapped, so this defaults **on** —
-    /// turn it off to make focus stop at the first/last window.
-    /// `swap` never wraps, matching the other array-order layouts.
-    /// Per-layout, like the scrolling/track wrap toggles.
-    public var wrapFocus = true
+    /// Whether moving focus past the last window wraps to the
+    /// first (and the reverse). Defaults **off**, matching the
+    /// other array-order layouts (scrolling/track) — one default
+    /// across all three. Turn it on for carousel-style cycling.
+    /// `swap` never wraps. Per-layout, like the scrolling/track
+    /// wrap toggles.
+    public var wrapFocus = false
     /// Where a new window lands in the flat array — and, since
     /// monocle shows one window at a time, where it sits in the
     /// focus cycle. `.first` by default: a new window comes to

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -275,7 +275,6 @@
   "layout_params.split_strategy": "Split strategy",
   "layout_params.split_strategy.help": "**Longest side** — Cuts whichever side of the region is longer, keeping new windows close to square.\n**Alternating** — Alternates left/right and top/bottom cuts as the layout gets deeper, regardless of shape.",
   "layout_params.wrap_focus.help": "When on, moving focus past the last window wraps around to the first, and past the first back to the last, instead of stopping at the end.",
-  "layout_params.wrap_focus.monocle.help": "On by default: monocle is a carousel, so moving focus past the last window returns to the first (and the reverse). Turn it off to stop focus at the first and last window.",
   "lua_editor.adopt": "Adopt",
   "lua_editor.adopt.title": "Adopt this config into the visual editor?",
   "lua_editor.adopt_help.body": "Nothing is lost: your current code isn't deleted, it's kept as a commented-out backup in init.lua. Gaps, layouts, rules, and keybindings are imported; a shortcut that can't be read back stays in the backup — re-add it in the Shortcuts section.",

--- a/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
@@ -110,7 +110,7 @@ struct LayoutParamsCodingParityTests {
     private static func monocle() -> MonocleParams {
         var params = MonocleParams()
         params.orientation = .vertical
-        params.wrapFocus = false
+        params.wrapFocus = true
         params.newWindowPlacement = .last
         params.appBar.enabled = false
         var over = MonocleOverride()

--- a/Tests/KiwiDeskCoreTests/MonocleNavigationTests.swift
+++ b/Tests/KiwiDeskCoreTests/MonocleNavigationTests.swift
@@ -41,19 +41,23 @@ private func makeMonocleSpace(
     return space
 }
 
-/// Monocle focus cycle & the opt-out wrap toggle (#168): monocle
-/// is a carousel, so focus wraps by default; `swap` never wraps,
-/// matching the other array-order layouts.
+/// Monocle focus cycle & the opt-in wrap toggle (#168): wrap
+/// defaults off, matching the other array-order layouts (#257);
+/// turn it on and focus wraps past the ends. `swap` never wraps.
 @Suite("Monocle navigation (#168)", .serialized)
 @MainActor
 struct MonocleNavigationTests {
-    @Test("Focus wraps past the ends by default")
-    func focusWrapsByDefault() {
+    @Test("Focus wraps past the ends when wrap_focus is on")
+    func focusWrapsWhenOn() {
         let core = makeCore()
         let space = makeMonocleSpace(
             core,
             windows: 3,
             focus: WindowID(1)
+        )
+        core.execute(
+            "monocle.set_wrap_focus",
+            args: [.bool(true)]
         )
         // Left from the first wraps to the last.
         #expect(

--- a/Tests/KiwiDeskCoreTests/MonocleTests.swift
+++ b/Tests/KiwiDeskCoreTests/MonocleTests.swift
@@ -865,9 +865,15 @@ struct MonocleCycleTests {
         return core
     }
 
-    @Test("focus cycles along the orientation axis and wraps")
+    @Test("focus cycles the orientation axis, wraps when on")
     func cycleAndWrap() {
         let core = makeMonocleCore()
+        // Wrap is opt-in (#257: off by default like the other
+        // array-order layouts), so turn it on to exercise it.
+        core.execute(
+            "monocle.set_wrap_focus",
+            args: [.bool(true)]
+        )
         #expect(
             core.execute("focus", args: [.string("right")])
                 .isSuccess

--- a/Tests/KiwiDeskCoreTests/ScrollingNavigationTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingNavigationTests.swift
@@ -250,7 +250,7 @@ struct ScrollingNavigationTests {
         #expect(core.activeSpace?.focused == WindowID(3))
     }
 
-    @Test("Monocle keeps its wrapping cycle")
+    @Test("Monocle wraps when wrap_focus is on")
     func monocleCycleUntouched() {
         let core = makeCore()
         for id in 1...3 {
@@ -270,6 +270,11 @@ struct ScrollingNavigationTests {
         core.execute(
             "set_mode",
             args: [.string(space.raw), .string("monocle")]
+        )
+        // Wrap is opt-in (#257); enable it to cycle past the end.
+        core.execute(
+            "monocle.set_wrap_focus",
+            args: [.bool(true)]
         )
         core.state.workspaces.focus(WindowID(1), in: space)
         #expect(

--- a/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
+++ b/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
@@ -88,9 +88,9 @@ struct SettingsCodingTests {
         let grid = try object(layout["grid"])
         #expect(grid["auto_size"] as? Bool == false)
         // `monocle.set_wrap_focus` → `layout.monocle.wrap_focus`
-        // (#168), on by default (monocle is a carousel).
+        // (#168), off by default like scrolling/track (#257).
         let monocle = try object(layout["monocle"])
-        #expect(monocle["wrap_focus"] as? Bool == true)
+        #expect(monocle["wrap_focus"] as? Bool == false)
         let stack = try object(layout["stack"])
         #expect(stack["master_ratio"] as? Double == 0.6)
         // `track.set_axis` → `layout.track.axis` (#128);

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -669,8 +669,7 @@ first, and vice versa). Default is `false` — focus stops at the
 ends, matching the physical-strip feel of the layout. Applies to
 `focus` only; `swap` never wraps (it would teleport a window
 across the whole row). Monocle has the same toggle
-(`monocle.set_wrap_focus`) but defaults it **on**, since it's a
-carousel.
+(`monocle.set_wrap_focus`), with the same **off** default.
 
 **Example:**
 
@@ -898,13 +897,13 @@ monocle.set_orientation_override("3", "vertical")
 
 ### monocle.set_wrap_focus
 
-**Expects:** `true` or `false` (default `true`).
+**Expects:** `true` or `false` (default `false`).
 
-**Does:** whether the focus cycle wraps past the ends. Monocle is
-a carousel, so this defaults **on** (unlike the linear scrolling
-and track wraps, which default off) — `focus` past the last window
-returns to the first, and vice versa. Turn it off to make focus
-stop at the first/last window. `swap` never wraps.
+**Does:** whether the focus cycle wraps past the ends. Defaults
+**off**, matching the scrolling and track wraps — the same default
+across all three array-order layouts. Turn it on and `focus` past
+the last window returns to the first, and vice versa; off, focus
+stops at the first/last window. `swap` never wraps.
 
 **Example:**
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -313,9 +313,9 @@ Adjust each mode's defaults:
   never wraps.
 - **Monocle**: orientation (affects which arrow keys cycle focus
   and where the app bar sits), wrap focus, and **New window**
-  placement. Monocle is a carousel, so wrap focus is **on** by
-  default — cycling past the last window returns to the first;
-  turn it off to stop at the ends. New window defaults to
+  placement. Wrap focus is **off** by default, the same as
+  scrolling and track — turn it on and cycling past the last
+  window returns to the first. New window defaults to
   **first**, so a new window comes to the front of the cycle
   rather than the back.
 - **Grid**: type (dynamic or rigid), fill empty space (yes/no),


### PR DESCRIPTION
Closes #257.

Monocle's `wrap_focus` defaulted **on** (carousel) while Scrolling and Track defaulted **off**. Three array-order layouts with the same toggle should share one default — flip Monocle to off.

Bonus cleanup: this lets all three share `LayoutHelp.wrapFocus`. The monocle-specific help string (`LayoutHelp.wrapFocusMonocle`, added by #251 *only* to note the flipped default) and its key are deleted.

## Change
- `MonocleParams.wrapFocus` → `false`.
- `MonocleEditor` uses `LayoutHelp.wrapFocus`; `wrapFocusMonocle` + key removed (en.json 531→530).
- Docs (`lua-reference.md` ×2, `user-guide.md`): monocle wrap now defaults off like the others.
- Tests that assumed default-on now enable wrap explicitly (wrap coverage preserved); `SettingsCodingTests` + `LayoutParamsCodingParityTests` fixtures updated.

Pre-release, no migration (§5): re-saving is the migration.

## Verify
`swift build` · `swift test` (1145) · `scripts/lint.sh` (extract-keys OK, 530 keys) · `swift build -c release` · `site` build (15 pages) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)