### PR TITLE
fix(gui): drop parens from move-to-track caption

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingSections.swift
@@ -86,8 +86,8 @@ struct MoveWindowsSection: View {
             Text(
                 L(
                     "shortcuts.move_to_track.caption",
-                    "(only relevant if you're using the track "
-                        + "layout)"
+                    "Only relevant if you're using the track "
+                        + "layout."
                 )
             )
             .font(.caption)

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -458,7 +458,7 @@
   "shortcuts.modes.caption": "Modes are alternate shortcut sets — only the active mode's shortcuts fire. Bind a key below to switch between them. “default” is the standard mode and is always the active one after the app starts.",
   "shortcuts.move_to_space": "Move to space",
   "shortcuts.move_to_track": "Move to track",
-  "shortcuts.move_to_track.caption": "(only relevant if you're using the track layout)",
+  "shortcuts.move_to_track.caption": "Only relevant if you're using the track layout.",
   "shortcuts.other_ellipsis": "Other…",
   "shortcuts.override.caption": "Dimmed rows are inherited from the base shortcuts and stay in sync with them. Edit a row to override it for this profile only; matching the base again makes it inherited again. Removing an inherited row only resets it — to disable a combo in this profile, rebind it to a no-op action instead.",
   "shortcuts.override.overrides": "This profile overrides base keybindings.",


### PR DESCRIPTION
## What

The Shortcuts tab's `shortcuts.move_to_track.caption` was the one section caption wrapped in literal parens — "(only relevant if you're using the track layout)". Parens conventionally signal a skippable aside, but this is **must-know** context: the Move-to-track rows below it are always rendered (no gate), so without the caption they read as dead/broken config for the ~5-of-6 layout users who aren't on the track layout.

Rephrased as a plain declarative sentence to match every sibling caption of the same shape (`sizeFloatCaption`, `titledPatternCaption`, `modesCaption`):

> Only relevant if you're using the track layout.

## Why

Surfaced by a UI-designer consult on contextual-help scope. The designer rejected both a `?` (this is must-know, not optional depth) and a disclosure (`@State` re-collapses on every Settings reopen, punishing the actual Track users). Keeping it an always-open caption and just dropping the parens was the recommendation.

`en.json` regenerated via `scripts/extract-keys en`; other locales keep their translations (cosmetic punctuation edit per the translations-follow-meaning convention).

## Verify
- `swift build` ✅
- `swift test` ✅ (1145 tests)
- `scripts/lint.sh` ✅ (`extract-keys --check` OK)
- `swift build -c release` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)