### PR TITLE
fix(gui): pin app-picker chevron trailing, hug the trigger (#263)

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/AppPickerButton.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppPickerButton.swift
@@ -19,8 +19,11 @@ struct AppPickerButton: View {
     let placeholder: String
     /// The current selection's display name, or nil for none.
     let selection: String?
-    /// Trigger width, so pickers line up with their neighbors.
-    var minWidth: CGFloat = 150
+    /// Floor width for the trigger — just enough for the
+    /// "Choose app…" placeholder; it hugs longer names. A caller
+    /// that needs a fixed column (Open Applications) wraps the
+    /// button in its own `.frame(width:)` instead.
+    var minWidth: CGFloat = 110
     let onPick: (KeybindingCatalog.InstalledApp) -> Void
     /// The persistent escape row: its label (Custom… / Other…)
     /// and the action it triggers (reveal a field / open a
@@ -37,6 +40,12 @@ struct AppPickerButton: View {
         } label: {
             HStack(spacing: 4) {
                 Text(selection ?? placeholder)
+                    .lineLimit(1)
+                // Absorbs the slack between text and chevron, so
+                // the chevron pins to the trailing edge (native
+                // pop-up look) instead of floating mid-button when
+                // the frame is wider than the content.
+                Spacer(minLength: 4)
                 Image(systemName: "chevron.up.chevron.down")
                     .font(.caption2)
                     .foregroundStyle(.secondary)

--- a/Sources/KiwiDesk/Settings/Tabs/AppRuleControls.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppRuleControls.swift
@@ -49,6 +49,9 @@ struct AppSelector: View {
                     name = ""
                 }
             )
+            // Hug the content (no fixed column to align with, just
+            // the trailing "+" button) instead of filling the row.
+            .fixedSize()
         }
     }
 }

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingAppSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingAppSection.swift
@@ -156,12 +156,14 @@ struct ApplicationsSection: View {
             selection: binding.wrappedValue.label.isEmpty
                 ? nil
                 : binding.wrappedValue.label,
-            minWidth: 160,
             onPick: { assign(binding, app: $0) },
             escapeLabel: L("shortcuts.other_ellipsis", "Other…"),
             onEscape: { chooseBundle(binding) }
         )
-        .frame(width: 200)
+        // Hug the content: the row's `Spacer()` pins the recorder
+        // to the trailing edge, so the picker's width doesn't gate
+        // recorder alignment — no fixed column needed.
+        .fixedSize()
     }
 
     private func assign(


### PR DESCRIPTION
Follow-up polish on the searchable app picker (#263, merged in #267).

## Problem
The picker trigger rendered wide with the chevron floating mid-button: the `HStack { Text, chevron }` was measured as one unit, then `.frame(alignment: .leading)` pinned the whole unit leading, so all slack fell *after* the chevron.

## Fix (designer-reviewed)
- `Spacer` between text and chevron → chevron pins to the trailing edge (native pop-up look).
- `.fixedSize()` at both call sites so the trigger **hugs its content** (minWidth 110 floor for the "Choose app…" placeholder) instead of filling the row.
- Both sections hug: App Rules has only a trailing "+" beside the picker; Open Applications' row pins its shortcut recorder to the trailing edge with a `Spacer()`, so the picker width never gated recorder alignment (no fixed column needed).
- Kept `chevron.up.chevron.down` (HIG value-swap affordance).

## Verify
`swift build` · `swift test` (1157 pass) · `scripts/lint.sh` · `swift build -c release` — all pass. Confirmed live on a German system.

Refs #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)