### PR TITLE
feat(gui): declutter Layout Defaults min-size + mode-strip separation (#275)

### DIFF
--- a/Sources/KiwiDesk/Settings/Sections/LayoutDefaultsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/LayoutDefaultsSection.swift
@@ -30,7 +30,15 @@ struct LayoutDefaultsSection: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 minSizeSection
-                Divider()
+                // No `Divider()` (#275): every other top-level
+                // pane separates sibling regions with the stack
+                // spacing alone — a rule between top-level
+                // regions exists nowhere else in the app. The
+                // min-size card's own background already reads as
+                // a region boundary, and the segmented strip
+                // self-announces the pivot (Trackpad/Displays
+                // precedent), so whitespace is the native + most
+                // consistent break.
                 tabStrip
                 editor
             }
@@ -91,6 +99,10 @@ struct LayoutDefaultsSection: View {
                     + "sets the auto-size grid's cell size."
             )
         ) {
+            // Label hidden (#275): the section header already
+            // names this sole control, so the row shows value +
+            // unit only (Dock "Size" pattern). `label` still
+            // carries the accessibility name.
             StepperRow(
                 label: L(
                     "layout_defaults.min_window_size",
@@ -99,7 +111,8 @@ struct LayoutDefaultsSection: View {
                 value: minSizeBinding,
                 in: 100...800,
                 step: 10,
-                suffix: "pt"
+                suffix: "pt",
+                labelHidden: true
             )
         }
     }

--- a/Sources/KiwiDesk/Settings/SettingsRows.swift
+++ b/Sources/KiwiDesk/Settings/SettingsRows.swift
@@ -157,6 +157,13 @@ struct StepperRow: View {
     let range: ClosedRange<Int>
     let step: Int
     let suffix: String?
+    /// Hide the visual label, leaving value + arrows only (#275):
+    /// for a section whose header already names the sole control,
+    /// restating it on the row is native-atypical (Dock "Size").
+    /// `label` still feeds the accessibility label, so VoiceOver
+    /// is unaffected — the control is left-aligned under the
+    /// header instead of trailing an empty label column.
+    let labelHidden: Bool
     /// The field edits a string proxy so intermediate/empty
     /// typing never clobbers `value`; it commits (parse +
     /// clamp) on Return or focus loss, matching the rename
@@ -169,20 +176,24 @@ struct StepperRow: View {
         value: Binding<Int>,
         in range: ClosedRange<Int>,
         step: Int = 1,
-        suffix: String? = nil
+        suffix: String? = nil,
+        labelHidden: Bool = false
     ) {
         self.label = label
         self._value = value
         self.range = range
         self.step = step
         self.suffix = suffix
+        self.labelHidden = labelHidden
         self._text = State(initialValue: "\(value.wrappedValue)")
     }
 
     var body: some View {
         HStack {
-            Text(label)
-            Spacer()
+            if !labelHidden {
+                Text(label)
+                Spacer()
+            }
             TextField("", text: $text)
                 .labelsHidden()
                 .frame(width: 48)
@@ -205,6 +216,12 @@ struct StepperRow: View {
                     suffix.map { "\(value) \($0)" }
                         ?? "\(value)"
                 )
+            // Label hidden → nothing anchors the control to the
+            // leading edge, so a trailing spacer keeps it left
+            // under the section header instead of centering.
+            if labelHidden {
+                Spacer()
+            }
         }
         // Keep the field in step with arrow taps / external
         // changes — but never while the user is mid-edit, or a


### PR DESCRIPTION
Two native-idiom polish items in the **Layout Defaults** pane (ui-designer-consulted). No behavior/config change. Sibling of the just-merged #259/#260/#264 lane (PR #274).

## A — "Minimum window size" appeared twice
It rendered as both the `SettingsSection` header and the sole `StepperRow`'s label. `StepperRow` gains a `labelHidden` option (default false → every other caller unchanged); the min-size row now shows value + `pt` + stepper, left-aligned under the header, with `label` still feeding the accessibility name. Matches the System-Settings single-control section (Dock "Size").

## B — separator before the mode tab strip
The `Divider()` before the headerless mode strip undersold a region pivot. **Removed it — whitespace only.** The ui-designer consult found every other top-level pane (Behavior/General/Spaces/Profiles/AppRules) separates sibling regions with stack spacing alone — no rule lives between top-level regions anywhere else in the app; the min-size card background already reads as a boundary and the segmented strip self-announces the pivot (Trackpad/Displays precedent). Whitespace is the native + most consistent break.

Also considered (ui-designer, rejected): docking min-size in the shared `ProfileHeaderBar` top-right. No System Settings precedent — that bar is scope-only chrome, it would strand the caption's non-obvious "also sets the auto-size grid cell" fact and touch already-fragile titlebar layout. Document order + whitespace already signals "global, tabs below per-mode."

## Verify
`swift build && swift test && scripts/lint.sh` + release build all green — **1157 tests**, lint OK, `extract-keys --check` OK (`layout_defaults.min_window_size` stays in use → no orphan). code-reviewer pass: approve, no blocking issues.

**Manual GUI pass pending** (visual change): min-size row reads value+unit left-aligned under its header; mode strip reads as a whitespace region-break, not the next row of the min-size card.

Closes #275. Refs #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)