### PR TITLE
fix(drag): stop the ghost overlay flashing during a mouse resize

### DIFF
--- a/Sources/KiwiDeskCore/Events/MouseTracker.swift
+++ b/Sources/KiwiDeskCore/Events/MouseTracker.swift
@@ -62,4 +62,11 @@ public final class MouseTracker {
     private func recordUp() {
         press?.upAt = Date()
     }
+
+    /// Test seam: seeds the last press directly (already in AX
+    /// coordinates), standing in for the global mouse-down
+    /// monitor, which does not fire under unit tests.
+    func seedPress(at location: CGPoint) {
+        press = Press(location: location, downAt: Date())
+    }
 }

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -81,13 +81,51 @@ extension KiwiCore {
             dragOverlay.hideAll()
             return
         }
-        // A resize gesture adjusts the layout in place; slot
-        // previews would only mislead. Compared against the
-        // gesture's START frame, never the slot: a window
-        // that can't shrink to its slot (min sizes, character
-        // grids) differs from it permanently, which would
-        // turn every plain move into a "resize".
-        if MouseResize.isResize(from: start, to: frame) {
+        // Show the swap overlays only once the gesture is
+        // clearly a MOVE — the window has translated with its
+        // size held; anything else hides them.
+        //
+        // A resize is caught from its first real frame by facts
+        // a magnitude test alone misses (it reads the sub-
+        // threshold start of a pull, and a dip back near the
+        // start size, as a move — flashing the ghost, #237):
+        //  - the press began in the slot's edge band, where
+        //    resize drags start (same signal isResizeGesture
+        //    uses), AND the size has already changed — so an
+        //    edge-grabbed move (drag near the top to swap) keeps
+        //    its ghost while a resize hides with no flash;
+        //  - the 10 pt magnitude test as the press-less
+        //    fallback, measured against the START frame, never
+        //    the slot: a window that can't shrink to its slot
+        //    (min sizes, character grids) differs forever, which
+        //    would call every plain move a resize.
+        // The gesture's FIRST frame has no delta (start ==
+        // frame) so it reads as neither; showing nothing there
+        // avoids a one-frame ghost before the size delta lands.
+        //
+        // This gate is intentionally stricter than the resize-
+        // vs-swap decision in handleDragEnd (plain isResize):
+        // the preview is advisory and biases toward hiding to
+        // kill the flash, so it may suppress a small edge resize
+        // the drop still treats as a swap — harmless, since a
+        // real move holds its size and never enters that band.
+        // Effectiveness rides on the live mouse monitor; with no
+        // recorded press (headless, tests) it falls back to the
+        // 10 pt magnitude test — the pre-fix behavior.
+        let pressNearEdge =
+            mouse.press.map {
+                MouseResize.nearEdge($0.location, of: slot)
+            } ?? false
+        let sizeChanged =
+            abs(frame.width - start.width) > 0.5
+            || abs(frame.height - start.height) > 0.5
+        let movedOrigin =
+            abs(frame.minX - start.minX) > 0.5
+            || abs(frame.minY - start.minY) > 0.5
+        let looksResize =
+            (pressNearEdge && sizeChanged)
+            || MouseResize.isResize(from: start, to: frame)
+        if looksResize || !movedOrigin {
             dragOverlay.hideAll()
             return
         }

--- a/Tests/KiwiDeskCoreTests/DragTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragTests.swift
@@ -328,6 +328,82 @@ struct DragDropTests {
         #expect(!core.dragOverlay.isDropZoneVisible)
     }
 
+    @Test(
+        """
+        The gesture's first frame (no motion) shows no preview \
+        so a resize can't flash the ghost (#237)
+        """
+    )
+    func firstFrameShowsNoPreview() throws {
+        guard NSScreen.main != nil else { return }
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        let slots = core.tiler.calculatedFrames(
+            state: core.state
+        )
+        let home = try #require(slots[WindowID(1)])
+        // start == frame: nothing has translated or resized yet,
+        // so the gesture reads as neither a move nor a resize.
+        // A resize begins here — showing the ghost now would be
+        // the one-frame flash.
+        core.handleDragMove(
+            WindowID(1),
+            start: home,
+            frame: home
+        )
+        #expect(!core.dragOverlay.isGhostVisible)
+        #expect(!core.dragOverlay.isDropZoneVisible)
+    }
+
+    @Test(
+        """
+        An edge-grabbed sub-threshold resize hides the ghost, \
+        while the same drag grabbed in the body shows it (#237)
+        """
+    )
+    func edgePressDiscriminatesSmallResize() throws {
+        guard NSScreen.main != nil else { return }
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        let slots = core.tiler.calculatedFrames(
+            state: core.state
+        )
+        let home = try #require(slots[WindowID(1)])
+        // A < 10 pt width growth, below the magnitude
+        // threshold, with the origin nudged so movedOrigin is
+        // true — this isolates the pressNearEdge && sizeChanged
+        // path from the first-frame guard.
+        var frame = home
+        frame.size.width += 4
+        frame.origin.x += 1
+
+        // Press on the right edge — a resize grab: hidden.
+        core.mouse.seedPress(
+            at: CGPoint(x: home.maxX, y: home.midY)
+        )
+        core.handleDragMove(
+            WindowID(1),
+            start: home,
+            frame: frame
+        )
+        #expect(!core.dragOverlay.isGhostVisible)
+
+        // Same frames, but the press began in the body: the
+        // sub-threshold size wobble reads as move noise, so the
+        // ghost stays (the character-grid-move fallback).
+        core.mouse.seedPress(
+            at: CGPoint(x: home.midX, y: home.midY)
+        )
+        core.handleDragMove(
+            WindowID(1),
+            start: home,
+            frame: frame
+        )
+        #expect(core.dragOverlay.isGhostVisible)
+    }
+
     @Test("Disabled toggles suppress the drag visuals")
     func previewDisabled() throws {
         guard NSScreen.main != nil else { return }


### PR DESCRIPTION
## What

Fixes #237 — the drag **ghost** / drop-zone overlay flashed while resizing a tiled window with the mouse: on at the sub-threshold start of a pull, and again whenever the size dipped back near its original size.

## Why

`handleDragMove` classified move-vs-resize every frame by size-delta magnitude against the gesture start frame (`MouseResize.isResize`, 10 pt). A resize *begins* sub-threshold, so its first frames read as a move and showed the swap overlays; a size dipping back within the threshold flashed them again.

## How

Classify from the first real frame instead. The overlays show only once the gesture is **clearly a move** — the window has translated (`movedOrigin`) with its size held. A resize is caught from frame one by two facts a magnitude test misses:

- the press began in the slot's **edge band** (`MouseResize.nearEdge` on `mouse.press` — the same signal `isResizeGesture` uses) **and** the size already changed (>0.5 pt); so an edge-grabbed *move* (drag near the top to swap) keeps its ghost while a resize hides with no flash;
- the 10 pt magnitude test stays as the **press-less fallback**, keeping a body-grabbed move of a character-grid app (whose size can wobble a few points) from being misread as a resize.

The gesture's first frame has no delta (`start == frame`), so it shows nothing — killing the one-frame flash before the size delta lands.

No new gesture-lifecycle machinery; the whole change is in the preview layer. Defaults unchanged (ghost stays on).

## Accepted limitation

The preview gate is intentionally stricter than `handleDragEnd`'s resize-vs-swap decision (advisory preview biases toward hiding). In a narrow band — press in the 10 pt edge band, a 0.5–10 pt size change — the preview hides while the drop would still route a swap. Harmless in practice: a real *move* holds its size, so that band is only entered during an actual small resize, whose barely-moved center yields no swap target and snaps back.

## Tests

- first frame (no motion) shows no preview — pins the anti-flash guard
- edge-grabbed sub-threshold resize hides the ghost, body-grabbed same drag shows it — pins the `pressNearEdge` discriminator both ways (new `MouseTracker.seedPress` test seam)

Verify gate green: `swift build && swift test` (1201 tests) `&& scripts/lint.sh && swift build -c release`.

Reviewed by code-reviewer + architect-reviewer (AGENTS §3): no critical/high findings; test-coverage + comment findings addressed, pure-predicate extraction deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)