### PR TITLE
refactor(settings): rule-driven segmented vs menu pickers (#291)

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
@@ -73,12 +73,22 @@ struct LayoutAppBarSection: View {
     // override chrome's own `?` slot is for "should I override",
     // not to re-explain the field — reserved for a field the
     // global editor can't already teach.
+    //
+    // Twin of `GlobalAppBarSection.behavior` (#291): the same four
+    // look fields, rendered here as `.segmented` overrides. Keep
+    // the two lists — and their segmented control choice — in
+    // lockstep. A fifth field, or a control-type change, must land
+    // on both surfaces (same field, same control on comparable
+    // full-width surfaces). Convention-guarded, not test-guarded:
+    // a missing row or mismatched pill is visible on first glance,
+    // not silent data loss, so it doesn't warrant a parity test.
     @ViewBuilder private var behaviorOverrides: some View {
         OverridePickerRow(
             label: L("app_bar.position.label", "Position"),
             value: $bar.position,
             global: global.position,
-            options: AppBarOptions.position
+            options: AppBarOptions.position,
+            style: .segmented
         )
         OverridePickerRow(
             label: L(
@@ -87,7 +97,8 @@ struct LayoutAppBarSection: View {
             ),
             value: $bar.tabBackground,
             global: global.tabBackground,
-            options: AppBarOptions.tabBackground
+            options: AppBarOptions.tabBackground,
+            style: .segmented
         )
         OverridePickerRow(
             label: L(
@@ -96,13 +107,15 @@ struct LayoutAppBarSection: View {
             ),
             value: $bar.activeIndicator,
             global: global.activeIndicator,
-            options: AppBarOptions.activeIndicator
+            options: AppBarOptions.activeIndicator,
+            style: .segmented
         )
         OverridePickerRow(
             label: L("app_bar.content.label", "Content"),
             value: $bar.content,
             global: global.content,
-            options: AppBarOptions.content
+            options: AppBarOptions.content,
+            style: .segmented
         )
         OverrideToggleRow(
             label: L(

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarOptions.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarOptions.swift
@@ -1,0 +1,40 @@
+import KiwiDeskCore
+
+/// The shared App Bar option lists so the global editor and the
+/// per-layout override pickers stay in sync — one source of the
+/// value/label pairs both surfaces render (as segments now, #291).
+/// Split out of `AppBarOverrideControls.swift` to keep that file
+/// under the line ceiling.
+enum AppBarOptions {
+    @MainActor
+    static let position: [(AppBarStyle.Position, String)] = [
+        (.start, L("app_bar.position.start", "Start")),
+        (.end, L("app_bar.position.end", "End")),
+    ]
+    @MainActor
+    static let tabBackground: [(AppBarStyle.TabBackground, String)] = [
+        (.boxed, L("app_bar.tab_background.boxed", "Boxed")),
+        (.plain, L("app_bar.tab_background.plain", "Plain")),
+    ]
+    @MainActor
+    static let activeIndicator: [(AppBarStyle.ActiveIndicator, String)] = [
+        (.ring, L("app_bar.active_indicator.ring", "Ring")),
+        (
+            .edgeMark,
+            L(
+                "app_bar.active_indicator.edge_mark",
+                "Edge mark"
+            )
+        ),
+        (.gap, L("app_bar.active_indicator.gap", "Gap")),
+    ]
+    @MainActor
+    static let content: [(AppBarStyle.Content, String)] = [
+        (.icon, L("app_bar.content.icon", "Icon")),
+        (.name, L("app_bar.content.name", "Name")),
+        (
+            .iconAndName,
+            L("app_bar.content.icon_and_name", "Icon & name")
+        ),
+    ]
+}

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarOverrideControls.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarOverrideControls.swift
@@ -258,10 +258,20 @@ struct OverrideFractionRow: View {
 
 /// An override picker over any labeled, hashable option set.
 struct OverridePickerRow<Value: Hashable & Sendable>: View {
+    /// Which control the row renders (#291). `.segmented` is the
+    /// rule's norm for 2–4 short peers and drives the full-width
+    /// App Bar per-layout overrides; `.menu` is the documented
+    /// compact-surface exception, kept by the narrow per-Space
+    /// popover where the inherit chrome already eats width.
+    /// Required, no default: every call site names its surface so
+    /// a new override row can't silently pick the wrong control.
+    enum Style { case menu, segmented }
+
     let label: String
     @Binding var value: Value?
     let global: Value
     let options: [(Value, String)]
+    let style: Style
     /// Optional `?` popover (#94), rendered by the chrome so
     /// it stays clickable while the row inherits.
     var help: String? = nil
@@ -272,55 +282,35 @@ struct OverridePickerRow<Value: Hashable & Sendable>: View {
             help: help,
             subject: label
         ) {
+            control
+        }
+    }
+
+    // The menu-vs-segmented branch is the only difference between
+    // the two surfaces; everything above (inherit chrome, help,
+    // label-column narrowing) is shared, so one component with a
+    // one-line branch beats forking the chrome wiring (§5 mirror).
+    @ViewBuilder private var control: some View {
+        switch style {
+        case .menu:
             DropdownRow(label: label) {
                 Picker(
                     label,
-                    selection: overrideValue(
-                        $value,
-                        global: global
-                    )
+                    selection: overrideValue($value, global: global)
                 ) {
                     ForEach(options, id: \.0) { option in
                         Text(option.1).tag(option.0)
                     }
                 }
             }
+        case .segmented:
+            // SegmentedPicker wants (title, value); the override
+            // option lists are (value, title), so flip the pair.
+            SegmentedPicker(
+                label,
+                selection: overrideValue($value, global: global),
+                options: options.map { ($0.1, $0.0) }
+            )
         }
     }
-}
-
-/// The shared option lists so the global editor and the
-/// per-layout override pickers stay in sync.
-enum AppBarOptions {
-    @MainActor
-    static let position: [(AppBarStyle.Position, String)] = [
-        (.start, L("app_bar.position.start", "Start")),
-        (.end, L("app_bar.position.end", "End")),
-    ]
-    @MainActor
-    static let tabBackground: [(AppBarStyle.TabBackground, String)] = [
-        (.boxed, L("app_bar.tab_background.boxed", "Boxed")),
-        (.plain, L("app_bar.tab_background.plain", "Plain")),
-    ]
-    @MainActor
-    static let activeIndicator: [(AppBarStyle.ActiveIndicator, String)] = [
-        (.ring, L("app_bar.active_indicator.ring", "Ring")),
-        (
-            .edgeMark,
-            L(
-                "app_bar.active_indicator.edge_mark",
-                "Edge mark"
-            )
-        ),
-        (.gap, L("app_bar.active_indicator.gap", "Gap")),
-    ]
-    @MainActor
-    static let content: [(AppBarStyle.Content, String)] = [
-        (.icon, L("app_bar.content.icon", "Icon")),
-        (.name, L("app_bar.content.name", "Name")),
-        (
-            .iconAndName,
-            L("app_bar.content.icon_and_name", "Icon & name")
-        ),
-    ]
 }

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
@@ -77,8 +77,10 @@ struct GlobalAppBarSection: View {
     }
 
     @ViewBuilder private var behavior: some View {
-        DropdownRow(
-            label: positionLabel,
+        SegmentedPicker(
+            positionLabel,
+            selection: $style.position,
+            options: AppBarOptions.position.map { ($0.1, $0.0) },
             help: L(
                 "app_bar.position.label.help",
                 "Which end of the bar the window tabs pack "
@@ -86,40 +88,23 @@ struct GlobalAppBarSection: View {
                     + "active layout's axis: Start is the left "
                     + "(or top) edge, End the right (or bottom)."
             )
-        ) {
-            Picker(positionLabel, selection: $style.position) {
-                ForEach(AppBarOptions.position, id: \.0) {
-                    Text($0.1).tag($0.0)
-                }
-            }
-        }
-        DropdownRow(label: tabBackgroundLabel) {
-            Picker(
-                tabBackgroundLabel,
-                selection: $style.tabBackground
-            ) {
-                ForEach(AppBarOptions.tabBackground, id: \.0) {
-                    Text($0.1).tag($0.0)
-                }
-            }
-        }
-        DropdownRow(label: activeIndicatorLabel) {
-            Picker(
-                activeIndicatorLabel,
-                selection: $style.activeIndicator
-            ) {
-                ForEach(AppBarOptions.activeIndicator, id: \.0) {
-                    Text($0.1).tag($0.0)
-                }
-            }
-        }
-        DropdownRow(label: contentLabel) {
-            Picker(contentLabel, selection: $style.content) {
-                ForEach(AppBarOptions.content, id: \.0) {
-                    Text($0.1).tag($0.0)
-                }
-            }
-        }
+        )
+        SegmentedPicker(
+            tabBackgroundLabel,
+            selection: $style.tabBackground,
+            options: AppBarOptions.tabBackground.map { ($0.1, $0.0) }
+        )
+        SegmentedPicker(
+            activeIndicatorLabel,
+            selection: $style.activeIndicator,
+            options: AppBarOptions.activeIndicator
+                .map { ($0.1, $0.0) }
+        )
+        SegmentedPicker(
+            contentLabel,
+            selection: $style.content,
+            options: AppBarOptions.content.map { ($0.1, $0.0) }
+        )
         ToggleRow(
             label: L(
                 "app_bar.group_adjacent",

--- a/Sources/KiwiDesk/Settings/Tabs/DragVisualsEditor.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/DragVisualsEditor.swift
@@ -200,17 +200,14 @@ struct DragVisualControls: View {
             value: $visual.borderThickness,
             range: 0...20
         )
-        DropdownRow(label: borderAlignmentLabel) {
-            Picker(
-                borderAlignmentLabel,
-                selection: $visual.borderAlignment
-            ) {
-                Text(L("drag.inside", "Inside"))
-                    .tag(BorderAlignment.inside)
-                Text(L("drag.outside", "Outside"))
-                    .tag(BorderAlignment.outside)
-            }
-        }
+        SegmentedPicker(
+            borderAlignmentLabel,
+            selection: $visual.borderAlignment,
+            options: [
+                (L("drag.inside", "Inside"), .inside),
+                (L("drag.outside", "Outside"), .outside),
+            ]
+        )
         Divider()
         Toggle(L("drag.fill", "Fill"), isOn: $visual.fill)
         HexColorField(

--- a/Sources/KiwiDesk/Settings/Tabs/FocusBorderEditor.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/FocusBorderEditor.swift
@@ -72,16 +72,14 @@ struct FocusBorderEditor: View {
             value: style.width,
             range: 1...20
         )
-        DropdownRow(label: cornerLabel) {
-            Picker(cornerLabel, selection: style.cornerStyle) {
-                Text(L("border.corner.rounded", "Rounded"))
-                    .tag(BorderStyle.CornerStyle.rounded)
-                Text(L("border.corner.square", "Square"))
-                    .tag(BorderStyle.CornerStyle.square)
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-        }
+        SegmentedPicker(
+            cornerLabel,
+            selection: style.cornerStyle,
+            options: [
+                (L("border.corner.rounded", "Rounded"), .rounded),
+                (L("border.corner.square", "Square"), .square),
+            ]
+        )
         if squareSitsInset {
             Text(
                 L(

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceOverrideRows+ModeRows.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceOverrideRows+ModeRows.swift
@@ -15,7 +15,8 @@ extension SpaceOverrideRows {
             options: [
                 (.dynamic, L("scroll_grid.dynamic", "Dynamic")),
                 (.rigid, L("scroll_grid.rigid", "Rigid")),
-            ]
+            ],
+            style: .menu
         )
         OverrideToggleRow(
             label: L(
@@ -54,7 +55,8 @@ extension SpaceOverrideRows {
                         "Rows first"
                     )
                 ),
-            ]
+            ],
+            style: .menu
         )
         OverrideStepperRow(
             label: L("scroll_grid.columns", "Columns"),
@@ -86,7 +88,8 @@ extension SpaceOverrideRows {
                     L("scroll_grid.horizontal", "Horizontal")
                 ),
                 (.vertical, L("scroll_grid.vertical", "Vertical")),
-            ]
+            ],
+            style: .menu
         )
     }
 
@@ -107,7 +110,8 @@ extension SpaceOverrideRows {
                     .horizontal,
                     L("scroll_grid.arrange.rows", "Rows")
                 ),
-            ]
+            ],
+            style: .menu
         )
         OverrideStepperRow(
             label: L("track.count", "Track limit"),
@@ -142,7 +146,8 @@ extension SpaceOverrideRows {
                         "Cascade all"
                     )
                 ),
-            ]
+            ],
+            style: .menu
         )
     }
 }

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceOverrideRows+StackRows.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceOverrideRows+StackRows.swift
@@ -59,6 +59,7 @@ extension SpaceOverrideRows {
                     )
                 ),
             ],
+            style: .menu,
             help: LayoutHelp.stackOverflow
         )
         OverridePickerRow(
@@ -90,6 +91,7 @@ extension SpaceOverrideRows {
                     L("layout_params.position.left", "Left")
                 ),
             ],
+            style: .menu,
             help: LayoutHelp.stackPosition
         )
         OverridePickerRow(
@@ -119,6 +121,7 @@ extension SpaceOverrideRows {
                     )
                 ),
             ],
+            style: .menu,
             help: LayoutHelp.masterOrientation
         )
         // Greyed at a resolved master count of 1, like the

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceOverrideRows.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceOverrideRows.swift
@@ -78,7 +78,8 @@ struct SpaceOverrideRows: View {
             options: [
                 (.horizontal, L("scroll_grid.horizontal", "Horizontal")),
                 (.vertical, L("scroll_grid.vertical", "Vertical")),
-            ]
+            ],
+            style: .menu
         )
         OverridePickerRow(
             label: L("scroll_grid.focus_anchor", "Focus anchor"),
@@ -99,7 +100,8 @@ struct SpaceOverrideRows: View {
                         : L("scroll_grid.anchor.end_h", "Right")
                 ),
                 (.follow, L("scroll_grid.anchor.follow", "Follow")),
-            ]
+            ],
+            style: .menu
         )
         placeholder(slotSizePlaceholder)
     }
@@ -142,6 +144,7 @@ struct SpaceOverrideRows: View {
                     L("layout_params.alternating", "Alternating")
                 ),
             ],
+            style: .menu,
             help: LayoutHelp.splitStrategy
         )
         OverrideFractionRow(

--- a/Sources/KiwiDesk/Settings/Tabs/StackEditor.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/StackEditor.swift
@@ -45,15 +45,27 @@ struct StackEditor: View {
                 ),
                 value: stack.masterRatio
             )
-            DropdownRow(
-                label: masterOrientationLabel,
+            SegmentedPicker(
+                masterOrientationLabel,
+                selection: stack.masterOrientation,
+                options: [
+                    (
+                        L(
+                            "layout_params.orientation.vertical",
+                            "Vertical"
+                        ),
+                        .vertical
+                    ),
+                    (
+                        L(
+                            "layout_params.orientation.horizontal",
+                            "Horizontal"
+                        ),
+                        .horizontal
+                    ),
+                ],
                 help: LayoutHelp.masterOrientation
-            ) {
-                orientationPicker(
-                    masterOrientationLabel,
-                    selection: stack.masterOrientation
-                )
-            }
+            )
             // Orientation only matters with several masters;
             // greyed (not hidden) at count 1 so its value stays
             // visible (§2.7 grey-don't-hide, #171).
@@ -61,58 +73,51 @@ struct StackEditor: View {
                 model.config.settings.stack.masterCount <= 1
             )
             Divider()
-            DropdownRow(
-                label: stackPositionLabel,
-                help: LayoutHelp.stackPosition
-            ) {
-                Picker(
-                    stackPositionLabel,
-                    selection: stack.stackPosition
-                ) {
-                    Text(L("layout_params.position.top", "Top"))
-                        .tag(StackParams.StackPosition.top)
-                    Text(
-                        L("layout_params.position.right", "Right")
-                    )
-                    .tag(StackParams.StackPosition.right)
-                    Text(
+            SegmentedPicker(
+                stackPositionLabel,
+                selection: stack.stackPosition,
+                options: [
+                    (L("layout_params.position.top", "Top"), .top),
+                    (
+                        L("layout_params.position.right", "Right"),
+                        .right
+                    ),
+                    (
                         L(
                             "layout_params.position.bottom",
                             "Bottom"
-                        )
-                    )
-                    .tag(StackParams.StackPosition.bottom)
-                    Text(L("layout_params.position.left", "Left"))
-                        .tag(StackParams.StackPosition.left)
-                }
-            }
+                        ),
+                        .bottom
+                    ),
+                    (
+                        L("layout_params.position.left", "Left"),
+                        .left
+                    ),
+                ],
+                help: LayoutHelp.stackPosition
+            )
             Divider()
-            DropdownRow(
-                label: overflowLabel,
-                help: LayoutHelp.stackOverflow
-            ) {
-                Picker(
-                    overflowLabel,
-                    selection: stack.overflowStyle
-                ) {
-                    Text(
+            SegmentedPicker(
+                overflowLabel,
+                selection: stack.overflowStyle,
+                options: [
+                    (
                         L(
                             "layout_params.cascade_overflow",
                             "Cascade overflow"
-                        )
-                    )
-                    .tag(
-                        StackParams.OverflowStyle.cascadeOverflow
-                    )
-                    Text(
+                        ),
+                        .cascadeOverflow
+                    ),
+                    (
                         L(
                             "layout_params.cascade_all",
                             "Cascade all"
-                        )
-                    )
-                    .tag(StackParams.OverflowStyle.cascadeAll)
-                }
-            }
+                        ),
+                        .cascadeAll
+                    ),
+                ],
+                help: LayoutHelp.stackOverflow
+            )
             PlacementPicker(placement: stack.newWindowPlacement)
         }
     }
@@ -130,29 +135,5 @@ struct StackEditor: View {
 
     private var stackPositionLabel: String {
         L("layout_params.stack_position", "Stack position")
-    }
-
-    /// One vertical/horizontal picker for both orientation
-    /// rows — same options, same tags.
-    private func orientationPicker(
-        _ label: String,
-        selection: Binding<StackParams.Orientation>
-    ) -> some View {
-        Picker(label, selection: selection) {
-            Text(
-                L(
-                    "layout_params.orientation.vertical",
-                    "Vertical"
-                )
-            )
-            .tag(StackParams.Orientation.vertical)
-            Text(
-                L(
-                    "layout_params.orientation.horizontal",
-                    "Horizontal"
-                )
-            )
-            .tag(StackParams.Orientation.horizontal)
-        }
     }
 }

--- a/Sources/KiwiDesk/Settings/Tabs/TrackEditor.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/TrackEditor.swift
@@ -66,6 +66,15 @@ struct TrackEditor: View {
                 ]
             )
             Divider()
+            overflow
+            // New-window mode + Position is standing placement
+            // policy (tier 3), clustered with Overflow directly
+            // above — no divider between, since dividers mark tier
+            // boundaries, not spacing — and after the
+            // schematic-defining Arrange row. Matches StackEditor,
+            // which keeps Overflow + new-window placement in one
+            // cluster (design-decisions "Row order within a
+            // section").
             SegmentedPicker(
                 L("track.new_window", "New window"),
                 selection: $model.config.settings.track
@@ -96,8 +105,6 @@ struct TrackEditor: View {
                 ),
                 help: LayoutHelp.trackPosition
             )
-            Divider()
-            overflow
             Divider()
             trackAuto
             VStack(alignment: .leading, spacing: 4) {
@@ -139,31 +146,27 @@ struct TrackEditor: View {
     /// fitting ones and piles the rest. Normal tracks are always
     /// `cascade_overflow`. Reuses stack's `overflow_style` labels.
     private var overflow: some View {
-        DropdownRow(
-            label: L("layout_params.overflow", "Overflow"),
-            help: LayoutHelp.trackOverflow
-        ) {
-            Picker(
-                L("layout_params.overflow", "Overflow"),
-                selection: $model.config.settings.track
-                    .overflowStyle
-            ) {
-                Text(
+        SegmentedPicker(
+            L("layout_params.overflow", "Overflow"),
+            selection: $model.config.settings.track.overflowStyle,
+            options: [
+                (
                     L(
                         "layout_params.cascade_overflow",
                         "Cascade overflow"
-                    )
-                )
-                .tag(StackParams.OverflowStyle.cascadeOverflow)
-                Text(
+                    ),
+                    .cascadeOverflow
+                ),
+                (
                     L(
                         "layout_params.cascade_all",
                         "Cascade all"
-                    )
-                )
-                .tag(StackParams.OverflowStyle.cascadeAll)
-            }
-        }
+                    ),
+                    .cascadeAll
+                ),
+            ],
+            help: LayoutHelp.trackOverflow
+        )
     }
 
     /// The automatic-tracks toggle with its caption. On (the

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1036,6 +1036,100 @@ switcher), a deliberate trade against content-sized
 segments. One control, one look — a chooser reads as "pick
 a tab" everywhere in the settings.
 
+**Segmented vs. menu is decided by a rule, not per row
+(#291).** A pick-one control is a `SegmentedPicker` when the
+choices are a *fixed set of 2–4 peers*, every label stays
+short and untruncated at the minimum Settings width **and**
+in the longest shipped localization, and seeing all choices
+at once helps the decision. It is a **menu** (`DropdownRow`)
+when any of: five or more choices; dynamic or user-generated
+choices; long, explanatory, or localization-risk labels; or
+a constrained repeated surface where showing every choice
+would crowd or truncate. A binary is a **toggle**, never two
+segments. Fixed editor-navigation tabs (the Layout Defaults
+mode strip) may exceed four — they switch the visible editor
+rather than edit a value, so the count cap doesn't apply.
+The *same semantic field uses the same control on comparable
+full-width surfaces*: the App Bar global editor and its
+per-layout override rows both render Position / Tab
+background / Active indicator / Content as segments, so the
+two never sit adjacent showing one field two ways. The audit
+(#291) converted those four App Bar fields (global and
+override), Stack's Master orientation / Stack position /
+Overflow, Track's Overflow, Drag's Border alignment, and the
+Focus border Corners (which had been a native `.segmented`
+`Picker` nested in a menu-styled `DropdownRow` — two
+segmented implementations at once — flattened to the shared
+`SegmentedPicker`). Menus were kept where the rule keeps
+them: new-window placement (comparative labels like "Before
+focused"), the Space layout mode (seven icon-bearing
+options), Language and Native-Desktop→Profile (dynamic
+lists).
+
+**The 384 pt per-Space popover is the documented
+compact-surface exception (#291).** There the inherit
+chrome (a checkbox plus accent bar, `OverrideChrome`) eats
+horizontal width, so its override rows stay menus even for
+2–4-peer fields. `OverridePickerRow` carries a **required**
+`Style` (`.menu` / `.segmented`, no default): the full-width
+App Bar per-layout overrides pass `.segmented`, the per-Space
+popover rows pass `.menu`, and a new override row can't
+silently pick the wrong control for its surface. The
+inherited (unchecked) state comes free from the chrome's
+existing `.disabled` + `.opacity(0.5)` — the segmented pill
+sits on the resolved global value, dimmed. App Bar Content
+("Icon &amp; name" → German "Symbol &amp; Name") is the one
+segmented label tight enough to warrant a real render at
+minimum width; kept segmented by width headroom, it is a
+truncation candidate to re-check when each new locale ships
+(#95), the same recurring de-review discipline the help-glyph
+labels already carry.
+
+**Row order within a section is fixed-tier, not
+usage-frequency.** A field's vertical position is decided by
+what *kind* of decision it represents, not by how often a
+user reaches for it — a canonical tier order is what lets the
+eye learn one shape across every editor. Natural adjust-order
+("what you'd tune right before/after this") only breaks ties
+*within* a tier, once the tier is fixed. A contributor
+placing a new field first asks **which tier**, then **where
+in it**. The tiers, top to bottom:
+
+1. **Preview / schematic** — leads unconditionally, *unless*
+   the section has one master on/off toggle whose own state
+   the preview depicts (Focus border's dimmed-when-off
+   preview): then the toggle sits directly above the preview,
+   the gate-above-gated rule extended to treat the preview as
+   a gated control.
+2. **Defining / structural fields** the schematic takes as
+   params — counts, ratios, axis / arrangement, positions —
+   ordered coarse-to-fine (what fixes the shape before what
+   refines it). A *numeric-threshold* gate needs no strict
+   adjacency to what it greys (Stack's Master count gates
+   Master orientation, yet the unconditionally-relevant
+   Master ratio sits between them): unconditional-before-
+   conditional outranks adjacency, because the greyed state
+   already signals the gating. Strict adjacency stays
+   mandatory only for a boolean-toggle-controls-one-row pair.
+3. **Standing placement / overflow policy** — New-window
+   placement and Overflow style, steady-state behaviour
+   rather than static geometry, cluster together and sit last
+   among the schematic-tied fields.
+4. **Secondary, occasional-use toggles** with their own
+   captions (auto-derivation, wrap-focus), each still
+   gate-above-gated internally.
+5. **Escape-hatch buttons / actions** ("Fit gaps to border")
+   — always last.
+
+Dividers mark tier boundaries, not just breathing room, so a
+new field's tier decides which divider-bounded cluster it
+joins — never wedge a field mid-cluster to dodge adding a
+divider. The audit that set this rule (#291) moved Track's
+New-window mode + Position out of tier 2 (it had sat right
+after Arrange) down to tier 3 after Overflow, so all five
+layout editors now place new-window placement last among
+their schematic-tied rows.
+
 **Sliders share the pill design.** Every value adjuster
 (ratios, gaps, sizes) is a `SettingsSlider`: the same capsule
 track as the segmented picker, a native-style solid white


### PR DESCRIPTION
Fixes #291.

## What

Settle **when a pick-one control is a segmented control vs. a menu**, document it, and apply it across Settings — plus a companion **row-order** rule for placing fields within a section.

### Picker rule (`docs/design-decisions.md` › Shared controls)
- Segmented for a fixed **2–4 short peers** that stay untruncated at min width and in the longest shipped locale; menu for 5+, dynamic, or long/localization-risk labels; toggle for a binary.
- Same semantic field → same control on comparable **full-width** surfaces. The **384 pt per-Space popover is the documented compact-surface menu exception** (inherit chrome eats width).

### Conversions (menu → `SegmentedPicker`, full-width surfaces)
App Bar Position / Tab background / Active indicator / Content (global **and** per-layout override), Stack Master orientation / Stack position / Overflow, Track Overflow, Drag Border alignment, Focus-border Corners (flattened from a native `.segmented` `Picker` nested in a menu-styled `DropdownRow`).

`OverridePickerRow` gains a **required** `Style` (`.menu`/`.segmented`, no default) so each call site names its surface; per-Space rows pass `.menu`. `AppBarOptions` extracted to its own file (line ceiling).

### Row-order rule + Track reorder
Within a section, **fixed tiers** decide position (preview → defining structure → placement/overflow policy → secondary toggles → escape-hatch buttons), not usage frequency; natural adjust-order only breaks ties within a tier. Track's New-window mode + Position moved to tier 3 (clustered with Overflow) so all five layout editors place new-window placement last among schematic-tied rows.

## Notes
- App Bar **Content** kept segmented; German "Symbol & Name" is tight — flagged as a truncation candidate to re-check at each new locale (#95).
- Both design rules vetted by a **ui-designer** consult; diff passed **code-reviewer + architect-reviewer** (one tier-3 clustering fix applied).

## Verify
Debug + **release** build, 1276 tests, lint, and site build all green locally. CI is red (GH Actions billing) — merged on the local gate per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)