### PR TITLE
feat(settings): smoother drag-reorder in the Spaces list

### DIFF
--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+Captions.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+Captions.swift
@@ -1,0 +1,35 @@
+import KiwiDeskCore
+import SwiftUI
+
+/// The Spaces-list captions, split out of `SpacesSection` to keep
+/// that file under the size ceiling — pure copy, no behavior.
+extension SpacesSection {
+    var emptyCaption: String {
+        L(
+            "spaces.empty",
+            "No spaces yet — add one below. Until you do, "
+                + "every window tiles in a single default "
+                + "space."
+        )
+    }
+
+    var spacesCaption: String {
+        L(
+            "spaces.caption",
+            "Each space has its own layout. Add spaces "
+                + "here; they appear in the shortcut and "
+                + "app-rule lists too. Drag rows to "
+                + "reorder."
+        )
+    }
+
+    var fallbackCaption: String {
+        L(
+            "spaces.fallback_caption",
+            "When you switch profiles, windows from a "
+                + "space the new profile doesn't have "
+                + "land in its fallback space (the first "
+                + "space when none is chosen)."
+        )
+    }
+}

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+Drag.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+Drag.swift
@@ -8,6 +8,12 @@ import SwiftUI
 /// constrained, while here the row itself steps slot to slot
 /// and never leaves the column.
 extension SpacesSection {
+    /// The rows to render: the live drag order while a drag is in
+    /// flight, otherwise the model's own order (#299).
+    var displayedSpaces: [SpaceID] {
+        dragOrder ?? model.config.spaces
+    }
+
     /// The open-hand cursor on hover is the drag affordance
     /// the handle glyph alone doesn't deliver. Cursor changes
     /// use `set()` rather than push/pop: the pointer leaves
@@ -50,7 +56,13 @@ extension SpacesSection {
                 if hoveredHandle == space {
                     hoveredHandle = nil
                 }
-                if dragged == space { dragged = nil }
+                if dragged == space {
+                    // A cancelled drag skips onEnded — flush the
+                    // in-flight order so the reorder isn't lost
+                    // and dragOrder can't linger stale.
+                    commitDragOrder()
+                    dragged = nil
+                }
                 (hoveredHandle != nil
                     ? NSCursor.openHand : .arrow)
                     .set()
@@ -67,6 +79,10 @@ extension SpacesSection {
         .onChanged { value in
             if dragged == nil {
                 dragged = space
+                // Snapshot the model into the live drag order
+                // so every crossing reorders a local array,
+                // not the @Published/profile-backed one.
+                dragOrder = model.config.spaces
                 NSCursor.closedHand.set()
             }
             retarget(space, at: value.location.y)
@@ -79,9 +95,8 @@ extension SpacesSection {
             (hoveredHandle != nil
                 ? NSCursor.openHand : .arrow)
                 .set()
-            withAnimation(
-                .spring(response: 0.35, dampingFraction: 0.7)
-            ) {
+            commitDragOrder()
+            withAnimation(Self.reorderSpring) {
                 dragged = nil
             }
         }
@@ -95,29 +110,48 @@ extension SpacesSection {
     /// tall row's new band and the next movement swaps them
     /// straight back).
     private func retarget(_ space: SpaceID, at y: CGFloat) {
+        var order = dragOrder ?? model.config.spaces
         guard
             let candidate = rowFrames.first(where: {
                 $0.key != space
                     && $0.value.minY <= y
                     && y <= $0.value.maxY
             }),
-            let from = model.config.spaces.firstIndex(
-                of: space
-            ),
-            let to = model.config.spaces.firstIndex(
-                of: candidate.key
-            ),
+            let from = order.firstIndex(of: space),
+            let to = order.firstIndex(of: candidate.key),
             from != to,
             to > from
                 ? y >= candidate.value.midY
                 : y <= candidate.value.midY
         else { return }
-        withAnimation(.easeInOut(duration: 0.15)) {
-            model.config.spaces.move(
+        withAnimation(Self.reorderSpring) {
+            order.move(
                 fromOffsets: IndexSet(integer: from),
                 toOffset: to > from ? to + 1 : to
             )
+            dragOrder = order
         }
+    }
+
+    /// One light spring for both the per-swap shuffle and the
+    /// drop settle — replaces the old stacked `easeInOut(0.15)`
+    /// per swap plus a separate drop spring, whose compounding
+    /// read as sluggish on a fast multi-row drag (#299).
+    static let reorderSpring: Animation = .interactiveSpring(
+        response: 0.25,
+        dampingFraction: 0.86
+    )
+
+    /// Flush the live drag order into the model exactly once, at
+    /// the end of a drag (or if the row tears down mid-drag). No-op
+    /// when nothing moved, so a plain click never dirties the
+    /// profile. Clearing `dragOrder` hands rendering back to the
+    /// model — identical order, so no visual jump.
+    func commitDragOrder() {
+        if let order = dragOrder, order != model.config.spaces {
+            model.config.spaces = order
+        }
+        dragOrder = nil
     }
 
     /// Row frames in list space, keyed by space — the drag

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection.swift
@@ -27,6 +27,14 @@ struct SpacesSection: View {
     // `private` (which is file-scoped).
     /// The space being handle-dragged, if any.
     @State var dragged: SpaceID?
+    /// The live display order *during* a drag — seeded from the
+    /// model on drag start, reordered locally on each threshold
+    /// cross, and written back to `model.config.spaces` once on
+    /// drop. Keeps the per-swap cost to a cheap array move instead
+    /// of a `@Published`/profile write (which re-evaluated the
+    /// whole config every crossing, #299). `nil` when idle: the
+    /// list then renders straight from the model.
+    @State var dragOrder: [SpaceID]?
     /// The handle currently under the pointer — tracked even
     /// mid-drag (when hover no longer drives the cursor), so
     /// drag end and row teardown can restore the right cursor.
@@ -40,6 +48,11 @@ struct SpacesSection: View {
     /// guessed) so every row's button locks to one column width
     /// that stays correct across locales and counts (#290).
     @State var overridesButtonWidth: CGFloat = 0
+    /// Whether this window is key/active — watched so a drag the
+    /// app deactivates out of (Cmd-Tab, a mouse-up delivered to
+    /// another app) still commits, since that path reaches
+    /// neither `onEnded` nor `onDisappear` (#299).
+    @Environment(\.controlActiveState) var activeState
 
     var body: some View {
         ScrollView {
@@ -53,6 +66,15 @@ struct SpacesSection: View {
             }
             .onPreferenceChange(OverridesButtonWidth.self) {
                 overridesButtonWidth = $0
+            }
+        }
+        .onChange(of: activeState) { _, now in
+            // The app deactivating mid-drag abandons the gesture
+            // without an onEnded — commit the live order so the
+            // list can't keep showing an unsaved reorder (#299).
+            if now != .key, dragged != nil {
+                commitDragOrder()
+                dragged = nil
             }
         }
         .confirmationDialog(
@@ -90,41 +112,14 @@ struct SpacesSection: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            ForEach(model.config.spaces, id: \.raw) { space in
+            ForEach(displayedSpaces, id: \.raw) { space in
                 spaceRow(space)
             }
             addRow
         }
     }
 
-    private var emptyCaption: String {
-        L(
-            "spaces.empty",
-            "No spaces yet — add one below. Until you do, "
-                + "every window tiles in a single default "
-                + "space."
-        )
-    }
-
-    private var spacesCaption: String {
-        L(
-            "spaces.caption",
-            "Each space has its own layout. Add spaces "
-                + "here; they appear in the shortcut and "
-                + "app-rule lists too. Drag rows to "
-                + "reorder."
-        )
-    }
-
-    private var fallbackCaption: String {
-        L(
-            "spaces.fallback_caption",
-            "When you switch profiles, windows from a "
-                + "space the new profile doesn't have "
-                + "land in its fallback space (the first "
-                + "space when none is chosen)."
-        )
-    }
+    // Captions live in `SpacesSection+Captions.swift`.
 
     // MARK: - Rows
 


### PR DESCRIPTION
## Summary

Reordering spaces via the grip handle in Profile ▸ Spaces felt sluggish. `retarget()` wrote the `@Published`, profile-backed `model.config.spaces` on **every** midpoint crossing (a full config equality/dirty recompute per swap), and stacked an `easeInOut(0.15)` per swap with a separate `spring(0.35)` drop-settle — the compounding read as slow on a fast multi-row drag.

## What changed

- **Decouple visual from model.** A local `@State dragOrder: [SpaceID]?` is seeded from the model on drag start, reordered (cheap array move) on each crossing, and written back to `model.config.spaces` **once** on drop. `commitDragOrder()` is idempotent and a no-op when nothing moved, so a plain click never dirties the profile.
- **Two teardown paths cover an abandoned drag** without losing or leaving a phantom order: `onDisappear` (same-app tab switch / row delete) and a `controlActiveState` watch (the app deactivating mid-drag — Cmd-Tab, a mouse-up delivered elsewhere — which reaches neither `onEnded` nor `onDisappear`).
- **One shared curve:** `interactiveSpring(response: 0.25, dampingFraction: 0.86)` for both the per-swap shuffle and the drop settle — `interactiveSpring` retargets from current velocity so consecutive swaps don't restart the curve.
- Captions moved into `SpacesSection+Captions.swift` to keep `SpacesSection.swift` under the 350-line ceiling.

**Mechanism unchanged** (handle-anchored axis-locked drag, midpoint-crossing swap, row-moves-not-a-ghost, no floating caret).

## Design / review

- **ui-designer consult** vetted the feel: single shared curve is the right restraint; nudged damping 0.8 → **0.86** for a crisper System-Settings-grade stop.
- **code-reviewer + architect-reviewer** (parallel, fresh) — architect clean; code-reviewer's one moderate finding (cancel path relied on `onDisappear`, which misses app-deactivation mid-drag) fixed via the `controlActiveState` watch, then **re-reviewed and confirmed resolved**.

## Verify gate

- `swift build` ✅ · `swift build -c release` ✅
- `swift test` — 1287 tests ✅ (one `ExecTests` flake on first run — real external-process timing, unrelated; green on re-run)
- `scripts/lint.sh` ✅

## Manual QA (open)

Eyes-on that macOS reports `.inactive` promptly on Cmd-Tab and a cross-app mouse-up mid-drag (OS-timed, not a code defect).

fixes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)