### PR TITLE
fix(borders): suppress the focus ring on launcher/panel overlays (#300)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
@@ -9,7 +9,8 @@ import CoreGraphics
 /// Every tiled window gets its own ring when unfocused borders are
 /// enabled, including every member of an overflow cascade. Monocle
 /// is always focused-only because only one window is visible;
-/// floating windows get a ring only while focused.
+/// floating windows get a ring only while focused, and transient
+/// overlays (launchers/panels, #300) never do.
 extension KiwiCore {
     func updateBorders() {
         let style = tiler.settings.borderStyle
@@ -26,6 +27,13 @@ extension KiwiCore {
                 state.windows[$0]?.isFloating == true
             }
         )
+        // Transient overlays (launchers, panels) never get a ring,
+        // even while focused — see `borderSpecs` (#300).
+        let overlays = Set(
+            space.windows.filter {
+                state.windows[$0]?.isTransientOverlay == true
+            }
+        )
         let slots = space.windows.compactMap {
             id -> (id: WindowID, frame: CGRect)? in
             guard let frame = targets[id] ?? state.windows[id]?.frame
@@ -37,6 +45,7 @@ extension KiwiCore {
             focused: space.focused,
             slots: slots,
             floating: floating,
+            overlays: overlays,
             isMonocle: space.mode == .monocle
         )
         // Draw each ring around the window's REAL frame (its
@@ -75,16 +84,20 @@ extension KiwiCore {
     }
 
     /// The rings to show for one space. Focused window always
-    /// (when borders are on); every other visible tiled slot only
-    /// when `unfocusedEnabled` and the space isn't monocle. Cascade
-    /// members remain independent: border presentation must not
-    /// change the shared pile semantics used by navigation and swap.
-    /// Pure over the flat slot list — no `self`, no AX.
+    /// (when borders are on), unless it is a transient overlay
+    /// (`overlays` — a launcher/panel that momentarily takes focus,
+    /// #300); every other visible tiled slot only when
+    /// `unfocusedEnabled` and the space isn't monocle. Overlays and
+    /// unfocused floating windows never get a ring. Cascade members
+    /// remain independent: border presentation must not change the
+    /// shared pile semantics used by navigation and swap. Pure over
+    /// the flat slot list — no `self`, no AX.
     nonisolated static func borderSpecs(
         style: BorderStyle,
         focused: WindowID?,
         slots: [(id: WindowID, frame: CGRect)],
         floating: Set<WindowID>,
+        overlays: Set<WindowID>,
         isMonocle: Bool
     ) -> [BorderManager.Spec] {
         guard style.enabled, let focused,
@@ -93,20 +106,29 @@ extension KiwiCore {
             })?.frame
         else { return [] }
         let width = style.clampedWidth
-        var specs = [
-            BorderManager.Spec(
-                window: focused,
-                frame: focusedFrame,
-                colorHex: style.focusedColor,
-                width: width,
-                cornerStyle: style.cornerStyle
+        var specs: [BorderManager.Spec] = []
+        // A focused transient overlay (Spotlight/Raycast/Alfred)
+        // gets no ring; a focused user-floated standard window
+        // still does.
+        if !overlays.contains(focused) {
+            specs.append(
+                BorderManager.Spec(
+                    window: focused,
+                    frame: focusedFrame,
+                    colorHex: style.focusedColor,
+                    width: width,
+                    cornerStyle: style.cornerStyle
+                )
             )
-        ]
+        }
         guard style.unfocusedEnabled, !isMonocle else {
             return specs
         }
         for slot in slots
-        where slot.id != focused && !floating.contains(slot.id) {
+        where slot.id != focused
+            && !floating.contains(slot.id)
+            && !overlays.contains(slot.id)
+        {
             specs.append(
                 BorderManager.Spec(
                     window: slot.id,

--- a/Sources/KiwiDeskCore/Events/EventLoop.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop.swift
@@ -187,6 +187,18 @@ public final class EventLoop {
                 layer: layer,
                 rules: floatRules
             )
+        // A transient overlay floats for a *structural* reason
+        // (accessory app, panel subrole, or raised layer), never
+        // just because a float rule matched — so a user-floated
+        // standard window keeps its ring while a launcher does not
+        // (#300).
+        window.isTransientOverlay =
+            shouldForceFloat(pid: pid)
+            || FloatDetection.shouldFloat(
+                role: role,
+                subrole: subrole,
+                layer: layer ?? 0
+            )
         detectedFloating[window.id] = window.isFloating
         elements[pid, default: [:]][window.id] = element
         observers[pid]?.observe(window: element)

--- a/Sources/KiwiDeskCore/Models/WindowModel.swift
+++ b/Sources/KiwiDeskCore/Models/WindowModel.swift
@@ -58,6 +58,14 @@ public struct ManagedWindow: Sendable, Equatable {
     public var title: String
     public var frame: CGRect
     public var isFloating: Bool
+    /// A transient overlay — a launcher/panel that floats for a
+    /// structural reason (accessory activation policy, non-standard
+    /// panel subrole, or a raised CGWindow layer), NOT because a
+    /// `float_rules` entry matched. Such windows (Spotlight,
+    /// Raycast, Alfred) take focus momentarily and must not receive
+    /// a KiwiDesk focus ring, unlike a user-floated standard window
+    /// (#300). Classified once at track time (`EventLoop.track`).
+    public var isTransientOverlay: Bool
 
     public init(
         id: WindowID,
@@ -66,7 +74,8 @@ public struct ManagedWindow: Sendable, Equatable {
         appBundleID: String? = nil,
         title: String = "",
         frame: CGRect = .zero,
-        isFloating: Bool = false
+        isFloating: Bool = false,
+        isTransientOverlay: Bool = false
     ) {
         self.id = id
         self.pid = pid
@@ -75,5 +84,6 @@ public struct ManagedWindow: Sendable, Equatable {
         self.title = title
         self.frame = frame
         self.isFloating = isFloating
+        self.isTransientOverlay = isTransientOverlay
     }
 }

--- a/Sources/KiwiDeskCore/State/StateCoordinator.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator.swift
@@ -249,16 +249,9 @@ public struct StateCoordinator: Sendable {
             // not revert an explicit make_floating/make_tiled
             // (docs promise re-checks never do).
             guard manualFloatOverrides[id] == nil else { break }
+            // `windows.setFloating` also clears any stale overlay
+            // flag when a window heals back to tiled (#300).
             windows.setFloating(id, floating)
-            // A transient overlay always floats, so when detection
-            // self-heals a window back to tiled (a mid-launch
-            // subrole/layer flicker corrected by `recheckFloat`),
-            // its overlay flag must clear too — otherwise a now-
-            // tiled standard window would silently keep losing its
-            // focus ring (#300). Overlay ⟹ floating, enforced here.
-            if !floating {
-                windows.setTransientOverlay(id, false)
-            }
 
         case .displaysChanged(let displays):
             reconcile(displays: displays)

--- a/Sources/KiwiDeskCore/State/StateCoordinator.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator.swift
@@ -250,6 +250,15 @@ public struct StateCoordinator: Sendable {
             // (docs promise re-checks never do).
             guard manualFloatOverrides[id] == nil else { break }
             windows.setFloating(id, floating)
+            // A transient overlay always floats, so when detection
+            // self-heals a window back to tiled (a mid-launch
+            // subrole/layer flicker corrected by `recheckFloat`),
+            // its overlay flag must clear too — otherwise a now-
+            // tiled standard window would silently keep losing its
+            // focus ring (#300). Overlay ⟹ floating, enforced here.
+            if !floating {
+                windows.setTransientOverlay(id, false)
+            }
 
         case .displaysChanged(let displays):
             reconcile(displays: displays)

--- a/Sources/KiwiDeskCore/State/WindowManager.swift
+++ b/Sources/KiwiDeskCore/State/WindowManager.swift
@@ -74,4 +74,11 @@ public struct WindowManager: Sendable {
     ) {
         windows[id]?.isFloating = floating
     }
+
+    public mutating func setTransientOverlay(
+        _ id: WindowID,
+        _ overlay: Bool
+    ) {
+        windows[id]?.isTransientOverlay = overlay
+    }
 }

--- a/Sources/KiwiDeskCore/State/WindowManager.swift
+++ b/Sources/KiwiDeskCore/State/WindowManager.swift
@@ -73,12 +73,14 @@ public struct WindowManager: Sendable {
         _ floating: Bool
     ) {
         windows[id]?.isFloating = floating
-    }
-
-    public mutating func setTransientOverlay(
-        _ id: WindowID,
-        _ overlay: Bool
-    ) {
-        windows[id]?.isTransientOverlay = overlay
+        // A transient overlay always floats, so untiling a window
+        // must clear its overlay flag — the single mutation point
+        // for `isFloating`, so every path (detection self-heal,
+        // make_tiled, remembered-tiled restore) upholds the
+        // invariant overlay ⟹ floating without re-asserting it
+        // (#300). Only track-time init ever sets the flag true.
+        if !floating {
+            windows[id]?.isTransientOverlay = false
+        }
     }
 }

--- a/Tests/KiwiDeskCoreTests/BorderSpecsTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderSpecsTests.swift
@@ -26,6 +26,7 @@ struct BorderSpecsTests {
         focused: WindowID?,
         slots: [(id: WindowID, frame: CGRect)],
         floating: Set<WindowID> = [],
+        overlays: Set<WindowID> = [],
         monocle: Bool = false
     ) -> [BorderManager.Spec] {
         KiwiCore.borderSpecs(
@@ -33,6 +34,7 @@ struct BorderSpecsTests {
             focused: focused,
             slots: slots,
             floating: floating,
+            overlays: overlays,
             isMonocle: monocle
         )
     }
@@ -115,6 +117,56 @@ struct BorderSpecsTests {
         )
         // Focused w1 + tiled w3; floating w2 neither rings nor
         // hides w3.
+        #expect(Set(result.map(\.window)) == [w1, w3])
+    }
+
+    @Test("A focused transient overlay gets no ring")
+    func focusedOverlaySuppressed() {
+        // A launcher (Spotlight/Raycast) momentarily takes focus.
+        // It floats and is classified an overlay, so it gets no
+        // focus ring even though it is the focused window.
+        #expect(
+            specs(
+                BorderStyle(),
+                focused: w1,
+                slots: disjoint,
+                floating: [w1],
+                overlays: [w1]
+            ).isEmpty
+        )
+    }
+
+    @Test("A focused user-floated window still gets a ring")
+    func focusedFloatStillRinged() {
+        // A user-floated *standard* window (float rule, not an
+        // overlay) keeps its focus ring — only overlays lose it.
+        let result = specs(
+            BorderStyle(),
+            focused: w1,
+            slots: disjoint,
+            floating: [w1],
+            overlays: []
+        )
+        #expect(result.map(\.window) == [w1])
+    }
+
+    @Test("An overlay is excluded from unfocused rings too")
+    func overlayExcludedWhenUnfocused() {
+        var style = BorderStyle()
+        style.unfocusedEnabled = true
+        // w2 is an unfocused overlay; w1 focused, w3 a tiled slot.
+        let slots: [(id: WindowID, frame: CGRect)] = [
+            (w1, CGRect(x: 0, y: 0, width: 100, height: 100)),
+            (w2, CGRect(x: 10, y: 10, width: 100, height: 100)),
+            (w3, CGRect(x: 400, y: 0, width: 100, height: 100)),
+        ]
+        let result = specs(
+            style,
+            focused: w1,
+            slots: slots,
+            floating: [w2],
+            overlays: [w2]
+        )
         #expect(Set(result.map(\.window)) == [w1, w3])
     }
 

--- a/Tests/KiwiDeskCoreTests/FloatPersistenceTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatPersistenceTests.swift
@@ -142,6 +142,21 @@ struct FloatPersistenceTests {
         )
     }
 
+    @Test("make_tiled also clears a stale overlay flag (#300)")
+    func manualTileClearsOverlay() {
+        var state = StateCoordinator()
+        var overlay = makeWindow(1, floating: true)
+        overlay.isTransientOverlay = true
+        state.apply(.windowCreated(overlay))
+        // The manual make_tiled path routes through the same
+        // `WindowManager.setFloating`, so the invariant holds there
+        // too, not just on the detection path.
+        state.setFloating(WindowID(1), false)
+        #expect(
+            state.windows[WindowID(1)]?.isTransientOverlay == false
+        )
+    }
+
     @Test("A window that stays floating keeps its overlay flag")
     func stillFloatingKeepsOverlay() {
         var state = StateCoordinator()

--- a/Tests/KiwiDeskCoreTests/FloatPersistenceTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatPersistenceTests.swift
@@ -119,6 +119,44 @@ struct FloatPersistenceTests {
         #expect(state.windows[WindowID(1)]?.isFloating == true)
     }
 
+    @Test("Detection self-heal clears a stale overlay flag (#300)")
+    func selfHealClearsOverlay() {
+        var state = StateCoordinator()
+        // A window mis-snapshotted at track time as a floating
+        // overlay (a one-off bad subrole/layer read).
+        var overlay = makeWindow(1, floating: true)
+        overlay.isTransientOverlay = true
+        state.apply(.windowCreated(overlay))
+        #expect(
+            state.windows[WindowID(1)]?.isTransientOverlay == true
+        )
+        // `recheckFloat` corrects it back to a tiled standard
+        // window; the overlay flag must clear with the float state
+        // so it keeps its focus ring.
+        state.apply(
+            .windowFloatChanged(WindowID(1), isFloating: false)
+        )
+        #expect(state.windows[WindowID(1)]?.isFloating == false)
+        #expect(
+            state.windows[WindowID(1)]?.isTransientOverlay == false
+        )
+    }
+
+    @Test("A window that stays floating keeps its overlay flag")
+    func stillFloatingKeepsOverlay() {
+        var state = StateCoordinator()
+        var overlay = makeWindow(1, floating: true)
+        overlay.isTransientOverlay = true
+        state.apply(.windowCreated(overlay))
+        // A verdict that stays floating leaves the flag intact.
+        state.apply(
+            .windowFloatChanged(WindowID(1), isFloating: true)
+        )
+        #expect(
+            state.windows[WindowID(1)]?.isTransientOverlay == true
+        )
+    }
+
     @Test("A late-loading title still restores the intent")
     func lazyTitleRestores() {
         var state = StateCoordinator()

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -152,6 +152,20 @@ monocle — where only the focused window is visible — borders stay
 focused-only. Floating windows are excluded from the unfocused set;
 the focused window is still ringed whether tiled or floating.
 
+A **transient overlay** — a launcher or panel (Spotlight, Raycast,
+Alfred) that floats for a *structural* reason (accessory activation
+policy, a non-standard panel subrole, or a raised CGWindow layer)
+rather than a matched `float_rules` entry — never receives a ring,
+even while it holds focus (#300). The suppression is a **draw-time
+heuristic**, not an entry in the `ignore_rules`/built-in ignore
+list (#176/#177): these overlays float and behave correctly, so
+they belong in managed state; only the ring is wrong, and the fix
+belongs where the ring is drawn. This is deliberately narrower than
+excluding *all* focused floats — a user who floats a standard
+window still wants its ring; a launcher does not. The classification
+is captured once at track time (`ManagedWindow.isTransientOverlay`),
+so the pure `borderSpecs` decision stays AX-free.
+
 The ring's **rendering backend is opportunistic, not architectural**
 (#285): when the complete runtime-linked SkyLight drawing and event
 surface resolves, an SLS window follows WindowServer move/resize/order

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -163,8 +163,13 @@ they belong in managed state; only the ring is wrong, and the fix
 belongs where the ring is drawn. This is deliberately narrower than
 excluding *all* focused floats — a user who floats a standard
 window still wants its ring; a launcher does not. The classification
-is captured once at track time (`ManagedWindow.isTransientOverlay`),
-so the pure `borderSpecs` decision stays AX-free.
+is captured at track time (`ManagedWindow.isTransientOverlay`), so
+the pure `borderSpecs` decision stays AX-free, and it clears the
+moment detection self-heals a window back to tiled — the flag can
+never outlive the float state it depends on (overlay ⟹ floating). A
+window that is genuinely an overlay is caught by the stable
+accessory-policy path at track time, independent of any one-off
+subrole read.
 
 The ring's **rendering backend is opportunistic, not architectural**
 (#285): when the complete runtime-linked SkyLight drawing and event

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -545,6 +545,9 @@ windows. Below it:
   radius; **Square** draws sharp corners — seamless on windows that
   are already square, an intentional squared frame on rounded ones.
 
+Launcher and panel overlays (Spotlight, Raycast, Alfred) never get
+a ring, even while you type into them — only genuine windows do.
+
 ## App Bar
 
 The **App Bar** section (in the **Design** group) is the app bar's


### PR DESCRIPTION
## Summary

A launcher overlay (Spotlight, Raycast, Alfred) auto-floats but momentarily takes focus, and `borderSpecs` drew the focused ring regardless of floating state — so a launcher you type into got a KiwiDesk focus ring around it (#300).

Fix with a **draw-time heuristic**, not an ignore-list entry: these overlays float and behave correctly, so they belong in managed state; only the ring is wrong.

- New `ManagedWindow.isTransientOverlay`, classified at `EventLoop.track` = `shouldForceFloat(pid) || FloatDetection.shouldFloat(role:subrole:layer:)` — accessory activation policy, non-standard panel subrole, or raised CGWindow layer. Deliberately **excludes** `float_rules`, so a user-floated *standard* window keeps its ring (#278) while a launcher does not.
- `updateBorders` threads an `overlays` set into the pure `nonisolated borderSpecs`, which skips a ring for any overlay, focused or not.

## Invariant `overlay ⟹ floating`

The overlay flag is set at track time but cleared at the single float mutation point (`WindowManager.setFloating`), so when detection self-heals a mid-launch mis-snapshot back to tiled — or `make_tiled` / a remembered-tiled restore untiles it — the flag never outlives the float state it depends on. A genuine overlay is re-caught by the stable accessory-policy path at track, independent of any one-off subrole read.

## Docs

design-decisions.md (draw-time-heuristic rationale, contrast with the #176/#177 ignore list, self-heal wording) + user-guide.md border section.

## Verify

Debug + release build, **1293 tests** (5 new: 3 border-spec, 2 float-persistence), lint, site build (15 pages) — all green.

## Review

Two-agent review (code-reviewer + architect-reviewer, fresh, parallel). Both independently flagged one Medium: stale overlay flag surviving `recheckFloat` self-heal. Fixed (`ee481b7`), then consolidated to the single mutation point on architect's re-review recommendation (`f6e…`). Both re-reviews clean; #292 separation confirmed.

fixes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)