### PR TITLE
fix(app): force content windows to the front on open (#318)

### DIFF
--- a/Sources/KiwiDesk/AppDelegate.swift
+++ b/Sources/KiwiDesk/AppDelegate.swift
@@ -198,8 +198,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
 
     private func showOnboarding() {
         if let window = onboardingWindow {
-            window.makeKeyAndOrderFront(nil)
-            NSApp.activate()
+            // No `activateAsRegular()` here (unlike Settings' reuse
+            // branch): `windowWillClose` nils `onboardingWindow` on
+            // close, so a non-nil window is guaranteed still
+            // `.regular` and the promotion never needs repeating.
+            NSApp.forceFront(window)
             return
         }
         onboardingModel.isTrusted = permissions.isTrusted
@@ -233,8 +236,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
         onboardingWindow = window
 
         NSApp.activateAsRegular()
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate()
+        NSApp.forceFront(window)
     }
 
     private func closeOnboarding() {

--- a/Sources/KiwiDesk/ConfigIssuesWindow.swift
+++ b/Sources/KiwiDesk/ConfigIssuesWindow.swift
@@ -28,8 +28,7 @@ final class ConfigIssuesWindowController: NSObject,
 
     func show() {
         if let window {
-            window.makeKeyAndOrderFront(nil)
-            NSApp.activate()
+            NSApp.forceFront(window)
             return
         }
         let window = NSWindow(
@@ -55,8 +54,7 @@ final class ConfigIssuesWindowController: NSObject,
         window.delegate = self
         window.center()
         self.window = window
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate()
+        NSApp.forceFront(window)
     }
 
     /// This window doesn't promote to `.regular` on its own, but

--- a/Sources/KiwiDesk/DockPresentation.swift
+++ b/Sources/KiwiDesk/DockPresentation.swift
@@ -18,6 +18,31 @@ extension NSApplication {
         }
     }
 
+    /// Bring a content window fully to the front — the strong
+    /// activation a menu-bar/agent process needs.
+    ///
+    /// Cooperative `activate()` foregrounds the app only when the
+    /// activation was user-initiated. A window opened on **service
+    /// (launchd) start** (onboarding) never is, so it reliably
+    /// lands behind the frontmost app; the bundle-less identity
+    /// (#89 not yet shipped) makes even a menu-bar-triggered
+    /// Settings open flaky. `orderFrontRegardless()` +
+    /// `activate(ignoringOtherApps:)` is the escape hatch AppKit
+    /// reserves for exactly this case (already relied on by
+    /// `SingleInstanceGuard`). The packaged `.app` (#89) will make
+    /// the cooperative path reliable and let this soften.
+    @MainActor func forceFront(_ window: NSWindow) {
+        // Two order-front calls by intent, not accident:
+        // `makeKeyAndOrderFront` sets the key window but only
+        // orders front *within* an active app; `orderFrontRegardless`
+        // additionally shows the window while the process is still
+        // `.accessory`/inactive — the launchd case the cooperative
+        // `activate()` can't foreground on its own.
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
+        activate(ignoringOtherApps: true)
+    }
+
     /// Return to menu-bar-only (`.accessory`) — but only if no
     /// other content window is still on screen. Closing one of
     /// {Settings, onboarding, Config Issues} must not drop the

--- a/Sources/KiwiDesk/Settings/SettingsWindowController.swift
+++ b/Sources/KiwiDesk/Settings/SettingsWindowController.swift
@@ -39,8 +39,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         // window must re-raise to get its Dock icon back.
         NSApp.activateAsRegular()
         if let window {
-            window.makeKeyAndOrderFront(nil)
-            NSApp.activate()
+            NSApp.forceFront(window)
             return
         }
         let window = NSWindow(
@@ -95,8 +94,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         }
         self.window = window
 
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate()
+        NSApp.forceFront(window)
     }
 
     /// Closing the dashboard returns KiwiDesk to menu-bar-only,


### PR DESCRIPTION
## What

Onboarding on **service (launchd) start**, and intermittently **Settings** from the menu bar, opened *behind* the frontmost app. All three content windows (onboarding, Settings, Config Issues) activated via cooperative `NSApp.activate()`, which foregrounds the process only when the activation is user-initiated. A launchd-started process never is, and the bundle-less identity (#89 not yet shipped) makes even a menu-bar-triggered open flaky.

## Fix

One shared `NSApplication.forceFront(_:)` primitive in `DockPresentation.swift` — `makeKeyAndOrderFront` + `orderFrontRegardless()` + `activate(ignoringOtherApps:)`, the escape hatch already relied on by `SingleInstanceGuard`. All six open paths (reuse + fresh branch × 3 windows) route through it. The `.regular` promotion (`activateAsRegular`) and the layout-save NSAlert are unchanged.

## Verify

- `swift build` ✅ · `swift test` ✅ (1,358 tests / 229 suites) · `scripts/lint.sh` ✅ · `swift build -c release` ✅
- Two-agent review (code-reviewer + architect-reviewer) clean: no correctness bugs; abstraction affirmed; two comment-only hardenings applied (order-front intent, onboarding reuse-branch nil-on-close reliance).

## Manual QA pending

- Launch as LaunchAgent while Accessibility untrusted → onboarding wizard comes to front (not behind frontmost app).
- Open Settings / Config Issues from the menu bar repeatedly → always foreground.

CI is expected red (GH Actions billing); merge gates on the local verify gate.

fixes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)