### PR TITLE
fix(settings): vertically center the paused-permission banner

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/PermissionPausedBanner.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/PermissionPausedBanner.swift
@@ -17,7 +17,13 @@ struct PermissionPausedBanner: View {
     let onResolve: () -> Void
 
     var body: some View {
-        HStack(alignment: .top, spacing: 10) {
+        // Center-aligned, not `.top`: the message is a single
+        // line and the action button is taller than it, so a
+        // top alignment leaves the icon + text hugging the top
+        // while the button sits centered (the
+        // KeybindingConflictBanner uses `.top` only because its
+        // text can wrap to several lines).
+        HStack(alignment: .center, spacing: 10) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
             Text(


### PR DESCRIPTION
The `PermissionPausedBanner` used `HStack(alignment: .top)`, copied from `KeybindingConflictBanner` — but that one top-aligns only because its text can wrap to multiple lines. Here the message is a single line and the "Enable Accessibility…" button is taller, so top-alignment left the icon + text hugging the top while the button sat centered (visible offset). Switch to `.center`.

Verify: `swift build` ✅ · `swift test` ✅ (1,358 tests) · `scripts/lint.sh` ✅ · `swift build -c release` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)