### PR TITLE
fix(borders): close the rounded-ring corner seam on very-rounded windows

### DIFF
--- a/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
@@ -22,10 +22,15 @@ struct BorderGeometry: Equatable {
     /// in the overlay's own bounds inset by `lineWidth / 2`.
     let cornerRadius: CGFloat
 
-    /// Rounded needs only a seam allowance; square needs enough
-    /// depth to fill tighter utility-window corner reveals. Both
-    /// are renderer-only and do not change the visible thickness.
-    static let roundedHiddenOverlap: CGFloat = 1
+    /// Rounded needs a seam allowance deep enough to close the
+    /// corner reveal on *very*-rounded windows (Settings-class
+    /// radii), where a 1 pt tuck left a visible gap; square needs
+    /// more still, to fill the harder 90° utility-window reveal.
+    /// Both are masked behind the target — over-provisioning is
+    /// free (the inner edge sits at `systemRadius − overlap`, so
+    /// a larger overlap only tucks deeper under the corner) — so
+    /// the value is set by the widest reveal seen, not minimized.
+    static let roundedHiddenOverlap: CGFloat = 2.5
     /// Fixed rather than derived from `systemRadius` (the old
     /// `systemRadius · (1 − √2/2)` tuck): because the overlap is
     /// masked behind the target, over-provisioning is free and


### PR DESCRIPTION
On very-rounded windows (Settings-class corner radii) the rounded focus ring left a visible gap at the corners: `roundedHiddenOverlap` was 1 pt, on the assumption a concentric rounded ring needs only a thin seam allowance.

The overlap is masked behind the target — its inner edge sits at `systemRadius − overlap`, so a larger value only tucks the ring deeper under the corner, filling the reveal. Over-provisioning is free (the same rationale `squareHiddenOverlap = 8` already relies on). Raise rounded to **2.5 pt**.

Visible width and `outwardReach` (what `border.fit_gaps` sizes gaps from) are unchanged — only the hidden masked depth grows. `BorderGeometry` tests assert against the symbol, so they hold.

Verify: `swift build` ✅ · `swift test` ✅ (1,358 tests) · `scripts/lint.sh` ✅ · `swift build -c release` ✅

Manual QA: focus a very-rounded window (Settings) with the rounded corner style — corner reveal should be filled, no seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)