### PR TITLE
feat(menu): hide Switch Profile row when there's nothing to switch to

### DIFF
--- a/Sources/KiwiDesk/StatusItemController+Menu.swift
+++ b/Sources/KiwiDesk/StatusItemController+Menu.swift
@@ -63,9 +63,18 @@ extension StatusItemController {
 
         // Daily actions — Layout first (the most-used control),
         // Switch Profile under it: same topic, no separator
-        // between them.
+        // between them. Switch Profile appears only when there is
+        // something to switch *to* — a saved profile that isn't the
+        // active one and isn't broken; with none, switching is a
+        // no-op or impossible, so the row is pure noise.
         menu.addItem(layoutItem())
-        menu.addItem(switchProfileItem(profiles))
+        let hasSwitchTarget = profiles.all.contains {
+            $0 != profiles.active
+                && !profiles.broken.contains($0)
+        }
+        if hasSwitchTarget {
+            menu.addItem(switchProfileItem(profiles))
+        }
 
         // App chrome: Settings sits low, next to Quit, as in
         // every native menu-bar extra — not mid-list among the

--- a/Tests/KiwiDeskGuiTests/QuickMenuProfileRowTests.swift
+++ b/Tests/KiwiDeskGuiTests/QuickMenuProfileRowTests.swift
@@ -1,0 +1,90 @@
+import AppKit
+import Testing
+
+@testable import KiwiDesk
+@testable import KiwiDeskCore
+
+/// The Switch Profile quick-menu row appears only when there is a
+/// profile worth switching to — one that isn't the active one and
+/// isn't broken. `.serialized` because `LocalizationManager` is a
+/// process-wide singleton (titles are matched in English).
+@Suite("Quick menu Switch Profile row", .serialized)
+@MainActor
+struct QuickMenuProfileRowTests {
+    private func reset() {
+        LocalizationManager.shared.select("en")
+    }
+
+    private func controller(
+        active: String?,
+        all: [String],
+        broken: [String] = []
+    ) -> StatusItemController {
+        let controller = StatusItemController()
+        controller.profilesProvider = {
+            (active: active, all: all, broken: Set(broken))
+        }
+        return controller
+    }
+
+    private func hasSwitchRow(
+        _ controller: StatusItemController
+    ) -> Bool {
+        let menu = NSMenu()
+        controller.menuNeedsUpdate(menu)
+        return menu.items.contains { $0.title == "Switch Profile" }
+    }
+
+    @Test("hidden with no profiles")
+    func noProfiles() {
+        reset()
+        #expect(!hasSwitchRow(controller(active: nil, all: [])))
+    }
+
+    @Test("hidden when the only profile is already active")
+    func loneActive() {
+        reset()
+        #expect(
+            !hasSwitchRow(
+                controller(active: "Work", all: ["Work"])
+            )
+        )
+    }
+
+    @Test("shown when the only profile isn't active")
+    func loneInactive() {
+        reset()
+        #expect(
+            hasSwitchRow(
+                controller(active: nil, all: ["Work"])
+            )
+        )
+    }
+
+    @Test("hidden when the only non-active profile is broken")
+    func loneBroken() {
+        reset()
+        #expect(
+            !hasSwitchRow(
+                controller(
+                    active: "Work",
+                    all: ["Work", "Bad"],
+                    broken: ["Bad"]
+                )
+            )
+        )
+    }
+
+    @Test("shown with two switchable profiles")
+    func twoProfiles() {
+        reset()
+        #expect(
+            hasSwitchRow(
+                controller(
+                    active: "Work",
+                    all: ["Work", "Play"]
+                )
+            )
+        )
+    }
+}


### PR DESCRIPTION
The quick menu always showed a Switch Profile row — even with zero saved profiles (a disabled "No saved profiles" line) or a single profile already active (switching is a no-op). Show it only when a **loadable target** exists: a saved profile that is neither the active one nor broken. Covers all cases (0 → hide; 1-active → hide; 1-inactive → show; 2+ → show). Test-covered (`QuickMenuProfileRowTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)