### PR TITLE
Shortcuts app-list sort, paused-save gate, quick-menu profile line (#333, #335, #339)

### DIFF
--- a/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
@@ -114,7 +114,22 @@ struct AppRulesSection: View {
             }
         }
         set.formUnion(draftApps)
-        return set.sorted()
+        // Sort by the display name the row actually shows, not
+        // the raw bundle id (#333). Resolve each name once into a
+        // map so the O(n log n) compare doesn't re-hit NSWorkspace/
+        // Spotlight per comparison; tie-break on the id for a
+        // stable order when two apps share a display name.
+        let names = Dictionary(
+            uniqueKeysWithValues: set.map {
+                ($0, KeybindingCatalog.displayName(forBundleID: $0))
+            }
+        )
+        return set.sorted { lhs, rhs in
+            let order = (names[lhs] ?? lhs)
+                .localizedCaseInsensitiveCompare(names[rhs] ?? rhs)
+            if order == .orderedSame { return lhs < rhs }
+            return order == .orderedAscending
+        }
     }
 
     private var addRow: some View {

--- a/Sources/KiwiDesk/Settings/SettingsFooter.swift
+++ b/Sources/KiwiDesk/Settings/SettingsFooter.swift
@@ -154,11 +154,15 @@ struct SettingsFooter: View {
             .buttonStyle(.bordered)
             .controlSize(.regular)
         } else if model.activeProfile != nil {
+            // Live active profile → a copy captures the live
+            // monitor set, so it is blocked while paused (#335).
             Button(saveCopyAsLabel) {
                 namingNewProfile = true
             }
             .buttonStyle(.bordered)
             .controlSize(.regular)
+            .disabled(model.profileSaveBlockedReason != nil)
+            .help(model.profileSaveBlockedReason ?? "")
         }
     }
 
@@ -184,20 +188,27 @@ struct SettingsFooter: View {
                 .controlSize(.regular)
                 .disabled(!model.isDirty)
         case .updateActiveProfile:
+            // Update refreshes the live monitor set, so it is
+            // blocked while paused (#335).
             Button(save) { model.updateActiveProfile() }
                 .keyboardShortcut("s")
                 .buttonStyle(.borderedProminent)
                 .controlSize(.regular)
                 .disabled(
-                    !model.updateEnabled
+                    model.profileSaveBlockedReason != nil
+                        || !model.updateEnabled
                         || !(model.isDirty
                             || model.profileDirty
                             || model.hasLayoutDrift)
                 )
-                .help(model.updateHint ?? "")
+                .help(
+                    model.profileSaveBlockedReason
+                        ?? model.updateHint ?? ""
+                )
         case .saveAsNewProfile:
             // No profile yet — the create action takes the
-            // primary slot.
+            // primary slot; it captures the live monitor set,
+            // so it is blocked while paused (#335).
             Button(
                 L(
                     "footer.save_as_new_profile",
@@ -209,6 +220,8 @@ struct SettingsFooter: View {
             .keyboardShortcut("s")
             .buttonStyle(.borderedProminent)
             .controlSize(.regular)
+            .disabled(model.profileSaveBlockedReason != nil)
+            .help(model.profileSaveBlockedReason ?? "")
         }
     }
 }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Profiles.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Profiles.swift
@@ -6,6 +6,29 @@ import SwiftUI
 /// two-button save UX (Update / Save as new), the preset Apply
 /// flow, list actions, and the Canvas placement resolution.
 extension SettingsModel {
+    /// Non-nil while a profile save that captures the live
+    /// monitor set must be blocked (#335): with Accessibility
+    /// off the engine has discovered no displays, so persisting
+    /// records a degenerate 0-screen set that can never resolve.
+    /// Gates the monitor-capturing actions — Save as New Profile,
+    /// Update, and Save a Copy As from the live active profile —
+    /// and doubles as their disabled-button tooltip. Stored-
+    /// profile edits are NOT gated: their write path only upserts
+    /// a monitor set that already matches the live set, and while
+    /// paused `set(matching: [])` finds none, so the refresh is
+    /// inert and no degenerate set is written (see
+    /// `KiwiCore+ProfileEdit.applyProfileEdits`).
+    var profileSaveBlockedReason: String? {
+        guard permissionPaused else { return nil }
+        return L(
+            "profiles.save_blocked_paused",
+            "Window management is paused because Accessibility "
+                + "access is off, so no displays are detected. "
+                + "Grant access first — a profile saved now would "
+                + "capture no monitors and never resolve."
+        )
+    }
+
     /// Whether Update can write into the active profile: it
     /// exists and covers the live screen count. A different
     /// count (extra screen attached) needs "Save as new…".

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingAppSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingAppSection.swift
@@ -17,6 +17,14 @@ struct ApplicationsSection: View {
     /// row only enters the list once an app is picked, so no
     /// app-less placeholder can exist (matches App Rules).
     @State private var newApp: KeybindingCatalog.InstalledApp?
+    /// Alphabetical display order snapshotted on section entry and
+    /// mode change (#333). NOT recomputed on `bindings` mutation:
+    /// the row's control is a `KeyRecorderField` capture, so a live
+    /// re-sort could yank a row out from under the cursor
+    /// mid-record. A committed *new* row stays at the bottom this
+    /// session and takes its alpha slot next entry; re-picking an
+    /// app keeps the row's id, so it holds its existing slot.
+    @State private var displayOrder: [UUID] = []
 
     var body: some View {
         SettingsSection(
@@ -25,13 +33,71 @@ struct ApplicationsSection: View {
                 "Open Applications"
             )
         ) {
-            ForEach($bindings) { $binding in
-                if binding.kind == .application {
-                    row($binding)
+            ForEach(orderedAppIDs, id: \.self) { id in
+                if let binding = bindingFor(id) {
+                    row(binding)
                 }
             }
             addRow
         }
+        .onAppear(perform: recomputeOrder)
+        // The section view is reused across keybinding modes (no
+        // per-mode `.id`), so `onAppear` fires once — re-snapshot
+        // when the mode changes or later modes would render in raw
+        // array order. Recording is invalidated on mode switch, so
+        // re-sorting here can't yank an in-flight recorder.
+        .onChange(of: modeName) { _, _ in recomputeOrder() }
+    }
+
+    /// Application-binding ids in the snapshot's alpha order, with
+    /// any added since (absent from the snapshot) kept in array
+    /// order at the bottom for this session (#333).
+    private var orderedAppIDs: [UUID] {
+        let appIDs =
+            bindings
+            .filter { $0.kind == .application }
+            .map(\.id)
+        let present = Set(appIDs)
+        let known = displayOrder.filter(present.contains)
+        let knownSet = Set(known)
+        return known + appIDs.filter { !knownSet.contains($0) }
+    }
+
+    private func recomputeOrder() {
+        displayOrder =
+            bindings
+            .filter { $0.kind == .application }
+            .sorted { lhs, rhs in
+                let order = lhs.label
+                    .localizedCaseInsensitiveCompare(rhs.label)
+                if order == .orderedSame {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return order == .orderedAscending
+            }
+            .map(\.id)
+    }
+
+    /// A stable, id-keyed binding into `bindings` — resolved at
+    /// access time so it survives any structural mutation of the
+    /// array (add / remove / Steal reorder).
+    private func bindingFor(_ id: UUID) -> Binding<KeyBinding>? {
+        guard bindings.contains(where: { $0.id == id }) else {
+            return nil
+        }
+        return Binding(
+            get: {
+                bindings.first { $0.id == id }
+                    ?? KeyBinding(kind: .application)
+            },
+            set: { newValue in
+                if let index = bindings.firstIndex(where: {
+                    $0.id == id
+                }) {
+                    bindings[index] = newValue
+                }
+            }
+        )
     }
 
     /// Pick an app, then commit it — mirroring App Rules, so a

--- a/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog+Apps.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/KeybindingCatalog+Apps.swift
@@ -133,6 +133,20 @@ extension KeybindingCatalog {
     /// the bulk, are already frozen for process life.
     static let installedAppsSnapshot: [InstalledApp] = installedApps
 
+    /// Process-life `bundleID → localized name` index over the
+    /// snapshot, so `displayName(forBundleID:)` resolves an
+    /// installed app with a dictionary hit instead of a live
+    /// `NSWorkspace` + Spotlight read. Immutable (`static let`), so
+    /// it's concurrency-safe and shared by every render that
+    /// resolves or sorts app rows (#333 sorts by display name, so
+    /// the App Rules list would otherwise re-hit Spotlight per app
+    /// on every pass — a §5 main-thread cost).
+    static let installedNameByID: [String: String] =
+        Dictionary(
+            installedAppsSnapshot.map { ($0.bundleID, $0.name) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
     /// The localized display name for a bundle id, for showing
     /// a stored rule or binding whose identity is the id. Routed
     /// through the same `localizedName` resolver as the picker,
@@ -140,6 +154,9 @@ extension KeybindingCatalog {
     /// back to the id itself when the app isn't installed.
     static func displayName(forBundleID id: String) -> String {
         let id = id.lowercased()
+        // The snapshot covers every app present at launch; a live
+        // lookup only remains for one installed mid-session.
+        if let name = installedNameByID[id] { return name }
         if let url = NSWorkspace.shared.urlForApplication(
             withBundleIdentifier: id
         ) {

--- a/Sources/KiwiDesk/StatusItemController+Menu.swift
+++ b/Sources/KiwiDesk/StatusItemController+Menu.swift
@@ -67,11 +67,32 @@ extension StatusItemController {
         // something to switch *to* — a saved profile that isn't the
         // active one and isn't broken; with none, switching is a
         // no-op or impossible, so the row is pure noise.
-        menu.addItem(layoutItem())
         let hasSwitchTarget = profiles.all.contains {
             $0 != profiles.active
                 && !profiles.broken.contains($0)
         }
+        // A disabled context line naming the active profile — shown
+        // only when a profile is loaded *and* a real alternative
+        // exists to switch to (the same gate as the Switch Profile
+        // row). With one profile or none there is no choice to
+        // orient, so the name would be permanent chrome the
+        // declutter (#324) removed. Any profile is loadable
+        // regardless of screen count (#36), so this does not filter
+        // by display setup.
+        if let active = profiles.active, hasSwitchTarget {
+            let current = NSMenuItem(
+                title: L(
+                    "menu.active_profile",
+                    "Profile: %1$@",
+                    active
+                ),
+                action: nil,
+                keyEquivalent: ""
+            )
+            current.isEnabled = false
+            menu.addItem(current)
+        }
+        menu.addItem(layoutItem())
         if hasSwitchTarget {
             menu.addItem(switchProfileItem(profiles))
         }

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -467,6 +467,7 @@
   "profiles.rename": "Rename",
   "profiles.rename.help": "Rename profile",
   "profiles.rename_failed": "Renaming failed: %1$@",
+  "profiles.save_blocked_paused": "Window management is paused because Accessibility access is off, so no displays are detected. Grant access first — a profile saved now would capture no monitors and never resolve.",
   "profiles.save_failed": "Saving failed: %1$@",
   "profiles.saved.empty": "No profiles saved yet — the built-in Standard resolves until you save one.",
   "profiles.saved.title": "Saved profiles",

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -333,6 +333,7 @@
   "lua_editor.foreign_code": "This init.lua contains hand-written Lua, so the visual editor is disabled to avoid overwriting it.",
   "menu.accessibility_paused": "Window Management Paused…",
   "menu.accessibility_paused.tooltip": "Click to grant Accessibility permission and resume tiling.",
+  "menu.active_profile": "Profile: %1$@",
   "menu.app.about": "About %1$@",
   "menu.app.hide": "Hide %1$@",
   "menu.app.hide_others": "Hide Others",

--- a/Tests/KiwiDeskGuiTests/ProfileSaveGateTests.swift
+++ b/Tests/KiwiDeskGuiTests/ProfileSaveGateTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+@testable import KiwiDeskCore
+
+@MainActor
+private final class GateRegistrar: HotkeyRegistrar {
+    func register(
+        keyCode: UInt32,
+        modifiers: HotkeyModifiers,
+        handler: @escaping @MainActor () -> Void
+    ) -> UInt32? { 1 }
+    func unregister(id: UInt32) {}
+}
+
+/// The footer blocks any profile save that captures the live
+/// monitor set while Accessibility is off — a paused engine has
+/// discovered no displays, so persisting would record a
+/// degenerate 0-screen set that never resolves (#335). The gate
+/// is the model's `profileSaveBlockedReason`.
+@Suite("Profile save gate while paused")
+@MainActor
+struct ProfileSaveGateTests {
+    private func makeModel() throws -> SettingsModel {
+        let core = KiwiCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-save-gate-\(UUID().uuidString)"
+                ),
+            hotkeyRegistrar: GateRegistrar()
+        )
+        try core.saveGuiConfig(GuiConfig())
+        return SettingsModel(core: core)
+    }
+
+    @Test("no reason when Accessibility is granted")
+    func unblockedWhenActive() throws {
+        let model = try makeModel()
+        model.permissionPaused = false
+        #expect(model.profileSaveBlockedReason == nil)
+    }
+
+    @Test("blocked with a reason while paused")
+    func blockedWhilePaused() throws {
+        let model = try makeModel()
+        model.permissionPaused = true
+        #expect(model.profileSaveBlockedReason != nil)
+    }
+}

--- a/Tests/KiwiDeskGuiTests/QuickMenuProfileRowTests.swift
+++ b/Tests/KiwiDeskGuiTests/QuickMenuProfileRowTests.swift
@@ -4,9 +4,10 @@ import Testing
 @testable import KiwiDesk
 @testable import KiwiDeskCore
 
-/// The Switch Profile quick-menu row appears only when there is a
-/// profile worth switching to — one that isn't the active one and
-/// isn't broken. `.serialized` because `LocalizationManager` is a
+/// The Switch Profile quick-menu row — and the active-profile
+/// context line above it — appear only when there is a profile
+/// worth switching to: one that isn't the active one and isn't
+/// broken. `.serialized` because `LocalizationManager` is a
 /// process-wide singleton (titles are matched in English).
 @Suite("Quick menu Switch Profile row", .serialized)
 @MainActor
@@ -33,6 +34,16 @@ struct QuickMenuProfileRowTests {
         let menu = NSMenu()
         controller.menuNeedsUpdate(menu)
         return menu.items.contains { $0.title == "Switch Profile" }
+    }
+
+    private func activeLine(
+        _ controller: StatusItemController
+    ) -> NSMenuItem? {
+        let menu = NSMenu()
+        controller.menuNeedsUpdate(menu)
+        return menu.items.first {
+            $0.title.hasPrefix("Profile: ")
+        }
     }
 
     @Test("hidden with no profiles")
@@ -85,6 +96,53 @@ struct QuickMenuProfileRowTests {
                     all: ["Work", "Play"]
                 )
             )
+        )
+    }
+
+    // MARK: - Active-profile context line
+
+    @Test("active line names the profile when a choice exists")
+    func activeLineShown() {
+        reset()
+        let line = activeLine(
+            controller(active: "Work", all: ["Work", "Play"])
+        )
+        #expect(line?.title == "Profile: Work")
+        // Context only — never an action.
+        #expect(line?.isEnabled == false)
+    }
+
+    @Test("active line hidden with only the active profile")
+    func activeLineLoneProfile() {
+        reset()
+        #expect(
+            activeLine(
+                controller(active: "Work", all: ["Work"])
+            ) == nil
+        )
+    }
+
+    @Test("active line hidden when no profile is loaded")
+    func activeLineNoActive() {
+        reset()
+        #expect(
+            activeLine(
+                controller(active: nil, all: ["Work"])
+            ) == nil
+        )
+    }
+
+    @Test("active line hidden when the only other is broken")
+    func activeLineOnlyBrokenAlternative() {
+        reset()
+        #expect(
+            activeLine(
+                controller(
+                    active: "Work",
+                    all: ["Work", "Bad"],
+                    broken: ["Bad"]
+                )
+            ) == nil
         )
     }
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -867,6 +867,8 @@ now, use **Custom…** and enter its bundle identifier by hand (see
 [Finding a bundle identifier](lua-reference.md#finding-a-bundle-identifier)).
 
 Click an app row to edit it, or use its trash button to delete.
+Rows are ordered alphabetically by the app's display name so a long
+list stays scannable.
 
 To **match only certain windows** of an app (not all), the Float
 picker's **Windows titled…** option lets you add title fragments —
@@ -1098,7 +1100,10 @@ Each row has an action. Built-in actions live under headings:
   can't apply** (default on): a resize shortcut pressed in a
   layout without a resize target (monocle, grid, a floating
   space) plays the system alert instead of failing silently.
-- **Applications** — open or focus an app.
+- **Applications** — open or focus an app. Rows are sorted
+  alphabetically by app name (settled when the section opens, so a
+  row never shifts out from under you while you are recording its
+  shortcut).
 - **Custom Bindings** — custom Lua (from Adopt/Import or hand-written).
 
 When you save, every shortcut lives in a mode in `gui.json`. To use

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -796,6 +796,15 @@ context; there is no separate fourth button:
   scratch. The banner's profile picker names the edit target
   authoritatively.
 
+While window management is **paused** because Accessibility access
+is off, KiwiDesk has detected no displays — so any save that would
+capture the live monitor set (**Save as New Profile…**, **Save a
+Copy As…** from the active profile, and **Save** when it refreshes
+the active profile's monitor set) is greyed out, with a tooltip
+explaining why. A profile saved with no monitors could never
+resolve later. Grant access first; editing a *stored* profile
+(which keeps its own on-disk monitor set) stays available.
+
 After saving, if a global setting changed (keybindings, app/float/
 ignore rules, or native Space bindings), `gui.json` is rewritten.
 Tiling-only edits touch only the profile JSON. `init.lua` is never

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -105,6 +105,10 @@ the KiwiDesk icon opens the quick menu where you can:
   - Click **Save Current Layout to Profile** below the separator to persist
     the new layout (adopts the whole live state into the active profile).
 - **Switch Profile**: Load any saved profile into the current layout.
+  A non-clickable **Profile: ‹name›** line appears above the actions
+  naming the profile you are currently on — shown only when there is
+  another profile to switch to, so it never adds noise when there is
+  no choice to make.
 - **View Shortcuts…**: Open a read-only reference of every shortcut
   bound in the currently active mode — see below.
 - **Settings…**: Open the full Settings window.


### PR DESCRIPTION
Wave-12 multi-issue bundle (ff-rebase merge, one commit per issue). Three file-disjoint Settings/menu lanes.

## Lanes

### #333 — alphabetize the Shortcuts app lists
- **App Rules** sorts live by display name (rows are click-to-open menus, so a shifting row is a minor scan cost).
- **Open Applications** snapshots an alphabetical order on section entry **and mode change** — its control is a `KeyRecorderField` capture, so a live re-sort could yank a row out mid-record. New rows stay at the bottom for the session; re-picking keeps a row's id/slot.
- `displayName(forBundleID:)` gains a process-life name index over the existing installed-apps snapshot → sorting resolves an installed app with a dict hit instead of a per-app NSWorkspace/Spotlight read.

### #335 — block profile save while Accessibility is off
- Paused ⟹ no displays ⟹ a saved profile would capture a degenerate 0-screen monitor set that never resolves.
- Gates the three live-capturing actions (**Save as New Profile**, **Update**, **Save a Copy As** from the live active profile) with a disabled button + tooltip (grey, don't hide). Stored-profile edits stay enabled (their upsert is inert while `set(matching: []) == nil`).
- New `SettingsModel.profileSaveBlockedReason` off the existing `permissionPaused` signal.

### #339 — name the active profile at the top of the quick menu
- Non-clickable `Profile: ‹name›` line, shown only when a profile is loaded **and** there's a real alternative to switch to (same gate as the Switch Profile row). Not screen-count gated (any profile loads regardless, #36).

## Verification
- Debug + **release** builds green; `scripts/lint.sh` OK; full suite green (the lone ExecTests flake is the known environmental external-command timeout — passes in isolation, this diff touches no exec code).
- New tests: `ProfileSaveGateTests` (#335) + active-profile-line cases in `QuickMenuProfileRowTests` (#339); App Rules/Applications sort covered by build + manual.
- Docs: `docs/user-guide.md` updated for all three; localization keys registered via `scripts/extract-keys`.

## Review
Two-agent review (code-reviewer + architect-reviewer) round 1 + sequential fix-range re-review. Both flagged the same mode-switch staleness bug → fixed (`.onChange(of: modeName)`); perf note → process-life name cache; comment/reference fixes applied. Re-review clean.

Fixes #333
Fixes #335
Fixes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)