### PR TITLE
fix(service): resume a loaded-but-idle job on start (#341)

### DIFF
--- a/Sources/KiwiDeskCore/Service/ServiceManager.swift
+++ b/Sources/KiwiDeskCore/Service/ServiceManager.swift
@@ -59,20 +59,35 @@ public enum ServiceManager {
 
     // MARK: - Commands
 
-    /// Bootstraps the agent, or no-ops when it is already loaded.
-    /// The plist is always (re)written first so a moved binary is
+    /// Bootstraps the agent, relaunches it when the job is loaded
+    /// but idle, or no-ops when a process is already running. The
+    /// plist is always (re)written first so a moved binary is
     /// picked up on the next `start`.
+    ///
+    /// The loaded-but-idle case matters: quitting via the quick
+    /// menu exits cleanly, and `KeepAlive{SuccessfulExit=false}`
+    /// leaves launchd holding the job registered without a process
+    /// — a bare `isLoaded()` check would then wrongly report
+    /// "already running" and never bring it back (#341).
     public static func start() -> Outcome {
         if let failure = writePlist() {
             return Outcome(failure, ok: false)
         }
-        if isLoaded() {
+        let (status, output) = printState()
+        switch startAction(
+            loaded: status == 0,
+            pid: parsePID(from: output)
+        ) {
+        case .bootstrap:
+            return bootstrap()
+        case .kickstart:
+            return kickstart()
+        case .alreadyRunning:
             return Outcome(
                 "KiwiDesk service is already running",
                 ok: true
             )
         }
-        return bootstrap()
     }
 
     /// Boots out the agent, or reports cleanly when nothing is
@@ -127,6 +142,24 @@ public enum ServiceManager {
 
     // MARK: - Helpers (pure — unit-tested)
 
+    /// What `start` must do given the agent's launchd state.
+    /// Loaded-but-idle (registered, no pid) means the process was
+    /// quit while the job stayed registered, so it is relaunched
+    /// rather than reported as already running (#341).
+    enum StartAction: Equatable {
+        case bootstrap
+        case kickstart
+        case alreadyRunning
+    }
+
+    static func startAction(
+        loaded: Bool,
+        pid: Int32?
+    ) -> StartAction {
+        guard loaded else { return .bootstrap }
+        return pid != nil ? .alreadyRunning : .kickstart
+    }
+
     /// The `status` line for a loaded agent: names the pid when
     /// launchd is running the process, else flags loaded-but-idle.
     static func statusMessage(pid: Int32?) -> String {
@@ -175,6 +208,21 @@ public enum ServiceManager {
             ? Outcome("KiwiDesk service started", ok: true)
             : Outcome(
                 "launchctl bootstrap failed: \(output)",
+                ok: false
+            )
+    }
+
+    /// Relaunches an already-loaded but idle job in place (#341) —
+    /// the job stays registered, launchd just spawns the process
+    /// again.
+    private static func kickstart() -> Outcome {
+        let (status, output) = launchctl([
+            "kickstart", "\(domain)/\(label)",
+        ])
+        return status == 0
+            ? Outcome("KiwiDesk service started", ok: true)
+            : Outcome(
+                "launchctl kickstart failed: \(output)",
                 ok: false
             )
     }

--- a/Tests/KiwiDeskCoreTests/ServiceStartActionTests.swift
+++ b/Tests/KiwiDeskCoreTests/ServiceStartActionTests.swift
@@ -1,0 +1,40 @@
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The pure decision behind `service start` (#341): a loaded-but-
+/// idle job (registered, no pid — the state a quick-menu Quit
+/// leaves behind) must be relaunched, not reported as already
+/// running. The launchctl calls themselves mutate real launchd
+/// state and aren't exercised here.
+@Suite("Service start decision")
+struct ServiceStartActionTests {
+    @Test("Not loaded → bootstrap")
+    func notLoaded() {
+        #expect(
+            ServiceManager.startAction(loaded: false, pid: nil)
+                == .bootstrap
+        )
+        // A stray pid without a loaded job is still not loaded.
+        #expect(
+            ServiceManager.startAction(loaded: false, pid: 42)
+                == .bootstrap
+        )
+    }
+
+    @Test("Loaded with a running process → already running")
+    func loadedRunning() {
+        #expect(
+            ServiceManager.startAction(loaded: true, pid: 4271)
+                == .alreadyRunning
+        )
+    }
+
+    @Test("Loaded but idle → kickstart (the quit-then-start case)")
+    func loadedIdle() {
+        #expect(
+            ServiceManager.startAction(loaded: true, pid: nil)
+                == .kickstart
+        )
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,9 +41,13 @@ KiwiDesk service restart
 KiwiDesk service status    # loaded? running? pid?
 ```
 
-`start` no-ops with `KiwiDesk service is already running` when
-the agent is loaded (use `restart` to force a relaunch); `stop`
-prints `KiwiDesk service is not running` cleanly when nothing is
+`start` bootstraps the agent when it isn't loaded, and
+**relaunches it when the job is loaded but idle** — the state a
+quick-menu Quit leaves behind (the app exits cleanly, so
+`KeepAlive` doesn't restart it, but the launchd job stays
+registered). It no-ops with `KiwiDesk service is already
+running` only when a process is actually running. `stop` prints
+`KiwiDesk service is not running` cleanly when nothing is
 loaded. `status` reports the loaded/running state and the pid.
 A real `launchctl` failure exits non-zero; the ordinary
 already-running / not-running cases exit 0.


### PR DESCRIPTION
## Bug

`KiwiDesk service start` refused to relaunch after quitting via the quick menu:

1. `service start` → launchd bootstraps the LaunchAgent, RunAtLoad launches the process.
2. Quick-menu Quit → `NSApplication.terminate` → clean `exit 0`.
3. `KeepAlive{SuccessfulExit=false}` correctly does **not** relaunch after a clean exit — but the **job stays loaded**, just idle (`applicationWillTerminate` only calls `core.stop()`).
4. `start()` checked only `isLoaded()`, which is still true → returned **"KiwiDesk service is already running"** and never brought it back.

Root cause: `start` conflated *loaded* with *running*. `status` already distinguished them; `start` didn't.

## Fix

Split the decision into a pure, unit-tested `startAction(loaded:pid:)`:

- not loaded → `bootstrap`
- loaded **with a pid** → already running (true no-op)
- loaded **but idle** (no pid) → `kickstart` the job in place ← the quit-then-start case

Quick-menu Quit stays **process-only** (owner decision, chat) — it must never silently unregister a service the user set up; `service stop` remains the explicit unload. `restart` is unchanged (genuine bootout + bootstrap).

## Verification
- Debug + release builds green; `scripts/lint.sh` OK; full suite green (the lone ExecTests failure is the known environmental external-command flake — passes in isolation, this diff touches no exec code).
- New `ServiceStartActionTests` pins all three decision branches; existing `ServiceStatusTests` unchanged.
- `docs/cli.md` Service Control section updated.

Follow-up filed: #342 (App Store distribution via `SMAppService` login item instead of the launchctl LaunchAgent — the sandbox forbids the current approach; ties into #89).

Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)