### PR TITLE
fix(borders): draw focus rings above the window with matched corners (#357)

### DIFF
--- a/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
@@ -11,6 +11,16 @@ import CoreGraphics
 /// the target masks the overlap and lets square rings fill the reveal
 /// beneath rounded window corners.
 struct BorderGeometry: Equatable {
+    /// Where the ring sits in the window stack, which flips what the
+    /// overlap *is* (#357). `below` masks the overlap behind the
+    /// target (the AppKit fallback); `above` draws it on top of the
+    /// target (the SkyLight fast path), so the overlap is visible and
+    /// must stay a hairline.
+    enum Order: Sendable, Equatable {
+        case above
+        case below
+    }
+
     /// The overlay window's frame in AX (top-left) coordinates:
     /// the window grown by the ring's outward reach on every
     /// side, big enough to hold the whole stroke.
@@ -22,26 +32,42 @@ struct BorderGeometry: Equatable {
     /// in the overlay's own bounds inset by `lineWidth / 2`.
     let cornerRadius: CGFloat
 
-    /// Rounded needs a seam allowance deep enough to close the
-    /// corner reveal on rounded windows, where a 1 pt tuck left a
-    /// visible gap; square needs more still, to fill the harder 90°
-    /// utility-window reveal. Both are masked behind the target —
-    /// over-provisioning is free (the visible outer edge stays at
-    /// `systemRadius + visible` regardless; a larger overlap only
-    /// tucks the hidden inner edge deeper under the corner) — so
-    /// the value is set by the widest reveal seen, not minimized.
-    /// Raised 2.5 → 5 after a hairline gap persisted at small
-    /// windows; the invariant is simply `≥ that reveal`.
+    /// **`below`-order only** (the AppKit fallback). Rounded needs a
+    /// seam allowance deep enough to close the corner reveal on
+    /// rounded windows, where a 1 pt tuck left a visible gap; square
+    /// needs more still, to fill the harder 90° utility-window
+    /// reveal. Both are masked behind the target — over-provisioning
+    /// is free (the visible outer edge stays at `systemRadius +
+    /// visible` regardless; a larger overlap only tucks the hidden
+    /// inner edge deeper under the corner) — so the value is set by
+    /// the widest reveal seen, not minimized. Raised 2.5 → 5 after a
+    /// hairline gap persisted at small windows; the invariant is
+    /// simply `≥ that reveal`. Never used by `above`-order, where the
+    /// overlap is on-screen and must instead stay a hairline (see
+    /// `aboveVisibleLapCap`).
     static let roundedHiddenOverlap: CGFloat = 5
-    /// Fixed rather than derived from `systemRadius` (the old
-    /// `systemRadius · (1 − √2/2)` tuck): because the overlap is
-    /// masked behind the target, over-provisioning is free and
-    /// only *under*-provisioning re-opens the corner reveal this
-    /// fills. 8 pt comfortably clears the square reveal for every
-    /// macOS window radius seen to date; the invariant to keep is
-    /// simply `squareHiddenOverlap ≥ that reveal` — raise it if a
-    /// future radius bump ever exposes a corner gap.
+    /// **`below`-order only.** Fixed rather than derived from
+    /// `systemRadius` (the old `systemRadius · (1 − √2/2)` tuck):
+    /// because the overlap is masked behind the target,
+    /// over-provisioning is free and only *under*-provisioning
+    /// re-opens the corner reveal this fills. 8 pt comfortably clears
+    /// the square reveal for every macOS window radius seen to date;
+    /// the invariant to keep is simply `squareHiddenOverlap ≥ that
+    /// reveal` — raise it if a future radius bump ever exposes a
+    /// corner gap.
     static let squareHiddenOverlap: CGFloat = 8
+    /// **`above`-order cap.** With the ring stacked above the target
+    /// the overlap laps *on top of* the window and is therefore
+    /// visible, so over-provisioning is no longer free — a 5/8 pt
+    /// band would smear across window content. Its only job here is
+    /// to close the hairline seam where our circular corner arc meets
+    /// the window's continuous-squircle corner, so it is capped to
+    /// `min(visible / 2, aboveVisibleLapCap)` (the #311 hybrid): at
+    /// most 1 pt, and never more than half the visible width so the
+    /// ring stays predominantly outside the window. The outer edge
+    /// stays at `systemRadius + visible` regardless (fit-gaps reach
+    /// unchanged); only the inner edge moves.
+    static let aboveVisibleLapCap: CGFloat = 1
 
     /// Builds the ring geometry for `windowFrame` (AX coords).
     /// `width` is clamped defensively; `systemRadius` is the
@@ -51,11 +77,16 @@ struct BorderGeometry: Equatable {
         windowFrame: CGRect,
         width: CGFloat,
         cornerStyle: BorderStyle.CornerStyle,
+        order: Order = .below,
         systemRadius: CGFloat = GeometryUtils
             .systemWindowCornerRadius
     ) -> BorderGeometry {
         let visible = Self.clamp(width)
-        let overlap = hiddenOverlap(for: cornerStyle)
+        let overlap = overlap(
+            for: cornerStyle,
+            order: order,
+            visible: visible
+        )
         let stroke = visible + overlap
         // The rounded stroke's outer edge stays concentric with the
         // target at `systemRadius + visible`. Square has no radius.
@@ -79,12 +110,23 @@ struct BorderGeometry: Equatable {
         clamp(width)
     }
 
-    private static func hiddenOverlap(
-        for style: BorderStyle.CornerStyle
+    /// The stroke depth beyond the visible width. `below`-order tucks
+    /// it behind the target (a generous, masked seam allowance);
+    /// `above`-order laps it onto the target (a visible hairline,
+    /// capped) — see the constants for the full rationale.
+    private static func overlap(
+        for style: BorderStyle.CornerStyle,
+        order: Order,
+        visible: CGFloat
     ) -> CGFloat {
-        switch style {
-        case .rounded: roundedHiddenOverlap
-        case .square: squareHiddenOverlap
+        switch order {
+        case .below:
+            switch style {
+            case .rounded: roundedHiddenOverlap
+            case .square: squareHiddenOverlap
+            }
+        case .above:
+            min(visible / 2, aboveVisibleLapCap)
         }
     }
 

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -87,14 +87,16 @@ public final class BorderManager {
             specs[spec.window] = spec
             let overlay = overlay(for: spec.window)
             overlay.update(
-                geometry: geometry(spec, frame: spec.frame),
+                frame: spec.frame,
+                width: spec.width,
+                cornerStyle: spec.cornerStyle,
                 colorHex: spec.colorHex,
                 screen: screen(for: spec.frame)
             )
             // Re-assert stacking each sync (focus change, retile,
             // z-order restore) — the target may have moved in the
             // window order since the ring last positioned.
-            overlay.order(behind: spec.window.raw)
+            overlay.order(relativeTo: spec.window.raw)
         }
     }
 
@@ -121,7 +123,9 @@ public final class BorderManager {
         guard let overlay = overlays[id], let spec = specs[id]
         else { return }
         overlay.update(
-            geometry: geometry(spec, frame: windowFrame),
+            frame: windowFrame,
+            width: spec.width,
+            cornerStyle: spec.cornerStyle,
             colorHex: spec.colorHex,
             screen: screen(for: windowFrame),
             restoreVisibility: restoreVisibility
@@ -168,17 +172,6 @@ public final class BorderManager {
         _ = eventSource?.watch([])
     }
 
-    private func geometry(
-        _ spec: Spec,
-        frame: CGRect
-    ) -> BorderGeometry {
-        BorderGeometry.compute(
-            windowFrame: frame,
-            width: spec.width,
-            cornerStyle: spec.cornerStyle
-        )
-    }
-
     private func overlay(for window: WindowID) -> BorderOverlay {
         if let existing = overlays[window] { return existing }
         let overlay = BorderOverlay(
@@ -208,13 +201,13 @@ public final class BorderManager {
         case .follow:
             _ = reconcile(id)
         case .reorder:
-            overlay.order(behind: id.raw)
+            overlay.order(relativeTo: id.raw)
         case .followAndReorder:
             // Unhide must re-assert order even when the bounds read
             // fails. Leave restoration to that one explicit order so
             // a successful reconcile cannot issue it twice.
             _ = reconcile(id, restoreVisibility: false)
-            overlay.order(behind: id.raw)
+            overlay.order(relativeTo: id.raw)
         case .hide:
             overlay.hide()
         }

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -40,6 +40,12 @@ public final class BorderManager {
     /// recompute geometry from a fresh frame while reusing the
     /// window's color / width / corner style.
     private var specs: [WindowID: Spec] = [:]
+    /// Each window's real corner radius, resolved once per window and
+    /// reused. A window's radius is a fixed OS attribute, and a query
+    /// that comes back empty (a square/borderless window reporting no
+    /// radius) is a permanent answer, not a transient one — so a
+    /// resolved default is cached too, never re-queried every sync.
+    private var cornerRadii: [WindowID: CGFloat] = [:]
     private var eventSource: SkyLightWindowEvents?
     private var triedEventSource = false
     private var privateRuntimeStarted = false
@@ -82,6 +88,7 @@ public final class BorderManager {
             overlay.hide()
             overlays[id] = nil
             specs[id] = nil
+            cornerRadii[id] = nil
         }
         for spec in desired {
             specs[spec.window] = spec
@@ -90,6 +97,7 @@ public final class BorderManager {
                 frame: spec.frame,
                 width: spec.width,
                 cornerStyle: spec.cornerStyle,
+                cornerRadius: cornerRadius(for: spec.window),
                 colorHex: spec.colorHex,
                 screen: screen(for: spec.frame)
             )
@@ -126,10 +134,24 @@ public final class BorderManager {
             frame: windowFrame,
             width: spec.width,
             cornerStyle: spec.cornerStyle,
+            cornerRadius: cornerRadius(for: id),
             colorHex: spec.colorHex,
             screen: screen(for: windowFrame),
             restoreVisibility: restoreVisibility
         )
+    }
+
+    /// The window's real corner radius so the ring's arc hugs it,
+    /// resolved once and cached (#357). Falls back to the shared
+    /// default when SkyLight reports none — that default is cached
+    /// too, so a radius-less window isn't re-queried on every sync.
+    private func cornerRadius(for id: WindowID) -> CGFloat {
+        if let cached = cornerRadii[id] { return cached }
+        let resolved =
+            SkyLight.windowCornerRadius(id.raw)
+            ?? GeometryUtils.systemWindowCornerRadius
+        cornerRadii[id] = resolved
+        return resolved
     }
 
     /// Geometry tracking is independent of rendering. If a raw SLS
@@ -169,6 +191,7 @@ public final class BorderManager {
         for overlay in overlays.values { overlay.hide() }
         overlays = [:]
         specs = [:]
+        cornerRadii = [:]
         _ = eventSource?.watch([])
     }
 

--- a/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
@@ -5,12 +5,18 @@ import AppKit
 /// and replay the latest state through the mandatory AppKit fallback.
 @MainActor
 protocol BorderOverlayBackend: AnyObject {
+    /// Where this backend stacks its ring, which the facade needs to
+    /// build the matching geometry: SkyLight draws `above` the target
+    /// (visible hairline overlap), AppKit draws `below` it (masked
+    /// overlap). The facade recomputes geometry for this mode on
+    /// every render and after a fallback swap (#357).
+    var orderMode: BorderGeometry.Order { get }
     func update(
         geometry: BorderGeometry,
         colorHex: String,
         screen: NSScreen?
     ) -> Bool
-    func order(behind windowNumber: CGWindowID) -> Bool
+    func order(relativeTo windowNumber: CGWindowID) -> Bool
     func hide() -> Bool
 }
 
@@ -20,10 +26,20 @@ protocol BorderOverlayBackend: AnyObject {
 @MainActor
 final class BorderOverlay {
     private var backend: any BorderOverlayBackend
-    private var lastGeometry: BorderGeometry?
+    /// The raw inputs of the last render, kept so a fallback swap can
+    /// rebuild geometry for the new backend's order mode — the
+    /// `above` SkyLight geometry cannot be reused by the `below`
+    /// AppKit panel (#357).
+    private var lastFrame: CGRect?
+    private var lastWidth: CGFloat = 0
+    private var lastCornerStyle: BorderStyle.CornerStyle = .rounded
     private var lastColorHex = ""
     private weak var lastScreen: NSScreen?
     private var targetWindow: CGWindowID
+    /// The target's real corner radius, cached once a query succeeds.
+    /// Until then each render retries, so a window that reports its
+    /// radius late still gets matched corners (#357).
+    private var resolvedRadius: CGFloat?
     private var isHidden = false
     private let makeFallback: @MainActor () -> any BorderOverlayBackend
     private let onFallback: @MainActor (String) -> Void
@@ -63,39 +79,74 @@ final class BorderOverlay {
         onFallback = { _ in }
     }
 
+    /// Renders the ring around `frame` (AX coords). Takes the raw
+    /// inputs, not a finished `BorderGeometry`, because the geometry
+    /// depends on the current backend's order mode — the facade owns
+    /// that choice and rebuilds it here and on any fallback swap.
     func update(
-        geometry: BorderGeometry,
+        frame: CGRect,
+        width: CGFloat,
+        cornerStyle: BorderStyle.CornerStyle,
         colorHex: String,
         screen: NSScreen?,
         restoreVisibility: Bool = false
     ) {
-        lastGeometry = geometry
+        lastFrame = frame
+        lastWidth = width
+        lastCornerStyle = cornerStyle
         lastColorHex = colorHex
         lastScreen = screen
         let shouldRestore = restoreVisibility && isHidden
         guard
             backend.update(
-                geometry: geometry,
+                geometry: geometry(for: backend),
                 colorHex: colorHex,
                 screen: screen
             )
         else {
             fallBackToAppKit(reason: "SLS renderer update failed")
-            if shouldRestore { order(behind: targetWindow) }
+            if shouldRestore { order(relativeTo: targetWindow) }
             return
         }
         if shouldRestore {
-            order(behind: targetWindow)
+            order(relativeTo: targetWindow)
         }
     }
 
-    func order(behind windowNumber: CGWindowID) {
+    func order(relativeTo windowNumber: CGWindowID) {
         targetWindow = windowNumber
         isHidden = false
-        guard backend.order(behind: windowNumber) else {
+        guard backend.order(relativeTo: windowNumber) else {
             fallBackToAppKit(reason: "SLS renderer ordering failed")
             return
         }
+    }
+
+    /// Builds the ring geometry for a backend's order mode from the
+    /// last rendered inputs.
+    private func geometry(
+        for backend: any BorderOverlayBackend
+    ) -> BorderGeometry {
+        BorderGeometry.compute(
+            windowFrame: lastFrame ?? .zero,
+            width: lastWidth,
+            cornerStyle: lastCornerStyle,
+            order: backend.orderMode,
+            systemRadius: cornerRadius()
+        )
+    }
+
+    /// The target window's real corner radius, so the ring's rounded
+    /// arc hugs the window instead of a fixed 16 pt guess (#357).
+    /// Retries until a query succeeds, then caches; falls back to the
+    /// shared default meanwhile.
+    private func cornerRadius() -> CGFloat {
+        if let resolvedRadius { return resolvedRadius }
+        if let queried = SkyLight.windowCornerRadius(targetWindow) {
+            resolvedRadius = queried
+            return queried
+        }
+        return GeometryUtils.systemWindowCornerRadius
     }
 
     func hide() {
@@ -122,16 +173,16 @@ final class BorderOverlay {
         if retireBackend { _ = backend.hide() }
         let appKit = makeFallback()
         backend = appKit
-        if let lastGeometry {
+        if lastFrame != nil {
             _ = appKit.update(
-                geometry: lastGeometry,
+                geometry: geometry(for: appKit),
                 colorHex: lastColorHex,
                 screen: lastScreen
             )
             if isHidden {
                 _ = appKit.hide()
             } else {
-                _ = appKit.order(behind: targetWindow)
+                _ = appKit.order(relativeTo: targetWindow)
             }
         }
     }
@@ -146,7 +197,7 @@ final class BorderOverlay {
 /// Non-interactive by design (`ignoresMouseEvents`) — unlike the
 /// app bar, a border is never clicked. Sits at the normal window
 /// level and is stacked directly behind its target window with
-/// `order(.below, relativeTo:)` (see `order(behind:)`). The stroke's
+/// `order(.below, relativeTo:)` (see `order(relativeTo:)`). The stroke's
 /// inner overlap sits under the target while its outward reach stays
 /// visible; child panels and other windows above the target therefore
 /// cover the ring naturally.
@@ -155,12 +206,19 @@ private final class AppKitBorderOverlay: BorderOverlayBackend {
     private var panel: NSPanel?
     private let shape = CAShapeLayer()
 
+    /// The AppKit panel stacks below its target (it cannot express a
+    /// SkyLight sub-level, so `above` here would paint over child
+    /// popovers — the #320 regression). Below keeps that occlusion
+    /// correct at the cost of the rounded corner seam, which only
+    /// the SkyLight `above` path fixes.
+    let orderMode: BorderGeometry.Order = .below
+
     /// Positions the ring around `geometry.overlayFrame` (AX
     /// coords) and strokes it in `colorHex`. Used both for a
     /// steady-state sync and per animation tick — implicit Core
     /// Animation is disabled so the ring snaps to each commanded
     /// frame instead of easing a step behind the window. Stacking
-    /// is left to `order(behind:)`, called only on sync (not per
+    /// is left to `order(relativeTo:)`, called only on sync (not per
     /// tick) so the ring isn't re-ordered every frame.
     func update(
         geometry: BorderGeometry,
@@ -213,7 +271,7 @@ private final class AppKitBorderOverlay: BorderOverlayBackend {
     /// ignored panel, a higher-level utility window — therefore
     /// stays in front of the ring. Called on sync, not per tick.
     /// A no-op until the panel exists (first `update` creates it).
-    func order(behind windowNumber: CGWindowID) -> Bool {
+    func order(relativeTo windowNumber: CGWindowID) -> Bool {
         panel?.order(.below, relativeTo: Int(windowNumber))
         return true
     }
@@ -235,7 +293,7 @@ private final class AppKitBorderOverlay: BorderOverlayBackend {
         panel.hasShadow = false
         panel.ignoresMouseEvents = true
         // Normal window level (not floating): the ring is stacked
-        // relative to its target by `order(behind:)`, so it must
+        // relative to its target by `order(relativeTo:)`, so it must
         // share the target's band to sit *below* windows layered
         // over it — a floating level would force it above them.
         panel.level = .normal

--- a/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
@@ -36,10 +36,11 @@ final class BorderOverlay {
     private var lastColorHex = ""
     private weak var lastScreen: NSScreen?
     private var targetWindow: CGWindowID
-    /// The target's real corner radius, cached once a query succeeds.
-    /// Until then each render retries, so a window that reports its
-    /// radius late still gets matched corners (#357).
-    private var resolvedRadius: CGFloat?
+    /// The target's real corner radius, resolved by `BorderManager`
+    /// (which owns OS I/O) and passed in, so the facade stays a pure
+    /// backend assembler and the radius path is injectable (#357).
+    private var lastCornerRadius: CGFloat =
+        GeometryUtils.systemWindowCornerRadius
     private var isHidden = false
     private let makeFallback: @MainActor () -> any BorderOverlayBackend
     private let onFallback: @MainActor (String) -> Void
@@ -87,6 +88,7 @@ final class BorderOverlay {
         frame: CGRect,
         width: CGFloat,
         cornerStyle: BorderStyle.CornerStyle,
+        cornerRadius: CGFloat,
         colorHex: String,
         screen: NSScreen?,
         restoreVisibility: Bool = false
@@ -94,6 +96,7 @@ final class BorderOverlay {
         lastFrame = frame
         lastWidth = width
         lastCornerStyle = cornerStyle
+        lastCornerRadius = cornerRadius
         lastColorHex = colorHex
         lastScreen = screen
         let shouldRestore = restoreVisibility && isHidden
@@ -132,21 +135,8 @@ final class BorderOverlay {
             width: lastWidth,
             cornerStyle: lastCornerStyle,
             order: backend.orderMode,
-            systemRadius: cornerRadius()
+            systemRadius: lastCornerRadius
         )
-    }
-
-    /// The target window's real corner radius, so the ring's rounded
-    /// arc hugs the window instead of a fixed 16 pt guess (#357).
-    /// Retries until a query succeeds, then caches; falls back to the
-    /// shared default meanwhile.
-    private func cornerRadius() -> CGFloat {
-        if let resolvedRadius { return resolvedRadius }
-        if let queried = SkyLight.windowCornerRadius(targetWindow) {
-            resolvedRadius = queried
-            return queried
-        }
-        return GeometryUtils.systemWindowCornerRadius
     }
 
     func hide() {

--- a/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
@@ -13,8 +13,15 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
         (1 << 1) | (1 << 9) | (1 << 18)
     private static let backingStoreBuffered: Int32 = 2
     private static let orderOut: Int32 = 0
-    private static let orderBelow: Int32 = -1
+    private static let orderAbove: Int32 = 1
     private static let parkedOrigin = CGPoint(x: -9_999, y: -9_999)
+
+    /// The ring stacks *above* its target so its own clean corner
+    /// arc is the only visible edge — nothing occludes it, so
+    /// rounded corners read symmetric (#357). Occlusion by child
+    /// windows is preserved by pinning the ring's sub-level to the
+    /// target's (see `order(relativeTo:)`), not by ordering below.
+    let orderMode: BorderGeometry.Order = .above
 
     private let connection: SkyLight.ConnectionID
     private let targetWindow: CGWindowID
@@ -99,51 +106,64 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
             destroyWindow()
             return false
         }
-        if recreatedForScale && !order(behind: targetWindow) {
+        if recreatedForScale && !order(relativeTo: targetWindow) {
             destroyWindow()
             return false
         }
         return true
     }
 
-    func order(behind windowNumber: CGWindowID) -> Bool {
+    func order(relativeTo windowNumber: CGWindowID) -> Bool {
         guard window != 0, windowNumber == targetWindow,
             let transaction = makeTransaction()
         else { return false }
+        // The `SLSTransaction*` mutators return no meaningful status
+        // (JankyBorders fires them and only commits), so they are
+        // best-effort: gating them on `.success` reads a junk register
+        // and would falsely retire this backend to the AppKit
+        // below-order fallback. Only `makeTransaction` is load-bearing.
         var level: Int64 = 0
-        guard
-            SkyLight.getWindowLevel?(
-                connection,
-                targetWindow,
-                &level
-            ) == .success,
-            level >= Int64(Int32.min), level <= Int64(Int32.max),
-            SkyLight.transactionLevel?(
+        if SkyLight.getWindowLevel?(connection, targetWindow, &level)
+            == .success,
+            level >= Int64(Int32.min), level <= Int64(Int32.max)
+        {
+            _ = SkyLight.transactionLevel?(
                 transaction,
                 window,
                 Int32(level)
-            ) == .success,
-            SkyLight.transactionOrder?(
-                transaction,
-                window,
-                Self.orderBelow,
-                targetWindow
-            ) == .success
-        else { return false }
-        return commit(transaction)
+            )
+        }
+        // Pin the ring into the target's exact sub-level band. A child
+        // the OS stacks over the target (a popover, a sheet) sits at a
+        // *higher* sub-level, so it keeps rendering above a
+        // sub-level-pinned ring even though the ring is ordered above
+        // the target itself. Without this pin, above-order paints over
+        // child popups — the #320 regression below-order avoided
+        // (#357).
+        let subLevel =
+            SkyLight.getWindowSubLevel?(connection, targetWindow) ?? 0
+        _ = SkyLight.transactionSubLevel?(transaction, window, subLevel)
+        _ = SkyLight.transactionOrder?(
+            transaction,
+            window,
+            Self.orderAbove,
+            targetWindow
+        )
+        commit(transaction)
+        return true
     }
 
     func hide() -> Bool {
         guard window != 0 else { return true }
-        guard let transaction = makeTransaction(),
-            SkyLight.transactionOrder?(
-                transaction,
-                window,
-                Self.orderOut,
-                targetWindow
-            ) == .success
-        else { return false }
-        return commit(transaction)
+        guard let transaction = makeTransaction() else { return false }
+        _ = SkyLight.transactionOrder?(
+            transaction,
+            window,
+            Self.orderOut,
+            targetWindow
+        )
+        commit(transaction)
+        return true
     }
 
     private func createWindow(frame: CGRect, scale: CGFloat) -> Bool {
@@ -273,40 +293,35 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
         to origin: CGPoint,
         resetTransform: Bool
     ) -> Bool {
-        guard let transaction = makeTransaction(),
-            SkyLight.transactionMove?(
-                transaction,
-                window,
-                origin
-            ) == .success
-        else { return false }
+        guard let transaction = makeTransaction() else { return false }
+        // Fire-and-forget mutators; only `makeTransaction` gates.
+        _ = SkyLight.transactionMove?(transaction, window, origin)
         if resetTransform {
             let transform = CGAffineTransform(
                 translationX: -origin.x,
                 y: -origin.y
             )
-            guard
-                SkyLight.transactionTransform?(
-                    transaction,
-                    window,
-                    0,
-                    0,
-                    transform
-                ) == .success
-            else { return false }
+            _ = SkyLight.transactionTransform?(
+                transaction,
+                window,
+                0,
+                0,
+                transform
+            )
         }
-        return commit(transaction)
+        commit(transaction)
+        return true
     }
 
     private func makeTransaction() -> CFTypeRef? {
         SkyLight.transactionCreate?(connection)?.takeRetainedValue()
     }
 
-    private func commit(_ transaction: CFTypeRef) -> Bool {
-        SkyLight.transactionCommit?(
-            transaction,
-            0
-        ) == .success
+    /// Commits and releases the transaction. `SLSTransactionCommit`
+    /// returns no meaningful status (JankyBorders ignores it), so this
+    /// is fire-and-forget — a garbage return must not read as failure.
+    private func commit(_ transaction: CFTypeRef) {
+        _ = SkyLight.transactionCommit?(transaction, 0)
     }
 
     private func makeRegion(_ rect: CGRect) -> CFTypeRef? {

--- a/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
@@ -97,15 +97,13 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
         // inverse transform that anchors the raw surface, while a
         // move-only update is one cheap origin transaction.
         let resetTransform = previous == nil || needsRedraw
-        guard
-            move(
-                to: geometry.overlayFrame.origin,
-                resetTransform: resetTransform
-            )
-        else {
-            destroyWindow()
-            return false
-        }
+        // Fire-and-forget: `move` commits a transaction whose ops
+        // report no meaningful status, so it cannot fail in a way
+        // worth a fallback (unlike create/reshape/draw above).
+        move(
+            to: geometry.overlayFrame.origin,
+            resetTransform: resetTransform
+        )
         if recreatedForScale && !order(relativeTo: targetWindow) {
             destroyWindow()
             return false
@@ -292,8 +290,8 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
     private func move(
         to origin: CGPoint,
         resetTransform: Bool
-    ) -> Bool {
-        guard let transaction = makeTransaction() else { return false }
+    ) {
+        guard let transaction = makeTransaction() else { return }
         // Fire-and-forget mutators; only `makeTransaction` gates.
         _ = SkyLight.transactionMove?(transaction, window, origin)
         if resetTransform {
@@ -310,7 +308,6 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
             )
         }
         commit(transaction)
-        return true
     }
 
     private func makeTransaction() -> CFTypeRef? {

--- a/Sources/KiwiDeskCore/OS/SkyLight+Borders.swift
+++ b/Sources/KiwiDeskCore/OS/SkyLight+Borders.swift
@@ -86,6 +86,10 @@ extension SkyLight {
             CGWindowID,
             UnsafeMutablePointer<Int64>
         ) -> CGError
+    typealias GetWindowSubLevelFn =
+        @convention(c) (
+            ConnectionID, CGWindowID
+        ) -> Int32
 
     typealias TransactionCreateFn =
         @convention(c) (
@@ -96,6 +100,10 @@ extension SkyLight {
             CFTypeRef, CGWindowID, CGPoint
         ) -> CGError
     typealias TransactionLevelFn =
+        @convention(c) (
+            CFTypeRef, CGWindowID, Int32
+        ) -> CGError
+    typealias TransactionSubLevelFn =
         @convention(c) (
             CFTypeRef, CGWindowID, Int32
         ) -> CGError
@@ -172,6 +180,10 @@ extension SkyLight {
         "SLSGetWindowLevel",
         as: GetWindowLevelFn.self
     )
+    static let getWindowSubLevel: GetWindowSubLevelFn? = symbol(
+        "SLSGetWindowSubLevel",
+        as: GetWindowSubLevelFn.self
+    )
     static let transactionCreate: TransactionCreateFn? = symbol(
         "SLSTransactionCreate",
         as: TransactionCreateFn.self
@@ -183,6 +195,10 @@ extension SkyLight {
     static let transactionLevel: TransactionLevelFn? = symbol(
         "SLSTransactionSetWindowLevel",
         as: TransactionLevelFn.self
+    )
+    static let transactionSubLevel: TransactionSubLevelFn? = symbol(
+        "SLSTransactionSetWindowSubLevel",
+        as: TransactionSubLevelFn.self
     )
     static let transactionTransform: TransactionTransformFn? = symbol(
         "SLSTransactionSetWindowTransform",
@@ -210,8 +226,10 @@ extension SkyLight {
             && windowContextCreate != nil
             && flushWindowContent != nil && windowFreeze != nil
             && windowThaw != nil && getWindowBounds != nil
-            && getWindowLevel != nil && transactionCreate != nil
+            && getWindowLevel != nil && getWindowSubLevel != nil
+            && transactionCreate != nil
             && transactionMove != nil && transactionLevel != nil
+            && transactionSubLevel != nil
             && transactionTransform != nil
             && transactionOrder != nil && transactionCommit != nil
     }

--- a/Sources/KiwiDeskCore/OS/SkyLight+WindowRadius.swift
+++ b/Sources/KiwiDeskCore/OS/SkyLight+WindowRadius.swift
@@ -66,6 +66,12 @@ extension SkyLight {
         else { return nil }
         let targets = [number] as CFArray
 
+        // `takeRetainedValue` on all three: despite the `…Get…` name,
+        // `SLSWindowIteratorGetCornerRadii` returns an **owned** (+1)
+        // array — JankyBorders `CFRelease`s it (`windows.c`), and it is
+        // too widely deployed for that to be an over-release. So one
+        // release (ARC at scope end) is the correct balance; do NOT
+        // switch this to `takeUnretainedValue` — that would leak.
         guard
             let query = queryWindows(connection, targets, 0)?
                 .takeRetainedValue(),
@@ -75,6 +81,8 @@ extension SkyLight {
             CFArrayGetCount(radiiRef) > 0
         else { return nil }
 
+        // Radii are whole points (10/12/16 …); JankyBorders reads them
+        // as `sInt32` the same way.
         let first = unsafeBitCast(
             CFArrayGetValueAtIndex(radiiRef, 0),
             to: CFNumber.self

--- a/Sources/KiwiDeskCore/OS/SkyLight+WindowRadius.swift
+++ b/Sources/KiwiDeskCore/OS/SkyLight+WindowRadius.swift
@@ -1,0 +1,86 @@
+import CoreFoundation
+import CoreGraphics
+
+/// Per-window corner-radius query for the focus border (#357). The
+/// ring's rounded corners must match the *actual* radius of each
+/// window, not a fixed guess — a mismatch leaves a visible gap where
+/// our arc and the window's corner diverge. JankyBorders reads the
+/// radius the same way (`SLSWindowQueryWindows` →
+/// `SLSWindowIteratorGetCornerRadii`), falling back to a default when
+/// the window reports none. Every symbol is optional; a failed lookup
+/// falls back to `GeometryUtils.systemWindowCornerRadius`.
+extension SkyLight {
+    typealias WindowQueryWindowsFn =
+        @convention(c) (
+            ConnectionID, CFArray, Int32
+        ) -> Unmanaged<CFTypeRef>?
+    typealias QueryResultCopyWindowsFn =
+        @convention(c) (CFTypeRef) -> Unmanaged<CFTypeRef>?
+    typealias IteratorGetCountFn =
+        @convention(c) (CFTypeRef) -> Int32
+    typealias IteratorAdvanceFn =
+        @convention(c) (CFTypeRef) -> Bool
+    typealias IteratorGetCornerRadiiFn =
+        @convention(c) (CFTypeRef) -> Unmanaged<CFArray>?
+
+    static let windowQueryWindows: WindowQueryWindowsFn? = symbol(
+        "SLSWindowQueryWindows",
+        as: WindowQueryWindowsFn.self
+    )
+    static let queryResultCopyWindows: QueryResultCopyWindowsFn? =
+        symbol(
+            "SLSWindowQueryResultCopyWindows",
+            as: QueryResultCopyWindowsFn.self
+        )
+    static let iteratorGetCount: IteratorGetCountFn? = symbol(
+        "SLSWindowIteratorGetCount",
+        as: IteratorGetCountFn.self
+    )
+    static let iteratorAdvance: IteratorAdvanceFn? = symbol(
+        "SLSWindowIteratorAdvance",
+        as: IteratorAdvanceFn.self
+    )
+    static let iteratorGetCornerRadii: IteratorGetCornerRadiiFn? =
+        symbol(
+            "SLSWindowIteratorGetCornerRadii",
+            as: IteratorGetCornerRadiiFn.self
+        )
+
+    /// The corner radius (pt) SkyLight reports for `wid`, or `nil`
+    /// when unavailable (symbol missing, window not found, or a
+    /// non-positive radius — matching JankyBorders' "> 0" gate). The
+    /// caller substitutes the shared default so a failed query never
+    /// blocks a ring.
+    static func windowCornerRadius(_ wid: CGWindowID) -> CGFloat? {
+        guard let connection,
+            let queryWindows = windowQueryWindows,
+            let copyWindows = queryResultCopyWindows,
+            let count = iteratorGetCount,
+            let advance = iteratorAdvance,
+            let cornerRadii = iteratorGetCornerRadii
+        else { return nil }
+
+        var raw = Int32(bitPattern: wid)
+        guard
+            let number = CFNumberCreate(nil, .sInt32Type, &raw)
+        else { return nil }
+        let targets = [number] as CFArray
+
+        guard
+            let query = queryWindows(connection, targets, 0)?
+                .takeRetainedValue(),
+            let iterator = copyWindows(query)?.takeRetainedValue(),
+            count(iterator) > 0, advance(iterator),
+            let radiiRef = cornerRadii(iterator)?.takeRetainedValue(),
+            CFArrayGetCount(radiiRef) > 0
+        else { return nil }
+
+        let first = unsafeBitCast(
+            CFArrayGetValueAtIndex(radiiRef, 0),
+            to: CFNumber.self
+        )
+        var value: Int32 = 0
+        CFNumberGetValue(first, .sInt32Type, &value)
+        return value > 0 ? CGFloat(value) : nil
+    }
+}

--- a/Tests/KiwiDeskCoreTests/BorderGeometryTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderGeometryTests.swift
@@ -81,6 +81,50 @@ struct BorderGeometryTests {
         )
     }
 
+    @Test("Above-order caps the overlap to a visible hairline")
+    func aboveRoundedCap() {
+        let g = BorderGeometry.compute(
+            windowFrame: window,
+            width: 4,
+            cornerStyle: .rounded,
+            order: .above,
+            systemRadius: 16
+        )
+        // Outer reach unchanged (fit-gaps invariant); only the inner
+        // edge moves onto the window by the capped lap.
+        #expect(g.overlayFrame == window.insetBy(dx: -4, dy: -4))
+        // min(4 / 2, 1) == 1 — the on-window lap, not the hidden 5.
+        #expect(g.lineWidth == 5.0)
+        #expect(g.cornerRadius == 16 + 4 - g.lineWidth / 2)
+    }
+
+    @Test("Above-order lap never exceeds half the visible width")
+    func aboveThinLap() {
+        let g = BorderGeometry.compute(
+            windowFrame: window,
+            width: 1,
+            cornerStyle: .rounded,
+            order: .above,
+            systemRadius: 16
+        )
+        // min(1 / 2, 1) == 0.5 — ring stays predominantly outside.
+        #expect(g.lineWidth == 1.5)
+    }
+
+    @Test("Above-order square uses the capped lap, not the 8 tuck")
+    func aboveSquareCap() {
+        let g = BorderGeometry.compute(
+            windowFrame: window,
+            width: 10,
+            cornerStyle: .square,
+            order: .above,
+            systemRadius: 16
+        )
+        #expect(g.cornerRadius == 0)
+        // The visible cap (1), never squareHiddenOverlap (8).
+        #expect(g.lineWidth == 11.0)
+    }
+
     @Test("Width is clamped defensively into range")
     func clamp() {
         let tooThin = BorderGeometry.compute(
@@ -105,25 +149,31 @@ struct BorderGeometryTests {
         )
     }
 
-    /// Seam guard: `outwardReach` must equal `compute`'s outward
-    /// growth for every style. The renderer-only overlap must never
-    /// leak into this public reach.
+    /// Seam guard + `border.fit_gaps` invariant (#295/#357):
+    /// `outwardReach` must equal `compute`'s outward growth for every
+    /// style **and both order modes**. The overlap (hidden below,
+    /// on-window above) must never leak into this public reach, or
+    /// the fit-gaps math would drift when the ring flips order.
     @Test("outwardReach matches compute's outward offset")
     func outwardReachMatchesCompute() {
         let widths: [CGFloat] = [BorderStyle.minWidth, 2, 10, 20]
-        for style in [BorderStyle.CornerStyle.rounded, .square] {
-            for width in widths {
-                let g = BorderGeometry.compute(
-                    windowFrame: window,
-                    width: width,
-                    cornerStyle: style,
-                    systemRadius: 16
-                )
-                let offset = window.minX - g.overlayFrame.minX
-                let reach = BorderGeometry.outwardReach(
-                    width: width
-                )
-                #expect(abs(reach - offset) < 0.0001)
+        let orders: [BorderGeometry.Order] = [.below, .above]
+        for order in orders {
+            for style in [BorderStyle.CornerStyle.rounded, .square] {
+                for width in widths {
+                    let g = BorderGeometry.compute(
+                        windowFrame: window,
+                        width: width,
+                        cornerStyle: style,
+                        order: order,
+                        systemRadius: 16
+                    )
+                    let offset = window.minX - g.overlayFrame.minX
+                    let reach = BorderGeometry.outwardReach(
+                        width: width
+                    )
+                    #expect(abs(reach - offset) < 0.0001)
+                }
             }
         }
     }

--- a/Tests/KiwiDeskCoreTests/BorderOrderModeTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderOrderModeTests.swift
@@ -21,6 +21,7 @@ struct BorderOrderModeTests {
             frame: frame,
             width: 6,
             cornerStyle: .rounded,
+            cornerRadius: 16,
             colorHex: "#0A84FF",
             screen: nil
         )
@@ -35,6 +36,39 @@ struct BorderOrderModeTests {
         #expect(backend.lastGeometry?.lineWidth == 7.0)
     }
 
+    @Test("The injected corner radius drives the arc")
+    func injectedRadiusDrivesGeometry() {
+        let backend = GeometryCapturingBackend(orderMode: .above)
+        let overlay = BorderOverlay(window: 7, backend: backend)
+        // A non-default radius (10, not the 16 fallback) must flow
+        // through to the stroke's corner radius — the radius path is
+        // injectable rather than queried inside the facade (#357).
+        overlay.update(
+            frame: frame,
+            width: 6,
+            cornerStyle: .rounded,
+            cornerRadius: 10,
+            colorHex: "#0A84FF",
+            screen: nil
+        )
+        let atTen = BorderGeometry.compute(
+            windowFrame: frame,
+            width: 6,
+            cornerStyle: .rounded,
+            order: .above,
+            systemRadius: 10
+        )
+        let atDefault = BorderGeometry.compute(
+            windowFrame: frame,
+            width: 6,
+            cornerStyle: .rounded,
+            order: .above,
+            systemRadius: 16
+        )
+        #expect(backend.lastGeometry?.cornerRadius == atTen.cornerRadius)
+        #expect(atTen.cornerRadius != atDefault.cornerRadius)
+    }
+
     @Test("A below backend receives below-order geometry")
     func belowBackendGetsBelowGeometry() {
         let backend = GeometryCapturingBackend(orderMode: .below)
@@ -43,6 +77,7 @@ struct BorderOrderModeTests {
             frame: frame,
             width: 6,
             cornerStyle: .rounded,
+            cornerRadius: 16,
             colorHex: "#0A84FF",
             screen: nil
         )
@@ -70,6 +105,7 @@ struct BorderOrderModeTests {
             frame: frame,
             width: 6,
             cornerStyle: .rounded,
+            cornerRadius: 16,
             colorHex: "#0A84FF",
             screen: nil
         )

--- a/Tests/KiwiDeskCoreTests/BorderOrderModeTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderOrderModeTests.swift
@@ -1,0 +1,104 @@
+import AppKit
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The facade owns the ring's order mode and rebuilds geometry for
+/// it — on every render and after a fallback swap (#357). An `above`
+/// SkyLight geometry (visible hairline lap) cannot be reused by the
+/// `below` AppKit panel (masked overlap), so the mode must drive the
+/// geometry, not a value precomputed upstream.
+@Suite("Border order mode")
+@MainActor
+struct BorderOrderModeTests {
+    private let frame = CGRect(x: 10, y: 20, width: 300, height: 200)
+
+    @Test("An above backend receives above-order geometry")
+    func aboveBackendGetsAboveGeometry() {
+        let backend = GeometryCapturingBackend(orderMode: .above)
+        let overlay = BorderOverlay(window: 7, backend: backend)
+        overlay.update(
+            frame: frame,
+            width: 6,
+            cornerStyle: .rounded,
+            colorHex: "#0A84FF",
+            screen: nil
+        )
+        let expected = BorderGeometry.compute(
+            windowFrame: frame,
+            width: 6,
+            cornerStyle: .rounded,
+            order: .above
+        )
+        #expect(backend.lastGeometry == expected)
+        // The on-window capped lap (1), not the hidden 5.
+        #expect(backend.lastGeometry?.lineWidth == 7.0)
+    }
+
+    @Test("A below backend receives below-order geometry")
+    func belowBackendGetsBelowGeometry() {
+        let backend = GeometryCapturingBackend(orderMode: .below)
+        let overlay = BorderOverlay(window: 7, backend: backend)
+        overlay.update(
+            frame: frame,
+            width: 6,
+            cornerStyle: .rounded,
+            colorHex: "#0A84FF",
+            screen: nil
+        )
+        #expect(
+            backend.lastGeometry?.lineWidth
+                == 6 + BorderGeometry.roundedHiddenOverlap
+        )
+    }
+
+    /// The #357 fallback contract: when an `above` primary fails and
+    /// the facade retires it, the replay through the `below` panel
+    /// must be recomputed for below-order — reusing the above
+    /// geometry would draw the hairline overlap as the whole ring.
+    @Test("Fallback rebuilds geometry for the below panel")
+    func fallbackRebuildsForBelow() {
+        let primary = GeometryCapturingBackend(orderMode: .above)
+        primary.updateSucceeds = false
+        let fallback = GeometryCapturingBackend(orderMode: .below)
+        let overlay = BorderOverlay(
+            window: 7,
+            backend: primary,
+            fallback: fallback
+        )
+        overlay.update(
+            frame: frame,
+            width: 6,
+            cornerStyle: .rounded,
+            colorHex: "#0A84FF",
+            screen: nil
+        )
+        #expect(
+            fallback.lastGeometry?.lineWidth
+                == 6 + BorderGeometry.roundedHiddenOverlap
+        )
+    }
+}
+
+@MainActor
+private final class GeometryCapturingBackend: BorderOverlayBackend {
+    let orderMode: BorderGeometry.Order
+    var updateSucceeds = true
+    var lastGeometry: BorderGeometry?
+
+    init(orderMode: BorderGeometry.Order) {
+        self.orderMode = orderMode
+    }
+
+    func update(
+        geometry: BorderGeometry,
+        colorHex: String,
+        screen: NSScreen?
+    ) -> Bool {
+        lastGeometry = geometry
+        return updateSucceeds
+    }
+
+    func order(relativeTo windowNumber: CGWindowID) -> Bool { true }
+    func hide() -> Bool { true }
+}

--- a/Tests/KiwiDeskCoreTests/BorderOverlayVisibilityTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderOverlayVisibilityTests.swift
@@ -16,6 +16,7 @@ struct BorderOverlayVisibilityTests {
             frame: frame,
             width: 4,
             cornerStyle: .rounded,
+            cornerRadius: 16,
             colorHex: "#FF0000",
             screen: nil
         )
@@ -27,6 +28,7 @@ struct BorderOverlayVisibilityTests {
             frame: frame,
             width: 4,
             cornerStyle: .rounded,
+            cornerRadius: 16,
             colorHex: "#FF0000",
             screen: nil,
             restoreVisibility: true
@@ -35,6 +37,7 @@ struct BorderOverlayVisibilityTests {
             frame: frame,
             width: 4,
             cornerStyle: .rounded,
+            cornerRadius: 16,
             colorHex: "#FF0000",
             screen: nil,
             restoreVisibility: true
@@ -64,6 +67,7 @@ struct BorderOverlayVisibilityTests {
             frame: CGRect(x: 10, y: 20, width: 300, height: 200),
             width: 4,
             cornerStyle: .rounded,
+            cornerRadius: 16,
             colorHex: "#FF0000",
             screen: nil
         )

--- a/Tests/KiwiDeskCoreTests/BorderOverlayVisibilityTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderOverlayVisibilityTests.swift
@@ -10,29 +10,31 @@ struct BorderOverlayVisibilityTests {
     func reconcileRestoresHiddenOverlayOnce() {
         let backend = RecordingBorderBackend()
         let overlay = BorderOverlay(window: 7, backend: backend)
-        let geometry = BorderGeometry.compute(
-            windowFrame: CGRect(x: 10, y: 20, width: 300, height: 200),
-            width: 4,
-            cornerStyle: .rounded
-        )
+        let frame = CGRect(x: 10, y: 20, width: 300, height: 200)
 
         overlay.update(
-            geometry: geometry,
+            frame: frame,
+            width: 4,
+            cornerStyle: .rounded,
             colorHex: "#FF0000",
             screen: nil
         )
-        overlay.order(behind: 7)
+        overlay.order(relativeTo: 7)
         backend.calls = []
 
         overlay.hide()
         overlay.update(
-            geometry: geometry,
+            frame: frame,
+            width: 4,
+            cornerStyle: .rounded,
             colorHex: "#FF0000",
             screen: nil,
             restoreVisibility: true
         )
         overlay.update(
-            geometry: geometry,
+            frame: frame,
+            width: 4,
+            cornerStyle: .rounded,
             colorHex: "#FF0000",
             screen: nil,
             restoreVisibility: true
@@ -58,24 +60,21 @@ struct BorderOverlayVisibilityTests {
             backend: primary,
             fallback: fallback
         )
-        let geometry = BorderGeometry.compute(
-            windowFrame: CGRect(x: 10, y: 20, width: 300, height: 200),
-            width: 4,
-            cornerStyle: .rounded
-        )
         overlay.update(
-            geometry: geometry,
+            frame: CGRect(x: 10, y: 20, width: 300, height: 200),
+            width: 4,
+            cornerStyle: .rounded,
             colorHex: "#FF0000",
             screen: nil
         )
-        overlay.order(behind: 7)
+        overlay.order(relativeTo: 7)
         primary.calls = []
 
         overlay.hide()
         #expect(primary.calls == [.hide])
         #expect(fallback.calls == [.update, .hide])
 
-        overlay.order(behind: 7)
+        overlay.order(relativeTo: 7)
         #expect(fallback.calls == [.update, .hide, .order(7)])
     }
 }
@@ -90,6 +89,7 @@ private final class RecordingBorderBackend: BorderOverlayBackend {
 
     var calls: [Call] = []
     var hideSucceeds = true
+    let orderMode: BorderGeometry.Order = .below
 
     func update(
         geometry: BorderGeometry,
@@ -100,7 +100,7 @@ private final class RecordingBorderBackend: BorderOverlayBackend {
         return true
     }
 
-    func order(behind windowNumber: CGWindowID) -> Bool {
+    func order(relativeTo windowNumber: CGWindowID) -> Bool {
         calls.append(.order(windowNumber))
         return true
     }

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1864,14 +1864,15 @@ focus otherwise lacks. It is **on by default** and marks only the
 focused window; you can optionally ring every other window too.
 
 The ring is a pure overlay: it never changes where windows tile
-(no gap coupling). The configured width is drawn entirely outward
-into the gap. The renderer adds a separate hidden overlap behind the
-target; the target masks it, so the overlap never counts toward the
-visible thickness or hides content. Rounded uses a small seam
-allowance; square reaches deeper to fill the reveal beneath rounded
-window corners. Corners match the real
-macOS window radius unless you pick square. Popovers, sheets, and
-other windows above the target stay above its ring.
+(no gap coupling). The configured width is the thickness drawn
+outward into the gap — the value `border.fit_gaps` sizes gaps from.
+The ring is stacked just above its window so its own rounded arc
+reads cleanly, with a small overlap lapping onto the window edge to
+keep the corners closed; that overlap isn't part of the width.
+Rounded corners match the real macOS window radius (queried per
+window); square draws sharp corners. The ring is pinned to its
+window's stacking level, so popovers, sheets, and other windows the
+system places above the target still stay above its ring.
 
 Overflow piles and monocle show a ring only on the visible
 top window; set gaps at least as wide as the border to avoid

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -617,12 +617,12 @@ windows. Below it:
   Floating windows aren't ringed when unfocused (only the focused
   window is, whether tiled or floating); monocle always shows only
   the focused ring.
-- **Width**: 1–20 pt of visible thickness outside the window. The
-  renderer adds a separate hidden overlap behind the window, which
-  does not count toward the width or hide content. Rounded uses a
-  small seam allowance; square reaches deeper to fill the reveal
-  beneath rounded corners. Keep gaps at least as wide as the border
-  so neighbouring rings don't touch.
+- **Width**: 1–20 pt — the visible thickness reaching outward into
+  the gap, and the value **Fit layout gaps** sizes gaps from. The
+  ring sits just above the window with a small overlap lapping onto
+  the window edge to keep its corners closed; that overlap isn't
+  part of the width. Keep gaps at least as wide as the border so
+  neighbouring rings don't touch.
 - **Corners**: **Rounded** matches your windows' real corner
   radius; **Square** draws sharp corners — seamless on windows that
   are already square, an intentional squared frame on rounded ones.
@@ -639,8 +639,8 @@ windows. Below it:
 Launcher and panel overlays (Spotlight, Raycast, Alfred) never get
 a ring, even while you type into them — only genuine windows do.
 Popovers, sheets, emoji pickers, and other windows above a bordered
-window stay above its ring; the underlying window remains focused
-and keeps the visible part of its border.
+window stay above its ring, which is pinned to the focused window's
+stacking level; the window stays focused and keeps its full ring.
 
 ## App Bar
 


### PR DESCRIPTION
## What & why

Focus rings drew **behind** the window with **asymmetric** rounded corners. Root cause turned out to be deeper than ordering: the SkyLight fast path was **dead on arrival**. The `SLSTransaction*` mutators and `commit` return no meaningful `CGError` (JankyBorders fires them and only commits); our `== .success` guards read a junk register and failed every `move`/`order`, retiring **every** ring to the AppKit below-order fallback. That fallback let the window's own continuous-squircle corner clip our circular arc — the "drawn behind / asymmetric" look.

Fixes #357.

## Changes

- **Revive the SkyLight path** — fire-and-forget the transaction mutators + commit (gate only on the load-bearing ops: window create, reshape, draw, `makeTransaction`). This is what JankyBorders does.
- **Draw above, pin sub-level** — stack the ring *above* its target so its own clean arc is the only visible edge (symmetric corners), and pin the ring's window **level and sub-level** to the target's, so child popovers/sheets (higher sub-level) still stay above it — above-order **without** the #320 regression.
- **Real per-window corner radius** — query each window's actual radius (`SLSWindowQueryWindows` → `SLSWindowIteratorGetCornerRadii`, fallback 16) so the arc hugs the window instead of a fixed 16 pt guess. Resolved once and cached per window in `BorderManager`.
- **`BorderGeometry` order mode** — `below` keeps the masked hidden-overlap (AppKit fallback); `above` uses a capped visible lap `min(visible/2, 1)` that only closes the corner seam. The `BorderOverlay` facade holds raw inputs and rebuilds geometry for the current backend's order mode, including after a fallback swap. `outwardReach == clampedWidth` is preserved, so `border.fit_gaps` is unchanged (guard-tested).

The AppKit fallback stays below-order (an `NSPanel` can't express a sub-level), so its corner seam remains only on that path.

## Testing

- `swift build && swift test` (1426 tests) + `scripts/lint.sh` + `swift build -c release` all green.
- New tests: above-order geometry, order-mode threading, fallback geometry rebuild, injected-radius drives the arc, fit-gaps invariant across both order modes.
- Manual: corner gap at the Settings window confirmed closed; rings render above with symmetric corners; emoji-picker popover still sits above the ring (#320 preserved).

## Review

Two-agent review (code-reviewer + architect-reviewer), one fix round, both re-reviews clean:
- code-reviewer HIGH (radii-array over-release) **withdrawn** — `SLSWindowIteratorGetCornerRadii` returns an owned (+1) array despite its `Get` name (JankyBorders `CFRelease`s it); `takeRetainedValue` is correct. Documented in-code.
- architect findings (facade OS-I/O, retry-forever, dead `move` branch) all fixed: radius resolution + cache moved to `BorderManager`; `move()` de-Bool'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
