### PR TITLE
fix(ax): tile Chromium browsers via AXManualAccessibility (#360)

### DIFF
--- a/Sources/KiwiDeskCore/AX/AXHelper.swift
+++ b/Sources/KiwiDeskCore/AX/AXHelper.swift
@@ -159,6 +159,23 @@ public enum AXHelper {
         )
     }
 
+    /// Chromium-family browsers (Chrome, Brave, Edge, Arc, …) build
+    /// their AX tree lazily and gate it behind `AXManualAccessibility`
+    /// rather than `AXEnhancedUserInterface` — until it is set,
+    /// `kAXWindowsAttribute` stays empty and their windows are never
+    /// discovered or tiled. Setting it makes that tree materialize.
+    /// Harmless no-op on apps that do not recognize the attribute.
+    public static func setManualAccessibility(
+        pid: pid_t,
+        enabled: Bool
+    ) {
+        AXUIElementSetAttributeValue(
+            appElement(pid: pid),
+            "AXManualAccessibility" as CFString,
+            enabled as CFBoolean
+        )
+    }
+
     /// Raises a window without focusing it or activating its
     /// app — z-order only. Blocking IPC (returns after the
     /// target app processed the action), safe off the main

--- a/Sources/KiwiDeskCore/Events/EventLoop+AppObservation.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop+AppObservation.swift
@@ -60,7 +60,7 @@ extension EventLoop {
         if app.activationPolicy == .regular
             || windows.contains(where: Self.isStandardWindow)
         {
-            enableEnhancedUI(pid: pid)
+            warmAccessibilityTree(pid: pid)
         }
         let displayBounds = FloatDetection.activeDisplayBounds()
         for element in windows {
@@ -81,12 +81,33 @@ extension EventLoop {
                 == kAXStandardWindowSubrole
     }
 
-    func enableEnhancedUI(pid: pid_t) {
-        guard enhancedUIBaselines[pid] == nil,
+    /// Makes an app's AX tree materialize so its windows show up in
+    /// `kAXWindowsAttribute`, by whichever mechanism the app honors:
+    /// `AXEnhancedUserInterface` for Electron/WebKit, or
+    /// `AXManualAccessibility` for Chromium-family browsers (which
+    /// never answer the EUI read). Idempotent; called at attach and
+    /// re-tried on later reconciles for cold apps.
+    func warmAccessibilityTree(pid: pid_t) {
+        guard enhancedUIBaselines[pid] == nil else { return }
+        guard
             let baseline = AXHelper.getEnhancedUserInterface(
                 pid: pid
             )
-        else { return }
+        else {
+            // The app does not answer the EUI read. Chromium-family
+            // browsers (Chrome, Brave, Edge, Arc, …) behave this way
+            // and gate their AX tree behind AXManualAccessibility, so
+            // the EUI warm-up below can never reach them and their
+            // windows never appear in kAXWindowsAttribute. The *set* is
+            // what materializes the tree; the ordinary reconcile
+            // window re-scan then finds the windows — so set it once
+            // (the attribute sticks) rather than re-writing on every
+            // reconcile, since the EUI read that would record a
+            // baseline stays nil for a Chromium app forever (#360).
+            guard manualAXApplied.insert(pid).inserted else { return }
+            AXHelper.setManualAccessibility(pid: pid, enabled: true)
+            return
+        }
         enhancedUIBaselines[pid] = baseline
         guard !baseline else { return }
         // Keep Electron/WebKit AX trees warm (see AGENTS.md).
@@ -106,6 +127,10 @@ extension EventLoop {
                 enabled: false
             )
         }
+        // AXManualAccessibility is left set on the app (an eager AX
+        // tree is what a managed app wants); only forget the pid so a
+        // re-attach re-applies the warm-up (#360).
+        manualAXApplied.remove(pid)
         for id in Array(elements[pid, default: [:]].keys) {
             detectedFloating[id] = nil
             ignorePending.remove(id)

--- a/Sources/KiwiDeskCore/Events/EventLoop+Notifications.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop+Notifications.swift
@@ -47,7 +47,7 @@ extension EventLoop {
         switch note {
         case kAXWindowCreatedNotification:
             if Self.isStandardWindow(element) {
-                enableEnhancedUI(pid: pid)
+                warmAccessibilityTree(pid: pid)
             }
             // A native-tab window's create may really be a tab switch
             // (the old tab vanishes as this one appears). Route it

--- a/Sources/KiwiDeskCore/Events/EventLoop+Reconcile.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop+Reconcile.swift
@@ -50,7 +50,7 @@ extension EventLoop {
             // A cold app may not answer the baseline EUI read at
             // attach time. Retry on later reconciles until one
             // succeeds, without taking another window snapshot.
-            enableEnhancedUI(pid: pid)
+            warmAccessibilityTree(pid: pid)
         }
         var live: Set<WindowID> = []
         var minimized: Set<WindowID> = []

--- a/Sources/KiwiDeskCore/Events/EventLoop.swift
+++ b/Sources/KiwiDeskCore/Events/EventLoop.swift
@@ -48,6 +48,16 @@ public final class EventLoop {
     /// changed it. An ignore transition or stop restores that
     /// exact value instead of assuming KiwiDesk owned `true`.
     var enhancedUIBaselines: [pid_t: Bool] = [:]
+    /// Apps sent `AXManualAccessibility` — the Chromium warm-up used
+    /// when an app never answers the EUI read (#360). Set-once per
+    /// process: unlike the EUI baseline, a Chromium app answers that
+    /// read permanently with nil, so without this the warm-up would
+    /// re-fire a blocking AX write on every reconcile. Deliberately
+    /// not restored on detach — unlike EUI, an eager AX tree is what a
+    /// managed app wants and Chromium's does not tear down, so re-poking
+    /// it costs more than it buys; only the pid is cleared so a
+    /// re-attach re-applies the warm-up.
+    var manualAXApplied: Set<pid_t> = []
     /// Last float-detection verdict per tracked window, so
     /// reconcile can re-check and emit only actual changes
     /// (manual make_floating overrides stay untouched).
@@ -129,6 +139,7 @@ public final class EventLoop {
         observers = [:]
         elements = [:]
         enhancedUIBaselines = [:]
+        manualAXApplied = []
         detectedFloating = [:]
         ignorePending = []
         trackedFrames = [:]


### PR DESCRIPTION
## Summary

Google Chrome — and every Chromium-family browser (Brave, Edge, Arc) — was **completely ignored** for tiling: never enumerated, tracked, or placed.

Root cause: Chromium builds its AX tree lazily and gates it behind **`AXManualAccessibility`**, not `AXEnhancedUserInterface`. Our only warm-up lever was EUI, and the warm-up bailed the moment the baseline EUI read returned nil — which Chromium apps do permanently — so their `kAXWindowsAttribute` stayed empty and no windows were ever discovered.

## Fix

- New `AXHelper.setManualAccessibility(pid:enabled:)` (public AX, mirrors `setEnhancedUserInterface`).
- `warmAccessibilityTree` (renamed from `enableEnhancedUI`, since it now dispatches both mechanisms) sets `AXManualAccessibility` on exactly the apps that don't answer the EUI read. The *set* materializes the tree; the ordinary reconcile window re-scan then finds the windows.
- **Set-once** per process (`manualAXApplied`): a Chromium app answers the EUI read with nil *forever*, so without this guard the warm-up would re-fire a blocking main-thread AX write on every reconcile for the app's whole lifetime (both reviewers flagged this). The attribute is left set on detach (an eager AX tree is what a managed app wants); only the pid is forgotten so a re-attach re-applies.

Scoping on *"doesn't answer EUI"* rather than a hardcoded bundle-id list auto-covers every Chromium fork and is a documented no-op on apps that ignore the attribute.

## Verification

- Debug build, full `swift test` (only the known ExecTests env-flake, passes isolated), lint, **release build** — all green.
- **Manual QA: Chrome now tiles.** ✅
- Reviewed by `code-reviewer` + `architect-reviewer`; the shared Medium finding (perpetual per-reconcile AX write) is fixed by the set-once guard.

Fixes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)