### PR TITLE
feat(space-bar): grouping, overflow cap, badges, front-app segment (#293 stage 2)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+SpaceBar.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+SpaceBar.swift
@@ -120,15 +120,14 @@ extension KiwiCore {
         in space: Space,
         style: SpaceBarStyle
     ) -> (apps: [SpaceBarItemView.App], overflow: Int) {
-        let windows = space.windows.filter {
-            state.windows[$0] != nil
+        // One pass: ids and names stay index-aligned with no
+        // unreachable "?" fallback.
+        let pairs = space.windows.compactMap { id in
+            state.windows[id].map { (id, $0.appName) }
         }
-        let names = windows.map {
-            state.windows[$0]?.appName ?? "?"
-        }
-        let groups = Self.adjacentRuns(of: names).map {
-            Array(windows[$0])
-        }
+        let windows = pairs.map(\.0)
+        let groups = Self.adjacentRuns(of: pairs.map(\.1))
+            .map { Array(windows[$0]) }
         let visible = groups.prefix(Self.spaceBarGlyphCap)
         let hidden = groups.dropFirst(Self.spaceBarGlyphCap)
         let apps = visible.compactMap { group in

--- a/Sources/KiwiDeskCore/App/KiwiCore+SpaceBar.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+SpaceBar.swift
@@ -45,7 +45,30 @@ extension KiwiCore {
         return SpaceBarManager.Bar(
             display: display.id,
             items: items,
+            frontApp: frontApp(display: display.id, style: style),
             strip: strip,
+            style: style
+        )
+    }
+
+    /// The front-app segment's content (#293 verdict 6): the
+    /// focused window of the space this display currently
+    /// shows. Nil while the toggle is off or nothing is
+    /// focused — the segment then hides.
+    func frontApp(
+        display: DisplayID,
+        style: SpaceBarStyle
+    ) -> SpaceBarItemView.App? {
+        guard style.showFrontApp,
+            let current = state.workspaces.currentSpace(
+                on: display
+            ),
+            let space = state.workspaces[current],
+            let focused = space.focused
+        else { return nil }
+        return spaceBarApp(
+            group: [focused],
+            space: space,
             style: style
         )
     }
@@ -64,7 +87,7 @@ extension KiwiCore {
                 guard let space = state.workspaces[id] else {
                     return nil
                 }
-                let apps = spaceBarApps(
+                let (apps, overflow) = spaceBarApps(
                     in: space,
                     style: style
                 )
@@ -77,51 +100,82 @@ extension KiwiCore {
                     space: id,
                     spaceGlyph: spaceIdentifier(for: id),
                     apps: apps,
-                    active: id == current
+                    active: id == current,
+                    overflow: overflow
                 )
             }
     }
 
-    /// One glyph per window in the space's flat array order
-    /// (grouping and the overflow cap land in stage 2).
-    private func spaceBarApps(
+    /// Visible glyph slots per space item (#293 stage 2):
+    /// grouping runs first, then the cap.
+    static let spaceBarGlyphCap = 5
+
+    /// Adjacent same-app runs in the space's flat array order
+    /// collapse into one glyph + count (the App Bar's grouping
+    /// model, without focused-inside expansion), then the cap
+    /// keeps the first `spaceBarGlyphCap` slots. Returns the
+    /// visible slots and the number of *windows* hidden past
+    /// the cap (the "+n" badge).
+    func spaceBarApps(
         in space: Space,
         style: SpaceBarStyle
-    ) -> [SpaceBarItemView.App] {
-        space.windows.compactMap { id in
-            guard let window = state.windows[id] else {
-                return nil
-            }
-            let name = window.appName
-            let icon = NSRunningApplication(
-                processIdentifier: window.pid
-            )?.icon
-            var glyph = appFont.glyph(
-                forAppName: name,
-                source: style.iconSource
-            )
-            if glyph == nil, icon == nil {
-                // No image either way: fall back to the App
-                // Font (specific glyph, else `Default`) so the
-                // slot never renders blank — monochrome, so it
-                // adapts to the bar's colors.
-                glyph =
-                    appFont.glyph(
-                        forAppName: name,
-                        source: .appFont
-                    )
-                    ?? appFont.glyph(
-                        forAppName: "Default",
-                        source: .appFont
-                    )
-            }
-            return SpaceBarItemView.App(
-                name: name,
-                icon: icon,
-                glyph: glyph,
-                focused: space.focused == id
-            )
+    ) -> (apps: [SpaceBarItemView.App], overflow: Int) {
+        let windows = space.windows.filter {
+            state.windows[$0] != nil
         }
+        let names = windows.map {
+            state.windows[$0]?.appName ?? "?"
+        }
+        let groups = Self.adjacentRuns(of: names).map {
+            Array(windows[$0])
+        }
+        let visible = groups.prefix(Self.spaceBarGlyphCap)
+        let hidden = groups.dropFirst(Self.spaceBarGlyphCap)
+        let apps = visible.compactMap { group in
+            spaceBarApp(group: group, space: space, style: style)
+        }
+        return (apps, hidden.reduce(0) { $0 + $1.count })
+    }
+
+    /// One glyph slot for a same-app run.
+    private func spaceBarApp(
+        group: [WindowID],
+        space: Space,
+        style: SpaceBarStyle
+    ) -> SpaceBarItemView.App? {
+        guard let first = group.first,
+            let window = state.windows[first]
+        else { return nil }
+        let name = window.appName
+        let icon = NSRunningApplication(
+            processIdentifier: window.pid
+        )?.icon
+        var glyph = appFont.glyph(
+            forAppName: name,
+            source: style.iconSource
+        )
+        if glyph == nil, icon == nil {
+            // No image either way: fall back to the App Font
+            // (specific glyph, else `Default`) so the slot
+            // never renders blank — monochrome, so it adapts
+            // to the bar's colors.
+            glyph =
+                appFont.glyph(
+                    forAppName: name,
+                    source: .appFont
+                )
+                ?? appFont.glyph(
+                    forAppName: "Default",
+                    source: .appFont
+                )
+        }
+        return SpaceBarItemView.App(
+            name: name,
+            icon: icon,
+            glyph: glyph,
+            focused: space.focused.map(group.contains) ?? false,
+            count: group.count
+        )
     }
 
     /// The configured Space icon (SF Symbol | emoji | single

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
@@ -18,13 +18,16 @@ extension SpaceBarItemView {
 
     /// The slot length an item with `appCount` glyphs wants
     /// along the bar axis: identifier cell + one cell per app
-    /// glyph + padding. The overlay uses this for auto sizing.
+    /// glyph (+ one for the "+n" overflow badge) + padding.
+    /// The overlay uses this for auto sizing.
     static func autoLength(
         appCount: Int,
+        overflow: Int = 0,
         depth: CGFloat
     ) -> CGFloat {
         let cell = max(depth - pad * 2, 8)
-        return pad * 2 + cell + CGFloat(appCount) * cell
+        let slots = appCount + (overflow > 0 ? 1 : 0)
+        return pad * 2 + cell + CGFloat(slots) * cell
     }
 
     override func layout() {
@@ -42,13 +45,84 @@ extension SpaceBarItemView {
         place(identifierImage, at: cursor, cell: cell)
         place(identifierLabel, at: cursor, cell: cell)
         cursor += cell
-        for view in appViews {
+        for (index, view) in appViews.enumerated() {
             place(view, at: cursor, cell: cell)
+            if index < badgeViews.count {
+                layoutBadge(
+                    badgeViews[index],
+                    onCellAt: cursor,
+                    cell: cell
+                )
+            }
+            cursor += cell
+        }
+        if overflow > 0 {
+            // The "+n" badge occupies its own trailing slot,
+            // centered like a glyph.
+            layoutBadge(
+                overflowBadge,
+                onCellAt: cursor,
+                cell: cell,
+                centered: true
+            )
             cursor += cell
         }
         layoutAccent()
         // Corner radius and fonts depend on the final bounds.
         restyle()
+    }
+
+    /// A count badge hugging its glyph cell's top-trailing
+    /// corner (flipped coordinates), or centered in the cell
+    /// for the overflow slot. Circle grows for multi-digit
+    /// counts — same shape as the App Bar's badge.
+    private func layoutBadge(
+        _ badge: NSTextField,
+        onCellAt offset: CGFloat,
+        cell: CGFloat,
+        centered: Bool = false
+    ) {
+        guard !badge.isHidden else { return }
+        let base = min(max(cell * 0.5, 9), 13)
+        badge.font = .systemFont(
+            ofSize: base * 0.9,
+            weight: .bold
+        )
+        let textWidth = ceil(badge.cell?.cellSize.width ?? 0)
+        let diameter = max(base, textWidth + 2)
+        let cellRect =
+            horizontal
+            ? CGRect(
+                x: offset,
+                y: (bounds.height - cell) / 2,
+                width: cell,
+                height: cell
+            )
+            : CGRect(
+                x: (bounds.width - cell) / 2,
+                y: offset,
+                width: cell,
+                height: cell
+            )
+        let rect =
+            centered
+            ? CGRect(
+                x: cellRect.midX - diameter / 2,
+                y: cellRect.midY - diameter / 2,
+                width: diameter,
+                height: diameter
+            )
+            : CGRect(
+                x: cellRect.maxX - diameter + 1,
+                y: cellRect.minY - 1,
+                width: diameter,
+                height: diameter
+            )
+        badge.frame = backingAlignedRect(
+            rect,
+            options: .alignAllEdgesNearest
+        )
+        badge.layer?.cornerRadius = diameter / 2
     }
 
     private func place(

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
@@ -89,7 +89,12 @@ extension SpaceBarItemView {
             weight: .bold
         )
         let textWidth = ceil(badge.cell?.cellSize.width ?? 0)
-        let diameter = max(base, textWidth + 2)
+        // Capped at the cell so a "+42" on a thin bar squeezes
+        // rather than clipping top/bottom under masksToBounds.
+        let diameter = min(
+            max(base, textWidth + 2),
+            cell + 2
+        )
         let cellRect =
             horizontal
             ? CGRect(

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
@@ -1,0 +1,161 @@
+import AppKit
+
+/// State-dependent styling for one Space item (#293): the box,
+/// the two-accent identifier/glyph tints, the count and
+/// overflow badges, and the active indicator. Split from
+/// `SpaceBarItemView.swift` for the file ceiling.
+extension SpaceBarItemView {
+
+    func restyle() {
+        layer?.masksToBounds = true
+        layer?.cornerRadius =
+            style.tabBackground == .boxed ? cornerRadius : 0
+        layer?.backgroundColor = boxColor.cgColor
+        styleIdentifier()
+        styleApps()
+        styleBadges()
+        styleAccent()
+    }
+
+    /// Count and overflow badges follow the space state (#293
+    /// verdict 5, amended): configured badge colors on the
+    /// active space, muted (derived from `textColor`) on
+    /// inactive ones — a saturated badge on a muted space would
+    /// fight the two-accent hierarchy.
+    private func styleBadges() {
+        let background =
+            isActive
+            ? NSColor(kiwiHex: style.groupBadgeColor)
+            : NSColor(kiwiHex: style.textColor)
+                .withAlphaComponent(0.3)
+        let text =
+            isActive
+            ? NSColor(kiwiHex: style.groupBadgeTextColor)
+            : NSColor(kiwiHex: style.textColor)
+        for (index, app) in apps.enumerated() {
+            guard index < badgeViews.count else { break }
+            let badge = badgeViews[index]
+            badge.isHidden = app.count < 2
+            badge.stringValue = "\(app.count)"
+            badge.layer?.backgroundColor = background.cgColor
+            badge.textColor = text
+        }
+        overflowBadge.isHidden = overflow < 1
+        overflowBadge.stringValue = "+\(overflow)"
+        overflowBadge.layer?.backgroundColor =
+            background.cgColor
+        overflowBadge.textColor = text
+    }
+
+    var cornerRadius: CGFloat {
+        style.resolvedCornerRadius(
+            forThickness: min(bounds.width, bounds.height)
+        )
+    }
+
+    private var boxColor: NSColor {
+        // Active wins over hover (matching `stateColor` and the
+        // mouseEntered guard): a click that activates the item
+        // under the pointer must not leave it hover-tinted.
+        if isActive, style.tabBackground == .boxed {
+            return NSColor(kiwiHex: style.activeBoxColor)
+        }
+        if isActive { return .clear }
+        if isHovered {
+            return NSColor(kiwiHex: style.hoverColor)
+        }
+        guard style.tabBackground == .boxed else {
+            return .clear
+        }
+        return NSColor(kiwiHex: style.boxColor)
+    }
+
+    /// The state tier a tinted element takes: active space
+    /// accent, hover text, or the inactive tier.
+    private var stateColor: NSColor {
+        if isActive {
+            return NSColor(kiwiHex: style.activeTextColor)
+        }
+        if isHovered {
+            return NSColor(kiwiHex: style.hoverTextColor)
+        }
+        return NSColor(kiwiHex: style.textColor)
+    }
+
+    private func styleIdentifier() {
+        switch spaceGlyph {
+        case .symbol(let name):
+            identifierLabel.isHidden = true
+            identifierImage.isHidden = false
+            identifierImage.image = NSImage(
+                systemSymbolName: name,
+                accessibilityDescription: nil
+            )
+            identifierImage.symbolConfiguration =
+                NSImage.SymbolConfiguration(
+                    pointSize: identifierFont,
+                    weight: .regular
+                )
+            identifierImage.contentTintColor = stateColor
+        case .text(let text, let tinted):
+            identifierImage.isHidden = true
+            identifierLabel.isHidden = false
+            identifierLabel.stringValue = text
+            identifierLabel.textColor =
+                tinted ? stateColor : .labelColor
+        }
+    }
+
+    private func styleApps() {
+        for (index, app) in apps.enumerated() {
+            guard index < appViews.count else { break }
+            if let glyphField = appViews[index] as? NSTextField {
+                glyphField.stringValue = app.glyph ?? ""
+                glyphField.font =
+                    AppFont.font(size: glyphSize)
+                    ?? .systemFont(ofSize: glyphSize)
+                glyphField.textColor =
+                    app.focused && isActive
+                    ? NSColor(kiwiHex: style.focusedItemColor)
+                    : stateColor
+            }
+        }
+    }
+
+    private func styleAccent() {
+        accent.isHidden = !isActive
+        guard isActive else { return }
+        let highlight = NSColor(kiwiHex: style.highlightColor)
+        switch style.activeIndicator {
+        case .ring:
+            accent.layer?.backgroundColor = nil
+            accent.layer?.borderColor = highlight.cgColor
+            accent.layer?.borderWidth = 2
+            accent.layer?.cornerRadius =
+                style.tabBackground == .boxed ? cornerRadius : 0
+        case .edgeMark:
+            accent.layer?.borderWidth = 0
+            accent.layer?.cornerRadius = 0
+            accent.layer?.backgroundColor = highlight.cgColor
+        case .gap:
+            // No shape marker: `gap` hides the App Bar's active
+            // item, which cannot apply to a space identifier —
+            // colors alone carry the state.
+            accent.isHidden = true
+        }
+    }
+
+    var identifierFont: CGFloat {
+        let thickness =
+            horizontal
+            ? bounds.height : bounds.width
+        let base =
+            style.fontSize > 0
+            ? style.fontSize : thickness * 0.5
+        return min(base, max(thickness - 8, 8))
+    }
+
+    var glyphSize: CGFloat {
+        identifierFont * 0.9
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
@@ -5,6 +5,9 @@ import AppKit
 /// overflow badges, and the active indicator. Split from
 /// `SpaceBarItemView.swift` for the file ceiling.
 extension SpaceBarItemView {
+    /// Muted-badge background alpha over `text_color` — named
+    /// so the stage-3 preview can share the derivation.
+    static let mutedBadgeAlpha: CGFloat = 0.3
 
     func restyle() {
         layer?.masksToBounds = true
@@ -27,7 +30,7 @@ extension SpaceBarItemView {
             isActive
             ? NSColor(kiwiHex: style.groupBadgeColor)
             : NSColor(kiwiHex: style.textColor)
-                .withAlphaComponent(0.3)
+                .withAlphaComponent(Self.mutedBadgeAlpha)
         let text =
             isActive
             ? NSColor(kiwiHex: style.groupBadgeTextColor)

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView.swift
@@ -21,7 +21,12 @@ final class SpaceBarItemView: NSView {
         case text(String, tinted: Bool)
     }
 
-    /// One app glyph in the space's row.
+    /// One app glyph in the space's row — one slot per
+    /// adjacent same-app run (#293 stage 2), wearing a count
+    /// badge when the run holds several windows. No
+    /// focused-inside expansion: glyphs aren't click targets,
+    /// so a group containing the focused window just takes the
+    /// focused accent.
     struct App: Equatable {
         let name: String
         let icon: NSImage?
@@ -29,6 +34,8 @@ final class SpaceBarItemView: NSView {
         /// follows the text-color ladder (#294).
         let glyph: String?
         let focused: Bool
+        /// Windows behind this glyph; > 1 shows a count badge.
+        let count: Int
     }
 
     let identifierImage = NSImageView()
@@ -39,6 +46,10 @@ final class SpaceBarItemView: NSView {
         return tf
     }()
     var appViews: [NSView] = []
+    /// One count badge per glyph slot (hidden below 2).
+    var badgeViews: [NSTextField] = []
+    /// The "+n" overflow badge, its own trailing slot.
+    let overflowBadge = SpaceBarItemView.makeBadge()
     let accent = NSView()
 
     private(set) var space = SpaceID("1")
@@ -47,8 +58,9 @@ final class SpaceBarItemView: NSView {
         tinted: true
     )
     private(set) var apps: [App] = []
+    private(set) var overflow = 0
     private(set) var isActive = false
-    private var isHovered = false
+    private(set) var isHovered = false
     var horizontal = true
     var style = SpaceBarStyle()
     var onSelect: (SpaceID) -> Void = { _ in }
@@ -64,7 +76,25 @@ final class SpaceBarItemView: NSView {
         accent.wantsLayer = true
         addSubview(identifierImage)
         addSubview(identifierLabel)
+        addSubview(overflowBadge)
         addSubview(accent)
+    }
+
+    /// The App Bar's badge shape: a filled circle around a
+    /// bold centered count (`IndicatorBarBadgeCell`).
+    static func makeBadge() -> NSTextField {
+        let tf = NSTextField(labelWithString: "")
+        let cell = IndicatorBarBadgeCell(textCell: "")
+        cell.alignment = .center
+        cell.isEditable = false
+        cell.isSelectable = false
+        cell.isBordered = false
+        cell.isBezeled = false
+        cell.drawsBackground = false
+        tf.cell = cell
+        tf.wantsLayer = true
+        tf.setAccessibilityElement(false)
+        return tf
     }
 
     @available(*, unavailable)
@@ -110,11 +140,13 @@ final class SpaceBarItemView: NSView {
         apps: [App],
         active: Bool,
         horizontal: Bool,
-        style: SpaceBarStyle
+        style: SpaceBarStyle,
+        overflow: Int = 0
     ) {
         self.space = space
         self.spaceGlyph = spaceGlyph
         self.apps = apps
+        self.overflow = overflow
         self.isActive = active
         self.horizontal = horizontal
         self.style = style
@@ -130,11 +162,15 @@ final class SpaceBarItemView: NSView {
     }
 
     private var axLabel: String {
+        // Windows, not visible slots: grouped and past-the-cap
+        // windows still count.
+        let windows =
+            apps.reduce(0) { $0 + $1.count } + overflow
         let name = L(
             "space_bar.item.ax.space",
             "Space %1$@, %2$d applications",
             space.raw,
-            apps.count
+            windows
         )
         return isActive
             ? L(
@@ -155,6 +191,7 @@ final class SpaceBarItemView: NSView {
     /// `image`, so naive reuse would show stale icons.
     private func syncAppViews() {
         appViews.forEach { $0.removeFromSuperview() }
+        badgeViews.forEach { $0.removeFromSuperview() }
         appViews = apps.map { app in
             if app.glyph != nil {
                 let tf = NSTextField(labelWithString: "")
@@ -170,131 +207,13 @@ final class SpaceBarItemView: NSView {
             addSubview(iv)
             return iv
         }
-    }
-
-    // MARK: - Styling
-
-    func restyle() {
-        layer?.masksToBounds = true
-        layer?.cornerRadius =
-            style.tabBackground == .boxed ? cornerRadius : 0
-        layer?.backgroundColor = boxColor.cgColor
-        styleIdentifier()
-        styleApps()
-        styleAccent()
-    }
-
-    var cornerRadius: CGFloat {
-        style.resolvedCornerRadius(
-            forThickness: min(bounds.width, bounds.height)
-        )
-    }
-
-    private var boxColor: NSColor {
-        // Active wins over hover (matching `stateColor` and the
-        // mouseEntered guard): a click that activates the item
-        // under the pointer must not leave it hover-tinted.
-        if isActive, style.tabBackground == .boxed {
-            return NSColor(kiwiHex: style.activeBoxColor)
-        }
-        if isActive { return .clear }
-        if isHovered {
-            return NSColor(kiwiHex: style.hoverColor)
-        }
-        guard style.tabBackground == .boxed else {
-            return .clear
-        }
-        return NSColor(kiwiHex: style.boxColor)
-    }
-
-    /// The state tier a tinted element takes: active space
-    /// accent, hover text, or the inactive tier.
-    private var stateColor: NSColor {
-        if isActive {
-            return NSColor(kiwiHex: style.activeTextColor)
-        }
-        if isHovered {
-            return NSColor(kiwiHex: style.hoverTextColor)
-        }
-        return NSColor(kiwiHex: style.textColor)
-    }
-
-    private func styleIdentifier() {
-        switch spaceGlyph {
-        case .symbol(let name):
-            identifierLabel.isHidden = true
-            identifierImage.isHidden = false
-            identifierImage.image = NSImage(
-                systemSymbolName: name,
-                accessibilityDescription: nil
-            )
-            identifierImage.symbolConfiguration =
-                NSImage.SymbolConfiguration(
-                    pointSize: identifierFont,
-                    weight: .regular
-                )
-            identifierImage.contentTintColor = stateColor
-        case .text(let text, let tinted):
-            identifierImage.isHidden = true
-            identifierLabel.isHidden = false
-            identifierLabel.stringValue = text
-            identifierLabel.textColor =
-                tinted ? stateColor : .labelColor
+        badgeViews = apps.map { _ in
+            let badge = Self.makeBadge()
+            addSubview(badge)
+            return badge
         }
     }
 
-    private func styleApps() {
-        for (index, app) in apps.enumerated() {
-            guard index < appViews.count else { break }
-            if let glyphField = appViews[index] as? NSTextField {
-                glyphField.stringValue = app.glyph ?? ""
-                glyphField.font =
-                    AppFont.font(size: glyphSize)
-                    ?? .systemFont(ofSize: glyphSize)
-                glyphField.textColor =
-                    app.focused && isActive
-                    ? NSColor(kiwiHex: style.focusedItemColor)
-                    : stateColor
-            }
-        }
-    }
-
-    private func styleAccent() {
-        accent.isHidden = !isActive
-        guard isActive else { return }
-        let highlight = NSColor(kiwiHex: style.highlightColor)
-        switch style.activeIndicator {
-        case .ring:
-            accent.layer?.backgroundColor = nil
-            accent.layer?.borderColor = highlight.cgColor
-            accent.layer?.borderWidth = 2
-            accent.layer?.cornerRadius =
-                style.tabBackground == .boxed ? cornerRadius : 0
-        case .edgeMark:
-            accent.layer?.borderWidth = 0
-            accent.layer?.cornerRadius = 0
-            accent.layer?.backgroundColor = highlight.cgColor
-        case .gap:
-            // No shape marker: `gap` hides the App Bar's active
-            // item, which cannot apply to a space identifier —
-            // colors alone carry the state.
-            accent.isHidden = true
-        }
-    }
-
-    var identifierFont: CGFloat {
-        let thickness =
-            horizontal
-            ? bounds.height : bounds.width
-        let base =
-            style.fontSize > 0
-            ? style.fontSize : thickness * 0.5
-        return min(base, max(thickness - 8, 8))
-    }
-
-    var glyphSize: CGFloat {
-        identifierFont * 0.9
-    }
-
-    // Layout lives in SpaceBarItemView+Layout.swift.
+    // Styling lives in SpaceBarItemView+Style.swift;
+    // layout in SpaceBarItemView+Layout.swift.
 }

--- a/Sources/KiwiDeskCore/Bar/SpaceBarManager.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarManager.swift
@@ -11,19 +11,24 @@ public final class SpaceBarManager {
     public struct Bar {
         public let display: DisplayID
         public let items: [SpaceBarOverlay.Item]
+        /// The trailing front-app segment's app; nil while the
+        /// toggle is off or nothing is focused.
+        let frontApp: SpaceBarItemView.App?
         public let strip: CGRect
         /// The resolved style; its `edge` is the stored
         /// absolute edge — single source, like the App Bar.
         public let style: SpaceBarStyle
 
-        public init(
+        init(
             display: DisplayID,
             items: [SpaceBarOverlay.Item],
+            frontApp: SpaceBarItemView.App? = nil,
             strip: CGRect,
             style: SpaceBarStyle
         ) {
             self.display = display
             self.items = items
+            self.frontApp = frontApp
             self.strip = strip
             self.style = style
         }
@@ -88,6 +93,7 @@ public final class SpaceBarManager {
         for bar in valid {
             overlay(for: bar.display).show(
                 items: bar.items,
+                frontApp: bar.frontApp,
                 strip: bar.strip,
                 style: bar.style
             )

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
@@ -6,6 +6,10 @@ import AppKit
 /// text, never hidden — and the divider flips to a horizontal
 /// rule. Informational; no click target.
 extension SpaceBarOverlay {
+    /// The divider rule's alpha over `text_color` — named so
+    /// the stage-3 preview can share it instead of re-deriving.
+    static let frontDividerAlpha: CGFloat = 0.4
+
     /// Lays out (or hides) the segment starting at `cursor`
     /// along the bar axis.
     func renderFrontSegment(
@@ -38,12 +42,14 @@ extension SpaceBarOverlay {
             depth: depth,
             cell: cell,
             horizontal: horizontal,
-            accent: accent
+            accent: accent,
+            style: style
         )
         layoutFrontName(
             app,
             at: offset,
             depth: depth,
+            strip: strip,
             horizontal: horizontal,
             accent: accent,
             style: style
@@ -52,13 +58,21 @@ extension SpaceBarOverlay {
 
     private func attachFrontViewsIfNeeded() {
         guard let content = panelContentView else { return }
+        // Re-added every render so the segment stays ABOVE item
+        // views created later (`syncItemViewCount` appends on
+        // top) — otherwise a long item row paints over it.
         for view in [
             frontDivider, frontIcon, frontGlyph, frontName,
-        ]
-        where view.superview == nil {
-            content.addSubview(view)
+        ] {
+            content.addSubview(
+                view,
+                positioned: .above,
+                relativeTo: nil
+            )
         }
         frontDivider.wantsLayer = true
+        frontIcon.setAccessibilityElement(false)
+        frontName.setAccessibilityElement(false)
     }
 
     /// The separator rule; returns the axis length consumed.
@@ -71,7 +85,8 @@ extension SpaceBarOverlay {
     ) -> CGFloat {
         frontDivider.isHidden = false
         frontDivider.layer?.backgroundColor =
-            color.withAlphaComponent(0.4).cgColor
+            color.withAlphaComponent(Self.frontDividerAlpha)
+            .cgColor
         let inset = (depth - cell) / 2
         frontDivider.frame =
             horizontal
@@ -88,7 +103,8 @@ extension SpaceBarOverlay {
         depth: CGFloat,
         cell: CGFloat,
         horizontal: Bool,
-        accent: NSColor
+        accent: NSColor,
+        style: SpaceBarStyle
     ) -> CGFloat {
         let inset = (depth - cell) / 2
         let frame =
@@ -105,21 +121,39 @@ extension SpaceBarOverlay {
                 width: cell,
                 height: cell
             )
+        // The one AX element the segment exposes: the visible
+        // glyph carries "Front app: <name>"; everything else
+        // stays silent (glyphs are informational).
+        let axLabel = L(
+            "space_bar.front_app.ax",
+            "Front app: %1$@",
+            app.name
+        )
         if let glyph = app.glyph {
             frontIcon.isHidden = true
             frontGlyph.isHidden = false
             frontGlyph.stringValue = glyph
+            // Same ladder as item glyphs: an explicit font_size
+            // wins, else scale with the cell.
+            let size =
+                style.fontSize > 0
+                ? style.fontSize * 0.9 : cell * 0.72
             frontGlyph.font =
-                AppFont.font(size: cell * 0.72)
-                ?? .systemFont(ofSize: cell * 0.72)
+                AppFont.font(size: size)
+                ?? .systemFont(ofSize: size)
             frontGlyph.textColor = accent
             frontGlyph.frame = frame
+            frontGlyph.setAccessibilityElement(true)
+            frontGlyph.setAccessibilityLabel(axLabel)
         } else {
             frontGlyph.isHidden = true
+            frontGlyph.setAccessibilityElement(false)
             frontIcon.isHidden = false
             frontIcon.image = app.icon
             frontIcon.imageScaling = .scaleProportionallyUpOrDown
             frontIcon.frame = frame
+            frontIcon.setAccessibilityElement(true)
+            frontIcon.setAccessibilityLabel(axLabel)
         }
         return cell + SpaceBarItemView.pad
     }
@@ -130,6 +164,7 @@ extension SpaceBarOverlay {
         _ app: SpaceBarItemView.App,
         at offset: CGFloat,
         depth: CGFloat,
+        strip: CGRect,
         horizontal: Bool,
         accent: NSColor,
         style: SpaceBarStyle
@@ -148,10 +183,16 @@ extension SpaceBarOverlay {
         frontName.lineBreakMode = .byTruncatingTail
         frontName.sizeToFit()
         let height = frontName.frame.height
+        // Clamp to the strip's remaining length so a long name
+        // ellipsizes instead of hard-clipping at the panel edge.
+        let available = max(
+            strip.width - offset - SpaceBarItemView.pad,
+            0
+        )
         frontName.frame = CGRect(
             x: offset,
             y: (depth - height) / 2,
-            width: frontName.frame.width,
+            width: min(frontName.frame.width, available),
             height: height
         )
     }

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
@@ -1,0 +1,158 @@
+import AppKit
+
+/// The trailing front-app segment (#293 verdict 6):
+/// `| <glyph + app name>` after the last Space item. On
+/// vertical bars the segment is icon-only — never rotated
+/// text, never hidden — and the divider flips to a horizontal
+/// rule. Informational; no click target.
+extension SpaceBarOverlay {
+    /// Lays out (or hides) the segment starting at `cursor`
+    /// along the bar axis.
+    func renderFrontSegment(
+        _ app: SpaceBarItemView.App?,
+        after cursor: CGFloat,
+        strip: CGRect,
+        style: SpaceBarStyle,
+        horizontal: Bool
+    ) {
+        guard let app else {
+            [frontDivider, frontIcon, frontGlyph, frontName]
+                .forEach { $0.isHidden = true }
+            return
+        }
+        attachFrontViewsIfNeeded()
+        let depth = horizontal ? strip.height : strip.width
+        let cell = max(depth - SpaceBarItemView.pad * 2, 8)
+        let accent = NSColor(kiwiHex: style.activeTextColor)
+        var offset = cursor
+        offset += layoutDivider(
+            at: offset,
+            depth: depth,
+            cell: cell,
+            horizontal: horizontal,
+            color: NSColor(kiwiHex: style.textColor)
+        )
+        offset += layoutFrontGlyph(
+            app,
+            at: offset,
+            depth: depth,
+            cell: cell,
+            horizontal: horizontal,
+            accent: accent
+        )
+        layoutFrontName(
+            app,
+            at: offset,
+            depth: depth,
+            horizontal: horizontal,
+            accent: accent,
+            style: style
+        )
+    }
+
+    private func attachFrontViewsIfNeeded() {
+        guard let content = panelContentView else { return }
+        for view in [
+            frontDivider, frontIcon, frontGlyph, frontName,
+        ]
+        where view.superview == nil {
+            content.addSubview(view)
+        }
+        frontDivider.wantsLayer = true
+    }
+
+    /// The separator rule; returns the axis length consumed.
+    private func layoutDivider(
+        at offset: CGFloat,
+        depth: CGFloat,
+        cell: CGFloat,
+        horizontal: Bool,
+        color: NSColor
+    ) -> CGFloat {
+        frontDivider.isHidden = false
+        frontDivider.layer?.backgroundColor =
+            color.withAlphaComponent(0.4).cgColor
+        let inset = (depth - cell) / 2
+        frontDivider.frame =
+            horizontal
+            ? CGRect(x: offset, y: inset, width: 1, height: cell)
+            : CGRect(x: inset, y: offset, width: cell, height: 1)
+        return 1 + SpaceBarItemView.pad
+    }
+
+    /// The focused app's glyph (App Font ligature or image);
+    /// returns the axis length consumed.
+    private func layoutFrontGlyph(
+        _ app: SpaceBarItemView.App,
+        at offset: CGFloat,
+        depth: CGFloat,
+        cell: CGFloat,
+        horizontal: Bool,
+        accent: NSColor
+    ) -> CGFloat {
+        let inset = (depth - cell) / 2
+        let frame =
+            horizontal
+            ? CGRect(
+                x: offset,
+                y: inset,
+                width: cell,
+                height: cell
+            )
+            : CGRect(
+                x: inset,
+                y: offset,
+                width: cell,
+                height: cell
+            )
+        if let glyph = app.glyph {
+            frontIcon.isHidden = true
+            frontGlyph.isHidden = false
+            frontGlyph.stringValue = glyph
+            frontGlyph.font =
+                AppFont.font(size: cell * 0.72)
+                ?? .systemFont(ofSize: cell * 0.72)
+            frontGlyph.textColor = accent
+            frontGlyph.frame = frame
+        } else {
+            frontGlyph.isHidden = true
+            frontIcon.isHidden = false
+            frontIcon.image = app.icon
+            frontIcon.imageScaling = .scaleProportionallyUpOrDown
+            frontIcon.frame = frame
+        }
+        return cell + SpaceBarItemView.pad
+    }
+
+    /// The app name — horizontal bars only (vertical stays
+    /// icon-only, never rotated).
+    private func layoutFrontName(
+        _ app: SpaceBarItemView.App,
+        at offset: CGFloat,
+        depth: CGFloat,
+        horizontal: Bool,
+        accent: NSColor,
+        style: SpaceBarStyle
+    ) {
+        guard horizontal else {
+            frontName.isHidden = true
+            return
+        }
+        frontName.isHidden = false
+        frontName.stringValue = app.name
+        let size =
+            style.fontSize > 0
+            ? style.fontSize : depth * 0.42
+        frontName.font = .systemFont(ofSize: size)
+        frontName.textColor = accent
+        frontName.lineBreakMode = .byTruncatingTail
+        frontName.sizeToFit()
+        let height = frontName.frame.height
+        frontName.frame = CGRect(
+            x: offset,
+            y: (depth - height) / 2,
+            width: frontName.frame.width,
+            height: height
+        )
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
@@ -15,6 +15,8 @@ public final class SpaceBarOverlay {
         let spaceGlyph: SpaceBarItemView.Identifier
         let apps: [SpaceBarItemView.App]
         let active: Bool
+        /// Windows hidden past the glyph cap ("+n" badge).
+        let overflow: Int
     }
 
     /// Click-to-focus hook; wired to `KiwiCore.focusSpace`.
@@ -22,18 +24,40 @@ public final class SpaceBarOverlay {
 
     private var panel: NSPanel?
     var itemViews: [SpaceBarItemView] = []
+    // The optional trailing front-app segment (#293 verdict 6):
+    // a divider rule, the focused app's glyph, and — on
+    // horizontal bars only — its name.
+    let frontDivider = NSView()
+    let frontIcon = NSImageView()
+    let frontGlyph: NSTextField = {
+        let tf = NSTextField(labelWithString: "")
+        tf.alignment = .center
+        tf.setAccessibilityElement(false)
+        return tf
+    }()
+    let frontName = NSTextField(labelWithString: "")
     private var lastShown:
         (
-            items: [Item], strip: CGRect, style: SpaceBarStyle
+            items: [Item],
+            frontApp: SpaceBarItemView.App?,
+            strip: CGRect,
+            style: SpaceBarStyle
         )?
 
     public init() {}
 
     public var isVisible: Bool { panel?.isVisible ?? false }
 
+    /// The panel's content view, for the front-segment
+    /// extension (the panel itself stays private).
+    var panelContentView: NSView? { panel?.contentView }
+
     /// Renders `items` into `strip` (AX coordinates).
-    public func show(
+    /// `frontApp` is the trailing segment's app; nil while the
+    /// toggle is off or no window is focused.
+    func show(
         items: [Item],
+        frontApp: SpaceBarItemView.App? = nil,
         strip: CGRect,
         style: SpaceBarStyle
     ) {
@@ -43,7 +67,7 @@ public final class SpaceBarOverlay {
             hide()
             return
         }
-        lastShown = (items, strip, style)
+        lastShown = (items, frontApp, strip, style)
         render()
     }
 
@@ -56,7 +80,7 @@ public final class SpaceBarOverlay {
 
     private func render() {
         guard let state = lastShown else { return }
-        let (items, strip, style) = state
+        let (items, frontApp, strip, style) = state
         let panel = self.panel ?? makePanel()
         self.panel = panel
         styleContainer(panel, style: style, strip: strip)
@@ -71,6 +95,7 @@ public final class SpaceBarOverlay {
                 ? style.itemSize
                 : SpaceBarItemView.autoLength(
                     appCount: item.apps.count,
+                    overflow: item.overflow,
                     depth: depth
                 )
             view.frame =
@@ -94,12 +119,20 @@ public final class SpaceBarOverlay {
                 apps: item.apps,
                 active: item.active,
                 horizontal: horizontal,
-                style: style
+                style: style,
+                overflow: item.overflow
             )
             view.onSelect = { [weak self] space in
                 self?.onSelect(space)
             }
         }
+        renderFrontSegment(
+            frontApp,
+            after: cursor,
+            strip: strip,
+            style: style,
+            horizontal: horizontal
+        )
         panel.setFrame(
             GeometryUtils.flip(
                 strip,

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -593,6 +593,7 @@
   "slot_size.points": "Points",
   "slot_size.row_height": "Row height",
   "slot_size.unit": "Size unit",
+  "space_bar.front_app.ax": "Front app: %1$@",
   "space_bar.item.ax.current": "%1$@, current",
   "space_bar.item.ax.not_current": "%1$@, not current",
   "space_bar.item.ax.space": "Space %1$@, %2$d applications",

--- a/Tests/KiwiDeskCoreTests/SpaceBarDriverTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDriverTests.swift
@@ -120,9 +120,8 @@ struct SpaceBarDriverTests {
         let core = makeCore()
         core.state.workspaces.assign(SpaceID("1"), to: display)
         core.state.workspaces.activate(SpaceID("1"))
-        // 7 distinct apps → 7 groups; cap 5 → 2 hidden groups.
-        // The last hidden one holds two windows, so n counts
-        // WINDOWS (3), not slots.
+        // 7 apps → 7 groups; cap 5 → 2 hidden groups of two
+        // windows each, so n counts WINDOWS (4), not slots (2).
         for id in 1...6 {
             core.state.apply(
                 .windowCreated(

--- a/Tests/KiwiDeskCoreTests/SpaceBarDriverTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDriverTests.swift
@@ -90,6 +90,81 @@ struct SpaceBarDriverTests {
         )
     }
 
+    @Test("Adjacent same-app runs group; non-adjacent stay")
+    func grouping() throws {
+        let core = makeCore()
+        core.state.workspaces.assign(SpaceID("1"), to: display)
+        core.state.workspaces.activate(SpaceID("1"))
+        for (id, app) in [
+            (1, "Zed"), (2, "Zed"), (3, "Finder"), (4, "Zed"),
+        ] {
+            core.state.apply(
+                .windowCreated(window(UInt32(id), app: app))
+            )
+        }
+        // Focus a member of the leading run: the group takes
+        // the focused flag, and stays collapsed (no expansion).
+        core.state.apply(.windowFocused(WindowID(1)))
+        let (apps, overflow) = core.spaceBarApps(
+            in: core.state.workspaces[SpaceID("1")]!,
+            style: SpaceBarStyle()
+        )
+        #expect(overflow == 0)
+        #expect(apps.map(\.name) == ["Zed", "Finder", "Zed"])
+        #expect(apps.map(\.count) == [2, 1, 1])
+        #expect(apps.map(\.focused) == [true, false, false])
+    }
+
+    @Test("Groups past the cap collapse into the +n overflow")
+    func overflowCap() throws {
+        let core = makeCore()
+        core.state.workspaces.assign(SpaceID("1"), to: display)
+        core.state.workspaces.activate(SpaceID("1"))
+        // 7 distinct apps → 7 groups; cap 5 → 2 hidden groups.
+        // The last hidden one holds two windows, so n counts
+        // WINDOWS (3), not slots.
+        for id in 1...6 {
+            core.state.apply(
+                .windowCreated(
+                    window(UInt32(id), app: "App\(id)")
+                )
+            )
+        }
+        core.state.apply(
+            .windowCreated(window(7, app: "App6"))
+        )
+        core.state.apply(
+            .windowCreated(window(8, app: "App7"))
+        )
+        core.state.apply(
+            .windowCreated(window(9, app: "App7"))
+        )
+        let (apps, overflow) = core.spaceBarApps(
+            in: core.state.workspaces[SpaceID("1")]!,
+            style: SpaceBarStyle()
+        )
+        #expect(apps.count == 5)
+        #expect(overflow == 4)
+    }
+
+    @Test("Front segment follows the toggle and the focus")
+    func frontSegment() throws {
+        let core = seededCore()
+        // Toggle off → nil.
+        #expect(
+            core.frontApp(
+                display: display,
+                style: SpaceBarStyle()
+            ) == nil
+        )
+        // Toggle on → the focused window's app ("Mail").
+        var style = SpaceBarStyle()
+        style.showFrontApp = true
+        let app = core.frontApp(display: display, style: style)
+        #expect(app?.name == "Mail")
+        #expect(app?.count == 1)
+    }
+
     @Test("Identifier ladder: icon, symbol probe, monogram")
     func identifierLadder() {
         let core = makeCore()

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1124,6 +1124,26 @@ choice: no conflict dialog, no automatic relocation, no blocked
 picker. The GUI explains the resulting order inline; profile
 load/import accepts it silently.
 
+**The Space Bar always groups; there is no knob.** (#293.)
+Adjacent same-app runs collapse into one glyph + count badge
+unconditionally — unlike the App Bar's `group_adjacent_windows`
+toggle. The asymmetry is structural, not an oversight: App Bar
+tabs are click targets, so grouping changes interaction and
+earns a toggle; Space Bar glyphs are informational, and the
+fixed cap of five glyph slots depends on grouping running
+first (an ungrouped mode would burn the cap on duplicates
+while conveying less). The overflow badge's `+n` counts hidden
+**windows**, not slots — the same unit as the per-glyph count
+badges and the item's accessibility label.
+
+**The front-app segment is per-display.** (#293.) With
+`space_bar.show_front_app` on, each display's bar shows the
+focused window of the Space that display currently shows — not
+the globally frontmost app (sketchybar's `front_app`). One bar
+per display means per-display content, consistent with every
+other per-display fact in the bar; a secondary display shows
+its own space's remembered focus.
+
 **Tab background and active indicator are orthogonal.** (#228.)
 The old coupled `style` enum (`pills` / `segments` / `underline`)
 conflated two orthogonal concerns: the per-tab box rendering and

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1803,9 +1803,11 @@ space_bar.set_corner_roundness(50)
 **Expects:** boolean (default `false`).
 
 **Does:** shows a trailing front-app segment after the last
-Space item — a divider, then the focused app's glyph and name.
-On vertical (left/right) bars the segment is icon-only; the
-divider flips to a horizontal rule.
+Space item — a divider, then the glyph and name of the focused
+window of the Space **this display currently shows** (per
+display, not the globally frontmost app — one bar per display,
+per-display content). On vertical (left/right) bars the
+segment is icon-only; the divider flips to a horizontal rule.
 
 **Example:**
 

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1643,8 +1643,15 @@ Spaces: one bar per display, listing that display's Spaces in
 profile order — each item shows the Space's identifier
 (configured icon, else `N.square` for numeric ids or a
 two-letter monogram for named ones) plus a compact glyph per
-window in that Space. Clicking a Space switches to it. App
-glyphs are informational — not click targets.
+window in that Space. Adjacent windows of the same app collapse
+into one glyph wearing a count badge (non-adjacent duplicates
+stay separate); past five glyph slots the rest fold into a
+`+n` badge counting the hidden windows. Badges use the
+configured badge colors on the active Space and render muted on
+inactive ones. Clicking a Space switches to it. App glyphs are
+informational — not click targets, and a group holding the
+focused window stays collapsed (it just takes the focused
+accent).
 
 The bar is **layout-independent** and reserves real screen area
 on its edge before any layout runs. It may share an edge with
@@ -1795,9 +1802,10 @@ space_bar.set_corner_roundness(50)
 
 **Expects:** boolean (default `false`).
 
-**Does:** reserved for the trailing front-app segment
-(`| <icon + app name>`); rendering lands with the runtime
-polish stage.
+**Does:** shows a trailing front-app segment after the last
+Space item — a divider, then the focused app's glyph and name.
+On vertical (left/right) bars the segment is icon-only; the
+divider flips to a horizontal rule.
 
 **Example:**
 
@@ -1837,9 +1845,9 @@ setting. The three-state ladder is the bar's signature:
   `space_bar.set_highlight_color` /
   `space_bar.set_background_color` — as the App Bar.
 - `space_bar.set_group_badge_color` /
-  `space_bar.set_group_badge_text_color` — the count badges
-  (grouping and the overflow cap land with the runtime polish
-  stage).
+  `space_bar.set_group_badge_text_color` — the count and `+n`
+  overflow badges (active Space; inactive Spaces mute them
+  from `text_color`).
 
 **Example:**
 


### PR DESCRIPTION
## Summary

Stage 2 of #293 — runtime polish on the merged Space Bar core, per the settled verdicts (5 & 6, incl. the 2026-07-17 amendments):

- **Grouping**: adjacent same-app runs collapse into one glyph + count badge (shared `adjacentRuns` detection); non-adjacent duplicates stay separate; **no focused-inside expansion** — a group holding the focused window stays collapsed and takes the focused accent. Always on, no knob (recorded in design-decisions: glyphs aren't click targets and the cap depends on grouping).
- **Cap**: grouping first, then five visible glyph slots; the rest fold into a `+n` badge counting hidden **windows** (same unit as the count badges and the AX label).
- **Badges**: App Bar's circle shape; configured `group_badge_*` colors on the active space, muted (`text_color` @ named alpha) on inactive ones.
- **Front-app segment** (`show_front_app`, default off): divider + focused app's glyph + name after the last item; **per display** (the focused window of the space that display shows — documented + design-decisions row); vertical bars icon-only with the divider flipped; one AX element ("Front app: X").
- AX item labels count windows (grouped + past-the-cap), not visible slots.
- Tests: grouping/no-expansion/focused-group, window-counted overflow, front segment toggle+focus.

## Review

Two fresh agents round 1 → all findings Low/text → fix batch `daac0ed` (name-truncation clamp, font_size ladder for the front glyph, AX consolidation, z-order guard, badge diameter cap, named alphas, one-pass driver pairing, doc rows). Per §3 gating, self-verified — no re-review round.

## Verify

lint exit 0, build, 1465 tests, release build — green locally. CI red = billing, known.

Part of #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SemgNPhxraCu16L1Tx2CRo