### PR TITLE
fix(settings): bars QA polish — switch, previews, copy button

### DIFF
--- a/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
@@ -20,16 +20,22 @@ struct BarsSection: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                Picker("", selection: $editor) {
-                    Text(L("bars.switch.app_bar", "App Bar"))
-                        .tag(Editor.appBar)
-                    Text(
-                        L("bars.switch.space_bar", "Space Bar")
-                    )
-                    .tag(Editor.spaceBar)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
+                SegmentedPicker(
+                    selection: $editor,
+                    options: [
+                        (
+                            L("bars.switch.app_bar", "App Bar"),
+                            Editor.appBar
+                        ),
+                        (
+                            L(
+                                "bars.switch.space_bar",
+                                "Space Bar"
+                            ),
+                            Editor.spaceBar
+                        ),
+                    ]
+                )
                 switch editor {
                 case .appBar: appBarEditor
                 case .spaceBar:

--- a/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
@@ -36,6 +36,9 @@ struct BarsSection: View {
                         ),
                     ]
                 )
+                .accessibilityLabel(
+                    L("bars.switch", "Bar")
+                )
                 switch editor {
                 case .appBar: appBarEditor
                 case .spaceBar:

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip+Geometry.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip+Geometry.swift
@@ -1,0 +1,98 @@
+import KiwiDeskCore
+import SwiftUI
+
+// The mock can't be to-scale (a 200 pt tab won't fit an 84 pt
+// canvas), so each dimension maps its full real range onto a
+// legible preview range *proportionally* — dragging any
+// slider always keeps moving the mock, rather than hitting a
+// hard cap partway (which read as "the setting stopped
+// working"). Relative, not absolute; the slider readouts show
+// the true pt values.
+//
+// Split from AppBarPreviewStrip.swift (file-size ceiling); the
+// SpaceBar twin keeps its metrics inline — its budget block is
+// smaller.
+extension AppBarPreviewStrip {
+    /// Real thickness 8–80 pt → 14–44 pt of canvas depth.
+    var thickness: CGFloat {
+        scale(style.thickness, from: 8...80, to: 14...44)
+    }
+
+    /// Real gap 0–40 pt → 0–16 pt (0–5 pt on a vertical bar,
+    /// where the inner-box height budgets the axis).
+    var gap: CGFloat {
+        style.edge.isHorizontal
+            ? scale(style.itemGap, from: 0...40, to: 0...16)
+            : scale(style.itemGap, from: 0...40, to: 0...5)
+    }
+
+    /// The shared %-resolve against the preview's own (scaled)
+    /// thickness, so the mock rounds like the runtime bar;
+    /// clamped to the slot's smaller dimension so a vertical
+    /// bar's short slots keep sane corners.
+    var corner: CGFloat {
+        min(
+            style.resolvedCornerRadius(forThickness: thickness),
+            min(slotWidth, slotHeight) / 2
+        )
+    }
+
+    /// Item length along the bar axis: honor an explicit
+    /// `itemSize` (mapped 1–200 pt → 20–72 pt), else size to the
+    /// content kind.
+    var slotLength: CGFloat {
+        if style.itemSize > 0 {
+            return scale(style.itemSize, from: 1...200, to: 20...72)
+        }
+        switch style.content {
+        case .icon: return max(thickness, 22)
+        case .name: return 44
+        case .iconAndName: return 56
+        }
+    }
+
+    /// Length along a **vertical** bar's axis, compressed so
+    /// three slots plus gaps stay inside the 72 pt inner box
+    /// (the 84 pt canvas minus the 12 pt edge-hug inset):
+    /// 3 × 18 + 2 × 5 + 8 strip padding = 72 at the maxima.
+    /// The item-size slider still visibly moves the mock.
+    var verticalSlotLength: CGFloat {
+        if style.itemSize > 0 {
+            return scale(style.itemSize, from: 1...200, to: 14...18)
+        }
+        return 16
+    }
+
+    /// Concrete slot frame for the current orientation: along a
+    /// horizontal bar the length runs in x and the thickness in
+    /// y; a vertical bar swaps them.
+    var slotWidth: CGFloat {
+        style.edge.isHorizontal ? slotLength : thickness
+    }
+    var slotHeight: CGFloat {
+        style.edge.isHorizontal ? thickness : verticalSlotLength
+    }
+
+    /// Linear map of `value` from one closed range onto another,
+    /// clamped to the target range at the ends.
+    func scale(
+        _ value: CGFloat,
+        from src: ClosedRange<CGFloat>,
+        to dst: ClosedRange<CGFloat>
+    ) -> CGFloat {
+        let span = src.upperBound - src.lowerBound
+        guard span > 0 else { return dst.lowerBound }
+        let t = (value - src.lowerBound) / span
+        let mapped =
+            dst.lowerBound
+            + min(max(t, 0), 1) * (dst.upperBound - dst.lowerBound)
+        return mapped
+    }
+
+    var font: CGFloat {
+        let base =
+            style.fontSize > 0
+            ? style.fontSize : thickness * 0.42
+        return min(base, thickness * 0.55, slotHeight * 0.55)
+    }
+}

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
@@ -119,23 +119,38 @@ struct AppBarPreviewStrip: View {
             .overlay(alignment: .topTrailing) { badge(t) }
     }
 
+    /// Vertical edges never draw a horizontal name: the real
+    /// bar letter-stacks it ("S/a/f/…", `AppBarItemView`'s
+    /// stacked()) and hides text a slot can't fit. The mock's
+    /// mini slots can't fit a stack, so the icon — or the
+    /// name's initial in Name-only mode — stands in.
     @ViewBuilder private func tabContent(
         _ t: MockTab
     ) -> some View {
-        HStack(spacing: 3) {
-            if style.content != .name {
-                Image(systemName: t.icon)
-                    .font(.system(size: font))
-                    .foregroundStyle(iconColor(t))
+        if style.edge.isHorizontal {
+            HStack(spacing: 3) {
+                if style.content != .name {
+                    Image(systemName: t.icon)
+                        .font(.system(size: font))
+                        .foregroundStyle(iconColor(t))
+                }
+                if style.content != .icon {
+                    Text(t.name)
+                        .font(.system(size: font))
+                        .lineLimit(1)
+                        .foregroundStyle(textColor(t))
+                }
             }
-            if style.content != .icon {
-                Text(t.name)
-                    .font(.system(size: font))
-                    .lineLimit(1)
-                    .foregroundStyle(textColor(t))
-            }
+            .padding(.horizontal, 4)
+        } else if style.content == .name {
+            Text(String(t.name.prefix(1)))
+                .font(.system(size: font))
+                .foregroundStyle(textColor(t))
+        } else {
+            Image(systemName: t.icon)
+                .font(.system(size: font))
+                .foregroundStyle(iconColor(t))
         }
-        .padding(.horizontal, 4)
     }
 
     private func textColor(_ t: MockTab) -> Color {
@@ -253,96 +268,6 @@ struct AppBarPreviewStrip: View {
         Color(kiwiHex: hex)
     }
 
-    // MARK: - Geometry
-
-    // The mock can't be to-scale (a 200 pt tab won't fit an 84 pt
-    // canvas), so each dimension maps its full real range onto a
-    // legible preview range *proportionally* — dragging any
-    // slider always keeps moving the mock, rather than hitting a
-    // hard cap partway (which read as "the setting stopped
-    // working"). Relative, not absolute; the slider readouts show
-    // the true pt values.
-
-    /// Real thickness 8–80 pt → 14–44 pt of canvas depth.
-    private var thickness: CGFloat {
-        scale(style.thickness, from: 8...80, to: 14...44)
-    }
-
-    /// Real gap 0–40 pt → 0–16 pt (0–8 pt on a vertical bar,
-    /// where the canvas height budgets the axis).
-    private var gap: CGFloat {
-        style.edge.isHorizontal
-            ? scale(style.itemGap, from: 0...40, to: 0...16)
-            : scale(style.itemGap, from: 0...40, to: 0...5)
-    }
-
-    /// The shared %-resolve against the preview's own (scaled)
-    /// thickness, so the mock rounds like the runtime bar;
-    /// clamped to the slot's smaller dimension so a vertical
-    /// bar's short slots keep sane corners.
-    private var corner: CGFloat {
-        min(
-            style.resolvedCornerRadius(forThickness: thickness),
-            min(slotWidth, slotHeight) / 2
-        )
-    }
-
-    /// Item length along the bar axis: honor an explicit
-    /// `itemSize` (mapped 1–200 pt → 20–72 pt), else size to the
-    /// content kind.
-    private var slotLength: CGFloat {
-        if style.itemSize > 0 {
-            return scale(style.itemSize, from: 1...200, to: 20...72)
-        }
-        switch style.content {
-        case .icon: return max(thickness, 22)
-        case .name: return 44
-        case .iconAndName: return 56
-        }
-    }
-
-    /// Length along a **vertical** bar's axis, compressed so
-    /// three slots plus gaps stay inside the 72 pt inner box
-    /// (the 84 pt canvas minus the 12 pt edge-hug inset):
-    /// 3 × 18 + 2 × 5 + 8 strip padding = 72 at the maxima.
-    /// The item-size slider still visibly moves the mock.
-    private var verticalSlotLength: CGFloat {
-        if style.itemSize > 0 {
-            return scale(style.itemSize, from: 1...200, to: 14...18)
-        }
-        return 16
-    }
-
-    /// Concrete slot frame for the current orientation: along a
-    /// horizontal bar the length runs in x and the thickness in
-    /// y; a vertical bar swaps them.
-    private var slotWidth: CGFloat {
-        style.edge.isHorizontal ? slotLength : thickness
-    }
-    private var slotHeight: CGFloat {
-        style.edge.isHorizontal ? thickness : verticalSlotLength
-    }
-
-    /// Linear map of `value` from one closed range onto another,
-    /// clamped to the target range at the ends.
-    private func scale(
-        _ value: CGFloat,
-        from src: ClosedRange<CGFloat>,
-        to dst: ClosedRange<CGFloat>
-    ) -> CGFloat {
-        let span = src.upperBound - src.lowerBound
-        guard span > 0 else { return dst.lowerBound }
-        let t = (value - src.lowerBound) / span
-        let mapped =
-            dst.lowerBound
-            + min(max(t, 0), 1) * (dst.upperBound - dst.lowerBound)
-        return mapped
-    }
-
-    private var font: CGFloat {
-        let base =
-            style.fontSize > 0
-            ? style.fontSize : thickness * 0.42
-        return min(base, thickness * 0.55, slotHeight * 0.55)
-    }
+    // Geometry/scale mapping lives in
+    // AppBarPreviewStrip+Geometry.swift.
 }

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
@@ -34,6 +34,9 @@ struct AppBarPreviewStrip: View {
                 strip.padding(6)
             }
             .frame(height: 84)
+            // Belt-and-braces (SpaceBar twin has the same):
+            // a mock must never spill over the caption below.
+            .clipShape(RoundedRectangle(cornerRadius: 6))
             .animation(LayoutSchematic.damping, value: style)
             .accessibilityElement()
             .accessibilityLabel(axLabel)
@@ -270,7 +273,7 @@ struct AppBarPreviewStrip: View {
     private var gap: CGFloat {
         style.edge.isHorizontal
             ? scale(style.itemGap, from: 0...40, to: 0...16)
-            : scale(style.itemGap, from: 0...40, to: 0...8)
+            : scale(style.itemGap, from: 0...40, to: 0...5)
     }
 
     /// The shared %-resolve against the preview's own (scaled)
@@ -299,14 +302,15 @@ struct AppBarPreviewStrip: View {
     }
 
     /// Length along a **vertical** bar's axis, compressed so
-    /// three slots plus gaps stay inside the 84 pt canvas
-    /// (3 × 20 + 2 × 8 + padding = 84 at the maxima). The
-    /// item-size slider still visibly moves the mock.
+    /// three slots plus gaps stay inside the 72 pt inner box
+    /// (the 84 pt canvas minus the 12 pt edge-hug inset):
+    /// 3 × 18 + 2 × 5 + 8 strip padding = 72 at the maxima.
+    /// The item-size slider still visibly moves the mock.
     private var verticalSlotLength: CGFloat {
         if style.itemSize > 0 {
-            return scale(style.itemSize, from: 1...200, to: 16...20)
+            return scale(style.itemSize, from: 1...200, to: 14...18)
         }
-        return 18
+        return 16
     }
 
     /// Concrete slot frame for the current orientation: along a

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
@@ -28,10 +28,10 @@ struct AppBarPreviewStrip: View {
 
     var body: some View {
         VStack(spacing: 4) {
-            ZStack {
+            ZStack(alignment: canvasAlignment) {
                 RoundedRectangle(cornerRadius: 6)
                     .fill(Color.secondary.opacity(0.12))
-                strip
+                strip.padding(6)
             }
             .frame(height: 84)
             .animation(LayoutSchematic.damping, value: style)
@@ -45,6 +45,20 @@ struct AppBarPreviewStrip: View {
     }
 
     // MARK: - Strip
+
+    /// The strip hugs the canvas side matching the chosen
+    /// edge (top bar sits at the canvas top), so the edge
+    /// choice is visible, not just captioned. The off-axis
+    /// emptiness is the point — it mirrors the bar's real
+    /// relationship to the desktop.
+    private var canvasAlignment: Alignment {
+        switch style.edge {
+        case .top: .top
+        case .bottom: .bottom
+        case .left: .leading
+        case .right: .trailing
+        }
+    }
 
     private var strip: some View {
         stack {

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceBarPreviewStrip.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceBarPreviewStrip.swift
@@ -125,8 +125,9 @@ struct SpaceBarPreviewStrip: View {
     // MARK: - Metrics
 
     /// Cross-axis depth. The vertical range is tighter so two
-    /// whole items + the strip padding stay inside the 96 pt
-    /// canvas at every thickness.
+    /// whole items + the strip padding stay inside the 84 pt
+    /// inner box (96 pt canvas minus the 12 pt edge-hug
+    /// inset) at every thickness.
     var thickness: CGFloat {
         style.edge.isHorizontal
             ? scale(style.thickness, from: 8...80, to: 16...40)
@@ -135,7 +136,9 @@ struct SpaceBarPreviewStrip: View {
 
     /// Square glyph cell. Vertical budget: two items of
     /// (2 cells + 2 spacing + 6 padding) + one gap + 8 strip
-    /// padding ≤ 96 → cell ≤ 13 at the maxima.
+    /// padding ≤ 84 (canvas minus edge-hug inset) → cell ≤ 13
+    /// exactly at the maxima — no slack left; re-derive before
+    /// touching any of these constants.
     var cell: CGFloat {
         style.edge.isHorizontal
             ? thickness * 0.62

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceBarPreviewStrip.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceBarPreviewStrip.swift
@@ -24,10 +24,10 @@ struct SpaceBarPreviewStrip: View {
 
     var body: some View {
         VStack(spacing: 4) {
-            ZStack {
+            ZStack(alignment: canvasAlignment) {
                 RoundedRectangle(cornerRadius: 6)
                     .fill(Color.secondary.opacity(0.12))
-                content
+                content.padding(6)
             }
             .frame(height: 96)
             // Belt-and-braces: a mock must never spill over
@@ -44,6 +44,18 @@ struct SpaceBarPreviewStrip: View {
     }
 
     // MARK: - Composition
+
+    /// The composite hugs the canvas side matching the chosen
+    /// edge (`AppBarPreviewStrip` twin) — edge choice is seen,
+    /// not just captioned; off-axis emptiness is deliberate.
+    private var canvasAlignment: Alignment {
+        switch style.edge {
+        case .top: .top
+        case .bottom: .bottom
+        case .left: .leading
+        case .right: .trailing
+        }
+    }
 
     /// The strip plus, when stacked, the App Bar stand-in on
     /// the window-facing side of the shared edge.

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
@@ -39,11 +39,11 @@ struct SpaceBarEditorSection: View {
             )
             behavior
             appearance
-            copyAppearance
         }
         SettingsSection(
             L("space_bar.colors.title", "Space Bar colors")
         ) {
+            copyAppearance
             accentLadder
             AppBarColorGrid { otherColors }
         }
@@ -236,29 +236,47 @@ struct SpaceBarEditorSection: View {
 
     /// One-shot copy, then fully independent — never a live
     /// inherit. Excludes enabled and edge (visibility and
-    /// placement are not appearance).
+    /// placement are not appearance). Leads the colors section
+    /// (colors are its most consequential effect), leading-
+    /// aligned in the Reset-Overrides button language; the
+    /// one-shot caveat rides a persistent caption, never
+    /// hover alone.
     private var copyAppearance: some View {
-        Button {
-            model.config.settings.spaceBarStyle
-                .copyAppearance(
-                    from: model.config.settings.appBarStyle
+        VStack(alignment: .leading, spacing: 4) {
+            Button {
+                model.config.settings.spaceBarStyle
+                    .copyAppearance(
+                        from: model.config.settings.appBarStyle
+                    )
+            } label: {
+                Text(
+                    L(
+                        "space_bar.copy_appearance",
+                        "Copy App Bar appearance…"
+                    )
                 )
-        } label: {
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .help(
+                L(
+                    "space_bar.copy_appearance.help",
+                    "Takes the App Bar's current sizes, style, "
+                        + "and colors once; edits afterwards "
+                        + "stay independent."
+                )
+            )
             Text(
                 L(
-                    "space_bar.copy_appearance",
-                    "Copy App Bar appearance…"
+                    "space_bar.copy_appearance.caption",
+                    "Copies the App Bar's current sizes, "
+                        + "style, and colors — a one-time "
+                        + "starting point, not a live link."
                 )
             )
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
-        .help(
-            L(
-                "space_bar.copy_appearance.help",
-                "Takes the App Bar's current sizes, style, "
-                    + "and colors once; edits afterwards stay "
-                    + "independent."
-            )
-        )
     }
 
     private var caption: String {

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -612,6 +612,7 @@
   "space_bar.color.text": "Text",
   "space_bar.colors.title": "Space Bar colors",
   "space_bar.copy_appearance": "Copy App Bar appearance…",
+  "space_bar.copy_appearance.caption": "Copies the App Bar's current sizes, style, and colors — a one-time starting point, not a live link.",
   "space_bar.copy_appearance.help": "Takes the App Bar's current sizes, style, and colors once; edits afterwards stay independent.",
   "space_bar.corner_roundness": "Corner roundness",
   "space_bar.corner_roundness.boxed_only": "Corner roundness only applies to Boxed items.",

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -84,6 +84,7 @@
   "app_selector.bundle_id": "Bundle identifier",
   "app_selector.clear_custom": "Clear custom app",
   "app_selector.custom": "Custom…",
+  "bars.switch": "Bar",
   "bars.switch.app_bar": "App Bar",
   "bars.switch.space_bar": "Space Bar",
   "behavior.animations.duration": "Duration",


### PR DESCRIPTION
## What

Manual-QA polish round on the shipped Space Bar (#293). Three designer-settled changes (two-agent design consult; verdicts recorded in the local plan doc):

- **Bars switch**: native segmented `Picker` → the shared custom `SegmentedPicker` (Layout Defaults / Behavior precedent), plus the precedent's accessibility label.
- **Edge-hug previews**: both bar preview strips now hug the canvas side matching the chosen edge instead of floating centered — top vs bottom (and left vs right) are visibly different, not just captioned. Vertical scale budgets re-derived for the 12 pt inset; belt-and-braces clip added to the App Bar strip.
- **Copy App Bar appearance**: moved into the Space Bar colors section (colors are its most consequential effect), styled like the Reset-Overrides buttons, with a persistent caption carrying the one-shot caveat instead of hover-only.

## Review

Both `code-reviewer` and `architect-reviewer` ran on the diff; the one MEDIUM (preview budget overflow from the new inset) is fixed in the second commit. Dismissed: RTL leading/trailing flip (consistent with the pre-existing `edgeMark` pattern; no RTL locale ships yet), `AppBarPreviewStrip` file split (deferred to the alignment feature branch that touches it next).

## Verify

`swift build` + 1467 tests + `scripts/lint.sh` + `swift build -c release` all green after each commit.

Refs #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)