### PR TITLE
fix(bar): center Space Bar text glyphs vertically

### DIFF
--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
@@ -41,6 +41,10 @@ extension SpaceBarItemView {
                 ofSize: identifierFont
             )
         }
+        // Restyle BEFORE placing: `place` measures each text
+        // glyph to center it vertically, and the glyph fonts
+        // are set in `restyle` (bounds are already final here).
+        restyle()
         var cursor = Self.pad
         place(identifierImage, at: cursor, cell: cell)
         place(identifierLabel, at: cursor, cell: cell)
@@ -68,8 +72,6 @@ extension SpaceBarItemView {
             cursor += cell
         }
         layoutAccent()
-        // Corner radius and fonts depend on the final bounds.
-        restyle()
     }
 
     /// A count badge hugging its glyph cell's top-trailing
@@ -135,7 +137,7 @@ extension SpaceBarItemView {
         at offset: CGFloat,
         cell: CGFloat
     ) {
-        let rect =
+        var rect =
             horizontal
             ? CGRect(
                 x: offset,
@@ -149,6 +151,22 @@ extension SpaceBarItemView {
                 width: cell,
                 height: cell
             )
+        // AppKit draws text from the frame's TOP, so a text
+        // glyph (App Font ligature, character identifier)
+        // handed the whole square cell reads top-aligned.
+        // Shrink to its measured height, centered — the
+        // `AppBarItemView+GlyphSlot` midY idiom. Images
+        // center natively and keep the full cell.
+        if let field = view as? NSTextField {
+            let height = ceil(
+                field.cell?.cellSize.height ?? 0
+            )
+            if height > 0, height < rect.height {
+                rect.origin.y +=
+                    ((rect.height - height) / 2).rounded()
+                rect.size.height = height
+            }
+        }
         view.frame = backingAlignedRect(
             rect,
             options: .alignAllEdgesNearest

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
@@ -138,7 +138,20 @@ extension SpaceBarOverlay {
                 AppFont.font(size: size)
                 ?? .systemFont(ofSize: size)
             frontGlyph.textColor = accent
-            frontGlyph.frame = frame
+            // Text draws from the frame's top: shrink to the
+            // measured height, centered in the cell — the
+            // `SpaceBarItemView.place` twin.
+            var glyphFrame = frame
+            let height = ceil(
+                frontGlyph.cell?.cellSize.height ?? 0
+            )
+            if height > 0, height < glyphFrame.height {
+                glyphFrame.origin.y +=
+                    ((glyphFrame.height - height) / 2)
+                    .rounded()
+                glyphFrame.size.height = height
+            }
+            frontGlyph.frame = glyphFrame
             frontGlyph.setAccessibilityElement(true)
             frontGlyph.setAccessibilityLabel(axLabel)
         } else {


### PR DESCRIPTION
QA finding from the #293 manual pass: Space Bar glyphs sat top-aligned, not centered.

Root cause: `NSTextField` draws text from the frame's top, and `SpaceBarItemView.place()` handed text glyphs (App Font ligatures, character identifiers) the full square cell — images center natively, which is why only text glyphs drifted. Fix applies the `AppBarItemView+GlyphSlot` midY idiom: shrink to measured height, center in the cell. Same fix for the front-app segment's glyph.

`restyle()` moved before placement (measurement needs fonts + string values set; bounds are final either way). Bonus: `layoutBadge` previously measured the previous render's badge text/hidden state — the reorder closes that latent one-frame staleness too.

Verify gate green (build, 1467 tests, lint, release). Visual centering itself needs the in-app pass.

Refs #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)