### PR TITLE
fix(settings): floor auto-gated sliders at 1 pt

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
@@ -152,7 +152,7 @@ struct LayoutAppBarSection: View {
             value: $bar.boxSize,
             global: global.boxSize,
             restore: 120,
-            range: 0...200
+            range: 1...200
         )
         OverrideSliderRow(
             label: L("app_bar.box_gap", "Box gap"),
@@ -166,7 +166,7 @@ struct LayoutAppBarSection: View {
             value: $bar.fontSize,
             global: global.fontSize,
             restore: 14,
-            range: 0...32
+            range: 1...32
         )
         Divider()
         // Roundness only shapes a Boxed tab; grey it when this

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarOverrideControls.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarOverrideControls.swift
@@ -161,7 +161,10 @@ struct OverrideAutoSliderRow: View {
     @Binding var value: CGFloat?
     let global: CGFloat
     let restore: CGFloat
-    var range: ClosedRange<Double> = 0...200
+    /// Floors at 1 pt: 0 is the auto sentinel and only the
+    /// toggle may write it — a slider dragged to its minimum
+    /// must never silently flip Auto on (#293 QA).
+    var range: ClosedRange<Double> = 1...200
 
     var body: some View {
         OverrideChrome(isOn: overrideToggle($value, global: global)) {

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
@@ -198,7 +198,7 @@ struct GlobalAppBarSection: View {
             PtSlider(
                 label: L("app_bar.box_size", "Box size"),
                 value: $style.boxSize,
-                range: 0...200
+                range: 1...200
             )
         }
         PtSlider(
@@ -213,7 +213,7 @@ struct GlobalAppBarSection: View {
             PtSlider(
                 label: L("app_bar.font_size", "Font size"),
                 value: $style.fontSize,
-                range: 0...32
+                range: 1...32
             )
         }
         Divider()

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
@@ -183,7 +183,7 @@ struct SpaceBarEditorSection: View {
             PtSlider(
                 label: L("space_bar.box_size", "Box size"),
                 value: style.boxSize,
-                range: 0...200
+                range: 1...200
             )
         }
         PtSlider(
@@ -201,7 +201,7 @@ struct SpaceBarEditorSection: View {
             PtSlider(
                 label: L("space_bar.font_size", "Font size"),
                 value: style.fontSize,
-                range: 0...32
+                range: 1...32
             )
         }
         Divider()


### PR DESCRIPTION
QA finding from the #293 pass: dragging **Box size** to the slider minimum wrote 0 — the auto sentinel — which silently flipped the Auto toggle on. Same latent defect on the **Font size** sliders (0 = auto there too).

Fix: the auto-gated sliders floor at 1 pt (both bar editors + the per-layout override rows + the `OverrideAutoSliderRow` default). 0 stays the model's auto sentinel, but only the Auto toggle writes it. The preview scale mappings already treated 1–200, so nothing else moves.

Verify gate green (build, 1473 tests, lint, release).

Refs #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)