### PR TITLE
feat(space-bar): drag-and-drop windows onto Space items (#372)

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsRows.swift
+++ b/Sources/KiwiDesk/Settings/SettingsRows.swift
@@ -45,6 +45,49 @@ struct PtSlider: View {
     }
 }
 
+/// A seconds-valued slider backed by a millisecond `Int` store,
+/// with a `1.5 s` readout — the Space Bar drag-drop spring dwell
+/// (#372). Bounds come in seconds; the binding converts to/from
+/// the stored milliseconds.
+struct SecondsRow: View {
+    let label: String
+    @Binding var ms: Int
+    var range: ClosedRange<Double> = 0.5...4.0
+    /// Optional `?` popover (#94), label-adjacent.
+    var help: String? = nil
+    @Environment(\.settingsLabelColumn)
+    private var labelColumn
+
+    var body: some View {
+        HStack {
+            HStack(spacing: 4) {
+                Text(label).lineLimit(1)
+                if let help {
+                    HelpButton(explanation: help, subject: label)
+                }
+            }
+            .frame(width: labelColumn, alignment: .leading)
+            SettingsSlider(
+                value: Binding(
+                    get: { Double(ms) / 1000 },
+                    set: { ms = Int(($0 * 1000).rounded()) }
+                ),
+                range: range,
+                step: 0.1
+            )
+            Text(
+                String(format: "%.1f s", Double(ms) / 1000)
+            )
+            .frame(
+                width: SettingsMetrics.readoutColumn,
+                alignment: .trailing
+            )
+            .foregroundStyle(.secondary)
+            .font(.system(.body, design: .monospaced))
+        }
+    }
+}
+
 /// A 0.1–0.9 ratio slider with a percentage readout.
 struct RatioRow: View {
     let label: String

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
@@ -154,7 +154,7 @@ struct SpaceBarEditorSection: View {
         SecondsRow(
             label: L("space_bar.spring_delay", "Spring delay"),
             ms: style.springDelay,
-            range: 0.5...4.0,
+            range: 1.0...4.0,
             help: L(
                 "space_bar.spring_delay.help",
                 "Drag a window onto a Space and hold this long "

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
@@ -151,6 +151,19 @@ struct SpaceBarEditorSection: View {
                     + "bars."
             )
         )
+        SecondsRow(
+            label: L("space_bar.spring_delay", "Spring delay"),
+            ms: style.springDelay,
+            range: 0.5...4.0,
+            help: L(
+                "space_bar.spring_delay.help",
+                "Drag a window onto a Space and hold this long "
+                    + "for the view to spring to that Space, so "
+                    + "you can drop the window into its layout. A "
+                    + "quicker drop moves the window there "
+                    + "without switching."
+            )
+        )
     }
 
     /// Gate stays here (needs the model); chrome and text are

--- a/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
@@ -166,7 +166,7 @@ extension KiwiCore {
             // echo will never land, and WindowIDs can be reused
             // (#152/#158).
             outstandingSelfRaises.remove(id)
-            drag.cancel(id)
+            cancelDrag(id)
             dragOverlay.hideAll()
             // The switch timestamp is set by the
             // .nativeSpaceChanged event, which the event loop
@@ -204,7 +204,7 @@ extension KiwiCore {
             if pendingFocusRaise == old {
                 pendingFocusRaise = new
             }
-            drag.cancel(old)
+            cancelDrag(old)
         default:
             break
         }

--- a/Sources/KiwiDeskCore/App/KiwiCore+SpaceBar.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+SpaceBar.swift
@@ -10,6 +10,9 @@ import AppKit
 extension KiwiCore {
     func updateSpaceBar() {
         let style = tiler.settings.spaceBarStyle
+        // Keep the drag-drop dwell (and its ring sweep) in sync
+        // with the configured value on every settings apply (#372).
+        spaceBarDrop.dwell = style.resolvedSpringDelay
         guard style.enabled else {
             spaceBars.sync([])
             return

--- a/Sources/KiwiDeskCore/App/KiwiCore+SpaceBar.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+SpaceBar.swift
@@ -10,9 +10,6 @@ import AppKit
 extension KiwiCore {
     func updateSpaceBar() {
         let style = tiler.settings.spaceBarStyle
-        // Keep the drag-drop dwell (and its ring sweep) in sync
-        // with the configured value on every settings apply (#372).
-        spaceBarDrop.dwell = style.resolvedSpringDelay
         guard style.enabled else {
             spaceBars.sync([])
             return

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -16,6 +16,8 @@ public final class KiwiCore {
     public let dragOverlay = DragOverlay()
     public let appBars = AppBarManager()
     public let spaceBars = SpaceBarManager()
+    /// Space Bar drag-drop gesture state (#372).
+    let spaceBarDrop = SpaceBarDropCoordinator()
     /// Glyph-vs-image icon decisions for bar items (#294),
     /// shared by the App Bar, the Space Bar (#293) and the
     /// shortcuts panel.

--- a/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
@@ -21,10 +21,12 @@ extension KiwiCore {
         spaceBarDrop.setHover = { [weak self] space in
             self?.spaceBars.setDragHover(space)
         }
-        spaceBarDrop.beginSweep = { [weak self] space, duration in
+        spaceBarDrop.beginSweep = {
+            [weak self] space, fill, delay in
             self?.spaceBars.beginSpringSweep(
                 on: space,
-                duration: duration
+                duration: fill,
+                delay: delay
             )
         }
         spaceBarDrop.clearFeedback = { [weak self] in

--- a/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
@@ -48,13 +48,22 @@ extension KiwiCore {
         }
     }
 
-    /// Springs the visible space to `target` mid-drag without
-    /// touching the dragged window (#372): activate + a forced,
-    /// un-animated retile, with `window` exempt from
-    /// `stashInactive` (it is still a member of its source space).
+    /// Springs the visible space to `target` mid-drag (#372):
+    /// eager-moves the dragged window into the target, activates
+    /// it, and does a forced, un-animated retile.
+    ///
+    /// Eager membership (QA fix): moving the window into the target
+    /// NOW — not at drop — means the live drag shows the ordinary
+    /// drop preview (ghost + drop-zone) in the target's layout, and
+    /// the release lands the window in the exact slot under the
+    /// cursor. `window` is exempt from `stashInactive` (pinned at
+    /// the gesture's first move and re-pinned here), so neither the
+    /// membership move nor the retile stashes it mid-drag; an
+    /// abnormal end is cleaned up by `cancelDrag`.
+    ///
     /// Deliberately NOT `focusSpace` — that warps the cursor to
-    /// hand off AX focus, which would rip the pointer out of the
-    /// OS drag loop. No focus hand-off, no warp, no settle timer.
+    /// hand off AX focus, which would rip the pointer out of the OS
+    /// drag loop. No focus hand-off, no warp, no settle timer.
     private func springSwitchSpace(
         to target: SpaceID,
         dragging window: WindowID
@@ -62,10 +71,19 @@ extension KiwiCore {
         guard state.workspaces.activeSpace != target else {
             return
         }
-        // Belt-and-suspenders: the move handler set this at the
-        // gesture's first frame, but pin it again so the retile
-        // below can never stash the in-flight window.
         tiler.dragExemptWindow = window
+        let from = state.workspaces.space(of: window)
+        if from != target {
+            addFocusedToSpace(window, to: target)
+            state.workspaces.focus(window, in: target)
+            emitWindowMovedToSpace(
+                window,
+                app: state.windows[window]?.appName ?? "",
+                bundleID: state.windows[window]?.appBundleID,
+                from: from,
+                to: target
+            )
+        }
         state.workspaces.activate(target)
         retile(animated: false, force: true)
         emitSpaceChange()

--- a/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
@@ -8,6 +8,10 @@ extension KiwiCore {
     /// Connects the Space Bar drop coordinator to the bars, state,
     /// and the spring-switch action.
     func wireSpaceBarDrop() {
+        spaceBarDrop.dwellProvider = { [weak self] in
+            self?.tiler.settings.spaceBarStyle.resolvedSpringDelay
+                ?? 1.5
+        }
         spaceBarDrop.hitTest = { [weak self] point in
             self?.spaceBars.spaceItem(atGlobal: point)
         }

--- a/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
@@ -31,6 +31,23 @@ extension KiwiCore {
         }
     }
 
+    /// Abnormal drag end (window closed / native tab rekeyed
+    /// mid-drag): `DragCoordinator.cancel` never fires `onDragEnd`,
+    /// so the gesture teardown that lives there is bypassed. Tear
+    /// the Space Bar drop state down here too, scoped to `id`, so a
+    /// pending dwell can't fire a phantom spring, `sprungSpace`
+    /// can't teleport the next drag, and `dragExemptWindow` can't
+    /// leak onto a reused WindowID (#372, review).
+    func cancelDrag(_ id: WindowID) {
+        drag.cancel(id)
+        if tiler.dragExemptWindow == id {
+            tiler.dragExemptWindow = nil
+        }
+        if spaceBarDrop.draggingWindow == id {
+            spaceBarDrop.reset()
+        }
+    }
+
     /// Springs the visible space to `target` mid-drag without
     /// touching the dragged window (#372): activate + a forced,
     /// un-animated retile, with `window` exempt from

--- a/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
@@ -1,0 +1,56 @@
+import AppKit
+
+/// Wiring for the Space Bar drag-drop gesture (#372): connects the
+/// drop coordinator to the bars, workspace state, and the
+/// spring-switch action. Split from `KiwiCore+Drag.swift` for the
+/// file ceiling; the drag handlers themselves stay there.
+extension KiwiCore {
+    /// Connects the Space Bar drop coordinator to the bars, state,
+    /// and the spring-switch action.
+    func wireSpaceBarDrop() {
+        spaceBarDrop.hitTest = { [weak self] point in
+            self?.spaceBars.spaceItem(atGlobal: point)
+        }
+        spaceBarDrop.currentSpace = { [weak self] id in
+            self?.state.workspaces.space(of: id)
+        }
+        spaceBarDrop.setHover = { [weak self] space in
+            self?.spaceBars.setDragHover(space)
+        }
+        spaceBarDrop.beginSweep = { [weak self] space, duration in
+            self?.spaceBars.beginSpringSweep(
+                on: space,
+                duration: duration
+            )
+        }
+        spaceBarDrop.clearFeedback = { [weak self] in
+            self?.spaceBars.clearDragFeedback()
+        }
+        spaceBarDrop.spring = { [weak self] target, window in
+            self?.springSwitchSpace(to: target, dragging: window)
+        }
+    }
+
+    /// Springs the visible space to `target` mid-drag without
+    /// touching the dragged window (#372): activate + a forced,
+    /// un-animated retile, with `window` exempt from
+    /// `stashInactive` (it is still a member of its source space).
+    /// Deliberately NOT `focusSpace` — that warps the cursor to
+    /// hand off AX focus, which would rip the pointer out of the
+    /// OS drag loop. No focus hand-off, no warp, no settle timer.
+    private func springSwitchSpace(
+        to target: SpaceID,
+        dragging window: WindowID
+    ) {
+        guard state.workspaces.activeSpace != target else {
+            return
+        }
+        // Belt-and-suspenders: the move handler set this at the
+        // gesture's first frame, but pin it again so the retile
+        // below can never stash the in-flight window.
+        tiler.dragExemptWindow = window
+        state.workspaces.activate(target)
+        retile(animated: false, force: true)
+        emitSpaceChange()
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
@@ -30,11 +30,12 @@ final class SpaceBarDropCoordinator {
         case placeInSprung(SpaceID)
     }
 
-    /// Dwell before a hover springs the space. Designer verdict
-    /// (#372): 2.0s — longer than Finder's ~0.7s is right here
-    /// because the ring-sweep shows progress and a space switch
-    /// is a bigger disruption than a folder opening.
-    var dwell: TimeInterval = 2.0
+    /// The dwell before a hover springs the space, read fresh at
+    /// arm time so a live `space_bar.set_spring_delay` change takes
+    /// effect on the next gesture with no cached-value staleness
+    /// (#372). Injected so this type stays settings-free; the
+    /// default is only a pre-wiring placeholder.
+    var dwellProvider: @MainActor () -> TimeInterval = { 1.5 }
 
     /// Space whose item contains a Cocoa screen point, else nil.
     var hitTest: @MainActor (CGPoint) -> SpaceID? = { _ in nil }
@@ -116,11 +117,14 @@ final class SpaceBarDropCoordinator {
 
     private func arm(_ target: SpaceID, _ id: WindowID) {
         armedSpace = target
+        // Read the dwell once, so the ring sweep and the timer
+        // that fires the spring share the exact same duration.
+        let dwell = dwellProvider()
         setHover(target)
         beginSweep(target, dwell)
         dwellTask?.cancel()
         dwellTask = Task { [weak self] in
-            let ns = UInt64((self?.dwell ?? 2) * 1_000_000_000)
+            let ns = UInt64(dwell * 1_000_000_000)
             try? await Task.sleep(nanoseconds: ns)
             guard !Task.isCancelled else { return }
             self?.fire(target, id)

--- a/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
@@ -64,6 +64,10 @@ final class SpaceBarDropCoordinator {
     private(set) var armedSpace: SpaceID?
     /// The space this drag has already sprung into, if any.
     private(set) var sprungSpace: SpaceID?
+    /// The window this gesture is dragging, or nil between
+    /// gestures. Lets an abnormal drag end (window closed / tab
+    /// rekeyed mid-drag) scope its teardown to the right window.
+    private(set) var draggingWindow: WindowID?
     private var dwellTask: Task<Void, Never>?
 
     /// True while a bar target is armed pre-spring — the caller
@@ -72,6 +76,7 @@ final class SpaceBarDropCoordinator {
 
     /// Feed every live drag move (button down).
     func moved(_ id: WindowID, cursor: CGPoint) {
+        draggingWindow = id
         let target = hitTest(cursor)
         // A valid spring target is a bar item that is neither the
         // window's own space nor one we already sprang into.
@@ -92,6 +97,7 @@ final class SpaceBarDropCoordinator {
         let sprung = sprungSpace
         disarm()
         sprungSpace = nil
+        draggingWindow = nil
         if let sprung { return .placeInSprung(sprung) }
         if let target = hitTest(cursor),
             target != currentSpace(id)
@@ -105,6 +111,7 @@ final class SpaceBarDropCoordinator {
     func reset() {
         disarm()
         sprungSpace = nil
+        draggingWindow = nil
     }
 
     private func arm(_ target: SpaceID, _ id: WindowID) {

--- a/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
@@ -46,11 +46,21 @@ final class SpaceBarDropCoordinator {
     /// Tint a space's item with the synthetic drag-hover (nil
     /// clears all).
     var setHover: @MainActor (SpaceID?) -> Void = { _ in }
-    /// Start the pending-spring ring sweep on a space's item.
-    var beginSweep: @MainActor (SpaceID, TimeInterval) -> Void = {
-        _,
-        _ in
-    }
+    /// Start the pending-spring ring sweep on a space's item: it
+    /// stays empty for `delay`, then fills over `fill`.
+    var beginSweep:
+        @MainActor (
+            _ space: SpaceID, _ fill: TimeInterval,
+            _ delay: TimeInterval
+        ) -> Void = { _, _, _ in }
+
+    /// Quiet time after entering an item before the sweep starts
+    /// (#372 QA): a quick flick-to-relocate shows no loading ring.
+    /// The spring still fires at the full dwell, so the sweep fills
+    /// over `dwell - springPreDelay`; the dwell range floors above
+    /// this so the sweep is always visible.
+    static let springPreDelay: TimeInterval = 0.5
+
     /// Clear every hover tint and pending sweep.
     var clearFeedback: @MainActor () -> Void = {}
     /// Spring the visible space to `target` while `window` stays
@@ -116,12 +126,18 @@ final class SpaceBarDropCoordinator {
     }
 
     private func arm(_ target: SpaceID, _ id: WindowID) {
+        // Clear the previously-armed item first: moving straight
+        // from one Space item to another re-arms without a gap, and
+        // the old item's ring sweep would otherwise keep animating
+        // (#372 QA). Covers every bar/display.
+        clearFeedback()
         armedSpace = target
         // Read the dwell once, so the ring sweep and the timer
         // that fires the spring share the exact same duration.
         let dwell = dwellProvider()
+        let delay = min(Self.springPreDelay, dwell)
         setHover(target)
-        beginSweep(target, dwell)
+        beginSweep(target, dwell - delay, delay)
         dwellTask?.cancel()
         dwellTask = Task { [weak self] in
             let ns = UInt64(dwell * 1_000_000_000)

--- a/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
@@ -1,0 +1,137 @@
+import CoreGraphics
+import Foundation
+
+/// The Space Bar drag-drop state machine (#372).
+///
+/// A two-speed gesture, driven off the same AX drag signal the
+/// rest of tiling uses (`DragCoordinator` → `onDragMove`/
+/// `onDragEnd`):
+///
+/// - **Fast drop** — release on a Space item before the dwell
+///   fires → relocate the window there, stay put (`move_to_space`).
+/// - **Dwell** — hold over a Space item for `dwell` seconds → the
+///   visible space springs to it; the drop is then an ordinary
+///   in-space placement into the now-live layout.
+///
+/// The switch and the relocate are performed by injected closures
+/// (KiwiCore), so this type stays AppKit-free and unit-testable.
+@MainActor
+final class SpaceBarDropCoordinator {
+    /// What `ended` asks the driver to do.
+    enum Outcome: Equatable {
+        /// No bar target — hand back to the ordinary drag-end
+        /// logic (same-space swap / snap-back).
+        case none
+        /// Fast drop onto a different space's item — relocate.
+        case relocate(SpaceID)
+        /// The space had already sprung; the window is on the
+        /// now-visible target, so place it there with the
+        /// ordinary in-space drop after re-homing its membership.
+        case placeInSprung(SpaceID)
+    }
+
+    /// Dwell before a hover springs the space. Designer verdict
+    /// (#372): 2.0s — longer than Finder's ~0.7s is right here
+    /// because the ring-sweep shows progress and a space switch
+    /// is a bigger disruption than a folder opening.
+    var dwell: TimeInterval = 2.0
+
+    /// Space whose item contains a Cocoa screen point, else nil.
+    var hitTest: @MainActor (CGPoint) -> SpaceID? = { _ in nil }
+    /// The window's current virtual space.
+    var currentSpace: @MainActor (WindowID) -> SpaceID? = {
+        _ in nil
+    }
+    /// Tint a space's item with the synthetic drag-hover (nil
+    /// clears all).
+    var setHover: @MainActor (SpaceID?) -> Void = { _ in }
+    /// Start the pending-spring ring sweep on a space's item.
+    var beginSweep: @MainActor (SpaceID, TimeInterval) -> Void = {
+        _,
+        _ in
+    }
+    /// Clear every hover tint and pending sweep.
+    var clearFeedback: @MainActor () -> Void = {}
+    /// Spring the visible space to `target` while `window` stays
+    /// pinned mid-drag.
+    var spring:
+        @MainActor (_ target: SpaceID, _ window: WindowID)
+            -> Void = { _, _ in }
+
+    /// The item currently armed (hover tint + running sweep), or
+    /// nil. Lets `handleDragMove` suppress the in-space ghost
+    /// while a bar target is armed.
+    private(set) var armedSpace: SpaceID?
+    /// The space this drag has already sprung into, if any.
+    private(set) var sprungSpace: SpaceID?
+    private var dwellTask: Task<Void, Never>?
+
+    /// True while a bar target is armed pre-spring — the caller
+    /// hides its own drag ghost/drop-zone then.
+    var isArmed: Bool { armedSpace != nil }
+
+    /// Feed every live drag move (button down).
+    func moved(_ id: WindowID, cursor: CGPoint) {
+        let target = hitTest(cursor)
+        // A valid spring target is a bar item that is neither the
+        // window's own space nor one we already sprang into.
+        if let target,
+            target != currentSpace(id),
+            target != sprungSpace
+        {
+            guard target != armedSpace else { return }
+            arm(target, id)
+        } else if armedSpace != nil {
+            disarm()
+        }
+    }
+
+    /// Feed the settled drop. Returns what the driver should do;
+    /// resets all gesture state.
+    func ended(_ id: WindowID, cursor: CGPoint) -> Outcome {
+        let sprung = sprungSpace
+        disarm()
+        sprungSpace = nil
+        if let sprung { return .placeInSprung(sprung) }
+        if let target = hitTest(cursor),
+            target != currentSpace(id)
+        {
+            return .relocate(target)
+        }
+        return .none
+    }
+
+    /// The gesture ended or was abandoned — drop all state.
+    func reset() {
+        disarm()
+        sprungSpace = nil
+    }
+
+    private func arm(_ target: SpaceID, _ id: WindowID) {
+        armedSpace = target
+        setHover(target)
+        beginSweep(target, dwell)
+        dwellTask?.cancel()
+        dwellTask = Task { [weak self] in
+            let ns = UInt64((self?.dwell ?? 2) * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: ns)
+            guard !Task.isCancelled else { return }
+            self?.fire(target, id)
+        }
+    }
+
+    private func disarm() {
+        dwellTask?.cancel()
+        dwellTask = nil
+        armedSpace = nil
+        clearFeedback()
+    }
+
+    private func fire(_ target: SpaceID, _ id: WindowID) {
+        dwellTask = nil
+        armedSpace = nil
+        sprungSpace = target
+        clearFeedback()
+        spring(target, id)
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+DragDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+DragDrop.swift
@@ -1,0 +1,64 @@
+import AppKit
+
+/// Drag-drop feedback for one Space item (#372): the synthetic
+/// hover tint during a window drag and the pending-spring ring
+/// sweep. The dwell timing and the decision to spring live on the
+/// driver side; this view only renders the two cues.
+extension SpaceBarItemView {
+
+    /// Lights (or clears) the synthetic drag-hover tint — the
+    /// same `hoverColor` an ordinary mouse hover shows, driven
+    /// from the AX cursor position because tracking areas stay
+    /// silent while another app owns the drag.
+    func setDragHover(_ on: Bool) {
+        guard isDragHovered != on else { return }
+        isDragHovered = on
+        restyle()
+    }
+
+    /// Starts the ring sweep: a `highlightColor` stroke filling
+    /// 0→1 over `duration`, sitting on top of the hover tint as
+    /// the "this will become active" cue. Reuses the active
+    /// indicator's ring vocabulary (2 pt, `highlightColor`).
+    func beginSpringSweep(duration: TimeInterval) {
+        let inset = springRing.lineWidth / 2
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        springRing.frame = bounds
+        springRing.path =
+            CGPath(
+                roundedRect: bounds.insetBy(dx: inset, dy: inset),
+                cornerWidth: cornerRadius,
+                cornerHeight: cornerRadius,
+                transform: nil
+            )
+        springRing.strokeColor =
+            NSColor(kiwiHex: style.highlightColor).cgColor
+        springRing.isHidden = false
+        springRing.strokeEnd = 0
+        CATransaction.commit()
+
+        let sweep = CABasicAnimation(keyPath: "strokeEnd")
+        sweep.fromValue = 0
+        sweep.toValue = 1
+        sweep.duration = duration
+        sweep.timingFunction =
+            CAMediaTimingFunction(name: .linear)
+        sweep.fillMode = .forwards
+        sweep.isRemovedOnCompletion = false
+        springRing.strokeEnd = 1
+        springRing.add(sweep, forKey: "springSweep")
+    }
+
+    /// Cancels a pending sweep and resets the ring — leaving the
+    /// item, or the spring firing, both end here (all-or-nothing;
+    /// re-entering restarts from zero).
+    func cancelSpringSweep() {
+        springRing.removeAnimation(forKey: "springSweep")
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        springRing.strokeEnd = 0
+        springRing.isHidden = true
+        CATransaction.commit()
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+DragDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+DragDrop.swift
@@ -20,7 +20,10 @@ extension SpaceBarItemView {
     /// 0→1 over `duration`, sitting on top of the hover tint as
     /// the "this will become active" cue. Reuses the active
     /// indicator's ring vocabulary (2 pt, `highlightColor`).
-    func beginSpringSweep(duration: TimeInterval) {
+    func beginSpringSweep(
+        duration: TimeInterval,
+        delay: TimeInterval
+    ) {
         let inset = springRing.lineWidth / 2
         CATransaction.begin()
         CATransaction.setDisableActions(true)
@@ -42,9 +45,13 @@ extension SpaceBarItemView {
         sweep.fromValue = 0
         sweep.toValue = 1
         sweep.duration = duration
+        // Stay empty for `delay` first: `.both` shows the
+        // fromValue (0) before beginTime, so a quick flick shows
+        // no ring until the hold is deliberate (#372 QA).
+        sweep.beginTime = CACurrentMediaTime() + delay
         sweep.timingFunction =
             CAMediaTimingFunction(name: .linear)
-        sweep.fillMode = .forwards
+        sweep.fillMode = .both
         sweep.isRemovedOnCompletion = false
         springRing.strokeEnd = 1
         springRing.add(sweep, forKey: "springSweep")

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
@@ -61,7 +61,7 @@ extension SpaceBarItemView {
             return NSColor(kiwiHex: style.activeBoxColor)
         }
         if isActive { return .clear }
-        if isHovered {
+        if isHovered || isDragHovered {
             return NSColor(kiwiHex: style.hoverColor)
         }
         guard style.tabBackground == .boxed else {
@@ -76,7 +76,7 @@ extension SpaceBarItemView {
         if isActive {
             return NSColor(kiwiHex: style.activeTextColor)
         }
-        if isHovered {
+        if isHovered || isDragHovered {
             return NSColor(kiwiHex: style.hoverTextColor)
         }
         return NSColor(kiwiHex: style.textColor)

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView.swift
@@ -157,6 +157,14 @@ final class SpaceBarItemView: NSView {
         style: SpaceBarStyle,
         overflow: Int = 0
     ) {
+        // A pooled view reused for a different Space drops any
+        // drag-drop cues it was showing for the old one — a stale
+        // hover tint or half-swept spring ring would otherwise
+        // paint on the wrong item (#372, review).
+        if self.space != space {
+            cancelSpringSweep()
+            isDragHovered = false
+        }
         self.space = space
         self.spaceGlyph = spaceGlyph
         self.apps = apps

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView.swift
@@ -61,6 +61,15 @@ final class SpaceBarItemView: NSView {
     private(set) var overflow = 0
     private(set) var isActive = false
     private(set) var isHovered = false
+    /// Synthetic hover during a window drag (#372). Tracking
+    /// areas stay silent while another app owns the drag loop,
+    /// so the driver sets this from the AX cursor position; it
+    /// routes through the same `hoverColor` path as `isHovered`.
+    /// Mutated via `setDragHover` (SpaceBarItemView+DragDrop).
+    var isDragHovered = false
+    /// The pending-spring sweep ring (#372): a stroke that fills
+    /// 0→1 over the dwell, layered on top of the hover tint.
+    let springRing = CAShapeLayer()
     var horizontal = true
     var style = SpaceBarStyle()
     var onSelect: (SpaceID) -> Void = { _ in }
@@ -78,6 +87,11 @@ final class SpaceBarItemView: NSView {
         addSubview(identifierLabel)
         addSubview(overflowBadge)
         addSubview(accent)
+        springRing.fillColor = nil
+        springRing.lineWidth = 2
+        springRing.strokeEnd = 0
+        springRing.isHidden = true
+        layer?.addSublayer(springRing)
     }
 
     /// The App Bar's badge shape: a filled circle around a

--- a/Sources/KiwiDeskCore/Bar/SpaceBarManager.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarManager.swift
@@ -100,6 +100,41 @@ public final class SpaceBarManager {
         }
     }
 
+    // MARK: - Drag-drop routing (#372)
+
+    /// The Space whose item contains a global (Cocoa) screen
+    /// point, across every painted bar; nil when the point is on
+    /// no bar. Point-based hit test — see `SpaceBarOverlay`.
+    public func spaceItem(atGlobal point: CGPoint) -> SpaceID? {
+        for overlay in overlays.values {
+            if let space = overlay.spaceItem(atGlobal: point) {
+                return space
+            }
+        }
+        return nil
+    }
+
+    /// Tints `space`'s item with the synthetic drag-hover and
+    /// clears every other bar's items; nil clears all.
+    public func setDragHover(_ space: SpaceID?) {
+        overlays.values.forEach { $0.setDragHover(space) }
+    }
+
+    /// Starts the pending-spring sweep on `space`'s item.
+    public func beginSpringSweep(
+        on space: SpaceID,
+        duration: TimeInterval
+    ) {
+        overlays.values.forEach {
+            $0.beginSpringSweep(on: space, duration: duration)
+        }
+    }
+
+    /// Clears every hover tint and pending sweep across all bars.
+    public func clearDragFeedback() {
+        overlays.values.forEach { $0.clearDragFeedback() }
+    }
+
     #if DEBUG
         /// Test seam: the overlay currently backing a display.
         func overlayForTesting(

--- a/Sources/KiwiDeskCore/Bar/SpaceBarManager.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarManager.swift
@@ -120,13 +120,19 @@ public final class SpaceBarManager {
         overlays.values.forEach { $0.setDragHover(space) }
     }
 
-    /// Starts the pending-spring sweep on `space`'s item.
+    /// Starts the pending-spring sweep on `space`'s item — empty
+    /// for `delay`, then filling over `duration`.
     public func beginSpringSweep(
         on space: SpaceID,
-        duration: TimeInterval
+        duration: TimeInterval,
+        delay: TimeInterval
     ) {
         overlays.values.forEach {
-            $0.beginSpringSweep(on: space, duration: duration)
+            $0.beginSpringSweep(
+                on: space,
+                duration: duration,
+                delay: delay
+            )
         }
     }
 

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+DragDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+DragDrop.swift
@@ -1,0 +1,54 @@
+import AppKit
+
+/// Drag-drop routing for the Space Bar overlay (#372): the
+/// point-based hit test and the per-item hover / spring-sweep
+/// cues. The dwell timing and the spring decision live on the
+/// driver (`KiwiCore`); the overlay only maps a cursor point to a
+/// Space and forwards the visual cues to the matching item view.
+extension SpaceBarOverlay {
+
+    /// The Space whose item contains a global (Cocoa, bottom-
+    /// left) screen point, or nil when the point is off the strip
+    /// or over a gap. Point-based — the cursor location, never
+    /// the dragged window's frame: a maximized window can graze
+    /// the bar while its grab point is far away. Glyphs and the
+    /// "+n" badge are not separate targets; the whole item is one
+    /// drop well.
+    func spaceItem(atGlobal cocoaPoint: CGPoint) -> SpaceID? {
+        guard isPanelVisible else { return nil }
+        let ax = GeometryUtils.axPoint(cocoaPoint)
+        guard hitStrip.contains(ax) else { return nil }
+        let local = CGPoint(
+            x: ax.x - hitStrip.minX,
+            y: ax.y - hitStrip.minY
+        )
+        return hitFrames.first { $0.frame.contains(local) }?.space
+    }
+
+    /// Tints `space`'s item with the synthetic drag-hover and
+    /// clears every other item — nil clears all.
+    func setDragHover(_ space: SpaceID?) {
+        for view in itemViews {
+            view.setDragHover(view.space == space)
+        }
+    }
+
+    /// Starts the pending-spring sweep on `space`'s item.
+    func beginSpringSweep(
+        on space: SpaceID,
+        duration: TimeInterval
+    ) {
+        for view in itemViews where view.space == space {
+            view.beginSpringSweep(duration: duration)
+        }
+    }
+
+    /// Clears any hover tint and pending sweep across all items —
+    /// the drag left the bar or ended.
+    func clearDragFeedback() {
+        for view in itemViews {
+            view.setDragHover(false)
+            view.cancelSpringSweep()
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+DragDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+DragDrop.swift
@@ -33,13 +33,18 @@ extension SpaceBarOverlay {
         }
     }
 
-    /// Starts the pending-spring sweep on `space`'s item.
+    /// Starts the pending-spring sweep on `space`'s item — empty
+    /// for `delay`, then filling over `duration`.
     func beginSpringSweep(
         on space: SpaceID,
-        duration: TimeInterval
+        duration: TimeInterval,
+        delay: TimeInterval
     ) {
         for view in itemViews where view.space == space {
-            view.beginSpringSweep(duration: duration)
+            view.beginSpringSweep(
+                duration: duration,
+                delay: delay
+            )
         }
     }
 

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Metrics.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Metrics.swift
@@ -1,0 +1,64 @@
+import CoreGraphics
+
+/// Pure geometry of one Space Bar run: where each item sits in the
+/// strip and where the trailing front segment starts. Shared by
+/// `render()` and the drag-drop hit test (#372) so the highlighted
+/// drop target can never disagree with the drawn layout. The run
+/// origin is alignment- and front-segment-dependent, so both
+/// consumers must derive it from one place. `pad`/`alignment`/
+/// `frontExtent` come from the caller (the scalar, already
+/// computed on the main actor) so this stays nonisolated and
+/// unit-testable.
+extension SpaceBarOverlay {
+    struct RunMetrics {
+        /// Per-item frame in strip-local AX coordinates, in the
+        /// same order as the input `lengths`.
+        let itemFrames: [CGRect]
+        /// Axis coordinate where the front segment begins — the
+        /// post-run cursor, one gap past the last item (matching
+        /// the pre-extraction loop's trailing `cursor`).
+        let frontStart: CGFloat
+    }
+
+    nonisolated static func runMetrics(
+        lengths: [CGFloat],
+        gap: CGFloat,
+        frontExtent: CGFloat,
+        strip: CGRect,
+        horizontal: Bool,
+        alignment: SpaceBarStyle.Alignment,
+        pad: CGFloat
+    ) -> RunMetrics {
+        let total =
+            lengths.reduce(0, +)
+            + gap * CGFloat(max(lengths.count - 1, 0))
+            + frontExtent
+        var cursor = contentStart(
+            total: total,
+            axis: horizontal ? strip.width : strip.height,
+            alignment: alignment,
+            pad: pad
+        )
+        var frames: [CGRect] = []
+        frames.reserveCapacity(lengths.count)
+        for length in lengths {
+            frames.append(
+                horizontal
+                    ? CGRect(
+                        x: cursor,
+                        y: 0,
+                        width: length,
+                        height: strip.height
+                    )
+                    : CGRect(
+                        x: 0,
+                        y: cursor,
+                        width: strip.width,
+                        height: length
+                    )
+            )
+            cursor += length + gap
+        }
+        return RunMetrics(itemFrames: frames, frontStart: cursor)
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
@@ -24,6 +24,12 @@ public final class SpaceBarOverlay {
 
     private var panel: NSPanel?
     var itemViews: [SpaceBarItemView] = []
+    /// Last-rendered strip in AX coordinates and the per-item
+    /// frames within it (strip-local, top-left), for the #372
+    /// drag-drop hit test. Kept in lockstep with what `render()`
+    /// drew so a drop target can never disagree with the layout.
+    var hitStrip: CGRect = .zero
+    var hitFrames: [(space: SpaceID, frame: CGRect)] = []
     // The optional trailing front-app segment (#293 verdict 6):
     // a divider rule, the focused app's glyph, and — on
     // horizontal bars only — its name.
@@ -73,8 +79,14 @@ public final class SpaceBarOverlay {
 
     public func hide() {
         lastShown = nil
+        hitStrip = .zero
+        hitFrames = []
         panel?.orderOut(nil)
     }
+
+    /// Whether the panel is on screen — the hit test is only
+    /// meaningful for a visible bar.
+    var isPanelVisible: Bool { panel?.isVisible == true }
 
     // MARK: - Rendering
 
@@ -113,6 +125,10 @@ public final class SpaceBarOverlay {
             alignment: style.alignment,
             pad: SpaceBarItemView.pad
         )
+        hitStrip = strip
+        hitFrames = zip(items, metrics.itemFrames).map {
+            ($0.space, $1)
+        }
         for (index, item) in items.enumerated() {
             let view = itemViews[index]
             view.frame = metrics.itemFrames[index]

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
@@ -99,40 +99,23 @@ public final class SpaceBarOverlay {
         // Items plus the trailing front segment align as ONE
         // run — an end-aligned bar must end at the strip's
         // rim including the segment, not push it past.
-        let total =
-            lengths.reduce(0, +)
-            + style.boxGap
-            * CGFloat(max(items.count - 1, 0))
-            + frontExtent(
+        let metrics = Self.runMetrics(
+            lengths: lengths,
+            gap: style.boxGap,
+            frontExtent: frontExtent(
                 frontApp,
                 depth: depth,
                 horizontal: horizontal,
                 style: style
-            )
-        var cursor = Self.contentStart(
-            total: total,
-            axis: horizontal ? strip.width : strip.height,
+            ),
+            strip: strip,
+            horizontal: horizontal,
             alignment: style.alignment,
             pad: SpaceBarItemView.pad
         )
         for (index, item) in items.enumerated() {
             let view = itemViews[index]
-            let length = lengths[index]
-            view.frame =
-                horizontal
-                ? CGRect(
-                    x: cursor,
-                    y: 0,
-                    width: length,
-                    height: strip.height
-                )
-                : CGRect(
-                    x: 0,
-                    y: cursor,
-                    width: strip.width,
-                    height: length
-                )
-            cursor += length + style.boxGap
+            view.frame = metrics.itemFrames[index]
             view.configure(
                 space: item.space,
                 spaceGlyph: item.spaceGlyph,
@@ -148,7 +131,7 @@ public final class SpaceBarOverlay {
         }
         renderFrontSegment(
             frontApp,
-            after: cursor,
+            after: metrics.frontStart,
             strip: strip,
             style: style,
             horizontal: horizontal

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -140,6 +140,7 @@ public enum APIReference {
             "set_icon_source", "set_tab_background",
             "set_active_indicator", "set_corner_roundness",
             "set_show_front_app", "set_hide_empty",
+            "set_spring_delay",
             "set_text_color", "set_active_text_color",
             "set_focused_item_color",
             "set_hover_color", "set_hover_text_color",

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -154,7 +154,7 @@ extension KiwiCore {
     /// and a floating window always appends (it has no track
     /// slot). Without this a `move_to_space` into a track space
     /// silently dropped the window into the last track.
-    private func addFocusedToSpace(
+    func addFocusedToSpace(
         _ window: WindowID,
         to target: SpaceID
     ) {

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -186,21 +186,38 @@ extension KiwiCore {
         guard let focused = activeSpace?.focused else {
             return .fail("no focused window")
         }
-        let target = SpaceID(raw)
-        let from = state.workspaces.space(of: focused)
-        addFocusedToSpace(focused, to: target)
+        moveWindow(focused, to: SpaceID(raw), follow: follow)
+        return .ok()
+    }
+
+    /// Relocates an explicit `window` into `target`. `follow`
+    /// switches the visible space to the target; otherwise the
+    /// caller's space stays put and the moved window becomes the
+    /// target's focus for its next visit. The window-explicit
+    /// core behind `move_to_space(_and_follow)` and the Space Bar
+    /// drag-drop (#372) — the drag knows the window id, the
+    /// command resolves the focused one. When the target is
+    /// already the active space (a Space Bar spring drop), this
+    /// files the window into the visible layout and focuses it.
+    func moveWindow(
+        _ window: WindowID,
+        to target: SpaceID,
+        follow: Bool
+    ) {
+        let from = state.workspaces.space(of: window)
+        addFocusedToSpace(window, to: target)
         // The moved window becomes the target space's focus, so
         // the FIRST focus of that space raises it. Without this,
         // `focusSpace` finds no focus to hand over and the window
         // is un-stashed frame-wise but never brought forward —
         // the space renders empty until a later focus event
         // stamps the focus and a second switch surfaces it (#22).
-        state.workspaces.focus(focused, in: target)
+        state.workspaces.focus(window, in: target)
         if from != target {
             emitWindowMovedToSpace(
-                focused,
-                app: state.windows[focused]?.appName ?? "",
-                bundleID: state.windows[focused]?.appBundleID,
+                window,
+                app: state.windows[window]?.appName ?? "",
+                bundleID: state.windows[window]?.appBundleID,
                 from: from,
                 to: target
             )
@@ -208,7 +225,7 @@ extension KiwiCore {
         if follow {
             state.workspaces.activate(target)
             // The retile below owns placement (see focusWindow).
-            focusWindow(focused, refocusRetile: false, warp: true)
+            focusWindow(window, refocusRetile: false, warp: true)
             emitSpaceChange()
             // Following is a space switch too: re-assert so the
             // target's other windows survive a dropped frame.
@@ -223,6 +240,5 @@ extension KiwiCore {
                 ? tiler.settings.animations.onSpaceChange : true,
             force: follow
         )
-        return .ok()
     }
 }

--- a/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
+++ b/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
@@ -20,6 +20,7 @@ enum SpaceBarCommandSetting {
     case cornerRoundness(CGFloat)
     case showFrontApp(Bool)
     case hideEmpty(Bool)
+    case springDelay(Int)
     case textColor(String)
     case activeTextColor(String)
     case focusedItemColor(String)
@@ -43,6 +44,9 @@ enum SpaceBarCommandSetting {
                 return .failure("expected boolean")
             }
             return .success(keyword(flag))
+        }
+        if field == "spring_delay" {
+            return springDelay(args)
         }
         if let setting = parseChoice(field: field, args: args) {
             return setting
@@ -134,6 +138,23 @@ enum SpaceBarCommandSetting {
         ]
     }
 
+    /// Milliseconds, clamped to the Space Bar's valid dwell
+    /// range — a stored out-of-range value can't spring instantly
+    /// or hang.
+    private static func springDelay(
+        _ args: [JSONValue]
+    ) -> Result<SpaceBarCommandSetting, AppBarSettingError> {
+        guard let value = args.first?.numberValue else {
+            return .failure("expected milliseconds")
+        }
+        let range = SpaceBarStyle.springDelayRange
+        let clamped = min(
+            max(Int(value), range.lowerBound),
+            range.upperBound
+        )
+        return .success(.springDelay(clamped))
+    }
+
     private static func number(
         _ args: [JSONValue]
     ) -> Result<CGFloat, AppBarSettingError> {
@@ -189,6 +210,8 @@ enum SpaceBarCommandSetting {
         case .showFrontApp(let value):
             style.showFrontApp = value
         case .hideEmpty(let value): style.hideEmpty = value
+        case .springDelay(let value):
+            style.springDelay = value
         case .textColor(let value): style.textColor = value
         case .activeTextColor(let value):
             style.activeTextColor = value

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
@@ -95,8 +95,10 @@ public struct SpaceBarStyle: Sendable, Equatable {
     public static let frontDividerAlpha: CGFloat = 0.4
 
     /// Valid drag-drop dwell bounds (ms): fast enough to feel
-    /// responsive, slow enough not to spring by accident.
-    public static let springDelayRange = 500...4000
+    /// responsive, slow enough not to spring by accident. Floored
+    /// at 1000 so the sweep (which starts after a 0.5 s quiet
+    /// pre-delay) still has visible fill time.
+    public static let springDelayRange = 1000...4000
 
     public init() {}
 

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
@@ -58,6 +58,13 @@ public struct SpaceBarStyle: Sendable, Equatable {
     /// Hides empty spaces except the current one (verdict 4);
     /// off by default.
     public var hideEmpty = false
+    /// Drag-drop spring dwell (#372): how long a dragged window
+    /// must hover a Space item before the visible space springs
+    /// to it, in milliseconds. Read through `resolvedSpringDelay`,
+    /// which clamps to `springDelayRange`. Default 1500 (1.5 s).
+    /// (Named without the `MS` suffix so the reflected field name
+    /// snakes to the `spring_delay` key the parity guard expects.)
+    public var springDelay = 1500
     /// Inactive spaces: identifier + glyphs (muted tier).
     public var textColor = "#F2EBD966"
     /// The active space's accent (identifier + its glyphs).
@@ -87,7 +94,22 @@ public struct SpaceBarStyle: Sendable, Equatable {
     /// shared the same way.
     public static let frontDividerAlpha: CGFloat = 0.4
 
+    /// Valid drag-drop dwell bounds (ms): fast enough to feel
+    /// responsive, slow enough not to spring by accident.
+    public static let springDelayRange = 500...4000
+
     public init() {}
+
+    /// The drag-drop spring dwell in seconds, clamped to
+    /// `springDelayRange` — the coordinator and the sweep both
+    /// read this so a stored out-of-range value can't misbehave.
+    public var resolvedSpringDelay: TimeInterval {
+        let ms = min(
+            max(springDelay, Self.springDelayRange.lowerBound),
+            Self.springDelayRange.upperBound
+        )
+        return TimeInterval(ms) / 1000
+    }
 
     /// Same %-resolve as `AppBarStyle.resolvedCornerRadius` —
     /// small duplicated helper over a shared protocol (§2.4).
@@ -119,6 +141,7 @@ extension SpaceBarStyle: Codable {
         case cornerRoundness = "corner_roundness"
         case showFrontApp = "show_front_app"
         case hideEmpty = "hide_empty"
+        case springDelay = "spring_delay"
         case textColor = "text_color"
         case activeTextColor = "active_text_color"
         case focusedItemColor = "focused_item_color"
@@ -204,6 +227,11 @@ extension SpaceBarStyle: Codable {
                 Bool.self,
                 forKey: .hideEmpty
             ) ?? defaults.hideEmpty
+        springDelay =
+            try container.decodeIfPresent(
+                Int.self,
+                forKey: .springDelay
+            ) ?? defaults.springDelay
         try decodeColors(from: container)
     }
 

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -648,6 +648,8 @@
   "space_bar.preview.caption": "Position: %1$@ · %2$@",
   "space_bar.show_front_app": "Show front app",
   "space_bar.show_front_app.help": "Adds a trailing segment with the focused window of the Space each display currently shows. Icon-only on vertical bars.",
+  "space_bar.spring_delay": "Spring delay",
+  "space_bar.spring_delay.help": "Drag a window onto a Space and hold this long for the view to spring to that Space, so you can drop the window into its layout. A quicker drop moves the window there without switching.",
   "space_bar.tab_background.label": "Item background",
   "space_bar.thickness": "Thickness",
   "space_menu.placeholder": "Space…",

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -53,6 +53,7 @@ extension KiwiCore {
         drag.isMousePressed = {
             NSEvent.pressedMouseButtons & 1 == 1
         }
+        wireSpaceBarDrop()
     }
 
     /// Live feedback while a tiled window is dragged: a ghost
@@ -64,6 +65,19 @@ extension KiwiCore {
         start: CGRect,
         frame: CGRect
     ) {
+        // Pin the dragged window against `stashInactive` for the
+        // gesture's life, so a Space Bar spring can't stash it
+        // mid-drag (#372). Cleared at drop.
+        tiler.dragExemptWindow = id
+        // Feed the Space Bar drop machine the live cursor. While a
+        // bar target is armed (hover + pending spring), suppress
+        // the in-space ghost/drop-zone — the drag is heading off
+        // this space, not swapping within it.
+        spaceBarDrop.moved(id, cursor: NSEvent.mouseLocation)
+        if spaceBarDrop.isArmed {
+            dragOverlay.hideAll()
+            return
+        }
         let settings = tiler.settings
         guard
             settings.dragGhost.enabled
@@ -185,8 +199,24 @@ extension KiwiCore {
         start: CGRect,
         frame: CGRect
     ) {
+        tiler.dragExemptWindow = nil
         dragOverlay.hideAll()
         defer { scheduleBorderDropReconcile() }
+        // Space Bar drop resolves first (#372). A fast drop onto a
+        // different space's item relocates the window (stay put);
+        // a drop after the space sprang files it into the now-
+        // visible target layout. Both route through `moveWindow`,
+        // which handles either active-space case. Anything else
+        // (own space, off-bar) falls through to the in-space
+        // swap/snap-back logic unchanged.
+        switch spaceBarDrop.ended(id, cursor: NSEvent.mouseLocation)
+        {
+        case .relocate(let target), .placeInSprung(let target):
+            moveWindow(id, to: target, follow: false)
+            return
+        case .none:
+            break
+        }
         // A floating window is excluded from the layout swap/resize
         // logic below, but a drop that leaves it under a top app bar
         // hides its title bar and makes it ungrabbable — clamp it

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -203,18 +203,18 @@ extension KiwiCore {
         dragOverlay.hideAll()
         defer { scheduleBorderDropReconcile() }
         // Space Bar drop resolves first (#372). A fast drop onto a
-        // different space's item relocates the window (stay put);
-        // a drop after the space sprang files it into the now-
-        // visible target layout. Both route through `moveWindow`,
-        // which handles either active-space case. Anything else
-        // (own space, off-bar) falls through to the in-space
-        // swap/snap-back logic unchanged.
+        // different space's item relocates the window (stay put).
+        // A drop after the space sprang needs no move here — the
+        // window was already eager-moved into the now-active target
+        // at spring time — so it falls through to the ordinary in-
+        // space drop, which places it at the cursor's slot. Own-
+        // space / off-bar also fall through unchanged.
         switch spaceBarDrop.ended(id, cursor: NSEvent.mouseLocation)
         {
-        case .relocate(let target), .placeInSprung(let target):
+        case .relocate(let target):
             moveWindow(id, to: target, follow: false)
             return
-        case .none:
+        case .placeInSprung, .none:
             break
         }
         // A floating window is excluded from the layout swap/resize

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
@@ -31,14 +31,16 @@ public final class TilingEngine {
     /// and per-app EnhancedUserInterface toggling.
     private let applier = FrameApplier()
 
-    /// A window in an active drag gesture, exempt from
-    /// `stashInactive` (#372). While the user drags a window and
-    /// the Space Bar springs to another virtual space, the
-    /// dragged window is still a member of its SOURCE space, so
-    /// the spring's retile would stash it into the corner under
-    /// the cursor mid-drag. The drag handlers set this for the
-    /// gesture's life and clear it at drop. Same rationale as the
-    /// existing `!isFloating` exemption: pinned for the duration.
+    /// A window in an active drag gesture, exempt from ALL frame
+    /// application in `retile` — both the main layout loop and
+    /// `stashInactive` (#372). The pointer owns a dragged window's
+    /// frame, so a retile triggered mid-drag (notably a Space Bar
+    /// spring, which reframes the target space's other windows)
+    /// must not yank it to its computed slot or stash it into the
+    /// corner. The drag handlers set this for the gesture's life
+    /// and clear it at drop, when the window's real placement runs
+    /// un-exempt. Same spirit as the `!isFloating` stash exemption:
+    /// pinned for the duration.
     public var dragExemptWindow: WindowID?
 
     /// Resolves the AX element of a window (wired to the
@@ -166,6 +168,14 @@ public final class TilingEngine {
         let frames = calculatedFrames(state: state)
 
         for (id, target) in frames {
+            // A window in an active drag keeps its user-driven
+            // frame: the pointer owns it. Reframing it here would
+            // yank it to its computed slot mid-drag — a Space Bar
+            // spring retiles the target's OTHER windows but must
+            // leave the dragged one under the cursor (#372). Its
+            // real placement happens at drop, once the exemption
+            // clears.
+            if id == dragExemptWindow { continue }
             guard let current = state.windows[id]?.frame
             else { continue }
             // Tolerance: apps clamp what we set (character

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
@@ -31,6 +31,16 @@ public final class TilingEngine {
     /// and per-app EnhancedUserInterface toggling.
     private let applier = FrameApplier()
 
+    /// A window in an active drag gesture, exempt from
+    /// `stashInactive` (#372). While the user drags a window and
+    /// the Space Bar springs to another virtual space, the
+    /// dragged window is still a member of its SOURCE space, so
+    /// the spring's retile would stash it into the corner under
+    /// the cursor mid-drag. The drag handlers set this for the
+    /// gesture's life and clear it at drop. Same rationale as the
+    /// existing `!isFloating` exemption: pinned for the duration.
+    public var dragExemptWindow: WindowID?
+
     /// Resolves the AX element of a window (wired to the
     /// event loop's registry).
     public var elementProvider: @MainActor (WindowID) -> AXUIElement? = { _ in
@@ -259,7 +269,8 @@ public final class TilingEngine {
         where space.id != active {
             for id in space.windows {
                 guard let window = state.windows[id],
-                    !window.isFloating
+                    !window.isFloating,
+                    id != dragExemptWindow
                 else { continue }
                 let screen =
                     NSScreen.screens.first {

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
@@ -125,6 +125,25 @@ struct SpaceBarDropCoordinatorTests {
         #expect(coord.sprungSpace == nil)
     }
 
+    @Test("reset cancels a pending spring (abandoned drag)")
+    func resetCancelsSpring() async throws {
+        let (coord, rec) = make(
+            current: SpaceID("A"),
+            hit: SpaceID("B"),
+            dwell: 0.05
+        )
+        coord.moved(win, cursor: cursor)
+        #expect(coord.isArmed)
+        #expect(coord.draggingWindow == win)
+        coord.reset()
+        #expect(!coord.isArmed)
+        #expect(coord.draggingWindow == nil)
+        // Wait well past the (tiny) dwell: the spring must never
+        // fire — proven by the gap (200ms vs the 50ms dwell).
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(rec.sprang.isEmpty)
+    }
+
     /// Polls `condition` until true or `timeout` seconds elapse,
     /// yielding between checks. Passing runs exit at once.
     private func untilTrue(

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
@@ -34,7 +34,9 @@ struct SpaceBarDropCoordinatorTests {
         coord.hitTest = { _ in hit }
         coord.currentSpace = { _ in current }
         coord.setHover = { rec.hovered.append($0) }
-        coord.beginSweep = { space, _ in rec.sweeps.append(space) }
+        coord.beginSweep = { space, _, _ in
+            rec.sweeps.append(space)
+        }
         coord.clearFeedback = { rec.clears += 1 }
         coord.spring = { rec.sprang.append(($0, $1)) }
         return (coord, rec)
@@ -123,6 +125,21 @@ struct SpaceBarDropCoordinatorTests {
                 )
         )
         #expect(coord.sprungSpace == nil)
+    }
+
+    @Test("Re-arming a new item clears the previous sweep")
+    func rearmClearsPrevious() {
+        let (coord, rec) = make(
+            current: SpaceID("A"),
+            hit: SpaceID("B")
+        )
+        coord.moved(win, cursor: cursor)
+        let clearsAfterFirst = rec.clears
+        // Move straight onto another item without leaving the bar.
+        coord.hitTest = { _ in SpaceID("C") }
+        coord.moved(win, cursor: cursor)
+        #expect(rec.clears > clearsAfterFirst)
+        #expect(rec.sweeps == [SpaceID("B"), SpaceID("C")])
     }
 
     @Test("reset cancels a pending spring (abandoned drag)")

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
@@ -1,0 +1,143 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The Space Bar drag-drop state machine (#372): the two-speed
+/// gesture (fast drop relocates, dwell springs then places),
+/// hover arming, and cancellation. Injected closures keep the
+/// coordinator AppKit-free, so this drives it directly.
+@MainActor
+@Suite("Space bar drop coordinator")
+struct SpaceBarDropCoordinatorTests {
+    /// Records the visual cues the coordinator emits.
+    private final class Recorder {
+        var hovered: [SpaceID?] = []
+        var sweeps: [SpaceID] = []
+        var clears = 0
+        var sprang: [(SpaceID, WindowID)] = []
+    }
+
+    private let win = WindowID(1)
+    /// Cursor over space "B"; the hit test below maps to it.
+    private let cursor = CGPoint(x: 10, y: 10)
+
+    private func make(
+        current: SpaceID,
+        hit: SpaceID?,
+        dwell: TimeInterval = 30
+    ) -> (SpaceBarDropCoordinator, Recorder) {
+        let rec = Recorder()
+        let coord = SpaceBarDropCoordinator()
+        coord.dwell = dwell
+        coord.hitTest = { _ in hit }
+        coord.currentSpace = { _ in current }
+        coord.setHover = { rec.hovered.append($0) }
+        coord.beginSweep = { space, _ in rec.sweeps.append(space) }
+        coord.clearFeedback = { rec.clears += 1 }
+        coord.spring = { rec.sprang.append(($0, $1)) }
+        return (coord, rec)
+    }
+
+    @Test("Fast drop onto another space relocates it")
+    func fastDropRelocates() {
+        let (coord, rec) = make(
+            current: SpaceID("A"),
+            hit: SpaceID("B")
+        )
+        coord.moved(win, cursor: cursor)
+        #expect(coord.isArmed)
+        #expect(rec.hovered.last == SpaceID("B"))
+        #expect(rec.sweeps == [SpaceID("B")])
+        // Released before the (long) dwell → relocate, no spring.
+        #expect(
+            coord.ended(win, cursor: cursor)
+                == .relocate(
+                    SpaceID("B")
+                )
+        )
+        #expect(rec.sprang.isEmpty)
+    }
+
+    @Test("Hovering the window's own space never arms")
+    func ownSpaceInert() {
+        let (coord, rec) = make(
+            current: SpaceID("A"),
+            hit: SpaceID("A")
+        )
+        coord.moved(win, cursor: cursor)
+        #expect(!coord.isArmed)
+        #expect(rec.sweeps.isEmpty)
+        #expect(coord.ended(win, cursor: cursor) == .none)
+    }
+
+    @Test("Dropping off any bar item falls through")
+    func offBarFallsThrough() {
+        let (coord, _) = make(current: SpaceID("A"), hit: nil)
+        coord.moved(win, cursor: cursor)
+        #expect(!coord.isArmed)
+        #expect(coord.ended(win, cursor: cursor) == .none)
+    }
+
+    @Test("Leaving the item cancels the pending spring")
+    func leaveCancels() {
+        let (coord, rec) = make(
+            current: SpaceID("A"),
+            hit: SpaceID("B")
+        )
+        coord.moved(win, cursor: cursor)
+        #expect(coord.isArmed)
+        // Cursor leaves the strip: the next move hit-tests nil.
+        coord.hitTest = { _ in nil }
+        coord.moved(win, cursor: cursor)
+        #expect(!coord.isArmed)
+        #expect(rec.clears >= 1)
+    }
+
+    @Test(
+        "Dwell springs the space, then the drop places in it"
+    )
+    func dwellSpringsThenPlaces() async throws {
+        let (coord, rec) = make(
+            current: SpaceID("A"),
+            hit: SpaceID("B"),
+            dwell: 0.05
+        )
+        coord.moved(win, cursor: cursor)
+        // Generous hang-guard (AGENTS.md): the wait exits the
+        // instant the spring fires; the deadline only bounds a
+        // genuine hang under concurrent-suite load.
+        try await untilTrue(timeout: 30) {
+            !rec.sprang.isEmpty
+        }
+        #expect(rec.sprang.map(\.0) == [SpaceID("B")])
+        #expect(rec.sprang.first?.1 == win)
+        #expect(coord.sprungSpace == SpaceID("B"))
+        // The window is now on the visible target: the drop places
+        // it there rather than relocating.
+        #expect(
+            coord.ended(win, cursor: cursor)
+                == .placeInSprung(
+                    SpaceID("B")
+                )
+        )
+        #expect(coord.sprungSpace == nil)
+    }
+
+    /// Polls `condition` until true or `timeout` seconds elapse,
+    /// yielding between checks. Passing runs exit at once.
+    private func untilTrue(
+        timeout: TimeInterval,
+        _ condition: @MainActor () -> Bool
+    ) async throws {
+        let start = Date()
+        while !condition() {
+            if Date().timeIntervalSince(start) > timeout {
+                Issue.record("condition never became true")
+                return
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+}

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
@@ -30,7 +30,7 @@ struct SpaceBarDropCoordinatorTests {
     ) -> (SpaceBarDropCoordinator, Recorder) {
         let rec = Recorder()
         let coord = SpaceBarDropCoordinator()
-        coord.dwell = dwell
+        coord.dwellProvider = { dwell }
         coord.hitTest = { _ in hit }
         coord.currentSpace = { _ in current }
         coord.setHover = { rec.hovered.append($0) }

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
@@ -75,23 +75,25 @@ struct SpaceBarDropMoveTests {
         #expect(core.spaceBarDrop.draggingWindow == nil)
     }
 
-    @Test("Dropping into the sprung (now-active) space files it")
-    func filesIntoSprungSpace() {
+    @Test("Spring eager-moves the dragged window into the target")
+    func springEagerMovesWindow() {
         let core = makeCore()
         addWindow(core, 1)
-        // Emulate a spring: the visible space is now 2 while the
-        // dragged window still lives in its source space 1.
-        core.state.workspaces.activate(SpaceID("2"))
+        #expect(core.state.workspaces.activeSpace == SpaceID(1))
+
+        // Fire the spring the dwell would trigger (the coordinator
+        // calls this closure). Eager membership: the window moves
+        // into the target NOW, so the live drag can preview and the
+        // drop places it precisely.
+        core.spaceBarDrop.spring(SpaceID("2"), WindowID(1))
+
         #expect(core.state.workspaces.activeSpace == SpaceID("2"))
-
-        core.moveWindow(WindowID(1), to: SpaceID("2"), follow: false)
-
-        // The window joins the active target as its focus.
         #expect(
             core.state.workspaces[SpaceID("2")]?.windows
                 == [WindowID(1)]
         )
         #expect(core.activeSpace?.focused == WindowID(1))
-        #expect(core.state.workspaces.activeSpace == SpaceID("2"))
+        // Pinned against stashInactive for the rest of the drag.
+        #expect(core.tiler.dragExemptWindow == WindowID(1))
     }
 }

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
@@ -1,0 +1,79 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The window-explicit `moveWindow` core behind the Space Bar
+/// drag-drop (#372): a fast drop relocates an explicit (not
+/// necessarily focused) window, and a drop after a spring files
+/// the window into what is now the active space.
+@Suite("Space bar drop moves", .serialized)
+@MainActor
+struct SpaceBarDropMoveTests {
+    private func makeCore() -> KiwiCore {
+        KiwiCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-drop-\(UUID().uuidString)"
+                )
+        )
+    }
+
+    private func addWindow(_ core: KiwiCore, _ raw: UInt32) {
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(
+                    id: WindowID(raw),
+                    pid: 1,
+                    appName: "App"
+                )
+            )
+        )
+    }
+
+    @Test("Fast drop relocates an explicit, non-focused window")
+    func relocatesExplicitWindow() {
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        // Window 2 is the active-space focus; drag window 1.
+        #expect(core.activeSpace?.focused == WindowID(2))
+
+        core.moveWindow(WindowID(1), to: SpaceID("2"), follow: false)
+
+        // Stay on space 1; window 1 relocated; focus untouched.
+        #expect(core.state.workspaces.activeSpace == SpaceID(1))
+        #expect(
+            core.state.workspaces[SpaceID(2)]?.windows
+                == [WindowID(1)]
+        )
+        #expect(core.activeSpace?.focused == WindowID(2))
+        #expect(
+            core.state.workspaces[SpaceID(1)]?.windows
+                == [WindowID(2)]
+        )
+    }
+
+    @Test("Dropping into the sprung (now-active) space files it")
+    func filesIntoSprungSpace() {
+        let core = makeCore()
+        addWindow(core, 1)
+        // Emulate a spring: the visible space is now 2 while the
+        // dragged window still lives in its source space 1.
+        core.state.workspaces.activate(SpaceID("2"))
+        #expect(core.state.workspaces.activeSpace == SpaceID("2"))
+
+        core.moveWindow(WindowID(1), to: SpaceID("2"), follow: false)
+
+        // The window joins the active target as its focus.
+        #expect(
+            core.state.workspaces[SpaceID("2")]?.windows
+                == [WindowID(1)]
+        )
+        #expect(core.activeSpace?.focused == WindowID(1))
+        #expect(core.state.workspaces.activeSpace == SpaceID("2"))
+    }
+}

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
@@ -57,6 +57,24 @@ struct SpaceBarDropMoveTests {
         )
     }
 
+    @Test("cancelDrag tears down drop state, scoped to the window")
+    func cancelDragTearsDown() {
+        let core = makeCore()
+        addWindow(core, 1)
+        core.tiler.dragExemptWindow = WindowID(1)
+        core.spaceBarDrop.moved(WindowID(1), cursor: .zero)
+        #expect(core.spaceBarDrop.draggingWindow == WindowID(1))
+        // A cancel for a different window leaves the gesture alone.
+        core.cancelDrag(WindowID(2))
+        #expect(core.tiler.dragExemptWindow == WindowID(1))
+        #expect(core.spaceBarDrop.draggingWindow == WindowID(1))
+        // A cancel for the dragged window clears both — no leaked
+        // exemption, no stale spring target for the next drag.
+        core.cancelDrag(WindowID(1))
+        #expect(core.tiler.dragExemptWindow == nil)
+        #expect(core.spaceBarDrop.draggingWindow == nil)
+    }
+
     @Test("Dropping into the sprung (now-active) space files it")
     func filesIntoSprungSpace() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
@@ -75,6 +75,29 @@ struct SpaceBarDropMoveTests {
         #expect(core.spaceBarDrop.draggingWindow == nil)
     }
 
+    @Test("A dragged window is exempt from retile frame apply")
+    func dragExemptWindowNotReframed() {
+        // Slot geometry needs a real screen (headless CI skips).
+        guard NSScreen.main != nil else { return }
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        core.tiler.animation.isEnabled = false
+        var applied: Set<WindowID> = []
+        core.tiler.animation.apply = { id, _, _ in
+            applied.insert(id)
+        }
+        // With window 1 pinned as the in-flight drag, a forced
+        // retile must place the others but never reframe it — the
+        // pointer owns its frame (#372). Reframing it here is what
+        // yanked it to a slot mid-drag and tripped the echo guard.
+        core.tiler.dragExemptWindow = WindowID(1)
+        applied = []
+        core.retile(force: true)
+        #expect(!applied.contains(WindowID(1)))
+        #expect(applied.contains(WindowID(2)))
+    }
+
     @Test("Spring eager-moves the dragged window into the target")
     func springEagerMovesWindow() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/SpaceBarFixtures.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarFixtures.swift
@@ -24,6 +24,7 @@ enum SpaceBarFixtures {
         style.cornerRoundness = 5
         style.showFrontApp = true
         style.hideEmpty = true
+        style.springDelay = 1000
         style.textColor = "#010101"
         style.activeTextColor = "#020202"
         style.focusedItemColor = "#030303"

--- a/Tests/KiwiDeskCoreTests/SpaceBarParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarParityTests.swift
@@ -108,6 +108,7 @@ struct SpaceBarCommandParityTests {
         .iconSource(.appFont), .tabBackground(.plain),
         .activeIndicator(.gap), .cornerRoundness(5),
         .showFrontApp(true), .hideEmpty(true),
+        .springDelay(1000),
         .textColor("#010101"), .activeTextColor("#020202"),
         .focusedItemColor("#030303"), .hoverColor("#040404"),
         .hoverTextColor("#050505"), .boxColor("#060606"),
@@ -191,6 +192,7 @@ struct SpaceBarCommandParityTests {
         case .thickness, .boxSize, .boxGap, .fontSize,
             .cornerRoundness:
             return [.number(10)]
+        case .springDelay: return [.number(1000)]
         default:
             return [.string("#123456")]
         }

--- a/Tests/KiwiDeskCoreTests/SpaceBarRunMetricsTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarRunMetricsTests.swift
@@ -1,0 +1,106 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The pure Space Bar run geometry (#372): item frames and the
+/// trailing front-segment origin per alignment, edge, and front
+/// extent. Shared by `render()` and the drag-drop hit test, so it
+/// is pinned independently.
+@Suite("Space bar run metrics")
+struct SpaceBarRunMetricsTests {
+    private let horizontalStrip = CGRect(
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 32
+    )
+    private let lengths: [CGFloat] = [20, 20, 20]
+
+    @Test("Start alignment packs the run from the pad")
+    func startAlignment() {
+        let m = SpaceBarOverlay.runMetrics(
+            lengths: lengths,
+            gap: 4,
+            frontExtent: 0,
+            strip: horizontalStrip,
+            horizontal: true,
+            alignment: .start,
+            pad: 4
+        )
+        #expect(m.itemFrames.map(\.minX) == [4, 28, 52])
+        #expect(m.itemFrames.allSatisfy { $0.width == 20 })
+        #expect(m.itemFrames.allSatisfy { $0.height == 32 })
+        // Trailing cursor is one gap past the last item.
+        #expect(m.frontStart == 76)
+    }
+
+    @Test("Center alignment splits the slack both sides")
+    func centerAlignment() {
+        // total = 60 + 2*4 gaps = 68; slack = (200 - 68)/2 = 66.
+        let m = SpaceBarOverlay.runMetrics(
+            lengths: lengths,
+            gap: 4,
+            frontExtent: 0,
+            strip: horizontalStrip,
+            horizontal: true,
+            alignment: .center,
+            pad: 4
+        )
+        #expect(m.itemFrames.map(\.minX) == [66, 90, 114])
+    }
+
+    @Test("End alignment right-justifies, front extent included")
+    func endAlignmentWithFront() {
+        // total = 68 + front 12 = 80; start = 200 - 80 - 4 = 116.
+        let m = SpaceBarOverlay.runMetrics(
+            lengths: lengths,
+            gap: 4,
+            frontExtent: 12,
+            strip: horizontalStrip,
+            horizontal: true,
+            alignment: .end,
+            pad: 4
+        )
+        #expect(m.itemFrames.first?.minX == 116)
+        // The cursor advances a gap after every item (including
+        // the last), so the front segment starts one gap past the
+        // last item — a faithfully-preserved pre-extraction quirk:
+        // start 116 + 3 items (60) + 3 gaps (12) = 188.
+        #expect(m.frontStart == 188)
+        #expect(m.frontStart + 12 == 200)
+    }
+
+    @Test("Vertical strip lays the run down the y axis")
+    func verticalAxis() {
+        let strip = CGRect(x: 0, y: 0, width: 32, height: 200)
+        let m = SpaceBarOverlay.runMetrics(
+            lengths: lengths,
+            gap: 4,
+            frontExtent: 0,
+            strip: strip,
+            horizontal: false,
+            alignment: .start,
+            pad: 4
+        )
+        #expect(m.itemFrames.map(\.minY) == [4, 28, 52])
+        #expect(m.itemFrames.allSatisfy { $0.minX == 0 })
+        #expect(m.itemFrames.allSatisfy { $0.width == 32 })
+        #expect(m.itemFrames.map(\.height) == [20, 20, 20])
+    }
+
+    @Test("An oversized run floors to the pad (no scroll)")
+    func oversizedFloorsToStart() {
+        let m = SpaceBarOverlay.runMetrics(
+            lengths: [200, 200],
+            gap: 4,
+            frontExtent: 0,
+            strip: horizontalStrip,
+            horizontal: true,
+            alignment: .center,
+            pad: 4
+        )
+        #expect(m.itemFrames.first?.minX == 4)
+    }
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1189,14 +1189,24 @@ The load-bearing details, so they are not relitigated:
   `animated: false` regardless of `animations.on_space_change`
   (a crisp switch must not add motion competing with the live
   foreign-app drag).
-- Space membership flips lazily at drop (reading the active Space
-  then), never eagerly at spring, so a mind-change or cancel
-  leaves no stale state.
-- The dwell is 2 s (longer than Finder's ~0.7 s): the ring sweep
-  shows progress, and a whole-view switch is a bigger disruption
-  than a folder opening, so the accidental-trigger bar sits
-  higher. Always-on, no enable toggle; focus-after-drop is not a
-  new setting (`move_to_space_and_follow` already models
+- Space membership flips **eagerly at spring** (QA revision): the
+  window is moved into the target the moment the view springs, so
+  the live drag shows the ordinary drop preview (ghost + drop-
+  zone) in the target's layout and the release lands it in the
+  exact slot. An earlier design flipped membership lazily at drop
+  to avoid stale state on cancel, but that left no preview during
+  placement; the abnormal-end teardown (`cancelDrag` → `reset` +
+  clear `dragExemptWindow`) covers the cancel case instead, so
+  eager membership is safe. The window stays exempt from
+  `stashInactive` throughout, so the eager move never strands it.
+- The dwell defaults to **1.5 s** and is user-configurable
+  (`space_bar.spring_delay`, clamped 500–4000 ms; a Spring delay
+  slider in the Space Bar editor). Longer than Finder's ~0.7 s:
+  the ring sweep shows progress and a whole-view switch is a
+  bigger disruption than a folder opening, so the accidental-
+  trigger floor sits higher. The sweep animation tracks the
+  configured value. Always-on, no enable toggle; focus-after-drop
+  is not a new setting (`move_to_space_and_follow` already models
   following). Option-held-drop → follow is a deferred second gear.
 
 **Bar alignment is edge-relative, one shared default.**

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1212,12 +1212,18 @@ The load-bearing details, so they are not relitigated:
   cardinality change is deliberate; hooks keyed on the event see
   the intermediate moves.
 - The dwell defaults to **1.5 s** and is user-configurable
-  (`space_bar.spring_delay`, clamped 500–4000 ms; a Spring delay
+  (`space_bar.spring_delay`, clamped 1000–4000 ms; a Spring delay
   slider in the Space Bar editor). Longer than Finder's ~0.7 s:
   the ring sweep shows progress and a whole-view switch is a
   bigger disruption than a folder opening, so the accidental-
   trigger floor sits higher. The sweep animation tracks the
-  configured value. Always-on, no enable toggle; focus-after-drop
+  configured value, but only *starts* after a fixed 0.5 s quiet
+  pre-delay (`SpaceBarDropCoordinator.springPreDelay`) so a quick
+  flick-to-relocate never flashes a loading ring; the spring still
+  fires at the full dwell, so the sweep fills over
+  `dwell − 0.5 s`, and the range floors at 1 s to keep that fill
+  visible. The pre-delay is a `beginTime` offset on the stroke
+  animation, so leaving before it elapses shows nothing. Always-on, no enable toggle; focus-after-drop
   is not a new setting (`move_to_space_and_follow` already models
   following). Option-held-drop → follow is a deferred second gear.
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1169,6 +1169,36 @@ per display means per-display content, consistent with every
 other per-display fact in the bar; a secondary display shows
 its own space's remembered focus.
 
+**Space Bar drag-drop is a two-speed spring, not a blind
+relocate.** (#372.) Dragging a window onto a Space item either
+relocates it (fast drop, `move_to_space`) or, after a 2 s dwell,
+springs the view to that Space so the window is dropped into its
+live layout. A first design pass rejected spring-loading over a
+cross-process race fear; it was reconsidered once grounded in the
+code, because KiwiDesk's Spaces are *virtual* (a retile, not a
+WindowServer Space change), which narrows the risk to one place.
+The load-bearing details, so they are not relitigated:
+- The dragged window is exempted from `stashInactive` for the
+  gesture's life (`TilingEngine.dragExemptWindow`), the same kind
+  of pin as the existing `!isFloating` exemption — otherwise the
+  spring's retile would stash it under the cursor mid-drag.
+- The spring uses a private activate-plus-retile helper, **not**
+  `focusSpace`: that command warps the cursor to hand off AX
+  focus, which would rip the pointer out of the OS drag loop. No
+  focus hand-off, no warp, and the spring retile is
+  `animated: false` regardless of `animations.on_space_change`
+  (a crisp switch must not add motion competing with the live
+  foreign-app drag).
+- Space membership flips lazily at drop (reading the active Space
+  then), never eagerly at spring, so a mind-change or cancel
+  leaves no stale state.
+- The dwell is 2 s (longer than Finder's ~0.7 s): the ring sweep
+  shows progress, and a whole-view switch is a bigger disruption
+  than a folder opening, so the accidental-trigger bar sits
+  higher. Always-on, no enable toggle; focus-after-drop is not a
+  new setting (`move_to_space_and_follow` already models
+  following). Option-held-drop → follow is a deferred second gear.
+
 **Bar alignment is edge-relative, one shared default.**
 (#293 QA.) Both bars place their content run via `alignment` —
 `start` / `center` / `end`, values edge-relative (a left bar's

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1194,11 +1194,23 @@ The load-bearing details, so they are not relitigated:
   the live drag shows the ordinary drop preview (ghost + drop-
   zone) in the target's layout and the release lands it in the
   exact slot. An earlier design flipped membership lazily at drop
-  to avoid stale state on cancel, but that left no preview during
-  placement; the abnormal-end teardown (`cancelDrag` → `reset` +
-  clear `dragExemptWindow`) covers the cancel case instead, so
-  eager membership is safe. The window stays exempt from
-  `stashInactive` throughout, so the eager move never strands it.
+  to avoid stale state, but that left no preview during placement.
+  Eager membership needs no rollback: an abnormal end (window
+  closed / tab rekeyed) means the window is gone, so stranding is
+  moot, and a normal drop is *meant* to place into the sprung
+  space — `cancelDrag` only tears down the gesture bookkeeping
+  (pending spring, `dragExemptWindow`); it does not, and need not,
+  move the window back. The dragged window is exempt from **all**
+  frame application in `retile` for the gesture's life — both the
+  layout loop and `stashInactive`, via `dragExemptWindow` — so the
+  spring's retile places the target's OTHER windows but leaves the
+  dragged one under the cursor. Without the layout-loop exemption
+  the retile yanks it to its computed slot mid-drag (a small
+  dwindled BSP corner, say). Because the move commits at spring,
+  `window_moved_to_space` fires then rather than once at drop, and
+  once per spring — a chained A→B→C dwell emits two moves. That
+  cardinality change is deliberate; hooks keyed on the event see
+  the intermediate moves.
 - The dwell defaults to **1.5 s** and is user-configurable
   (`space_bar.spring_delay`, clamped 500–4000 ms; a Spring delay
   slider in the Space Bar editor). Longer than Finder's ~0.7 s:

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -162,6 +162,10 @@ following** it — you stay on the current space. The moved
 window becomes the target space's focused window, so the first
 time you switch there it is the window you land on.
 
+A quick drag-and-drop of a window onto a Space item in the Space
+Bar performs this same move (see the user guide); there is no
+separate verb for it.
+
 **Example:**
 
 ```lua

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1871,7 +1871,7 @@ space_bar.set_hide_empty(true)
 ### space_bar.set_spring_delay
 
 **Expects:** milliseconds (default `1500`, clamped to
-`500`–`4000`).
+`1000`–`4000`).
 
 **Does:** sets how long a window dragged onto a Space item must
 hover before the view springs to that Space (the "hold to place"

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1868,6 +1868,23 @@ reachable by shortcut.
 space_bar.set_hide_empty(true)
 ```
 
+### space_bar.set_spring_delay
+
+**Expects:** milliseconds (default `1500`, clamped to
+`500`–`4000`).
+
+**Does:** sets how long a window dragged onto a Space item must
+hover before the view springs to that Space (the "hold to place"
+half of the drag-drop gesture — see the user guide). A quicker
+drop, before this delay, moves the window without switching. The
+ring sweep around the item fills over the same duration.
+
+**Example:**
+
+```lua
+space_bar.set_spring_delay(1000)
+```
+
 ### Space Bar colors
 
 Same `#RRGGBB` / `#RRGGBBAA` grammar as every other color

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -727,6 +727,21 @@ collapse into one glyph with a count badge, and past five slots
 the rest fold into a `+n` badge. Click a Space to switch to it;
 glyphs are informational.
 
+**Drag a window onto a Space** to move it there — a two-speed
+gesture. Drag a window's title bar over another Space's item and
+either:
+
+- **Flick and drop** — release before the ring fills and the
+  window jumps straight to that Space; you stay where you are.
+- **Hold to place** — pause over the item; a ring sweeps around
+  it and after two seconds the view springs to that Space, so you
+  can drop the window exactly where you want in its live layout.
+
+Move the cursor off the item before the ring completes to cancel.
+The whole item is the target (glyphs and the `+n` badge are not
+separate drop zones), and dropping onto the Space a window is
+already on does nothing.
+
 The editor's order matches the App Bar editor's: preview,
 **Show Space Bar**, **Position** (any of the four screen edges
 — sharing an edge with the App Bar is fine, the Space Bar sits

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -739,7 +739,7 @@ either:
   where you want (the usual drag preview shows the slot).
 
 The hold length is the **Spring delay** (Space Bar editor,
-default 1.5 s, adjustable 0.5–4 s). Move the cursor off the item
+default 1.5 s, adjustable 1–4 s). Move the cursor off the item
 before the ring completes to cancel. The whole item is the target
 (glyphs and the `+n` badge are not separate drop zones), and
 dropping onto the Space a window is already on does nothing.
@@ -770,7 +770,7 @@ shortcut) and **Show front app** — a trailing segment with the
 focused window of the Space each display currently shows
 (icon-only on vertical bars). **Spring delay** sets how long a
 dragged window must hover a Space before the view springs to it
-(default 1.5 s, 0.5–4 s).
+(default 1.5 s, 1–4 s).
 
 ## Behavior
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -734,13 +734,15 @@ either:
 - **Flick and drop** — release before the ring fills and the
   window jumps straight to that Space; you stay where you are.
 - **Hold to place** — pause over the item; a ring sweeps around
-  it and after two seconds the view springs to that Space, so you
-  can drop the window exactly where you want in its live layout.
+  it and after a short hold the view springs to that Space, with
+  the window now in its live layout so you can drop it exactly
+  where you want (the usual drag preview shows the slot).
 
-Move the cursor off the item before the ring completes to cancel.
-The whole item is the target (glyphs and the `+n` badge are not
-separate drop zones), and dropping onto the Space a window is
-already on does nothing.
+The hold length is the **Spring delay** (Space Bar editor,
+default 1.5 s, adjustable 0.5–4 s). Move the cursor off the item
+before the ring completes to cancel. The whole item is the target
+(glyphs and the `+n` badge are not separate drop zones), and
+dropping onto the Space a window is already on does nothing.
 
 The editor's order matches the App Bar editor's: preview,
 **Show Space Bar**, **Position** (any of the four screen edges
@@ -766,7 +768,9 @@ Two behavior toggles: **Hide empty Spaces** (the current Space
 always stays visible; hidden Spaces remain reachable by
 shortcut) and **Show front app** — a trailing segment with the
 focused window of the Space each display currently shows
-(icon-only on vertical bars).
+(icon-only on vertical bars). **Spring delay** sets how long a
+dragged window must hover a Space before the view springs to it
+(default 1.5 s, 0.5–4 s).
 
 ## Behavior
 


### PR DESCRIPTION
Closes #372.

Drag a window onto a Space item in the Space Bar to move it there — a **two-speed gesture**:

- **Flick and drop** — release on a different Space's item before the ring fills → the window jumps there, you stay put (`move_to_space`).
- **Hold to place** — pause over an item; a ring sweeps around it and after 2 s the view springs to that Space, so you drop the window into its live layout exactly where you want.

Move off the item before the ring completes to cancel. The whole item is the target (glyphs / `+n` are not separate zones); dropping onto a window's own Space is a no-op.

## How it works

No `NSDraggingSession` is possible — the dragged window belongs to another app — so this hooks the existing AX drag pipeline (`DragCoordinator` → `handleDragMove`/`handleDragEnd`).

- **`SpaceBarDropCoordinator`** — injectable, AppKit-free state machine (arm → dwell → spring/relocate), unit-tested.
- **`SpaceBarOverlay.runMetrics`** — pure run geometry extracted from `render()`, shared with the point-based hit test so the drop target can't disagree with the drawn layout.
- Synthetic drag-hover reuses the item's `hoverColor`; the pending-spring sweep is a `CAShapeLayer` stroke reusing the active-indicator ring.
- **`TilingEngine.dragExemptWindow`** pins the in-flight window against `stashInactive`, so a spring's retile can't stash it under the cursor.
- The spring uses a private activate+retile helper, **not** `focusSpace` (which warps the cursor — that would rip the pointer out of the OS drag loop). No warp, `animated: false`.
- `moveToSpace` refactored to a window-explicit `moveWindow(_:to:follow:)` core the drag and the command both call.

Always-on (no new setting); focus-after-drop stays modeled by `move_to_space_and_follow`; Option-held-drop → follow is a deferred second gear.

## Design

Interaction settled by two ui-designer consults: spring-loading was reconsidered and accepted once grounded in the code (KiwiDesk's Spaces are virtual — the switch is a retile, not a WindowServer Space change). Load-bearing details (the `stashInactive` exemption, no-warp helper, lazy membership-at-drop, 2 s dwell) are pinned in `docs/design-decisions.md` so they aren't relitigated.

## Verification

- `swift build`, `swift test` (1487 pass), `scripts/lint.sh`, `swift build -c release` — all green.
- Reviewed by `code-reviewer` + `architect-reviewer`. One HIGH finding (abandoned-drag teardown leak on `drag.cancel` paths) fixed via scoped `cancelDrag(_:)` + tests; re-review confirmed correct. No guardrail violations.

## Docs

`docs/user-guide.md` (gesture), `docs/design-decisions.md` (decision + rationale), `docs/lua-reference.md` (note that the gesture maps to `move_to_space`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)