### PR TITLE
fix(commands): guard Int() traps on caller-supplied numbers

### DIFF
--- a/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
+++ b/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
@@ -148,15 +148,19 @@ enum SpaceBarCommandSetting {
     private static func springDelay(
         _ args: [JSONValue]
     ) -> Result<SpaceBarCommandSetting, AppBarSettingError> {
-        guard let value = args.first?.numberValue else {
+        guard let value = args.first?.numberValue,
+            value.isFinite
+        else {
             return .failure("expected milliseconds")
         }
         let range = SpaceBarStyle.springDelayRange
+        // Clamp as Double BEFORE Int(...) — `Int(1e300)` traps,
+        // so a config typo would otherwise kill the WM (#58/#386).
         let clamped = min(
-            max(Int(value), range.lowerBound),
-            range.upperBound
+            max(value.rounded(), Double(range.lowerBound)),
+            Double(range.upperBound)
         )
-        return .success(.springDelay(clamped))
+        return .success(.springDelay(Int(clamped)))
     }
 
     /// App-group glyph count, clamped to the Space Bar's valid

--- a/Sources/KiwiDeskCore/IPC/JSONValue.swift
+++ b/Sources/KiwiDeskCore/IPC/JSONValue.swift
@@ -56,9 +56,14 @@ public indirect enum JSONValue: Codable, Sendable, Equatable {
         case .string(let s):
             return s
         case .number(let n):
-            return n == n.rounded()
-                ? String(Int(n))
-                : String(n)
+            // A whole number prints without the ".0", but only
+            // via the Int path when it actually fits — `Int(1e300)`
+            // traps (#386), so an out-of-range whole number falls
+            // back to the Double formatting.
+            if n == n.rounded(), let i = n.finiteInt {
+                return String(i)
+            }
+            return String(n)
         default:
             return nil
         }
@@ -76,7 +81,7 @@ public indirect enum JSONValue: Codable, Sendable, Equatable {
     }
 
     public var intValue: Int? {
-        numberValue.map { Int($0) }
+        numberValue?.finiteInt
     }
 
     public var boolValue: Bool? {
@@ -90,6 +95,23 @@ public indirect enum JSONValue: Codable, Sendable, Equatable {
         default:
             return nil
         }
+    }
+}
+
+extension Double {
+    /// Safe `Int` conversion: nil unless the value is finite and
+    /// inside `Int`'s range. `Int(1e300)`, `Int(.nan)`, and
+    /// `Int(.infinity)` all trap, so any raw `Double → Int` on
+    /// caller-supplied config/IPC numbers must route through here
+    /// (#386). `Double(Int.max)` rounds up to 2^63, so the upper
+    /// bound is a strict `<` — every value it admits is a
+    /// representable `Int`.
+    public var finiteInt: Int? {
+        guard isFinite,
+            self >= Double(Int.min),
+            self < Double(Int.max)
+        else { return nil }
+        return Int(self)
     }
 }
 

--- a/Sources/KiwiDeskCore/Lua/LuaValue.swift
+++ b/Sources/KiwiDeskCore/Lua/LuaValue.swift
@@ -27,7 +27,7 @@ public indirect enum LuaValue: Sendable, Equatable {
     }
 
     public var intValue: Int? {
-        numberValue.map { Int($0) }
+        numberValue?.finiteInt
     }
 
     public var boolValue: Bool? {

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
@@ -165,11 +165,18 @@ extension TilingSettings: Codable {
             keyedBy: ResizeKeys.self,
             forKey: .resize
         )
-        resizeStep =
+        // Clamp at the decode boundary so `resizeStep` is always
+        // finite and in the command's range — a hand-edited
+        // `resize.step: 1e300` would otherwise trap the `Int(...)`
+        // read sites (GUI seed, keybinding rows) that assume a
+        // sane value (#386). Mirrors `set_resize_step`.
+        let rawStep =
             try resize.decodeIfPresent(
                 CGFloat.self,
                 forKey: .step
             ) ?? 50
+        resizeStep =
+            rawStep.isFinite ? min(max(rawStep, 1), 10_000) : 50
         resizeFeedback =
             try resize.decodeIfPresent(
                 Bool.self,

--- a/Tests/KiwiDeskCoreTests/NumberTrapSafetyTests.swift
+++ b/Tests/KiwiDeskCoreTests/NumberTrapSafetyTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// #386: caller-supplied config/IPC numbers must never trap a raw
+/// `Double → Int` conversion. `Int(1e300)`, `Int(.nan)`, and
+/// `Int(.infinity)` all crash the process; a single mistyped Lua
+/// or JSON number could otherwise take down the WM.
+@Suite("Number → Int trap safety (#386)")
+struct NumberTrapSafetyTests {
+    @Test("Double.finiteInt rejects out-of-range and non-finite")
+    func finiteInt() {
+        #expect((3.0).finiteInt == 3)
+        #expect((-7.0).finiteInt == -7)
+        #expect((1e300).finiteInt == nil)
+        #expect((-1e300).finiteInt == nil)
+        #expect(Double.nan.finiteInt == nil)
+        #expect(Double.infinity.finiteInt == nil)
+        // The boundary: Double(Int.max) rounds up to 2^63, which
+        // is NOT a valid Int — the strict `<` bound rejects it.
+        #expect(Double(Int.max).finiteInt == nil)
+        // ...but the low bound and the largest representable value
+        // below it are admitted, not wrongly rejected.
+        #expect(Double(Int.min).finiteInt == Int.min)
+        #expect(Double(Int.max).nextDown.finiteInt != nil)
+    }
+
+    @Test("resize.step decodes clamped, so Int() reads never trap")
+    func resizeStepDecodeClamped() throws {
+        let huge = try JSONDecoder().decode(
+            TilingSettings.self,
+            from: Data(#"{"resize":{"step":1e300}}"#.utf8)
+        )
+        #expect(huge.resizeStep <= 10_000)
+        #expect(huge.resizeStep.isFinite)
+        // A sane in-range value is preserved.
+        let ok = try JSONDecoder().decode(
+            TilingSettings.self,
+            from: Data(#"{"resize":{"step":75}}"#.utf8)
+        )
+        #expect(ok.resizeStep == 75)
+    }
+
+    @Test("JSONValue.intValue is trap-safe")
+    func intValue() {
+        #expect(JSONValue.number(42).intValue == 42)
+        #expect(JSONValue.number(1e300).intValue == nil)
+        #expect(JSONValue.number(.nan).intValue == nil)
+        #expect(JSONValue.string("5").intValue == 5)
+        #expect(JSONValue.string("1e300").intValue == nil)
+    }
+
+    @Test("LuaValue.intValue is trap-safe")
+    func luaIntValue() {
+        #expect(LuaValue.number(9).intValue == 9)
+        #expect(LuaValue.number(1e300).intValue == nil)
+        #expect(LuaValue.number(.infinity).intValue == nil)
+    }
+
+    @Test("JSONValue.stringValue never traps on a huge whole number")
+    func stringValue() {
+        // A whole number prints as an Int...
+        #expect(JSONValue.number(3).stringValue == "3")
+        // ...a fractional one keeps its Double form...
+        #expect(JSONValue.number(3.5).stringValue == "3.5")
+        // ...and a huge whole number falls back to Double
+        // formatting instead of trapping via `Int(1e300)`.
+        #expect(JSONValue.number(1e300).stringValue == String(1e300))
+    }
+
+    @Test("space_bar.set_spring_delay clamps a huge value, no trap")
+    func springDelayHuge() throws {
+        let parsed = SpaceBarCommandSetting.parse(
+            field: "spring_delay",
+            args: [.number(1e300)]
+        )
+        var style = SpaceBarStyle()
+        try parsed.get().apply(to: &style)
+        #expect(
+            style.springDelay
+                == SpaceBarStyle.springDelayRange.upperBound
+        )
+    }
+
+    @Test("space_bar.set_glyph_cap clamps a huge value, no trap")
+    func glyphCapHuge() throws {
+        let parsed = SpaceBarCommandSetting.parse(
+            field: "glyph_cap",
+            args: [.number(1e300)]
+        )
+        var style = SpaceBarStyle()
+        try parsed.get().apply(to: &style)
+        #expect(
+            style.glyphCap == SpaceBarStyle.glyphCapRange.upperBound
+        )
+    }
+
+    @Test("A non-finite setting value is rejected, not clamped")
+    func nonFiniteRejected() {
+        #expect(
+            (try? SpaceBarCommandSetting.parse(
+                field: "spring_delay",
+                args: [.number(.nan)]
+            ).get()) == nil
+        )
+        #expect(
+            (try? SpaceBarCommandSetting.parse(
+                field: "glyph_cap",
+                args: [.number(.infinity)]
+            ).get()) == nil
+        )
+    }
+}


### PR DESCRIPTION
## What

`Int(1e300)`, `Int(.nan)`, `Int(.infinity)` all trap and crash the WM. A single mistyped Lua/JSON/IPC number could take the process down. `fixes #386`.

## Sites closed

- `JSONValue.intValue`, `LuaValue.intValue` — `numberValue.map { Int($0) }`
- `JSONValue.stringValue` whole-number branch — `String(Int(n))` (a huge whole number rounds to itself, so it took the Int path)
- `space_bar.set_spring_delay` parser — `Int(value)` before the clamp
- **`resizeStep`** — decoded unclamped, then `Int(resizeStep)` at three read sites (GUI config seed, keybinding rows, shortcuts panel). Found by review.

## How

- One shared authority `Double.finiteInt` (nil unless finite and in `Int`'s range; upper bound is a strict `<` since `Double(Int.max)` rounds up to 2^63). The three `JSONValue`/`LuaValue` sites route through it.
- `spring_delay` guards `isFinite` and clamps as `Double` before `Int`, matching the `glyph_cap` sibling (#376) and the quit grid-depth precedent.
- `resizeStep` clamped at the **decode boundary** (finite, `1...10_000`, mirroring `set_resize_step`) — one guard neutralizes all three `Int()` read sites and keeps the invariant that `resizeStep` is always sane.

## Verify

`NumberTrapSafetyTests` feeds `1e300` / `nan` / `infinity` through every site (nil / clamp / fallback, no trap), asserts the `finiteInt` boundary (`Int.min` admitted, `2^63` rejected, `nextDown` valid), and the `resize.step: 1e300` decode clamp. `swift build`, `swift test` (1511 pass), `scripts/lint.sh` (OK), `swift build -c release` — all green.

Review: `code-reviewer` confirmed the boundary logic and semantic preservation, swept for siblings, found the `resizeStep` gap (now closed at the decode boundary as recommended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhNyRPqENsiEap8GebYBKy