### PR TITLE
feat(bars): Liquid Glass tab_background (macOS 26+) (#390)

### DIFF
--- a/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarLayoutSection.swift
@@ -183,8 +183,11 @@ struct LayoutAppBarSection: View {
         )
         .modifier(
             GreyOut(
+                // Roundness rounds a box or the glass plate — dead
+                // only for the boxless Plain strip (matches the
+                // global + Space editors).
                 active: bar.resolved(with: global)
-                    .tabBackground != .boxed
+                    .tabBackground == .plain
             )
         )
     }

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarOptions.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarOptions.swift
@@ -42,11 +42,28 @@ enum AppBarOptions {
         }
     }
 
+    /// Liquid Glass (#390) is offered only where it can render —
+    /// an OS-capability gate, so the option is absent (not greyed)
+    /// below macOS 26. The stored value still round-trips there.
     @MainActor
-    static let tabBackground: [(AppBarStyle.TabBackground, String)] = [
-        (.boxed, L("app_bar.tab_background.boxed", "Boxed")),
-        (.plain, L("app_bar.tab_background.plain", "Plain")),
-    ]
+    static var tabBackground: [(AppBarStyle.TabBackground, String)] {
+        var options: [(AppBarStyle.TabBackground, String)] = [
+            (.boxed, L("app_bar.tab_background.boxed", "Boxed")),
+            (.plain, L("app_bar.tab_background.plain", "Plain")),
+        ]
+        if AppBarStyle.TabBackground.glassAvailable {
+            options.append(
+                (
+                    .material,
+                    L(
+                        "app_bar.tab_background.material",
+                        "Liquid Glass"
+                    )
+                )
+            )
+        }
+        return options
+    }
     @MainActor
     static let activeIndicator: [(AppBarStyle.ActiveIndicator, String)] = [
         (.ring, L("app_bar.active_indicator.ring", "Ring")),

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip+Mock.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip+Mock.swift
@@ -81,6 +81,11 @@ extension AppBarPreviewStrip {
             return L("app_bar.tab_background.boxed", "Boxed")
         case .plain:
             return L("app_bar.tab_background.plain", "Plain")
+        case .material:
+            return L(
+                "app_bar.tab_background.material",
+                "Liquid Glass"
+            )
         }
     }
 }

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
@@ -244,7 +244,8 @@ struct AppBarPreviewStrip: View {
 
     private func boxColor(_ t: MockTab) -> Color {
         switch style.tabBackground {
-        case .plain:
+        // Glass renders boxless like plain in the static preview.
+        case .plain, .material:
             return .clear
         case .boxed:
             return color(

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarPreviewStrip.swift
@@ -66,7 +66,7 @@ struct AppBarPreviewStrip: View {
             // itself); Boxed keeps the strip in the background
             // color and boxes each tab.
             RoundedRectangle(
-                cornerRadius: style.tabBackground == .plain
+                cornerRadius: style.tabBackground != .boxed
                     ? corner : 0
             )
             .fill(

--- a/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/AppBarSections.swift
@@ -227,7 +227,9 @@ struct GlobalAppBarSection: View {
         )
         .modifier(
             GreyOut(
-                active: style.tabBackground != .boxed,
+                // Roundness rounds a box or the glass plate — dead
+                // only for the boxless Plain strip.
+                active: style.tabBackground == .plain,
                 help: L(
                     "app_bar.corner_roundness.boxed_only",
                     "Corner roundness only applies to Boxed tabs."

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceBarPreviewStrip.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceBarPreviewStrip.swift
@@ -94,7 +94,7 @@ struct SpaceBarPreviewStrip: View {
         .padding(4)
         .background(
             RoundedRectangle(
-                cornerRadius: style.tabBackground == .plain
+                cornerRadius: style.tabBackground != .boxed
                     ? corner : 0
             )
             .fill(

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceBarPreviewStrip.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceBarPreviewStrip.swift
@@ -216,6 +216,11 @@ struct SpaceBarPreviewStrip: View {
             return L("app_bar.tab_background.boxed", "Boxed")
         case .plain:
             return L("app_bar.tab_background.plain", "Plain")
+        case .material:
+            return L(
+                "app_bar.tab_background.material",
+                "Liquid Glass"
+            )
         }
     }
 }

--- a/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
+++ b/Sources/KiwiDesk/Settings/Tabs/SpaceBarSections.swift
@@ -242,7 +242,7 @@ struct SpaceBarEditorSection: View {
         .modifier(
             GreyOut(
                 active: style.wrappedValue.tabBackground
-                    != .boxed,
+                    == .plain,
                 help: L(
                     "space_bar.corner_roundness.boxed_only",
                     "Corner roundness only applies to Boxed "

--- a/Sources/KiwiDeskCore/Bar/AppBarItemView+Layout.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarItemView+Layout.swift
@@ -213,7 +213,7 @@ extension AppBarItemView {
     /// outline — a clean native selection mark that keeps `plain`
     /// boxless (ui-designer 2026-07-14).
     private func layoutRing() {
-        if style.tabBackground == .boxed {
+        if style.tabBackground.rendered == .boxed {
             accent.frame = bounds
             accent.layer?.cornerRadius =
                 style.resolvedCornerRadius(
@@ -240,7 +240,7 @@ extension AppBarItemView {
         accent.layer?.cornerRadius = 0
         let thickness: CGFloat = 3
         let r =
-            style.tabBackground == .boxed
+            style.tabBackground.rendered == .boxed
             ? style.resolvedCornerRadius(
                 forThickness: crossThickness
             )

--- a/Sources/KiwiDeskCore/Bar/AppBarItemView.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarItemView.swift
@@ -227,7 +227,7 @@ final class AppBarItemView: NSView {
     /// combo, including the active ring (which is a pure stroke).
     private var hasBox: Bool {
         if isHovered { return true }
-        return style.tabBackground == .boxed
+        return style.tabBackground.rendered == .boxed
     }
 
     // The settings App Bar preview (`AppBarPreviewStrip`, GUI
@@ -235,12 +235,14 @@ final class AppBarItemView: NSView {
     // keep the two in step when the box or accent rules change.
     private var boxColorHex: String {
         if isHovered { return style.hoverColor }
-        switch style.tabBackground {
+        switch style.tabBackground.rendered {
         case .boxed:
             return isActive
                 ? style.activeBoxColor
                 : style.boxColor
-        case .plain:
+        // `material` is boxless like `plain` — the glass plate is
+        // the background, so items paint no box of their own.
+        case .plain, .material:
             return "#00000000"
         }
     }

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+Panel.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+Panel.swift
@@ -21,17 +21,67 @@ extension AppBarOverlay {
         guard let layer = panel.contentView?.layer else {
             return
         }
+        let rendered = style.tabBackground.rendered
         layer.masksToBounds = true
+        // `boxed` keeps square corners; `plain` and `material`
+        // round the shared plate.
         layer.cornerRadius =
-            style.tabBackground == .plain
-            ? style.resolvedCornerRadius(forThickness: depth)
-            : 0
-        let background =
-            style.tabBackground == .plain
-            ? style.boxColor
-            : style.backgroundColor
+            rendered == .boxed
+            ? 0
+            : style.resolvedCornerRadius(forThickness: depth)
+        // `plain` paints the strip in the box color; `material`
+        // stays clear (the glass plate is the background);
+        // `boxed` keeps the (default transparent) background.
+        let background: String
+        switch rendered {
+        case .plain: background = style.boxColor
+        case .material: background = "#00000000"
+        case .boxed: background = style.backgroundColor
+        }
         layer.backgroundColor =
             NSColor(kiwiHex: background).cgColor
+    }
+
+    /// Shows / sizes the Liquid Glass plate under the items when
+    /// the background resolves to `material`, else hides it (#390).
+    func updateGlassPlate(
+        _ panel: NSPanel,
+        style: AppBarStyle,
+        strip: CGRect
+    ) {
+        let depth =
+            style.edge.isHorizontal ? strip.height : strip.width
+        guard style.tabBackground.rendered == .material,
+            let content = panel.contentView
+        else {
+            glassPlate?.isHidden = true
+            return
+        }
+        guard let plate = glassPlate ?? GlassPlate.make() else {
+            return
+        }
+        glassPlate = plate
+        if plate.superview !== content {
+            content.addSubview(
+                plate,
+                positioned: .below,
+                relativeTo: nil
+            )
+        }
+        plate.isHidden = false
+        GlassPlate.update(
+            plate,
+            frame: CGRect(
+                x: 0,
+                y: 0,
+                width: strip.width,
+                height: strip.height
+            ),
+            cornerRadius: style.resolvedCornerRadius(
+                forThickness: depth
+            ),
+            tintHex: style.backgroundColor
+        )
     }
 
     func syncItemViewCount(_ count: Int) {

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
@@ -76,6 +76,10 @@ public final class AppBarOverlay {
     let itemContainer = FlippedView()
     let backArrow = BarArrowView()
     let forwardArrow = BarArrowView()
+    /// The Liquid Glass plate under the items when `tabBackground`
+    /// resolves to `material` (#390); nil otherwise / below macOS
+    /// 26. Stored as a plain view — the concrete type is 26-only.
+    var glassPlate: NSView?
     var scrollOffset: CGFloat = 0
     /// The last render's geometry, kept for the drag
     /// handlers (AppBarOverlay+Drag).
@@ -136,6 +140,11 @@ public final class AppBarOverlay {
             panel,
             style: style,
             depth: edge.isHorizontal ? strip.height : strip.width
+        )
+        updateGlassPlate(
+            panel,
+            style: style,
+            strip: strip
         )
         syncItemViewCount(items.count)
         let m = metrics(

--- a/Sources/KiwiDeskCore/Bar/GlassPlate.swift
+++ b/Sources/KiwiDeskCore/Bar/GlassPlate.swift
@@ -1,0 +1,39 @@
+import AppKit
+
+/// A macOS 26 Liquid Glass plate for a bar strip (#390): one
+/// shared, rounded glass background under the items, tinted by the
+/// bar's `background_color`. Wrapped behind a plain `NSView?` so
+/// the overlays can store it without an availability annotation
+/// (the concrete `NSGlassEffectView` type is macOS-26-only) and
+/// drive it through one guarded entry point. Shared by both bars.
+enum GlassPlate {
+    /// A fresh glass plate, or nil below macOS 26.
+    @MainActor
+    static func make() -> NSView? {
+        if #available(macOS 26, *) {
+            let view = NSGlassEffectView()
+            view.style = .regular
+            return view
+        }
+        return nil
+    }
+
+    /// Sizes and tints an existing plate. A fully transparent
+    /// `background_color` means clear glass (no tint).
+    @MainActor
+    static func update(
+        _ view: NSView,
+        frame: CGRect,
+        cornerRadius: CGFloat,
+        tintHex: String
+    ) {
+        guard #available(macOS 26, *),
+            let glass = view as? NSGlassEffectView
+        else { return }
+        glass.frame = frame
+        glass.cornerRadius = cornerRadius
+        let tint = NSColor(kiwiHex: tintHex)
+        glass.tintColor =
+            tint.alphaComponent > 0 ? tint : nil
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
@@ -9,7 +9,7 @@ extension SpaceBarItemView {
     func restyle() {
         layer?.masksToBounds = true
         layer?.cornerRadius =
-            style.tabBackground == .boxed ? cornerRadius : 0
+            style.tabBackground.rendered == .boxed ? cornerRadius : 0
         layer?.backgroundColor = boxColor.cgColor
         styleIdentifier()
         styleApps()
@@ -57,14 +57,14 @@ extension SpaceBarItemView {
         // Active wins over hover (matching `stateColor` and the
         // mouseEntered guard): a click that activates the item
         // under the pointer must not leave it hover-tinted.
-        if isActive, style.tabBackground == .boxed {
+        if isActive, style.tabBackground.rendered == .boxed {
             return NSColor(kiwiHex: style.activeBoxColor)
         }
         if isActive { return .clear }
         if isHovered || isDragHovered {
             return NSColor(kiwiHex: style.hoverColor)
         }
-        guard style.tabBackground == .boxed else {
+        guard style.tabBackground.rendered == .boxed else {
             return .clear
         }
         return NSColor(kiwiHex: style.boxColor)
@@ -132,7 +132,7 @@ extension SpaceBarItemView {
             accent.layer?.borderColor = highlight.cgColor
             accent.layer?.borderWidth = 2
             accent.layer?.cornerRadius =
-                style.tabBackground == .boxed ? cornerRadius : 0
+                style.tabBackground.rendered == .boxed ? cornerRadius : 0
         case .edgeMark:
             accent.layer?.borderWidth = 0
             accent.layer?.cornerRadius = 0

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Panel.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Panel.swift
@@ -19,17 +19,67 @@ extension SpaceBarOverlay {
         let depth =
             style.edge.isHorizontal
             ? strip.height : strip.width
+        let rendered = style.tabBackground.rendered
         layer.masksToBounds = true
+        // `boxed` keeps square corners; `plain` and `material`
+        // round the shared plate.
         layer.cornerRadius =
-            style.tabBackground == .plain
-            ? style.resolvedCornerRadius(forThickness: depth)
-            : 0
-        let background =
-            style.tabBackground == .plain
-            ? style.boxColor
-            : style.backgroundColor
+            rendered == .boxed
+            ? 0
+            : style.resolvedCornerRadius(forThickness: depth)
+        // `material` stays clear — the glass plate is the
+        // background; `plain` paints the box color; `boxed` keeps
+        // the (default transparent) background.
+        let background: String
+        switch rendered {
+        case .plain: background = style.boxColor
+        case .material: background = "#00000000"
+        case .boxed: background = style.backgroundColor
+        }
         layer.backgroundColor =
             NSColor(kiwiHex: background).cgColor
+    }
+
+    /// Shows / sizes the Liquid Glass plate under the items when
+    /// the background resolves to `material`, else hides it (#390).
+    func updateGlassPlate(
+        _ panel: NSPanel,
+        style: SpaceBarStyle,
+        strip: CGRect
+    ) {
+        let depth =
+            style.edge.isHorizontal ? strip.height : strip.width
+        guard style.tabBackground.rendered == .material,
+            let content = panel.contentView
+        else {
+            glassPlate?.isHidden = true
+            return
+        }
+        guard let plate = glassPlate ?? GlassPlate.make() else {
+            return
+        }
+        glassPlate = plate
+        if plate.superview !== content {
+            content.addSubview(
+                plate,
+                positioned: .below,
+                relativeTo: nil
+            )
+        }
+        plate.isHidden = false
+        GlassPlate.update(
+            plate,
+            frame: CGRect(
+                x: 0,
+                y: 0,
+                width: strip.width,
+                height: strip.height
+            ),
+            cornerRadius: style.resolvedCornerRadius(
+                forThickness: depth
+            ),
+            tintHex: style.backgroundColor
+        )
     }
 
     func syncItemViewCount(_ count: Int) {

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
@@ -35,6 +35,10 @@ public final class SpaceBarOverlay {
     let itemContainer = AppBarOverlay.FlippedView()
     let backArrow = BarArrowView()
     let forwardArrow = BarArrowView()
+    /// The Liquid Glass plate under the items when `tabBackground`
+    /// resolves to `material` (#390); nil otherwise / below macOS
+    /// 26. Stored as a plain view — the concrete type is 26-only.
+    var glassPlate: NSView?
     /// Whole-bar scroll offset (#385); 0 while the run fits.
     var scrollOffset: CGFloat = 0
     /// Cached scroll geometry, kept for the arrow-zone hit test
@@ -123,6 +127,7 @@ public final class SpaceBarOverlay {
         let panel = self.panel ?? makePanel()
         self.panel = panel
         styleContainer(panel, style: style, strip: strip)
+        updateGlassPlate(panel, style: style, strip: strip)
         syncItemViewCount(items.count)
         let horizontal = style.edge.isHorizontal
         let depth = horizontal ? strip.height : strip.width

--- a/Sources/KiwiDeskCore/Commands/AppBarCommandSetting.swift
+++ b/Sources/KiwiDeskCore/Commands/AppBarCommandSetting.swift
@@ -87,7 +87,7 @@ enum AppBarCommandSetting {
             return choice(
                 args,
                 AppBarStyle.TabBackground.self,
-                "boxed|plain"
+                "boxed|plain|material"
             ).map(Self.tabBackground)
         case "active_indicator":
             return choice(

--- a/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
+++ b/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
@@ -91,7 +91,7 @@ enum SpaceBarCommandSetting {
             return choice(
                 args,
                 SpaceBarStyle.TabBackground.self,
-                "boxed|plain"
+                "boxed|plain|material"
             ).map(Self.tabBackground)
         case "active_indicator":
             return choice(

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
@@ -17,13 +17,42 @@ public struct AppBarStyle: Sendable, Equatable {
     /// the background is drawn the same on every tab, the
     /// indicator marks only the active one. An extensible set —
     /// more background treatments can join later.
-    public enum TabBackground: String, Sendable, Codable {
+    public enum TabBackground: String, Sendable, Codable,
+        CaseIterable
+    {
         /// A box per tab, honoring `cornerRoundness`
         /// (roundness 0 = square).
         case boxed
         /// No per-tab box; names sit on one shared translucent
         /// strip.
         case plain
+        /// A macOS 26 Liquid Glass plate under the items — one
+        /// shared plate like `plain`, but a live glass material
+        /// tinted by `background_color` (#390). macOS 26+ only:
+        /// the value round-trips everywhere, but on older macOS it
+        /// *renders* as `boxed` (see `rendered(glassAvailable:)`);
+        /// the GUI only offers it where it can render.
+        case material
+
+        /// True when this platform can render the glass material.
+        public static var glassAvailable: Bool {
+            if #available(macOS 26, *) { return true }
+            return false
+        }
+
+        /// The treatment actually painted: `material` degrades to
+        /// `boxed` where glass is unavailable, so an older macOS
+        /// opening a glass profile shows the default look rather
+        /// than an unbacked strip — without rewriting the stored
+        /// value. Pure (`glassAvailable` injected) for tests.
+        public func rendered(glassAvailable: Bool) -> TabBackground {
+            self == .material && !glassAvailable ? .boxed : self
+        }
+
+        /// The treatment painted on this platform.
+        public var rendered: TabBackground {
+            rendered(glassAvailable: Self.glassAvailable)
+        }
     }
 
     /// How the active tab is marked. Orthogonal to

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
@@ -17,9 +17,7 @@ public struct AppBarStyle: Sendable, Equatable {
     /// the background is drawn the same on every tab, the
     /// indicator marks only the active one. An extensible set —
     /// more background treatments can join later.
-    public enum TabBackground: String, Sendable, Codable,
-        CaseIterable
-    {
+    public enum TabBackground: String, Sendable, Codable {
         /// A box per tab, honoring `cornerRoundness`
         /// (roundness 0 = square).
         case boxed

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -62,6 +62,7 @@
   "app_bar.resolved.overrides": "%1$d field(s) override the global bar.",
   "app_bar.tab_background.boxed": "Boxed",
   "app_bar.tab_background.label": "Tab background",
+  "app_bar.tab_background.material": "Liquid Glass",
   "app_bar.tab_background.plain": "Plain",
   "app_bar.thickness": "Thickness",
   "app_picker.search.placeholder": "Search apps",

--- a/Tests/KiwiDeskCoreTests/TabBackgroundGlassTests.swift
+++ b/Tests/KiwiDeskCoreTests/TabBackgroundGlassTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The Liquid Glass `tab_background` case (#390): its render
+/// fallback, round-trip, and command parse. The actual glass
+/// rendering is AppKit and OS-gated, so it's exercised by hand;
+/// these pin the pure, portable behavior.
+@Suite("Tab background — Liquid Glass")
+struct TabBackgroundGlassTests {
+    typealias TB = AppBarStyle.TabBackground
+
+    @Test("material renders as boxed only where glass is missing")
+    func renderFallback() {
+        #expect(TB.material.rendered(glassAvailable: false) == .boxed)
+        #expect(
+            TB.material.rendered(glassAvailable: true) == .material
+        )
+        // boxed and plain are unaffected either way.
+        for base in [TB.boxed, .plain] {
+            #expect(base.rendered(glassAvailable: false) == base)
+            #expect(base.rendered(glassAvailable: true) == base)
+        }
+    }
+
+    @Test("tab_background round-trips material through JSON")
+    func roundTrip() throws {
+        var style = AppBarStyle()
+        style.tabBackground = .material
+        let data = try JSONEncoder().encode(style)
+        let back = try JSONDecoder().decode(
+            AppBarStyle.self,
+            from: data
+        )
+        #expect(back.tabBackground == .material)
+    }
+
+    @Test("both bar parsers accept material")
+    func parseMaterial() {
+        let app = AppBarCommandSetting.parse(
+            field: "tab_background",
+            args: [.string("material")]
+        )
+        guard case .success(let appSetting) = app else {
+            Issue.record("app bar rejected material")
+            return
+        }
+        var appStyle = AppBarStyle()
+        appSetting.apply(to: &appStyle)
+        #expect(appStyle.tabBackground == .material)
+
+        let space = SpaceBarCommandSetting.parse(
+            field: "tab_background",
+            args: [.string("material")]
+        )
+        guard case .success(let spaceSetting) = space else {
+            Issue.record("space bar rejected material")
+            return
+        }
+        var spaceStyle = SpaceBarStyle()
+        spaceSetting.apply(to: &spaceStyle)
+        #expect(spaceStyle.tabBackground == .material)
+    }
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -51,6 +51,7 @@ planned escape hatch; it is not a wontfix dumping ground.
 
 | Behavior | Why it's accepted | Architectural root | Escape hatch / planned fix |
 |---|---|---|---|
+| A bar whose `tab_background` is `material` (Liquid Glass) renders as **Boxed** on macOS earlier than 26 — the glass plate does not appear there. | Liquid Glass is a macOS 26 API (`NSGlassEffectView`); the value must still round-trip so a shared profile stays portable, so an older machine degrades to the shipped default look rather than an unbacked strip. The GUI never *offers* the option below 26 (an OS-capability gate, absent not greyed), so only a hand-written config or a profile authored on 26 reaches this state. | The stored `"material"` value is portable; only the render path is `#available(macOS 26)`-gated, resolving to `boxed` at paint time without rewriting the field ([#390](https://github.com/hajiboy95/KiwiDesk/issues/390)). | Use macOS 26+ to see the glass, or pick `boxed`/`plain` for a look identical on every macOS. |
 | With **"Displays have separate Spaces" on**, native Desktop→profile bindings cannot represent an independent Desktop choice on every connected display; KiwiDesk applies one global active profile. | Basic tiling remains valid, single-display use is unaffected, and users may want to inspect or prepare bindings before changing the macOS option, so hiding or disabling the controls would overstate the limitation. | Native-Space routing resolves one active Desktop number and one active profile for the whole display setup, not a per-display profile tuple ([#8](https://github.com/hajiboy95/KiwiDesk/issues/8)). | Turn the option off in Desktop & Dock Settings, then log out and back in. Onboarding and the binding-section warning share one gate and fire only in the affected multi-display state, never on a single display. See [Shared display Spaces are recommended, not required](#shared-display-spaces-are-recommended-not-required). |
 | In BSP, the inner window of a nested pair can't grow — a "grow" press (or edge-drag) widens its outer neighbor instead. | Its width `r·(1−r)·W` is already maximized at the default ratio, so no resize direction can widen it. | All same-orientation splits share the one per-space ratio; per-node ratios would need a container tree the flat-array model forbids (#56 trade). | **Shipped**: the [`track` layout (#128)](https://github.com/hajiboy95/KiwiDesk/issues/128) — `set_mode(space, "track")` gives every window one true resize target. See [BSP resize is focus-aware in *direction* only](#shortcuts). |
 | In stack, when the master zone lines up *along* the split axis (e.g. horizontal masters beside a right stack), the masters' individual shares can't be resized: that axis always moves the split, and the other axis beeps. | The split ratio owns its whole axis — giving the same keypress two meanings (split vs weight) by focus zone would make "grow" unpredictable at the boundary. | One knob per axis per arrangement ([#222](https://github.com/hajiboy95/KiwiDesk/issues/222)); weights live on a zone's own lineup axis by construction. | Pick the orthogonal (vertical) master orientation — since the 2026-07-16 default flip the standard side-by-side arrangement sits *inside* this limitation once `master_count` exceeds one — or put the windows that need individual shares in the stack zone. |
@@ -1323,6 +1324,35 @@ fonts, icon source with colors, or a tab restructure) waits on a
 real signal that people want to share the *whole look* as one
 artifact — not merely "more than seven palettes," which
 save/export/import already answers.
+
+**Liquid Glass is a third `tab_background`, macOS-26-gated.**
+(#390.) The glass treatment is a third `TabBackground` case
+(`material`) beside `boxed`/`plain`, not an orthogonal
+translucency toggle: the three are mutually-exclusive answers to
+one question ("how is the strip backed"), and a toggle would
+create a real ambiguity ("boxed + translucent" = glass boxes or a
+glass strip under opaque boxes?). Glass renders structurally like
+`plain` — one shared rounded plate (`NSGlassEffectView`), items on
+top, no per-item box — matching Control Center / Spotlight (one
+glass plate, never glass-per-tab). It reuses existing color
+vocabulary rather than adding keys: `background_color` becomes the
+glass tint (transparent default = clear glass, mapping to
+`NSGlassEffectView.tintColor`), `box_color` goes dormant (greyed,
+like `background_color` is under `plain`), and `corner_roundness`
+stays live (it rounds the plate). The default stays `boxed`: the
+earthy Kiwi identity is deliberate, and — decisively — an
+OS-gated look *can't* be a universal default without a shared
+profile or screenshot rendering differently per macOS. The stored
+value `"material"` round-trips on every macOS (portability), but
+only the *render* path is OS-conditional: below macOS 26 it
+resolves to `boxed` at paint time (never rewriting the field), and
+the GUI offers the case only where it can render — an
+OS-capability gate, so the option is *absent* below 26, not greyed
+(grey-don't-hide is for mode-inert controls, not missing
+hardware/OS capability). Explicitly out of scope: a glass
+border/stroke, a shadow (`BarPanel` is deliberately shadowless),
+and vibrancy-following text (glass replaces only the plate, never
+foreground color resolution) — each a separate issue if wanted.
 
 **Tab background and active indicator are orthogonal.** (#228.)
 The old coupled `style` enum (`pills` / `segments` / `underline`)

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1337,9 +1337,10 @@ top, no per-item box — matching Control Center / Spotlight (one
 glass plate, never glass-per-tab). It reuses existing color
 vocabulary rather than adding keys: `background_color` becomes the
 glass tint (transparent default = clear glass, mapping to
-`NSGlassEffectView.tintColor`), `box_color` goes dormant (greyed,
-like `background_color` is under `plain`), and `corner_roundness`
-stays live (it rounds the plate). The default stays `boxed`: the
+`NSGlassEffectView.tintColor`), `box_color` goes inert (unused —
+the color rows group by type and are never mode-greyed, §2.7,
+just as `background_color` is unused under `plain`), and
+`corner_roundness` stays live (it rounds the plate). The default stays `boxed`: the
 earthy Kiwi identity is deliberate, and — decisively — an
 OS-gated look *can't* be a universal default without a shared
 profile or screenshot rendering differently per macOS. The stored

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1382,18 +1382,24 @@ app_bar.set_thickness(32)
 
 ### app_bar.set_tab_background
 
-**Expects:** `"boxed"` or `"plain"`.
+**Expects:** `"boxed"`, `"plain"`, or `"material"`.
 
 **Does:** sets the visual style of the tab backgrounds:
 - **boxed** — a box per tab honoring the corner roundness
   (0% = square, 100% = full capsule).
 - **plain** — no per-tab box; names sit on one shared
   translucent strip.
+- **material** — a macOS 26 Liquid Glass plate under the items
+  (like `plain`, but a live glass material), tinted by
+  `background_color` (transparent = clear glass) and rounded by
+  the corner roundness. The value is accepted and round-trips on
+  any macOS; below macOS 26 it *renders* as `boxed` (the GUI
+  offers it only where it can render).
 
 **Example:**
 
 ```lua
-app_bar.set_tab_background("boxed")
+app_bar.set_tab_background("material")
 ```
 
 ### app_bar.set_active_indicator
@@ -1816,7 +1822,9 @@ space_bar.set_icon_source("app_font")
 
 ### space_bar.set_tab_background
 
-**Expects:** `"boxed"` or `"plain"` (default `"boxed"`).
+**Expects:** `"boxed"`, `"plain"`, or `"material"` (default
+`"boxed"`). `material` is the macOS 26 Liquid Glass plate — see
+`app_bar.set_tab_background`; below macOS 26 it renders as `boxed`.
 
 **Does:** boxes each Space item, or draws all items on one
 shared strip — same vocabulary as the App Bar.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -690,7 +690,12 @@ running windows.
 **Global settings:**
 
 - **Tab background**: boxed (a box per tab honoring corner
-  roundness) or plain (names on a shared translucent strip).
+  roundness), plain (names on a shared translucent strip), or
+  **Liquid Glass** — a macOS&nbsp;26 glass plate under the items,
+  tinted by the Background color (transparent = clear glass) and
+  rounded by corner roundness. Liquid Glass appears in the picker
+  only on macOS&nbsp;26 and later; a profile that selects it still
+  opens on older macOS, where it falls back to Boxed.
 - **Position**: the screen edge the bar occupies — top, bottom,
   left, or right (default top). Absolute for every layout; the
   preview strip rotates vertical for left/right. When the Space


### PR DESCRIPTION
Fixes #390.

## What

A third `tab_background` case — **`material`** — a macOS 26 **Liquid Glass** plate for the App Bar and Space Bar. Renders structurally like `plain`: one shared rounded glass plate (`NSGlassEffectView`) under the items, no per-item box, tinted by `background_color`.

- **Default stays `boxed`.** The GUI offers Liquid Glass only on macOS 26+ (an OS-capability gate — absent, not greyed). The stored value round-trips on every macOS; below 26 it **renders as `boxed`** at paint time (`rendered(glassAvailable:)`) without rewriting the field.
- `background_color` → the glass tint (transparent default = clear glass). `box_color` goes inert. `corner_roundness` stays live (rounds the plate).
- Both bars share the enum (typealias), the `GlassPlate` helper, and the picker options, so they get it together (#374 shape parity).

## Design

ui-designer + owner sign-off on #390 (incl. the radius/colors clarifications and the palette-tint auto-join note). API confirmed from the macOS 26.5 SDK header (`NSGlassEffectView`: `contentView`, `cornerRadius`, `tintColor`, `style`).

## How it's built

- OS fallback centralized in one pure `rendered(glassAvailable:)` on the enum (resolved-vs-stored split, like `AppBarStyle.resolved…`); every render decision site reads `.rendered`.
- `GlassPlate` wraps the 26-only `NSGlassEffectView` behind an availability guard; overlays store it as `NSView?` and add it as the bottom subview (behind items/arrows — no #385/#372 regression).
- Item box-drawing already keyed on `== .boxed`, so `material` renders boxless for free; `.rendered` makes a stored `material` show boxes on <26.

## ⚠️ Needs macOS 26 visual QA

Both reviewers flagged (and I confirm) the one thing the gate can't cover: **the plate is a bare `NSGlassEffectView` with no `contentView` (items are siblings above it).** The API is designed to glass its `contentView`; used as a bare background it *may* render flat rather than true Liquid Glass. Please verify on macOS 26 hardware that the plate actually shows the glass material — if it renders flat, the fix is to host the item container as the glass view's `contentView` instead of a sibling.

## Tests / docs

- `TabBackgroundGlassTests`: render fallback, JSON round-trip, both parsers accept `material`.
- user-guide, lua-reference, design-decisions (+ accepted-limitation row) updated; en.json regenerated.

## Review

code-reviewer + architect-reviewer, both on the full diff — design sound; converged findings (per-layout roundness gate, preview rounding, a doc wording fix, drop an unused conformance) **all fixed** in the last commit.

## Verification

Verify gate green: debug + **release** build, 1545 tests, lint, site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKj9eWmx371FDqXBATiDq7