### PR TITLE
chore(templates): prefix issue titles with type emoji, add docs template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Something is not working as expected
 labels: ["bug"]
+title: "🐛 "
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/collector.yml
+++ b/.github/ISSUE_TEMPLATE/collector.yml
@@ -1,6 +1,7 @@
 name: Collector (tracking)
 description: Themed collecting issue grouping related issues
 labels: ["roadmap"]
+title: "📦 Collector: "
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -1,0 +1,53 @@
+name: Docs
+description: Report missing, wrong, or unclear documentation
+labels: ["documentation"]
+title: "📝 "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For docs that are **wrong** (describe behavior the app
+        doesn't have), please include what the app actually
+        does — code and docs must never disagree.
+
+  - type: input
+    id: doc_location
+    attributes:
+      label: Which doc?
+      description: |
+        File or page (e.g. `docs/lua-reference.md`, the
+        user-guide page on profiles), plus section if known.
+      placeholder: "docs/lua-reference.md — space_bar section"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: problem_kind
+    attributes:
+      label: What kind of problem?
+      options:
+        - Wrong — doc contradicts actual behavior
+        - Missing — behavior/setting isn't documented
+        - Unclear — documented but confusing
+        - Structure — hard to find / poorly organized
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing?
+      description: |
+        Quote the current text if it exists; describe the
+        actual behavior if the doc contradicts it.
+      placeholder: |
+        The doc says `space_bar.set_glyph_cap` accepts 0-10,
+        but the command clamps to 1-8.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix (optional)
+      placeholder: "Proposed wording, structure, or example."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest an enhancement or new behavior
 labels: ["enhancement"]
+title: "💡 "
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/roadmap.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap.yml
@@ -1,7 +1,7 @@
 name: Roadmap
 description: Wave-sequenced execution plan across open issues
 labels: ["roadmap"]
-title: "Roadmap: "
+title: "🗺️ Roadmap: "
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

- Adds an emoji `title:` prefix to every issue form so the issue list reads as a typed column at a glance: 🐛 `bug_report`, 💡 `feature_request`, 📦 `collector` (`Collector: ` kept), 🗺️ `roadmap` (`Roadmap: ` kept).
- Adds a dedicated 📝 **Docs** template (`docs_report.yml`, `documentation` label) for wrong / missing / unclear / structure reports — answering #272's open question with yes.
- Glyph pick: 🐛 over 💥/🪲 (GitHub `:bug:` convention, renders everywhere); crash severity stays a label / hand-typed 💥, not a second template.

Retitling existing open issues to match is a follow-up needing maintainer sign-off (mass edit).

fixes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vmEvYzxBVqvRXLTodrxvv