### PR TITLE
fix(tiling): run own-window frame-sets on the main thread

### DIFF
--- a/Sources/KiwiDeskCore/Tiling/FrameApplier.swift
+++ b/Sources/KiwiDeskCore/Tiling/FrameApplier.swift
@@ -168,6 +168,14 @@ final class FrameApplier {
     // MARK: - Internals
 
     private func queue(for pid: pid_t) -> DispatchQueue {
+        // Frame-sets for our own windows (the floating Settings
+        // window) must run on the main queue: an in-process AX
+        // call never crosses to the AX server — HIServices runs
+        // the AppKit window move synchronously on the calling
+        // thread, and AppKit traps off the main thread.
+        if pid == getpid() {
+            return DispatchQueue.main
+        }
         if let existing = queues[pid] {
             return existing
         }


### PR DESCRIPTION
## Summary

Settings-save / Settings-open crash (SIGTRAP in `NSWMWindowCoordinator`) whenever a **top** bar overlapped KiwiDesk's own floating Settings window.

Root cause: an in-process AX frame-set never crosses to the AX server — HIServices runs the AppKit window move synchronously on the calling thread. `FrameApplier` issues frame-sets on per-app background queues, so the float clamp (`clampFloatsBelowTopBars`, top edge only — which is why bottom bars never crashed) moved our own Settings window off the main thread and AppKit trapped. All 10 crash reports from the QA session show the identical stack through `FrameApplier.applyInstant` → `WindowControl.setFrame` → `AXUIElementSetAttributeValue` → AppKit.

Fix: `FrameApplier.queue(for:)` returns `DispatchQueue.main` for our own pid, so the short-circuited AppKit call lands on the main thread. Ordering semantics unchanged (main queue is serial; everything for the pid still rides one queue).

## Verification

- `swift build`, `swift test` (1564 tests), `scripts/lint.sh`, `swift build -c release` all green.
- Manual QA needed: both bars on top edge, thick Space Bar → open Settings, save — previously crashed reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)