### PR TITLE
fix(ax): ignore Control Center menu-bar popovers

### DIFF
--- a/Sources/KiwiDeskCore/AX/FloatDetection.swift
+++ b/Sources/KiwiDeskCore/AX/FloatDetection.swift
@@ -141,6 +141,10 @@ public enum FloatDetection {
     private static let ignoredSystemApps: Set<String> = [
         "com.apple.textinputmenuagent",
         "com.apple.textinputswitcher",
+        // Menu-bar popovers (Wi-Fi, Bluetooth, sliders) are
+        // accessory windows that would otherwise be tracked
+        // and shown in the bars.
+        "com.apple.controlcenter",
     ]
 
     public static func isBuiltInIgnoredApp(

--- a/Tests/KiwiDeskCoreTests/LayoutMiscTests.swift
+++ b/Tests/KiwiDeskCoreTests/LayoutMiscTests.swift
@@ -289,6 +289,7 @@ struct FloatRuleTests {
         for bundleID in [
             "com.apple.TextInputMenuAgent",
             "com.apple.TextInputSwitcher",
+            "com.apple.controlcenter",
         ] {
             #expect(
                 FloatDetection.isBuiltInIgnoredApp(


### PR DESCRIPTION
## Summary

Opening a menu-bar popover (Bluetooth, Wi-Fi/Control Center panels) registered a window that appeared in the App Bar and Space Bar. Control Center is an accessory app whose windows are transient overlays, never user workspaces — added `com.apple.controlcenter` to `FloatDetection.ignoredSystemApps` (same class as the text-input overlays, #177), so its windows never enter state.

## Verification

- Extended the "macOS input-source overlays are never managed" test to cover the new bundle id.
- `swift build`, `swift test` (1564 tests), `scripts/lint.sh`, `swift build -c release` all green.
- Manual QA: open Bluetooth/Wi-Fi popover from the menu bar → no item should appear in either bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)