### PR TITLE
fix(profiles): stop save from pruning spaces created mid-session

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsModel+EditTarget.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+EditTarget.swift
@@ -79,6 +79,7 @@ extension SettingsModel {
         config = state.config
         luaSource = state.luaSource
         suppressDirty = false
+        seedSpaces = state.config.spaces
         // The dirty baselines: `isDirty` is a live comparison
         // against the as-applied state, so manually undoing
         // an edit reads as clean again.

--- a/Sources/KiwiDesk/Settings/SettingsModel+Profiles.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Profiles.swift
@@ -95,6 +95,15 @@ extension SettingsModel {
 
     @discardableResult
     private func persist(named name: String) -> Bool {
+        // Freshness net: a space that appeared live while the
+        // dashboard sat open (profile load, hotkey-created) is
+        // absent from the staged model; without the merge the
+        // apply below would prune it — and pruning the active
+        // space snapped focus to the first space on save.
+        core.mergeLiveSpaces(
+            into: &config,
+            seededWith: seedSpaces
+        )
         core.applyProfileScopedState(from: config)
         var saved = true
         do {

--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -46,6 +46,12 @@ final class SettingsModel: ObservableObject {
     /// transition funnels through `reload()`).
     var cleanConfig = GuiConfig()
     var cleanLuaSource = ""
+    /// The space list as last seeded from live/stored state.
+    /// `persist` diffs the edited list against it so a save can
+    /// tell a user deletion (in seed, removed from the model)
+    /// from model staleness (a space that appeared live while
+    /// the dashboard sat open) — see `KiwiCore.mergeLiveSpaces`.
+    var seedSpaces: [SpaceID] = []
 
     func recomputeDirty() {
         isDirty =

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
@@ -86,6 +86,30 @@ extension KiwiCore {
         config.fallbackSpace = fallbackSpace
     }
 
+    /// Save-time freshness net for the dashboard: appends
+    /// spaces that appeared live *after* the model was seeded
+    /// (a profile load or a hotkey-created space while the
+    /// dashboard sat open). Without it, `applyProfileScopedState`
+    /// read those spaces as deleted-in-the-Spaces-tab and pruned
+    /// them — snapping focus to the first space on every save.
+    /// Staged edits stay authoritative: a space present in
+    /// `seed` but removed from the model was deleted by the
+    /// user this session and is not resurrected.
+    public func mergeLiveSpaces(
+        into config: inout GuiConfig,
+        seededWith seed: [SpaceID]
+    ) {
+        var known = Set(seed)
+        known.formUnion(config.spaces)
+        for space in state.workspaces.allSpaces
+        where !known.contains(space.id) {
+            config.spaces.append(space.id)
+            if space.mode != .bsp {
+                config.spaceModes[space.id] = space.mode
+            }
+        }
+    }
+
     /// Builds an editable model from the running configuration.
     /// Keybindings and mode icons are recovered from the source
     /// file via `recoverKeybindings` (#4); the sidecar owns them

--- a/Tests/KiwiDeskCoreTests/GuiSpaceMergeTests.swift
+++ b/Tests/KiwiDeskCoreTests/GuiSpaceMergeTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    KiwiCore(
+        configDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "kiwi-merge-\(UUID().uuidString)"
+            )
+    )
+}
+
+/// `mergeLiveSpaces` is the dashboard's save-time freshness net:
+/// spaces that appeared live after the model was seeded are
+/// appended (so the save's prune can't drop them and snap focus
+/// to the first space), while staged user deletions stay
+/// authoritative.
+@Suite("GUI save-time space merge", .serialized)
+@MainActor
+struct GuiSpaceMergeTests {
+    @Test("A live space unknown to the model is appended")
+    func appendsLiveNewSpace() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("2"))
+        var config = GuiConfig()
+        config.spaces = [SpaceID("1")]
+        core.mergeLiveSpaces(
+            into: &config,
+            seededWith: [SpaceID("1")]
+        )
+        #expect(config.spaces == [SpaceID("1"), SpaceID("2")])
+    }
+
+    @Test("A staged deletion is not resurrected")
+    func keepsStagedDeletion() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("2"))
+        var config = GuiConfig()
+        // Seeded with both; the user deleted "2" this session.
+        config.spaces = [SpaceID("1")]
+        core.mergeLiveSpaces(
+            into: &config,
+            seededWith: [SpaceID("1"), SpaceID("2")]
+        )
+        #expect(config.spaces == [SpaceID("1")])
+    }
+
+    @Test("An appended space carries its live layout mode")
+    func appendedSpaceKeepsMode() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("3"))
+        core.state.workspaces.setMode(SpaceID("3"), .monocle)
+        var config = GuiConfig()
+        config.spaces = [SpaceID("1")]
+        core.mergeLiveSpaces(
+            into: &config,
+            seededWith: [SpaceID("1")]
+        )
+        #expect(config.spaceModes[SpaceID("3")] == .monocle)
+    }
+
+    @Test("Staged order and additions survive the merge")
+    func stagedEditsStayAuthoritative() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        core.state.workspaces.ensureSpace(SpaceID("2"))
+        core.state.workspaces.ensureSpace(SpaceID("new"))
+        var config = GuiConfig()
+        // User reordered and added "gui" in the Spaces tab.
+        config.spaces = [
+            SpaceID("2"), SpaceID("1"), SpaceID("gui"),
+        ]
+        core.mergeLiveSpaces(
+            into: &config,
+            seededWith: [SpaceID("1"), SpaceID("2")]
+        )
+        #expect(
+            config.spaces == [
+                SpaceID("2"), SpaceID("1"), SpaceID("gui"),
+                SpaceID("new"),
+            ]
+        )
+    }
+
+    @Test("A fresh model with no live drift merges to a no-op")
+    func noDriftNoChange() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+        var config = GuiConfig()
+        config.spaces = [SpaceID("1")]
+        let before = config
+        core.mergeLiveSpaces(
+            into: &config,
+            seededWith: [SpaceID("1")]
+        )
+        #expect(config == before)
+    }
+}


### PR DESCRIPTION
## Summary

QA finding: after a profile save, focus jumped back to space 1. Root cause: `applyProfileScopedState` treats the dashboard model's space list as authoritative and prunes live spaces missing from it. The model seeds at window open — a space created live afterwards (profile load, hotkey `focus_space` to a new space) was missing from the staged list, got pruned on save, and `WorkspaceManager.removeSpace` reset the active space to `order.first`.

Fix: `persist` now merges the live space list into the staged config before applying, via new `KiwiCore.mergeLiveSpaces(into:seededWith:)`. The seed snapshot (captured at every reload) distinguishes model staleness from a genuine Spaces-tab deletion, so user deletions are still honored and the prune semantics (#77) are unchanged.

## Verification

- New `GuiSpaceMergeTests` (5 tests): appends live-new spaces with their modes, honors staged deletions/order/additions, no-op without drift.
- Full gate green: `swift build`, `swift test` (1569), `scripts/lint.sh`, `swift build -c release`.
- Manual QA: open Settings, switch to a hotkey-created space, save profile → focus stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)