### PR TITLE
feat(bars): centralize glass hosting (#407) + tint the Liquid Glass (#408)

### DIFF
--- a/Sources/KiwiDeskCore/Appearance/PaletteCatalog.swift
+++ b/Sources/KiwiDeskCore/Appearance/PaletteCatalog.swift
@@ -3,13 +3,13 @@ import Foundation
 /// The built-in palettes (#375). "Kiwi (Default)" is derived from
 /// the shipped struct defaults at load — so it always equals a
 /// reset-to-default and never drifts from the real defaults — then
-/// the six authored palettes come from the bundled resource. The
+/// the eight authored palettes come from the bundled resource. The
 /// user-saved palettes live in `PaletteStore`, not here.
 public enum PaletteCatalog {
     /// The name of the always-present default palette.
     public static let defaultName = "Kiwi (Default)"
 
-    /// All seven built-ins, default first.
+    /// All nine built-ins, default first.
     public static func bundled() -> [ColorPalette] {
         [defaultPalette()] + authored()
     }
@@ -23,7 +23,7 @@ public enum PaletteCatalog {
         )
     }
 
-    /// The six authored palettes from `Resources/Palettes`.
+    /// The eight authored palettes from `Resources/Palettes`.
     static func authored() -> [ColorPalette] {
         guard
             let url = Bundle.module.url(

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+BoxGlass.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+BoxGlass.swift
@@ -28,6 +28,7 @@ extension AppBarOverlay {
         let n = min(frames.count, itemViews.count)
         syncBoxGlassCount(n)
         let radius = style.resolvedCornerRadius(forThickness: depth)
+        let tinted = GlassTint.wanted(style.fillColor)
         for i in 0..<n {
             let glass = boxGlasses[i]
             glass.isHidden = itemViews[i].isHidden
@@ -39,6 +40,22 @@ extension AppBarOverlay {
                 tintHex: style.fillColor,
                 animated: animated
             )
+            // Colored backdrop behind the box so the glass refracts
+            // a hue (#408); hidden with the box, or when the Fill is
+            // transparent (clear glass).
+            let tint = boxTints[i]
+            if tinted && !itemViews[i].isHidden {
+                GlassTint.apply(
+                    tint,
+                    below: glass,
+                    frame: frames[i],
+                    cornerRadius: radius,
+                    hex: style.fillColor,
+                    animated: animated
+                )
+            } else {
+                tint.isHidden = true
+            }
         }
     }
 
@@ -49,11 +66,14 @@ extension AppBarOverlay {
             let glass = boxGlasses.removeLast()
             GlassPlate.detach(glass)
             glass.removeFromSuperview()
+            boxTints.removeLast().removeFromSuperview()
         }
         while boxGlasses.count < n {
             guard let glass = GlassPlate.make() else { break }
             itemContainer.addSubview(glass)
             boxGlasses.append(glass)
+            // One tint backdrop per box, kept parallel (#408).
+            boxTints.append(NSView())
         }
     }
 
@@ -67,12 +87,14 @@ extension AppBarOverlay {
         guard let content = itemContainer.superview else { return }
         updateArrowGlass(
             &backArrowGlass,
+            tint: &backArrowTint,
             behind: backArrow,
             in: content,
             style: style
         )
         updateArrowGlass(
             &forwardArrowGlass,
+            tint: &forwardArrowTint,
             behind: forwardArrow,
             in: content,
             style: style
@@ -81,12 +103,14 @@ extension AppBarOverlay {
 
     private func updateArrowGlass(
         _ glass: inout NSView?,
+        tint: inout NSView?,
         behind arrow: BarArrowView,
         in content: NSView,
         style: AppBarStyle
     ) {
         guard !arrow.isHidden else {
             glass?.isHidden = true
+            tint?.isHidden = true
             return
         }
         guard let box = glass ?? GlassPlate.make() else { return }
@@ -107,6 +131,21 @@ extension AppBarOverlay {
             cornerRadius: radius,
             tintHex: style.fillColor
         )
+        // Colored backdrop so the arrow glass tints with the boxes
+        // (#408), or hidden for a transparent Fill (clear glass).
+        let backdrop = tint ?? NSView()
+        tint = backdrop
+        if GlassTint.wanted(style.fillColor) {
+            GlassTint.apply(
+                backdrop,
+                below: box,
+                frame: arrow.frame,
+                cornerRadius: radius,
+                hex: style.fillColor
+            )
+        } else {
+            backdrop.isHidden = true
+        }
     }
 
     /// The view drag moves for `item`: its glass box while per-box
@@ -128,6 +167,8 @@ extension AppBarOverlay {
     func teardownBoxGlasses() {
         backArrowGlass?.isHidden = true
         forwardArrowGlass?.isHidden = true
+        backArrowTint?.isHidden = true
+        forwardArrowTint?.isHidden = true
         guard !boxGlasses.isEmpty else { return }
         for glass in boxGlasses {
             for item in itemViews where GlassPlate.holds(glass, item) {
@@ -137,5 +178,7 @@ extension AppBarOverlay {
             glass.removeFromSuperview()
         }
         boxGlasses.removeAll()
+        for tint in boxTints { tint.removeFromSuperview() }
+        boxTints.removeAll()
     }
 }

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+Panel.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+Panel.swift
@@ -10,9 +10,9 @@ extension AppBarOverlay {
     }
 
     /// `plain` and `material` draw their shared plate as its
-    /// own view (`updatePlainPlate` / `updateGlassPlate`) so it
-    /// can hug the run (`tab_background_fit`); `boxed` boxes each
-    /// tab. The container itself never paints.
+    /// own view (`updatePlainPlate` / the glass-hosting dispatch)
+    /// so it can hug the run (`tab_background_fit`); `boxed` boxes
+    /// each tab. The container itself never paints.
     func styleContainer(
         _ panel: NSPanel,
         style: AppBarStyle,
@@ -75,47 +75,103 @@ extension AppBarOverlay {
             NSColor(kiwiHex: style.fillColor).cgColor
     }
 
-    /// Liquid Glass path (#390): embeds the item run as the glass
-    /// `contentView` — the supported usage that actually renders
-    /// the tint (a bare backdrop plate renders degraded). The
-    /// glass takes the `viewport` frame, so in Phase 1 material's
-    /// `hug` (`tab_background_fit`) is inert; a run wrapper will
-    /// restore it later. Leaving material hands the viewport back
-    /// below the arrows and hides the glass.
-    /// Resolves the glass hierarchy for every non-plain-glass mode
-    /// (teardown / restore); the plain + glass plate itself is
-    /// hosted at the end of `render` by `updatePlainGlass`, which
-    /// needs the item frames to hug the run.
-    func updateGlassPlate(
-        _ panel: NSPanel,
+    /// The one hosting mode for this render (#407), from the
+    /// resolved style and whether the run overflows.
+    func glassHosting(
+        _ style: AppBarStyle,
+        overflow: Bool
+    ) -> GlassHosting {
+        GlassHosting.resolve(
+            available: AppBarStyle.glassAvailable,
+            glassEnabled: style.glassEnabled,
+            boxed: style.tabBackground == .boxed,
+            overflow: overflow
+        )
+    }
+
+    /// Teardown half of the one glass-hosting dispatch (#407): run
+    /// once per render, *before* the item loop, so the items sit in
+    /// the container the target mode expects while their frames are
+    /// laid out. It tears down every mode except `mode`; the target
+    /// itself is installed post-loop by `installGlassHosting`, which
+    /// needs those frames (per-box and plain-glass both place items
+    /// from them). The solid plain plate self-gates in
+    /// `updatePlainPlate`. Keeps the `GlassPlate.holds` idempotency:
+    /// the target's parenting is left in place across renders.
+    func prepareGlassHosting(
+        _ mode: GlassHosting,
+        panel: NSPanel,
         style: AppBarStyle,
         strip: CGRect,
+        plateFrame: CGRect,
         viewport: CGRect,
         animated: Bool = false
     ) {
+        updatePlainPlate(
+            panel,
+            style: style,
+            strip: strip,
+            plateFrame: plateFrame,
+            animated: animated
+        )
         guard let content = panel.contentView else { return }
-        // Boxed + glass hosts each item in its own glass box
-        // (per-box, driven at the end of `render`); leave the single
-        // plate hidden and hand the item run back so the boxes can
-        // reparent the items out of it.
-        if wantsBoxGlass(style) {
+        switch mode {
+        case .boxGlass:
+            // Per-box glass keeps its boxes; hand the item run back
+            // so the boxes can reparent items out of it, unwind any
+            // plain-glass run, and hide the single plate.
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
             glassPlate?.isHidden = true
-            return
-        }
-        // Any other mode: no per-box glass — return items to the
-        // container before the plain/single-plate hierarchy resolves.
-        teardownBoxGlasses()
-        // Leaving glass entirely: unwind the run wrapper too and
-        // restore the plain hierarchy.
-        guard style.glassEnabled else {
+        case .plainGlassHug, .plainGlassSpan:
+            // The run + single plate are hosted post-loop by
+            // `updatePlainGlass`; only the boxes must go first.
+            teardownBoxGlasses()
+        case .plainPlate, .none:
+            // No glass: unwind boxes and run, restore the plain
+            // hierarchy, and hide the glass plate.
+            teardownBoxGlasses()
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
             glassPlate?.isHidden = true
-            return
         }
-        // Plain + glass: hosted post-loop by `updatePlainGlass`.
+    }
+
+    /// Install half of the one glass-hosting dispatch (#407): run
+    /// once per render, *after* the item loop, to host the target
+    /// mode from the laid-out `frames`. The teardown of the other
+    /// modes already happened in `prepareGlassHosting`.
+    func installGlassHosting(
+        _ mode: GlassHosting,
+        panel: NSPanel,
+        frames: [CGRect],
+        viewport: CGRect,
+        plateFrame: CGRect,
+        style: AppBarStyle,
+        depth: CGFloat,
+        animated: Bool
+    ) {
+        switch mode {
+        case .boxGlass:
+            updateBoxGlasses(
+                frames: frames,
+                style: style,
+                depth: depth,
+                animated: animated
+            )
+        case .plainGlassHug, .plainGlassSpan:
+            updatePlainGlass(
+                panel: panel,
+                frames: frames,
+                viewport: viewport,
+                plateFrame: plateFrame,
+                overflow: mode == .plainGlassSpan,
+                style: style,
+                depth: depth
+            )
+        case .plainPlate, .none:
+            break
+        }
     }
 
     /// Reparents the item viewport out of a glass plate back to
@@ -164,34 +220,5 @@ extension AppBarOverlay {
         view.addSubview(backArrow)
         view.addSubview(forwardArrow)
         return panel
-    }
-}
-
-extension AppBarOverlay {
-    /// Both shared plates (plain fill, Liquid Glass) in one
-    /// call — exactly one is visible per mode, and both take
-    /// the same `BarPlate` frame authority.
-    func updatePlates(
-        _ panel: NSPanel,
-        style: AppBarStyle,
-        strip: CGRect,
-        plateFrame: CGRect,
-        viewport: CGRect,
-        animated: Bool = false
-    ) {
-        updatePlainPlate(
-            panel,
-            style: style,
-            strip: strip,
-            plateFrame: plateFrame,
-            animated: animated
-        )
-        updateGlassPlate(
-            panel,
-            style: style,
-            strip: strip,
-            viewport: viewport,
-            animated: animated
-        )
     }
 }

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+Panel.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+Panel.swift
@@ -123,6 +123,7 @@ extension AppBarOverlay {
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
             glassPlate?.isHidden = true
+            glassTint?.isHidden = true
         case .plainGlassHug, .plainGlassSpan:
             // The run + single plate are hosted post-loop by
             // `updatePlainGlass`; only the boxes must go first.
@@ -134,6 +135,7 @@ extension AppBarOverlay {
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
             glassPlate?.isHidden = true
+            glassTint?.isHidden = true
         }
     }
 

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+PlainGlass.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+PlainGlass.swift
@@ -78,7 +78,11 @@ extension AppBarOverlay {
 
     /// Solid colored backdrop behind the glass plate so the near-
     /// colorless glass refracts a hue (#408); hidden for a
-    /// transparent Fill (clear glass). Tracks the plate's frame.
+    /// transparent Fill (clear glass). Snaps to the plate's frame —
+    /// the glass plate itself snaps (`GlassPlate.update` un-animated
+    /// in `hugRun`/`spanViewport`, installed outside the animation
+    /// group), so an animated backdrop would lag a color edge past
+    /// the plate on a run-size change. Matches the Space Bar twin.
     private func applyPlateTint(
         plate: NSView,
         frame: CGRect,
@@ -93,8 +97,7 @@ extension AppBarOverlay {
                 below: plate,
                 frame: frame,
                 cornerRadius: radius,
-                hex: hex,
-                animated: true
+                hex: hex
             )
         } else {
             backdrop.isHidden = true

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+PlainGlass.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+PlainGlass.swift
@@ -68,6 +68,37 @@ extension AppBarOverlay {
             cornerRadius: radius,
             tintHex: tintHex
         )
+        applyPlateTint(
+            plate: plate,
+            frame: viewport,
+            radius: radius,
+            hex: tintHex
+        )
+    }
+
+    /// Solid colored backdrop behind the glass plate so the near-
+    /// colorless glass refracts a hue (#408); hidden for a
+    /// transparent Fill (clear glass). Tracks the plate's frame.
+    private func applyPlateTint(
+        plate: NSView,
+        frame: CGRect,
+        radius: CGFloat,
+        hex: String
+    ) {
+        let backdrop = glassTint ?? NSView()
+        glassTint = backdrop
+        if GlassTint.wanted(hex) {
+            GlassTint.apply(
+                backdrop,
+                below: plate,
+                frame: frame,
+                cornerRadius: radius,
+                hex: hex,
+                animated: true
+            )
+        } else {
+            backdrop.isHidden = true
+        }
     }
 
     /// A reorder drag beginning while the plain+glass plate hugs the
@@ -130,6 +161,12 @@ extension AppBarOverlay {
             frame: plateFrame,
             cornerRadius: radius,
             tintHex: style.fillColor
+        )
+        applyPlateTint(
+            plate: plate,
+            frame: plateFrame,
+            radius: radius,
+            hex: style.fillColor
         )
         // Remember the viewport span so a drag can leave hug mode.
         glassDragSpan = GlassDragSpan(

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
@@ -236,6 +236,11 @@ public final class AppBarOverlay {
             horizontal: m.horizontal,
             fit: style.tabBackgroundFit
         )
+        // The one hosting mode for this render (#407): prepared
+        // (non-target teardown) in the animation group below, then
+        // installed post-loop once the item frames are laid out.
+        let depth = edge.isHorizontal ? strip.height : strip.width
+        let hosting = glassHosting(style, overflow: m.inset > 0)
         // Frame changes ease into place so group expansion
         // (and scroll-follow) widens out instead of popping;
         // fresh views snap. The plates ride the same group —
@@ -245,8 +250,9 @@ public final class AppBarOverlay {
             context.timingFunction = CAMediaTimingFunction(
                 name: .easeOut
             )
-            updatePlates(
-                panel,
+            prepareGlassHosting(
+                hosting,
+                panel: panel,
                 style: style,
                 strip: strip,
                 plateFrame: plateFrame,
@@ -297,30 +303,21 @@ public final class AppBarOverlay {
                 self?.dragEnded(view)
             }
         }
-        // Per-box glass rides the authoritative frames (the item's
-        // own frame is overridden once it's a glass contentView), so
-        // it runs after the item loop with the gap-hidden state set.
-        if wantsBoxGlass(style) {
-            updateBoxGlasses(
-                frames: frames,
-                style: style,
-                depth: edge.isHorizontal
-                    ? strip.height : strip.width,
-                animated: true
-            )
-        } else if style.glassEnabled {
-            // Plain + glass: hug the run when it fits (piece 1).
-            updatePlainGlass(
-                panel: panel,
-                frames: frames,
-                viewport: viewport,
-                plateFrame: plateFrame,
-                overflow: m.inset > 0,
-                style: style,
-                depth: edge.isHorizontal
-                    ? strip.height : strip.width
-            )
-        }
+        // Install the target hosting from the now-laid-out frames
+        // (per-box glass and the plain-glass run both position items
+        // from them, so this runs after the item loop with the
+        // gap-hidden state set). #407: one dispatch, no per-mode
+        // branching at the call site.
+        installGlassHosting(
+            hosting,
+            panel: panel,
+            frames: frames,
+            viewport: viewport,
+            plateFrame: plateFrame,
+            style: style,
+            depth: depth,
+            animated: true
+        )
         layoutArrows(strip: strip, m: m, style: style)
         panel.setFrame(
             GeometryUtils.flip(

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
@@ -85,11 +85,22 @@ public final class AppBarOverlay {
     /// (piece 2). Empty otherwise / below macOS 26. Plain views —
     /// the concrete type is 26-only (see AppBarOverlay+BoxGlass).
     var boxGlasses: [NSView] = []
+    /// Solid colored backdrops behind each per-box glass, filled
+    /// with the box Fill so the near-colorless glass refracts a hue
+    /// (#408). Kept parallel to `boxGlasses`. Empty / below macOS 26.
+    var boxTints: [NSView] = []
     /// The scroll arrows' own frosted backdrop boxes under per-box
     /// glass, so they read as glass, not solid islands. The arrow
     /// stays interactive on top (its own box goes transparent).
     var backArrowGlass: NSView?
     var forwardArrowGlass: NSView?
+    /// Colored backdrops behind the arrow glasses (#408), so the
+    /// arrows tint with the boxes instead of staying grey.
+    var backArrowTint: NSView?
+    var forwardArrowTint: NSView?
+    /// Colored backdrop behind the single glass plate (plain +
+    /// glass, hug and span), filled with the bar Fill (#408).
+    var glassTint: NSView?
     /// `plain`'s shared fill plate — its own view (not the
     /// container layer) so it can hug the run
     /// (`tab_background_fit`, QA 2026-07-19).

--- a/Sources/KiwiDeskCore/Bar/GlassHosting.swift
+++ b/Sources/KiwiDeskCore/Bar/GlassHosting.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// The single mode naming where a bar item lives for one render
+/// (#407). A bar item physically sits in one of these parentings
+/// depending on the resolved style; before #407 no value named the
+/// current/target mode, so every entry point independently tore
+/// down the *other* modes. Now one `resolve` per render feeds one
+/// dispatch (`prepareGlassHosting` tears down the non-target modes,
+/// `installGlassHosting` installs the target), so the "who tears
+/// down whom" invariant lives in one place. Shared by both bars.
+enum GlassHosting: Equatable {
+    /// No glass finish: the solid `plain` plate or the per-item
+    /// `boxed` fill. Items ride `itemContainer` on the panel.
+    case plainPlate
+    /// Plain + glass, the run fits: the glass hugs the run wrapper.
+    case plainGlassHug
+    /// Plain + glass, the run overflows: the glass spans the
+    /// scrolling item viewport (`itemContainer`).
+    case plainGlassSpan
+    /// Boxed + glass: each item hosted in its own glass box.
+    case boxGlass
+    /// Below macOS 26 — glass can't render, so nothing is hosted.
+    /// Same parenting as `plainPlate` (items in `itemContainer`);
+    /// named apart so the dispatch documents the below-26 reality.
+    case none
+
+    /// The one hosting mode for this render. `available` is the OS
+    /// gate (`glassAvailable`); `glassEnabled` the resolved finish;
+    /// `boxed` the shape; `overflow` whether the run scrolls (only
+    /// splits plain + glass into hug vs span). One authority so the
+    /// two bars can't drift on the decision.
+    static func resolve(
+        available: Bool,
+        glassEnabled: Bool,
+        boxed: Bool,
+        overflow: Bool
+    ) -> GlassHosting {
+        guard available else { return .none }
+        guard glassEnabled else { return .plainPlate }
+        if boxed { return .boxGlass }
+        return overflow ? .plainGlassSpan : .plainGlassHug
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/GlassTint.swift
+++ b/Sources/KiwiDeskCore/Bar/GlassTint.swift
@@ -13,6 +13,18 @@ import AppKit
 /// Shared by both bars, one per glass surface (each box, the plate,
 /// each arrow / the front segment).
 enum GlassTint {
+    /// The most opaque a backdrop is allowed to render (#408): above
+    /// this the solid color crowds out the blur / refraction and the
+    /// "glass" reads as a flat colored plate — the pointless case.
+    /// A *render* cap, not a stored-value clamp: the `fill_color`
+    /// keeps whatever alpha the user set (GUI or Lua, used in full by
+    /// the solid boxed/plain shapes and when glass is off); only the
+    /// glass backdrop is held translucent so glass always looks like
+    /// glass. Below it any alpha is honored, including 0 (clear
+    /// glass). Chosen on-device (macOS 26.5.2) — the top of the
+    /// legible tinted-glass band; the sweet spot sits ~35–50 %.
+    static let maxAlpha: CGFloat = 0.65
+
     /// Whether a tint backdrop should be drawn: only on macOS 26
     /// (where glass renders at all) and only for a visible Fill —
     /// a fully transparent Fill means clear, untinted glass.
@@ -55,7 +67,12 @@ enum GlassTint {
             backdrop.frame = frame
         }
         backdrop.layer?.cornerRadius = cornerRadius
-        backdrop.layer?.backgroundColor =
-            NSColor(kiwiHex: hex).cgColor
+        // Cap the backdrop's opacity so the glass keeps its blur;
+        // the stored Fill is untouched (see `maxAlpha`).
+        let fill = NSColor(kiwiHex: hex)
+        let capped =
+            fill.alphaComponent > maxAlpha
+            ? fill.withAlphaComponent(maxAlpha) : fill
+        backdrop.layer?.backgroundColor = capped.cgColor
     }
 }

--- a/Sources/KiwiDeskCore/Bar/GlassTint.swift
+++ b/Sources/KiwiDeskCore/Bar/GlassTint.swift
@@ -1,0 +1,61 @@
+import AppKit
+
+/// A solid colored backdrop for a Liquid Glass surface (#408). On
+/// macOS 26.5.2 an `NSGlassEffectView`'s own `tintColor` reads
+/// near-colorless — it shifts luminance, not hue, so a "brown
+/// glass" and a "blue glass" look the same frosted grey. So instead
+/// of fighting the tint API, a solid colored view sits directly
+/// *behind* the glass; the glass refracts / samples it and adopts
+/// that hue — the same way the Dock and Control Center tint their
+/// glass. The backdrop supplies only color; the glass keeps its
+/// blur and refraction intact. Below macOS 26 there is no glass, so
+/// there is no backdrop (the solid shape carries the color itself).
+/// Shared by both bars, one per glass surface (each box, the plate,
+/// each arrow / the front segment).
+enum GlassTint {
+    /// Whether a tint backdrop should be drawn: only on macOS 26
+    /// (where glass renders at all) and only for a visible Fill —
+    /// a fully transparent Fill means clear, untinted glass.
+    @MainActor
+    static func wanted(_ hex: String) -> Bool {
+        guard #available(macOS 26, *) else { return false }
+        return NSColor(kiwiHex: hex).alphaComponent > 0
+    }
+
+    /// Sizes and tints `backdrop`, placing it just below `glass` in
+    /// the glass's own superview, at the glass's `frame` and
+    /// `cornerRadius`, filled with `hex`. `animated` eases the frame
+    /// change so the backdrop tracks an animated glass plate instead
+    /// of lagging a color edge into view. The caller owns the view
+    /// (creating and storing it) so per-box backdrops can live in a
+    /// pool parallel to the glass boxes.
+    @MainActor
+    static func apply(
+        _ backdrop: NSView,
+        below glass: NSView,
+        frame: CGRect,
+        cornerRadius: CGFloat,
+        hex: String,
+        animated: Bool = false
+    ) {
+        backdrop.wantsLayer = true
+        if let parent = glass.superview, backdrop.superview !== parent {
+            parent.addSubview(
+                backdrop,
+                positioned: .below,
+                relativeTo: glass
+            )
+        }
+        backdrop.isHidden = false
+        if animated, backdrop.frame != .zero,
+            backdrop.frame != frame
+        {
+            backdrop.animator().frame = frame
+        } else {
+            backdrop.frame = frame
+        }
+        backdrop.layer?.cornerRadius = cornerRadius
+        backdrop.layer?.backgroundColor =
+            NSColor(kiwiHex: hex).cgColor
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+BoxGlass.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+BoxGlass.swift
@@ -24,6 +24,7 @@ extension SpaceBarOverlay {
         let n = min(frames.count, itemViews.count)
         syncBoxGlassCount(n)
         let radius = style.resolvedCornerRadius(forThickness: depth)
+        let tinted = GlassTint.wanted(style.fillColor)
         for i in 0..<n {
             let glass = boxGlasses[i]
             glass.isHidden = itemViews[i].isHidden
@@ -34,6 +35,21 @@ extension SpaceBarOverlay {
                 cornerRadius: radius,
                 tintHex: style.fillColor
             )
+            // Colored backdrop behind the box so the glass refracts
+            // a hue (#408); hidden with the box, or for a transparent
+            // Fill (clear glass).
+            let tint = boxTints[i]
+            if tinted && !itemViews[i].isHidden {
+                GlassTint.apply(
+                    tint,
+                    below: glass,
+                    frame: frames[i],
+                    cornerRadius: radius,
+                    hex: style.fillColor
+                )
+            } else {
+                tint.isHidden = true
+            }
         }
     }
 
@@ -42,11 +58,14 @@ extension SpaceBarOverlay {
             let glass = boxGlasses.removeLast()
             GlassPlate.detach(glass)
             glass.removeFromSuperview()
+            boxTints.removeLast().removeFromSuperview()
         }
         while boxGlasses.count < n {
             guard let glass = GlassPlate.make() else { break }
             itemContainer.addSubview(glass)
             boxGlasses.append(glass)
+            // One tint backdrop per box, kept parallel (#408).
+            boxTints.append(NSView())
         }
     }
 
@@ -59,6 +78,7 @@ extension SpaceBarOverlay {
     ) {
         guard let rect else {
             frontGlass?.isHidden = true
+            frontTint?.isHidden = true
             return
         }
         guard let glass = frontGlass ?? GlassPlate.make() else {
@@ -84,6 +104,21 @@ extension SpaceBarOverlay {
             cornerRadius: radius,
             tintHex: style.fillColor
         )
+        // Colored backdrop so the front glass tints with the boxes
+        // (#408), or hidden for a transparent Fill (clear glass).
+        let tint = frontTint ?? NSView()
+        frontTint = tint
+        if GlassTint.wanted(style.fillColor) {
+            GlassTint.apply(
+                tint,
+                below: glass,
+                frame: rect,
+                cornerRadius: radius,
+                hex: style.fillColor
+            )
+        } else {
+            tint.isHidden = true
+        }
     }
 
     /// Returns every hosted item to `itemContainer` and tears the
@@ -91,6 +126,7 @@ extension SpaceBarOverlay {
     /// `holds` per the reparent-restore gotcha so no item is trapped.
     func teardownBoxGlasses() {
         frontGlass?.isHidden = true
+        frontTint?.isHidden = true
         guard !boxGlasses.isEmpty else { return }
         for glass in boxGlasses {
             for item in itemViews where GlassPlate.holds(glass, item) {
@@ -100,5 +136,7 @@ extension SpaceBarOverlay {
             glass.removeFromSuperview()
         }
         boxGlasses.removeAll()
+        for tint in boxTints { tint.removeFromSuperview() }
+        boxTints.removeAll()
     }
 }

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Panel.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Panel.swift
@@ -103,6 +103,7 @@ extension SpaceBarOverlay {
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
             glassPlate?.isHidden = true
+            glassTint?.isHidden = true
         case .plainGlassHug, .plainGlassSpan:
             // The run + single plate are hosted post-passes by
             // `updatePlainGlass`; only the boxes must go first.
@@ -114,6 +115,7 @@ extension SpaceBarOverlay {
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
             glassPlate?.isHidden = true
+            glassTint?.isHidden = true
         }
     }
 

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Panel.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Panel.swift
@@ -6,9 +6,9 @@ import AppKit
 /// App Bar's `+Panel` twin.
 extension SpaceBarOverlay {
     /// `plain` and `material` draw their shared plate as its
-    /// own view (`updatePlainPlate` / `updateGlassPlate`) so it
-    /// can hug the run (`tab_background_fit`); `boxed` boxes each
-    /// item. The container itself never paints.
+    /// own view (`updatePlainPlate` / the glass-hosting dispatch)
+    /// so it can hug the run (`tab_background_fit`); `boxed` boxes
+    /// each item. The container itself never paints.
     func styleContainer(
         _ panel: NSPanel,
         style: SpaceBarStyle,
@@ -59,47 +59,95 @@ extension SpaceBarOverlay {
             NSColor(kiwiHex: style.fillColor).cgColor
     }
 
-    /// Liquid Glass path (#390): embeds the item run as the glass
-    /// `contentView` — the supported usage that actually renders
-    /// the tint (a bare backdrop plate renders degraded). The
-    /// glass takes the `viewport` frame, so in Phase 1 material's
-    /// `hug` (`tab_background_fit`) is inert; a run wrapper will
-    /// restore it later. Leaving material hands the viewport back
-    /// below the arrows and hides the glass. The front segment
-    /// rides `itemContainer`, so it is tinted as part of the run.
-    /// Resolves the glass hierarchy for every non-plain-glass mode
-    /// (teardown / restore); the plain + glass plate itself is
-    /// hosted at the end of `render` by `updatePlainGlass`, which
-    /// needs the run's frames to hug it.
-    func updateGlassPlate(
-        _ panel: NSPanel,
+    /// The one hosting mode for this render (#407), from the
+    /// resolved style and whether the run overflows.
+    func glassHosting(
+        _ style: SpaceBarStyle,
+        overflow: Bool
+    ) -> GlassHosting {
+        GlassHosting.resolve(
+            available: AppBarStyle.glassAvailable,
+            glassEnabled: style.glassEnabled,
+            boxed: style.tabBackground == .boxed,
+            overflow: overflow
+        )
+    }
+
+    /// Teardown half of the one glass-hosting dispatch (#407, App Bar
+    /// twin): run once per render, *before* the item + front passes,
+    /// so the run sits in the container the target mode expects while
+    /// frames are laid out. Tears down every mode except `mode`; the
+    /// target is installed post-passes by `installGlassHosting`. The
+    /// front segment rides `itemContainer`, so it is tinted as part of
+    /// the run. The solid plain plate self-gates in `updatePlainPlate`.
+    func prepareGlassHosting(
+        _ mode: GlassHosting,
+        panel: NSPanel,
         style: SpaceBarStyle,
         strip: CGRect,
+        plateFrame: CGRect,
         viewport: CGRect
     ) {
+        updatePlainPlate(
+            panel,
+            style: style,
+            strip: strip,
+            plateFrame: plateFrame
+        )
         guard let content = panel.contentView else { return }
-        // Boxed + glass hosts each item in its own glass box
-        // (per-box, driven at the end of `render`); leave the single
-        // plate hidden and hand the run back so the boxes can
-        // reparent the items out of it.
-        if wantsBoxGlass(style) {
+        switch mode {
+        case .boxGlass:
+            // Per-box glass keeps its boxes; hand the run back so the
+            // boxes can reparent items out of it, unwind any
+            // plain-glass run, and hide the single plate.
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
             glassPlate?.isHidden = true
-            return
-        }
-        // Any other mode: no per-box glass — return items to the
-        // container before the plain/single-plate hierarchy resolves.
-        teardownBoxGlasses()
-        // Leaving glass entirely: unwind the run wrapper too and
-        // restore the plain hierarchy.
-        guard style.glassEnabled else {
+        case .plainGlassHug, .plainGlassSpan:
+            // The run + single plate are hosted post-passes by
+            // `updatePlainGlass`; only the boxes must go first.
+            teardownBoxGlasses()
+        case .plainPlate, .none:
+            // No glass: unwind boxes and run, restore the plain
+            // hierarchy, and hide the glass plate.
+            teardownBoxGlasses()
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
             glassPlate?.isHidden = true
-            return
         }
-        // Plain + glass: hosted post-loop by `updatePlainGlass`.
+    }
+
+    /// Install half of the one glass-hosting dispatch (#407, App Bar
+    /// twin): run once per render, *after* the item + front passes,
+    /// to host the target mode from the laid-out `frames`.
+    func installGlassHosting(
+        _ mode: GlassHosting,
+        panel: NSPanel,
+        frames: [CGRect],
+        viewport: CGRect,
+        plateFrame: CGRect,
+        style: SpaceBarStyle,
+        depth: CGFloat
+    ) {
+        switch mode {
+        case .boxGlass:
+            updateBoxGlasses(
+                frames: frames,
+                style: style,
+                depth: depth
+            )
+        case .plainGlassHug, .plainGlassSpan:
+            updatePlainGlass(
+                panel: panel,
+                viewport: viewport,
+                plateFrame: plateFrame,
+                overflow: mode == .plainGlassSpan,
+                style: style,
+                depth: depth
+            )
+        case .plainPlate, .none:
+            break
+        }
     }
 
     /// Reparents the item viewport out of a glass plate back to
@@ -147,31 +195,5 @@ extension SpaceBarOverlay {
         view.addSubview(backArrow)
         view.addSubview(forwardArrow)
         return panel
-    }
-}
-
-extension SpaceBarOverlay {
-    /// Both shared plates (plain fill, Liquid Glass) in one
-    /// call — exactly one is visible per mode, and both take
-    /// the same `BarPlate` frame authority.
-    func updatePlates(
-        _ panel: NSPanel,
-        style: SpaceBarStyle,
-        strip: CGRect,
-        plateFrame: CGRect,
-        viewport: CGRect
-    ) {
-        updatePlainPlate(
-            panel,
-            style: style,
-            strip: strip,
-            plateFrame: plateFrame
-        )
-        updateGlassPlate(
-            panel,
-            style: style,
-            strip: strip,
-            viewport: viewport
-        )
     }
 }

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+PlainGlass.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+PlainGlass.swift
@@ -76,6 +76,36 @@ extension SpaceBarOverlay {
             cornerRadius: radius,
             tintHex: style.fillColor
         )
+        applyPlateTint(
+            plate: plate,
+            frame: viewport,
+            radius: radius,
+            hex: style.fillColor
+        )
+    }
+
+    /// Solid colored backdrop behind the glass plate so the near-
+    /// colorless glass refracts a hue (#408); hidden for a
+    /// transparent Fill (clear glass). Tracks the plate's frame.
+    private func applyPlateTint(
+        plate: NSView,
+        frame: CGRect,
+        radius: CGFloat,
+        hex: String
+    ) {
+        let backdrop = glassTint ?? NSView()
+        glassTint = backdrop
+        if GlassTint.wanted(hex) {
+            GlassTint.apply(
+                backdrop,
+                below: plate,
+                frame: frame,
+                cornerRadius: radius,
+                hex: hex
+            )
+        } else {
+            backdrop.isHidden = true
+        }
     }
 
     /// Hug: the glass takes the plate frame and hosts a run wrapper
@@ -115,6 +145,12 @@ extension SpaceBarOverlay {
             frame: plateFrame,
             cornerRadius: radius,
             tintHex: style.fillColor
+        )
+        applyPlateTint(
+            plate: plate,
+            frame: plateFrame,
+            radius: radius,
+            hex: style.fillColor
         )
     }
 

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
@@ -47,10 +47,17 @@ public final class SpaceBarOverlay {
     /// `contentView` (piece 2, App Bar twin). Empty otherwise /
     /// below macOS 26. See SpaceBarOverlay+BoxGlass.
     var boxGlasses: [NSView] = []
+    /// Colored backdrops behind each per-box glass (`GlassTint`,
+    /// #408); parallel to `boxGlasses`, empty / below macOS 26.
+    var boxTints: [NSView] = []
     /// The front-app segment's own frosted box under per-box glass.
     /// The segment is non-interactive, so this sits as a backdrop
     /// behind its loose views rather than hosting them.
     var frontGlass: NSView?
+    /// Colored backdrop behind the front segment's glass (#408).
+    var frontTint: NSView?
+    /// Colored backdrop behind the single glass plate (#408).
+    var glassTint: NSView?
     /// Under plain + glass when the run fits, the glass hosts this
     /// flipped run wrapper at the hugged plate frame with the run
     /// (items + front segment) placed run-local — so the frosted

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
@@ -230,8 +230,13 @@ public final class SpaceBarOverlay {
             horizontal: horizontal,
             fit: style.tabBackgroundFit
         )
-        updatePlates(
-            panel,
+        // The one hosting mode for this render (#407): prepared
+        // (non-target teardown) here, then installed post-passes
+        // once the item frames are laid out.
+        let hosting = glassHosting(style, overflow: inset > 0)
+        prepareGlassHosting(
+            hosting,
+            panel: panel,
             style: style,
             strip: strip,
             plateFrame: plateFrame,
@@ -274,26 +279,19 @@ public final class SpaceBarOverlay {
             style: style,
             horizontal: horizontal
         )
-        // Per-box glass rides the authoritative item frames (the
-        // item's own frame is overridden once it's a glass
-        // contentView), after the item + front passes.
-        if wantsBoxGlass(style) {
-            updateBoxGlasses(
-                frames: metrics.itemFrames,
-                style: style,
-                depth: horizontal ? strip.height : strip.width
-            )
-        } else if style.glassEnabled {
-            // Plain + glass: hug the run when it fits (piece 1).
-            updatePlainGlass(
-                panel: panel,
-                viewport: viewportRect,
-                plateFrame: plateFrame,
-                overflow: inset > 0,
-                style: style,
-                depth: horizontal ? strip.height : strip.width
-            )
-        }
+        // Install the target hosting from the now-laid-out item
+        // frames (per-box glass and the plain-glass run both position
+        // from them, so this runs after the item + front passes).
+        // #407: one dispatch, no per-mode branching at the call site.
+        installGlassHosting(
+            hosting,
+            panel: panel,
+            frames: metrics.itemFrames,
+            viewport: viewportRect,
+            plateFrame: plateFrame,
+            style: style,
+            depth: horizontal ? strip.height : strip.width
+        )
         layoutArrows(
             strip: strip,
             inset: inset,

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
@@ -70,13 +70,14 @@ public struct AppBarStyle: Sendable, Equatable {
     /// matches `BarAccent.untintedAlpha`. Clamped in `resolvedDim`.
     public var dimFactor: CGFloat = BarAccent.untintedAlpha
     /// Kiwi theme: cream item text/glyph, a translucent
-    /// shell-brown fill (box, plate, or glass tint), a
-    /// flesh-green active accent.
+    /// dark-moss fill (box, plate, or glass tint), a flesh-green
+    /// active accent — one green family, not the old brown/green
+    /// pair (2026-07-20; brown lives on only in the drag visuals).
     public var itemColor = "#F2EBD9"
     /// The fill under the items — a box per item (Boxed), one
     /// shared plate (Plain), or the Liquid Glass tint
     /// (Material). One knob, three renders.
-    public var fillColor = "#8B5E3C66"
+    public var fillColor = "#37452E66"
     public var activeItemColor = "#4E9F3D"
     public var highlightColor = "#4E9F3D"
     /// Hover feedback on clickable (non-active) items: a

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
@@ -72,7 +72,8 @@ public struct AppBarStyle: Sendable, Equatable {
     /// Kiwi theme: cream item text/glyph, a translucent
     /// dark-moss fill (box, plate, or glass tint), a flesh-green
     /// active accent — one green family, not the old brown/green
-    /// pair (2026-07-20; brown lives on only in the drag visuals).
+    /// pair (2026-07-20; brown fully retired, drag visuals now
+    /// green/amber).
     public var itemColor = "#F2EBD9"
     /// The fill under the items — a box per item (Boxed), one
     /// shared plate (Plain), or the Liquid Glass tint

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
@@ -107,7 +107,8 @@ public struct SpaceBarStyle: Sendable, Equatable {
     public var hoverItemColor = "#F2EBD9"
     /// The fill under the items — a box per Space (Boxed), one
     /// shared plate (Plain), or the Liquid Glass tint (Material).
-    public var fillColor = "#8B5E3C66"
+    /// Dark moss, one green family with the accent (2026-07-20).
+    public var fillColor = "#37452E66"
     public var highlightColor = "#4E9F3D"
     /// Count badges (grouped duplicates and the "+n" overflow),
     /// shown in these colors on the active space and muted from

--- a/Sources/KiwiDeskCore/Resources/Palettes/bundled.json
+++ b/Sources/KiwiDeskCore/Resources/Palettes/bundled.json
@@ -1,5 +1,61 @@
 [
   {
+    "name": "Kiwi Dark",
+    "colors": {
+      "app_bar.item_color": "#F2EBD9",
+      "app_bar.fill_color": "#12160D99",
+      "app_bar.active_item_color": "#4E9F3D",
+      "app_bar.highlight_color": "#4E9F3D",
+      "app_bar.hover_fill_color": "#6DBF5B80",
+      "app_bar.hover_item_color": "#F2EBD9",
+      "app_bar.group_badge_color": "#B00020",
+      "app_bar.group_badge_text_color": "#FFFFFF",
+      "space_bar.item_color": "#F2EBD966",
+      "space_bar.active_item_color": "#4E9F3D",
+      "space_bar.focused_item_color": "#E8A33D",
+      "space_bar.hover_fill_color": "#6DBF5B80",
+      "space_bar.hover_item_color": "#F2EBD9",
+      "space_bar.fill_color": "#12160D99",
+      "space_bar.highlight_color": "#4E9F3D",
+      "space_bar.group_badge_color": "#B00020",
+      "space_bar.group_badge_text_color": "#FFFFFF",
+      "border.focused_color": "#4E9F3D",
+      "border.unfocused_color": "#3A3A3C99",
+      "drag.ghost.border_color": "#4E9F3D",
+      "drag.ghost.fill_color": "#4E9F3D40",
+      "drag.drop_zone.border_color": "#E8A33D",
+      "drag.drop_zone.fill_color": "#E8A33D40"
+    }
+  },
+  {
+    "name": "Kiwi Gold",
+    "colors": {
+      "app_bar.item_color": "#F2EBD9",
+      "app_bar.fill_color": "#3A332666",
+      "app_bar.active_item_color": "#D9A521",
+      "app_bar.highlight_color": "#D9A521",
+      "app_bar.hover_fill_color": "#E8C34D80",
+      "app_bar.hover_item_color": "#F2EBD9",
+      "app_bar.group_badge_color": "#B00020",
+      "app_bar.group_badge_text_color": "#FFFFFF",
+      "space_bar.item_color": "#F2EBD966",
+      "space_bar.active_item_color": "#D9A521",
+      "space_bar.focused_item_color": "#4E9F3D",
+      "space_bar.hover_fill_color": "#E8C34D80",
+      "space_bar.hover_item_color": "#F2EBD9",
+      "space_bar.fill_color": "#3A332666",
+      "space_bar.highlight_color": "#D9A521",
+      "space_bar.group_badge_color": "#B00020",
+      "space_bar.group_badge_text_color": "#FFFFFF",
+      "border.focused_color": "#D9A521",
+      "border.unfocused_color": "#8A7E6C66",
+      "drag.ghost.border_color": "#D9A521",
+      "drag.ghost.fill_color": "#D9A52140",
+      "drag.drop_zone.border_color": "#4E9F3D",
+      "drag.drop_zone.fill_color": "#4E9F3D40"
+    }
+  },
+  {
     "name": "Clean Light",
     "colors": {
       "app_bar.item_color": "#1C1C1E",
@@ -84,6 +140,34 @@
     }
   },
   {
+    "name": "Monochrome",
+    "colors": {
+      "app_bar.item_color": "#E5E5EA",
+      "app_bar.fill_color": "#3A3A3C99",
+      "app_bar.active_item_color": "#FFFFFF",
+      "app_bar.highlight_color": "#FFFFFF",
+      "app_bar.hover_fill_color": "#FFFFFF40",
+      "app_bar.hover_item_color": "#000000",
+      "app_bar.group_badge_color": "#636366",
+      "app_bar.group_badge_text_color": "#000000",
+      "space_bar.item_color": "#E5E5EA99",
+      "space_bar.active_item_color": "#FFFFFF",
+      "space_bar.focused_item_color": "#FFD60A",
+      "space_bar.hover_fill_color": "#FFFFFF40",
+      "space_bar.hover_item_color": "#000000",
+      "space_bar.fill_color": "#3A3A3C99",
+      "space_bar.highlight_color": "#FFFFFF",
+      "space_bar.group_badge_color": "#636366",
+      "space_bar.group_badge_text_color": "#000000",
+      "border.focused_color": "#FFFFFF",
+      "border.unfocused_color": "#8E8E9366",
+      "drag.ghost.border_color": "#FFFFFF",
+      "drag.ghost.fill_color": "#FFFFFF40",
+      "drag.drop_zone.border_color": "#AEAEB2",
+      "drag.drop_zone.fill_color": "#AEAEB226"
+    }
+  },
+  {
     "name": "Sunset",
     "colors": {
       "app_bar.item_color": "#FFFFFF",
@@ -137,34 +221,6 @@
       "drag.ghost.fill_color": "#5E5CE640",
       "drag.drop_zone.border_color": "#64D2FF",
       "drag.drop_zone.fill_color": "#64D2FF26"
-    }
-  },
-  {
-    "name": "Monochrome",
-    "colors": {
-      "app_bar.item_color": "#E5E5EA",
-      "app_bar.fill_color": "#3A3A3C99",
-      "app_bar.active_item_color": "#FFFFFF",
-      "app_bar.highlight_color": "#FFFFFF",
-      "app_bar.hover_fill_color": "#FFFFFF40",
-      "app_bar.hover_item_color": "#000000",
-      "app_bar.group_badge_color": "#636366",
-      "app_bar.group_badge_text_color": "#000000",
-      "space_bar.item_color": "#E5E5EA99",
-      "space_bar.active_item_color": "#FFFFFF",
-      "space_bar.focused_item_color": "#FFD60A",
-      "space_bar.hover_fill_color": "#FFFFFF40",
-      "space_bar.hover_item_color": "#000000",
-      "space_bar.fill_color": "#3A3A3C99",
-      "space_bar.highlight_color": "#FFFFFF",
-      "space_bar.group_badge_color": "#636366",
-      "space_bar.group_badge_text_color": "#000000",
-      "border.focused_color": "#FFFFFF",
-      "border.unfocused_color": "#8E8E9366",
-      "drag.ghost.border_color": "#FFFFFF",
-      "drag.ghost.fill_color": "#FFFFFF40",
-      "drag.drop_zone.border_color": "#AEAEB2",
-      "drag.drop_zone.fill_color": "#AEAEB226"
     }
   }
 ]

--- a/Sources/KiwiDeskCore/Tiling/DragVisual.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragVisual.swift
@@ -17,26 +17,31 @@ public struct DragVisual: Sendable, Equatable, Encodable {
     public var fill: Bool
     public var fillColor: String
 
-    /// Ghost: kiwi-green fill inside a kiwi-brown border.
+    /// Ghost (drag origin): all kiwi-green — same hue as the
+    /// focus accent. Origin vs. target reads by hue against the
+    /// drop zone's amber (2026-07-20; was a brown/green swap, but
+    /// brown left the palette with the moss-fill refresh).
     public static let ghostDefault = DragVisual(
-        enabled: true,
-        border: true,
-        borderColor: "#8B5E3C",
-        borderThickness: 5,
-        borderAlignment: .inside,
-        fill: true,
-        fillColor: "#4E9F3D40"
-    )
-
-    /// Drop zone: kiwi-brown fill inside a kiwi-green border.
-    public static let dropZoneDefault = DragVisual(
         enabled: true,
         border: true,
         borderColor: "#4E9F3D",
         borderThickness: 5,
         borderAlignment: .inside,
         fill: true,
-        fillColor: "#8B5E3C40"
+        fillColor: "#4E9F3D40"
+    )
+
+    /// Drop zone (drag target): all amber — the palette's other
+    /// established hue (`focused_item_color`), so the target draws
+    /// the eye apart from the green origin.
+    public static let dropZoneDefault = DragVisual(
+        enabled: true,
+        border: true,
+        borderColor: "#E8A33D",
+        borderThickness: 5,
+        borderAlignment: .inside,
+        fill: true,
+        fillColor: "#E8A33D40"
     )
 
     public init(

--- a/Tests/KiwiDeskCoreTests/ColorPaletteTests.swift
+++ b/Tests/KiwiDeskCoreTests/ColorPaletteTests.swift
@@ -117,15 +117,15 @@ struct ColorPaletteTests {
         #expect(settings.appBarStyle.fillColor == before)
     }
 
-    @Test("The bundled catalog is 7 palettes, default first, unique")
+    @Test("The bundled catalog is 9 palettes, default first, unique")
     func bundledCatalog() {
         let all = PaletteCatalog.bundled()
-        #expect(all.count == 7)
+        #expect(all.count == 9)
         #expect(all.first?.name == PaletteCatalog.defaultName)
         let names = all.map(\.name)
-        #expect(Set(names).count == 7)
-        // The six authored palettes decoded from the resource.
-        #expect(PaletteCatalog.authored().count == 6)
+        #expect(Set(names).count == 9)
+        // The eight authored palettes decoded from the resource.
+        #expect(PaletteCatalog.authored().count == 8)
     }
 
     @Test("Every bundled palette's colors are valid hexes")

--- a/Tests/KiwiDeskCoreTests/PaletteStoreTests.swift
+++ b/Tests/KiwiDeskCoreTests/PaletteStoreTests.swift
@@ -23,7 +23,7 @@ struct PaletteStoreTests {
     @Test("Built-ins are the catalog; no user palettes at first")
     func initialState() {
         let (store, _) = makeStore()
-        #expect(store.builtins().count == 7)
+        #expect(store.builtins().count == 9)
         #expect(store.userPalettes().isEmpty)
     }
 

--- a/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
+++ b/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
@@ -157,15 +157,15 @@ struct SettingsCodingTests {
                 "border_alignment", "enabled", "fill", "fill_color",
             ]
         )
-        // Kiwi defaults: green fill / brown border (ghost),
-        // brown fill / green border (drop zone).
-        #expect(ghost["border_color"] as? String == "#8B5E3C")
+        // Kiwi defaults: all-green ghost (origin), all-amber
+        // drop zone (target) — hue carries origin vs. target.
+        #expect(ghost["border_color"] as? String == "#4E9F3D")
         #expect(ghost["fill_color"] as? String == "#4E9F3D40")
         #expect(ghost["border_thickness"] as? Double == 5)
         #expect(ghost["border_alignment"] as? String == "inside")
         let zone = try object(drag["drop_zone"])
-        #expect(zone["border_color"] as? String == "#4E9F3D")
-        #expect(zone["fill_color"] as? String == "#8B5E3C40")
+        #expect(zone["border_color"] as? String == "#E8A33D")
+        #expect(zone["fill_color"] as? String == "#E8A33D40")
         #expect(zone["border_thickness"] as? Double == 5)
         #expect(zone["border_alignment"] as? String == "inside")
     }

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -57,7 +57,7 @@ planned escape hatch; it is not a wontfix dumping ground.
 
 | Behavior | Why it's accepted | Architectural root | Escape hatch / planned fix |
 |---|---|---|---|
-| A bar with the `liquid_glass` finish on shows its plain **solid** shape on macOS earlier than 26 — the glass material does not appear there. | Liquid Glass is a macOS 26 API (`NSGlassEffectView`); the boolean must still round-trip so a shared profile stays portable, so an older machine shows the underlying `boxed`/`plain` shape rather than an unbacked strip. The GUI never *offers* the toggle below 26 (an OS-capability gate, absent not greyed), so only a hand-written config or a profile authored on 26 reaches this state. | The stored `liquid_glass` value is portable; only the render path is `#available(macOS 26)`-gated (`glassEnabled`), painting the solid shape without rewriting the field ([#390](https://github.com/hajiboy95/KiwiDesk/issues/390)). | Use macOS 26+ to see the glass; the finish is colorless there and near-colorless even on 26. |
+| A bar with the `liquid_glass` finish on shows its plain **solid** shape on macOS earlier than 26 — the glass material does not appear there. | Liquid Glass is a macOS 26 API (`NSGlassEffectView`); the boolean must still round-trip so a shared profile stays portable, so an older machine shows the underlying `boxed`/`plain` shape rather than an unbacked strip. The GUI never *offers* the toggle below 26 (an OS-capability gate, absent not greyed), so only a hand-written config or a profile authored on 26 reaches this state. | The stored `liquid_glass` value is portable; only the render path is `#available(macOS 26)`-gated (`glassEnabled`), painting the solid shape without rewriting the field ([#390](https://github.com/hajiboy95/KiwiDesk/issues/390)). | Use macOS 26+ to see the glass; there the `fill_color` tints it (a colored backdrop the glass refracts, #408). |
 | With **"Displays have separate Spaces" on**, native Desktop→profile bindings cannot represent an independent Desktop choice on every connected display; KiwiDesk applies one global active profile. | Basic tiling remains valid, single-display use is unaffected, and users may want to inspect or prepare bindings before changing the macOS option, so hiding or disabling the controls would overstate the limitation. | Native-Space routing resolves one active Desktop number and one active profile for the whole display setup, not a per-display profile tuple ([#8](https://github.com/hajiboy95/KiwiDesk/issues/8)). | Turn the option off in Desktop & Dock Settings, then log out and back in. Onboarding and the binding-section warning share one gate and fire only in the affected multi-display state, never on a single display. See [Shared display Spaces are recommended, not required](#spaces-profiles--config-ownership). |
 | In BSP, the inner window of a nested pair can't grow — a "grow" press (or edge-drag) widens its outer neighbor instead. | Its width `r·(1−r)·W` is already maximized at the default ratio, so no resize direction can widen it. | All same-orientation splits share the one per-space ratio; per-node ratios would need a container tree the flat-array model forbids (#56 trade). | **Shipped**: the [`track` layout (#128)](https://github.com/hajiboy95/KiwiDesk/issues/128) — `set_mode(space, "track")` gives every window one true resize target. See [BSP resize is focus-aware in *direction* only](#layout-and-resize-behavior). |
 | In stack, when the master zone lines up *along* the split axis (e.g. horizontal masters beside a right stack), the masters' individual shares can't be resized: that axis always moves the split, and the other axis beeps. | The split ratio owns its whole axis — giving the same keypress two meanings (split vs weight) by focus zone would make "grow" unpredictable at the boundary. | One knob per axis per arrangement ([#222](https://github.com/hajiboy95/KiwiDesk/issues/222)); weights live on a zone's own lineup axis by construction. | Pick the orthogonal (vertical) master orientation — since the 2026-07-16 default flip the standard side-by-side arrangement sits *inside* this limitation once `master_count` exceeds one — or put the windows that need individual shares in the stack zone. |
@@ -1387,23 +1387,25 @@ shipped as a third `TabBackground` case (`material`) beside
 `boxed`/`plain`, on the reasoning that a toggle would be ambiguous
 ("boxed + glass" = glass boxes or a glass strip under opaque
 boxes?). On-device testing (macOS 26.5.2) forced a rethink on two
-fronts. **First**, `NSGlassEffectView` reads **near-colorless**
-here — `tintColor` only nudges luminance, and `.clear` vs
-`.regular` are visually identical — so glass is a *finish*, not a
-colorable surface that could be a peer of the solid shapes.
+fronts. **First**, `NSGlassEffectView`'s own `tintColor` reads
+**near-colorless** here — it only nudges luminance, and `.clear`
+vs `.regular` are visually identical — so glass is a *finish*, not
+a colorable surface that could be a peer of the solid shapes.
 **Second**, the ambiguity dissolves once each combination has a
 defined rendering: `boxed + glass` = a glass view **per box**
 (grouped in an `NSGlassEffectContainerView`), `plain + glass` = one
 shared glass plate. So the model is now shape (`boxed` | `plain`)
 × a separate `liquid_glass: Bool` finish that lays over either.
-`fill_color` is still forwarded as the glass tint for forward-
-compatibility (should a future macOS honor a saturated tint), but
-the earlier "a palette re-tints the glass for free" claim is
-**walked back** — on current macOS the glass is effectively
-colorless, and the GUI notes the tint is subtle. Correct
-`NSGlassEffectView` usage requires embedding the content as the
-view's `contentView` (never a bare sibling backdrop, which renders
-degraded — the bug that first read as "glass has no color").
+**`fill_color` still tints the glass (#408)** — not through the
+inert `tintColor`, but by placing a solid colored view *behind*
+the glass, which the glass refracts into its hue (the way the Dock
+and Control Center tint their glass). This is distinct from the
+earlier degraded-render bug: the items stay embedded as the glass's
+`contentView` (the required usage); the colored view is an
+*additional* backdrop sibling **behind** the whole glass, supplying
+a hue for it to sample — never a replacement for the content. A
+fully transparent `fill_color` leaves the glass clear. One seam
+owns the five hosting modes (`GlassHosting` / `GlassTint`, #407).
 The default stays no-glass; the finish is OS-gated: ignored below
 macOS 26 (`glassEnabled` = `liquidGlass && glassAvailable`), and
 its Settings toggle is *hidden* there — an OS-capability gate, so

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1102,9 +1102,16 @@ new palette against, not a spec the reflection-based
 
 The Kiwi (Default) palette was refreshed the same day from a
 brown/green pair to one green family (dark-moss fill `#37452E66`,
-flesh-green accent `#4E9F3D`, cream text, amber focused) — brown
-now lives on only in the transient drag visuals, exactly the
-"minor flourish" band above.
+flesh-green accent `#4E9F3D`, cream text, amber focused). Brown
+was retired entirely, including the drag visuals — the ghost/drop
+-zone swap now re-sources its two hues from the palette's own
+green (ghost = origin) and amber (drop zone = target), per the
+two-hue drag pattern above, so nothing spends a stray third hue.
+Two branded siblings ship alongside the default and lead the
+shelf right after it: **Kiwi Dark** (a dark-base green identity,
+distinct from the neutral True Dark) and **Kiwi Gold** (a warm
+gold-fruit variant, green as its secondary) — both authored in
+`bundled.json`, both following the same guide.
 
 **The App Bar has its own sidebar destination.** (#229,
 superseding the earlier "Appearance ends with the App Bar

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1058,6 +1058,54 @@ was dropped — the stored value stays a hex string, and
 copy/paste theme sharing works through the panel. (#68
 §3.14, revised)
 
+**Palette colors follow a rough matching guide.** (#408
+follow-up, 2026-07-20.) A palette (the bar + border + drag
+colors, bundled or user-saved) reads as one system when its
+roles relate by a few loose heuristics — a guide to eyeball a
+new palette against, not a spec the reflection-based
+`ColorPaletteKeys` surface enforces:
+
+- **Hue budget: 1–3 chromatic hues, 2 is the sweet spot.**
+  Count only saturated identity hues, not neutrals or the
+  badge red. The common shape is one *primary accent* +
+  one *focused accent*; >3 hues is a smell (Monochrome and
+  the deliberately-busier Sunset/Ultraviolet are the ratified
+  exceptions).
+- **Primary vs. focused accent differ by *temperature*, not
+  just hue.** `active_item_color` / `highlight_color` /
+  `border.focused_color` share the *primary* hue;
+  `space_bar.focused_item_color` is the complementary
+  temperature (cool primary → warm focused, and vice-versa),
+  so "active space" and "focused window" read as two signals.
+- **Focus is one color across bar and border.**
+  `border.focused_color` = the primary accent; `highlight_color`
+  defaults to it too (borrow the secondary only as a flourish,
+  never invent a third hue for it).
+- **`border.unfocused_color` is always near-neutral grey**,
+  low saturation, ~35–60 % alpha — it must never compete with
+  the focused ring.
+- **`fill_color` sets the light/dark base; `item_color`
+  inverts against it** (`hover_item_color` mirrors the item
+  family, doesn't flip it). Fill alpha ~40–85 % for solid
+  shapes; **under `liquid_glass` the backdrop is render-capped
+  to ~65 %** so the glass stays glassy (`GlassTint.maxAlpha`).
+- **`hover_fill_color` ~50 % alpha** (`0x80`) of a hue *a
+  shade off* the accent — legible feedback that never reads as
+  the active state.
+- **`group_badge_color` defaults to the universal `#B00020` /
+  white**; a bespoke badge echoes the palette temperature and
+  pairs a text color chosen for contrast against *that* badge.
+- **Drag ghost / drop-zone:** either single-accent (same hue,
+  border opaque + fill ~15–25 %) or a deliberate two-hue swap
+  of hues already established elsewhere — never a fresh color
+  just for drag.
+
+The Kiwi (Default) palette was refreshed the same day from a
+brown/green pair to one green family (dark-moss fill `#37452E66`,
+flesh-green accent `#4E9F3D`, cream text, amber focused) — brown
+now lives on only in the transient drag visuals, exactly the
+"minor flourish" band above.
+
 **The App Bar has its own sidebar destination.** (#229,
 superseding the earlier "Appearance ends with the App Bar
 block" note.) Appearance kept only Gaps and Drag & Drop —

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1598,15 +1598,18 @@ app_bar.set_item_color("#F2EBD9")
 **Expects:** a hex color.
 
 **Does:** sets the fill under the items — a box per item
-(`boxed`) or one shared plate (`plain`). Default `#8B5E3C66`,
-translucent shell-brown. With the `liquid_glass` finish on, it
+(`boxed`) or one shared plate (`plain`). Default `#37452E66`,
+translucent dark moss. With the `liquid_glass` finish on, it
 also tints the glass: the color sits behind the glass, which
-refracts it into its hue (see `app_bar.set_liquid_glass`).
+refracts it into its hue (see `app_bar.set_liquid_glass`). Under
+glass the backdrop's opacity is held at ~65 % so the blur stays
+visible; the stored value is unchanged (Boxed/Plain use it in
+full).
 
 **Example:**
 
 ```lua
-app_bar.set_fill_color("#8B5E3C66")
+app_bar.set_fill_color("#37452E66")
 ```
 
 ### app_bar.set_active_item_color

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -2153,13 +2153,13 @@ drag.set_ghost_border_alignment("inside")
 
 **Expects:** a hex color.
 
-**Does:** sets the ghost border color (default `#8B5E3C`,
-shell-brown).
+**Does:** sets the ghost border color (default `#4E9F3D`,
+flesh-green — the ghost, drag's origin, is all-green).
 
 **Example:**
 
 ```lua
-drag.set_ghost_border_color("#8B5E3C")
+drag.set_ghost_border_color("#4E9F3D")
 ```
 
 ### drag.set_ghost_fill
@@ -2239,13 +2239,14 @@ drag.set_drop_zone_border_alignment("inside")
 
 **Expects:** a hex color.
 
-**Does:** sets the drop zone border color (default `#4E9F3D`,
-flesh-green).
+**Does:** sets the drop zone border color (default `#E8A33D`,
+amber — the drop zone, drag's target, is all-amber so it reads
+apart from the green ghost).
 
 **Example:**
 
 ```lua
-drag.set_drop_zone_border_color("#4E9F3D")
+drag.set_drop_zone_border_color("#E8A33D")
 ```
 
 ### drag.set_drop_zone_fill
@@ -2264,13 +2265,13 @@ drag.set_drop_zone_fill(true)
 
 **Expects:** a hex color.
 
-**Does:** sets the drop zone fill color (default `#8B5E3C40`,
-shell-brown with 25% alpha).
+**Does:** sets the drop zone fill color (default `#E8A33D40`,
+amber with 25% alpha).
 
 **Example:**
 
 ```lua
-drag.set_drop_zone_fill_color("#8B5E3C40")
+drag.set_drop_zone_fill_color("#E8A33D40")
 ```
 
 ### drag.set_corner_radius
@@ -3400,15 +3401,15 @@ stripped, grouped by namespace — `set_gap_override` becomes
       "corner_radius": 16,
       "ghost": {
         "enabled": true, "border": true,
-        "border_color": "#8B5E3C", "border_thickness": 5,
+        "border_color": "#4E9F3D", "border_thickness": 5,
         "border_alignment": "inside",
         "fill": true, "fill_color": "#4E9F3D40"
       },
       "drop_zone": {
         "enabled": true, "border": true,
-        "border_color": "#4E9F3D", "border_thickness": 5,
+        "border_color": "#E8A33D", "border_thickness": 5,
         "border_alignment": "inside",
-        "fill": true, "fill_color": "#8B5E3C40"
+        "fill": true, "fill_color": "#E8A33D40"
       }
     },
     "gap": {

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1405,9 +1405,13 @@ app_bar.set_tab_background("plain")
 
 **Does:** lays a macOS 26 Liquid Glass material over the tab
 backgrounds (the boxes or the plate) — an orthogonal finish, so
-it combines with either shape. `fill_color` is forwarded as the
-glass tint, though on current macOS the glass reads near-colorless
-(the tint only nudges luminance). Ignored below macOS 26, where
+it combines with either shape. `fill_color` tints the glass: a
+solid colored layer sits behind the glass and the glass refracts
+it (an `NSGlassEffectView`'s own tint reads near-colorless on
+macOS 26.5.2 — it shifts luminance, not hue — so the color is
+supplied behind it, the way the Dock tints its glass). A fully
+transparent `fill_color` leaves the glass clear. Ignored below
+macOS 26, where
 the Settings toggle is hidden (an OS-capability gate, absent not
 greyed); the stored value still round-trips so a profile stays
 portable. Per-layout override:
@@ -1595,9 +1599,9 @@ app_bar.set_item_color("#F2EBD9")
 
 **Does:** sets the fill under the items — a box per item
 (`boxed`) or one shared plate (`plain`). Default `#8B5E3C66`,
-translucent shell-brown. With the `liquid_glass` finish on it is
-also forwarded as the glass tint, though on current macOS the
-glass reads near-colorless (the tint only nudges luminance).
+translucent shell-brown. With the `liquid_glass` finish on, it
+also tints the glass: the color sits behind the glass, which
+refracts it into its hue (see `app_bar.set_liquid_glass`).
 
 **Example:**
 
@@ -1879,8 +1883,8 @@ space_bar.set_tab_background("boxed")
 
 **Does:** lays the macOS 26 Liquid Glass finish over the Space
 items — see `app_bar.set_liquid_glass` for the full behavior
-(orthogonal to the shape, `fill_color` forwarded as a subtle
-tint, hidden and inert below macOS 26).
+(orthogonal to the shape, `fill_color` tints the glass via a
+colored backdrop behind it, hidden and inert below macOS 26).
 
 **Example:**
 


### PR DESCRIPTION
Paired bars work: #407 (refactor) then #408 (tint), plus the appearance follow-ups the tint work surfaced. Reviewed (code-reviewer + architect-reviewer, round 1 clean bar minor findings, all addressed) and shipped on the green local gate.

## #407 — centralize glass view-hosting into one mode dispatch
A bar item lived in one of five parentings (solid plate/boxed, per-box glass, plain-glass hug, plain-glass span, none) with no single value naming the mode — every entry point tore down the *other* modes independently. Introduce `GlassHosting` (one `resolve` per render) and route through one dispatch per bar: `prepareGlassHosting` tears down the non-target modes before the item loop; `installGlassHosting` installs the target after, from the laid-out frames. Same call sequence and `GlassPlate.holds` idempotency as before — behavior-preserving (reviewer confirmed the teardown maps 1:1 to the old `updateGlassPlate`). Lifts the dispatch out of both `render()`s.

## #408 — tint the Liquid Glass with a colored backdrop
`NSGlassEffectView`'s own tint is near-colorless on macOS 26.5.2 (shifts luminance, not hue). Instead, place a solid colored view **behind** each glass surface (`GlassTint`), filled with the Fill color; the glass refracts it and adopts the hue (the Dock/Control-Center trick). The items stay embedded as the glass `contentView`; the backdrop is an additional sibling supplying only color. Added once per hosting mode at the #407 seam: per-box, the plain-glass plate (hug + span), and the App Bar arrow / Space Bar front-segment glasses. Backdrops kept parallel to the glass views and torn down with them.

- **Opacity cap** (`GlassTint.maxAlpha` ~65%): a render-time cap so an opaque Fill can't turn the glass into a flat plate. The stored `fill_color` is untouched (Boxed/Plain use it in full; Lua stays open) — glass just always renders glassy. A transparent Fill = clear glass.

## Appearance refresh (design-consult follow-ups)
- **Kiwi (Default) fill → dark moss `#37452E66`** (was shell-brown): one green family with the accent; brown fully retired.
- **Drag visuals → green/amber**: ghost (origin) green, drop-zone (target) amber — re-sourced from the palette's own hues.
- **Two new bundled palettes**: Kiwi Dark and Kiwi Gold, leading the shelf after the default; shelf reordered (Kiwi family → neutrals → expressive pair).
- **Palette matching guide** added to `docs/design-decisions.md`.

## Verify
`swift build && swift test` (1581 pass) `&& scripts/lint.sh && swift build -c release` — all green. Site docs build clean.

## Follow-ups
- #409 — Space Bar front-app divider spacing + pin-front-app-while-scrolling
- #411 — App Bar group badge clipped by the rounded corner under per-box glass
- Non-blocking (architect): `AppBarOverlay`/`SpaceBarOverlay` sit ~345/347 of the 350 ceiling; extract `render()` on the next touch.

Fixes #407, fixes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)