### PR TITLE
feat(commands): nudge a window toward center when it floats

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+FloatNudge.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+FloatNudge.swift
@@ -1,0 +1,47 @@
+import AppKit
+import CoreGraphics
+
+/// The float nudge: a just-floated window keeps its exact frame,
+/// so a tiled→floating toggle looks inert. A small fixed shove
+/// toward the screen center acknowledges the state change.
+///
+/// The geometry is the pure `FloatNudge` helper; this layer only
+/// snapshots the inputs (the cached state frame — never an AX
+/// read on the hot path — and the window's screen) and rides the
+/// existing relayout animation path via `applyFrame`, so the
+/// nudge shares the engine's DisplayLink duration and easing.
+extension KiwiCore {
+    /// Nudges `id` toward its screen's visible-frame center.
+    /// Callers gate the transition (float direction only, and
+    /// only tiled→floating); the `floatNudge` setting gate lives
+    /// here so a disabled nudge is a single no-op branch.
+    func nudgeFloating(_ id: WindowID) {
+        guard tiler.settings.floatNudge,
+            let current = state.windows[id]?.frame
+        else { return }
+        let screen =
+            NSScreen.screens.first {
+                GeometryUtils.axVisibleFrame(of: $0)
+                    .intersects(current)
+            } ?? NSScreen.main ?? NSScreen.screens.first
+        guard let screen else { return }
+        let visible = GeometryUtils.axVisibleFrame(of: screen)
+        let nudged = FloatNudge.target(
+            frame: current,
+            visible: visible
+        )
+        // `axVisibleFrame` excludes the menu bar but not the
+        // App/Space Bar strips; clear those too, the same clamp
+        // every float gets (#242).
+        let target = floatFrameClampedClearOfBars(
+            id,
+            frame: nudged
+        )
+        tiler.applyFrame(
+            id,
+            from: current,
+            to: target,
+            animated: tiler.settings.animations.onRelayout
+        )
+    }
+}

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -36,6 +36,7 @@ public enum APIReference {
                 "set_swap_skips_cascade",
                 "set_swap_skips_cascade"
             ),
+            ("set_float_nudge", "set_float_nudge"),
             ("set_resize_step", "set_resize_step"),
             (
                 "set_resize_feedback",

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
@@ -63,6 +63,8 @@ extension KiwiCore {
             return setMinWindowSize(args)
         case "set_swap_skips_cascade":
             return setSwapSkipsCascade(args)
+        case "set_float_nudge":
+            return setFloatNudge(args)
         case "set_resize_step":
             return setResizeStep(args)
         case "set_resize_feedback":
@@ -126,8 +128,18 @@ extension KiwiCore {
         guard let focused = activeSpace?.focused else {
             return .fail("no focused window")
         }
+        // Snapshot before the flip so the nudge fires on the
+        // tiled→floating transition only — not on a re-issued
+        // `make_floating` for an already-floating window.
+        let wasFloating =
+            state.windows[focused]?.isFloating ?? false
         state.setFloating(focused, floating)
         retile()
+        // Float direction only: `make_tiled` already animates a
+        // real move back into the layout, so no nudge there.
+        if floating, !wasFloating {
+            nudgeFloating(focused)
+        }
         return .ok()
     }
 

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
@@ -83,6 +83,19 @@ extension KiwiCore {
         return .ok()
     }
 
+    func setFloatNudge(
+        _ args: [JSONValue]
+    ) -> CommandResponse {
+        guard let on = args.first?.boolValue else {
+            return .fail("expected boolean")
+        }
+        tiler.settings.floatNudge = on
+        // No retile: the flag is read only at the moment a
+        // tiled→floating toggle fires, never by layout math, so
+        // flipping it can't move any window here.
+        return .ok()
+    }
+
     func setResizeStep(
         _ args: [JSONValue]
     ) -> CommandResponse {

--- a/Sources/KiwiDeskCore/Tiling/FloatNudge.swift
+++ b/Sources/KiwiDeskCore/Tiling/FloatNudge.swift
@@ -1,0 +1,70 @@
+import CoreGraphics
+
+/// Pure geometry for the float nudge (#412 sibling polish).
+///
+/// Toggling a window tiled→floating keeps its exact frame, so the
+/// toggle looks inert — nothing moved. A small fixed shove toward
+/// the current screen's visible-frame center acknowledges the
+/// state change.
+///
+/// The magnitude is FIXED (`min(maxDistance, distanceToCenter)`),
+/// never proportional to the window size: a size-scaled nudge
+/// teleports a maximized window and barely moves a tiny one. A
+/// window already near the center tapers to ~0 on its own (the
+/// distance term shrinks), so no edge special-casing is needed.
+///
+/// All math is a pure function over the window frame and the
+/// screen's AX visible frame — no AX, no AppKit — so it is
+/// unit-testable and safe to call off the layout hot path.
+public enum FloatNudge {
+    /// Cap on the shove, in points. Small enough to read as a
+    /// nudge (an acknowledgement), not a real move.
+    public static let maxDistance: CGFloat = 24
+
+    /// The nudged target frame for a floating window, shoved
+    /// toward `visible`'s center and confined fully inside
+    /// `visible` so it can never slip under the menu bar / a
+    /// reserved strip or partly off-screen.
+    ///
+    /// AX coordinates (origin top-left, y grows downward), so the
+    /// visible frame's bottom edge is `visible.maxY`.
+    public static func target(
+        frame: CGRect,
+        visible: CGRect,
+        maxDistance: CGFloat = FloatNudge.maxDistance
+    ) -> CGRect {
+        let dx = visible.midX - frame.midX
+        let dy = visible.midY - frame.midY
+        let distance = (dx * dx + dy * dy).squareRoot()
+
+        let offset: CGVector
+        if distance < 1 {
+            // Direction undefined at dead center: shove straight
+            // down toward the visible frame's bottom edge.
+            let room = max(0, visible.maxY - frame.midY)
+            offset = CGVector(dx: 0, dy: min(maxDistance, room))
+        } else {
+            let magnitude = min(maxDistance, distance)
+            offset = CGVector(
+                dx: dx / distance * magnitude,
+                dy: dy / distance * magnitude
+            )
+        }
+
+        let moved = frame.offsetBy(dx: offset.dx, dy: offset.dy)
+        return confine(moved, to: visible)
+    }
+
+    /// Clamps `frame`'s origin so the frame sits fully inside
+    /// `visible` (position only, size untouched) — the same "keep
+    /// it on screen" intent tiled placement gets for free from
+    /// its pure layout functions. A frame larger than `visible`
+    /// on an axis pins to that axis's min edge.
+    static func confine(_ frame: CGRect, to visible: CGRect) -> CGRect {
+        let maxX = max(visible.minX, visible.maxX - frame.width)
+        let maxY = max(visible.minY, visible.maxY - frame.height)
+        let x = min(max(frame.minX, visible.minX), maxX)
+        let y = min(max(frame.minY, visible.minY), maxY)
+        return CGRect(x: x, y: y, width: frame.width, height: frame.height)
+    }
+}

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
@@ -25,6 +25,7 @@ extension TilingSettings: Codable {
         case layout
         case minWindowSize = "min_window_size"
         case swapSkipsCascade = "swap_skips_cascade"
+        case floatNudge = "float_nudge"
         case placementOverride =
             "new_window_placement_override"
         case mouse
@@ -86,6 +87,11 @@ extension TilingSettings: Codable {
             try container.decodeIfPresent(
                 Bool.self,
                 forKey: .swapSkipsCascade
+            ) ?? true
+        floatNudge =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: .floatNudge
             ) ?? true
         placementOverride =
             try container.decodeIfPresent(

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Encoding.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Encoding.swift
@@ -19,6 +19,10 @@ extension TilingSettings {
             forKey: .swapSkipsCascade
         )
         try container.encode(
+            floatNudge,
+            forKey: .floatNudge
+        )
+        try container.encode(
             placementOverride,
             forKey: .placementOverride
         )

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
@@ -33,6 +33,15 @@ public struct TilingSettings: Sendable, Equatable {
     /// spaces), same tier as `minWindowSize`; power-user escape
     /// hatch, no GUI. `focus` is never affected.
     public var swapSkipsCascade = true
+    /// When true (default), toggling a window tiled→floating
+    /// gives it a small fixed shove toward the screen center so
+    /// the state change is visible — a float otherwise keeps its
+    /// exact frame, making the toggle look inert. Fires on the
+    /// float direction only (`make_tiled` already animates a real
+    /// move back into the layout). Global (per profile, all
+    /// spaces), same tier as `swapSkipsCascade`; a niche polish
+    /// toggle, Lua-only, no GUI. See `FloatNudge`.
+    public var floatNudge = true
     public var bsp = BspParams()
     public var stack = StackParams()
     public var scrolling = ScrollingParams()

--- a/Tests/KiwiDeskCoreTests/FloatNudgeTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatNudgeTests.swift
@@ -1,0 +1,83 @@
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Pure geometry of the float nudge (`FloatNudge.target`). AX
+/// coordinates throughout: origin top-left, y grows downward, so
+/// the visible frame's bottom edge is `maxY`.
+@Suite("Float nudge geometry")
+struct FloatNudgeTests {
+    /// A 1000×1000 visible frame; center at (500, 500).
+    private let visible = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+
+    private func center(_ rect: CGRect) -> CGPoint {
+        CGPoint(x: rect.midX, y: rect.midY)
+    }
+
+    private func distance(_ a: CGPoint, _ b: CGPoint) -> CGFloat {
+        let dx = a.x - b.x
+        let dy = a.y - b.y
+        return (dx * dx + dy * dy).squareRoot()
+    }
+
+    @Test("Far window shoves a fixed 24 pt toward center")
+    func fixedMagnitude() {
+        // Centered at (500, 800): 300 pt straight below center.
+        let frame = CGRect(x: 450, y: 750, width: 100, height: 100)
+        let result = FloatNudge.target(frame: frame, visible: visible)
+        // Moves exactly maxDistance, straight up toward center.
+        #expect(
+            abs(distance(center(result), center(frame)) - 24) < 0.001
+        )
+        #expect(abs(result.midX - 500) < 0.001)
+        #expect(abs(result.midY - 776) < 0.001)
+    }
+
+    @Test("Fixed magnitude ignores window size (no teleport)")
+    func magnitudeIndependentOfSize() {
+        // A large window off-center by 200 pt (and still fully on
+        // screen) must shove the same 24 pt as a small one — a
+        // size-proportional nudge would teleport it.
+        let frame = CGRect(x: 50, y: 400, width: 900, height: 600)
+        let result = FloatNudge.target(frame: frame, visible: visible)
+        #expect(
+            abs(distance(center(result), center(frame)) - 24) < 0.001
+        )
+    }
+
+    @Test("Near-center window tapers below the cap")
+    func nearCenterTapers() {
+        // Center only 10 pt from the visible center → shove 10 pt
+        // (min(24, 10)), landing exactly on center.
+        let frame = CGRect(x: 450, y: 460, width: 100, height: 100)
+        let result = FloatNudge.target(frame: frame, visible: visible)
+        let moved = distance(center(result), center(frame))
+        #expect(moved < 24)
+        #expect(abs(moved - 10) < 0.001)
+        #expect(abs(result.midX - 500) < 0.001)
+        #expect(abs(result.midY - 500) < 0.001)
+    }
+
+    @Test("Dead-center window shoves straight down")
+    func deadCenterGoesDown() {
+        // Exactly on center: direction undefined → straight down
+        // (increasing y in AX) by the cap.
+        let frame = CGRect(x: 450, y: 450, width: 100, height: 100)
+        let result = FloatNudge.target(frame: frame, visible: visible)
+        #expect(abs(result.midX - 500) < 0.001)
+        #expect(abs(result.midY - 524) < 0.001)
+    }
+
+    @Test("Result is always confined on screen")
+    func clampsOnScreen() {
+        // A window hanging off the top edge, nudged toward center:
+        // the result must sit fully inside the visible frame.
+        let frame = CGRect(x: 450, y: -38, width: 100, height: 100)
+        let result = FloatNudge.target(frame: frame, visible: visible)
+        #expect(result.minX >= visible.minX)
+        #expect(result.minY >= visible.minY)
+        #expect(result.maxX <= visible.maxX)
+        #expect(result.maxY <= visible.maxY)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
+++ b/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
@@ -27,7 +27,8 @@ struct SettingsCodingTests {
         )
         #expect(
             Set(root.keys) == [
-                "animations", "app_bar", "border", "drag", "gap",
+                "animations", "app_bar", "border", "drag",
+                "float_nudge", "gap",
                 "layout", "min_window_size", "mouse",
                 "mouse_resize", "new_window_placement_override", "quit",
                 "floating", "resize", "space", "space_bar",
@@ -79,6 +80,10 @@ struct SettingsCodingTests {
         // `set_swap_skips_cascade` → top-level `swap_skips_cascade`
         // (#172), on by default.
         #expect(root["swap_skips_cascade"] as? Bool == true)
+        // `set_float_nudge` → top-level `float_nudge`, on by
+        // default: a tiled→floating toggle shoves the window
+        // toward center so the state change is visible.
+        #expect(root["float_nudge"] as? Bool == true)
         // `set_space_icon` → `space.icon[space_id]` (#68).
         let space = try object(root["space"])
         let icons = try object(space["icon"])
@@ -220,6 +225,7 @@ struct SettingsCodingTests {
         settings.track.wrapFocus = true
         settings.minWindowSize = 200
         settings.swapSkipsCascade = false
+        settings.floatNudge = false
         settings.resizeStep = 75
         settings.resizeFeedback = false
         settings.dragGhost.enabled = false

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -85,6 +85,7 @@ already-running / not-running cases exit 0.
 | | `set_resize_step` | pt (default 50) — Grow/Shrink magnitude |
 | | `set_resize_feedback` | true\|false (default `true`) — alert sound when a resize hotkey can't act |
 | | `set_swap_skips_cascade` | true\|false (default `true`) — swap from a pile targets the outside neighbor |
+| | `set_float_nudge` | true\|false (default `true`) — shove a window toward center when it toggles to floating |
 | | `set_fallback_space` | space id ("" clears) — rehome target on profile switch |
 | | `set_space_icon` | space id, icon (SF Symbol\|emoji\|char; "" clears) |
 | | `quit.set_layout` | `grid` (default) — how windows are spread on quit |

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -512,6 +512,36 @@ this: it resizes itself directly, in every mode (width for x,
 height for y, floored at `min_window_size`). (#122, #124,
 #129)
 
+**The tiled→floating toggle nudges the window, and the nudge is
+a fixed magnitude, not proportional.** A window keeps its exact
+frame the instant it turns floating, so `make_floating` /
+`toggle_floating` looked like they did nothing — no acknowledgement
+of the state change. The float direction now gives the window a
+small shove toward its screen's visible-frame center (the tiled
+direction already animates a real move back into the layout, so it
+needs none). The magnitude is deliberately **fixed** —
+`min(24 pt, distance to center)` along the unit vector to the
+center — rather than proportional to the window size: a
+size-scaled nudge (longest-side × 0.2, say) teleports a maximized
+window clear across the screen while barely moving a small one.
+The fixed form self-tapers instead — a window already near the
+center has a short distance term and so moves less, reaching zero
+with no edge special-casing; a dead-centered window (direction
+undefined) shoves straight down. The target is clamped fully
+inside the visible frame, exactly like tiled placement, so it can
+never land under the menu bar / a reserved bar strip or partly
+off-screen, and it rides the existing relayout animation so the
+motion reads as a deliberate move, not a jump. Fires on the
+explicit float verbs only — `make_floating` and a
+`toggle_floating` that lands on floating — once per tiled→floating
+flip, never on an already-floating window. `make_auto` is
+deliberately excluded: its flip is detection-driven, not a
+deliberate user float, so it gets no acknowledging nudge.
+Fixed, not proportional, is the whole point — recorded
+here so it is not "optimized" back into a size-scaled form. A
+niche polish behavior, so the disable knob (`set_float_nudge`,
+default on) is Lua-only with no Settings toggle.
+
 ### Spaces, profiles & config ownership
 
 **The fallback space is an explicit choice, not "whichever

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -341,6 +341,31 @@ case, so this lives in config only.
 KiwiDesk.set_swap_skips_cascade(true)
 ```
 
+### set_float_nudge
+
+**Expects:** `true` or `false` (default `true`).
+
+**Does:** whether toggling a window from tiled to floating gives
+it a small nudge toward the screen center. A window keeps its
+exact frame when it floats, so without the nudge the toggle looks
+like it did nothing; a fixed shove (up to 24 pt, tapering to zero
+for a window already near the center) acknowledges the state
+change. Fires on the float direction only — `make_floating` and a
+`toggle_floating` that lands on floating — never on `make_tiled`,
+which already animates a real move back into the layout. The
+magnitude is fixed, not scaled by window size, so a maximized
+window does not leap across the screen and a tiny one still
+moves; the target is always kept fully on screen and clear of the
+menu bar and any App/Space Bar. Global (per profile, all spaces);
+a niche polish toggle, so it lives in config only, with no
+Settings toggle.
+
+**Example:**
+
+```lua
+KiwiDesk.set_float_nudge(true)
+```
+
 ### set_resize_feedback
 
 **Expects:** `true` or `false` (default `true`).


### PR DESCRIPTION
## What

A window toggled tiled→floating keeps its exact frame, so the toggle looks inert — nothing visibly moves. This gives the float a small fixed shove toward the screen's visible-frame center to acknowledge the state change.

## Design (settled)

- **Fixed magnitude** `min(24pt, distanceToCenter)` along the unit vector to the visible center — NOT size-proportional (proportional teleports a maximized window, barely moves a tiny one).
- Near-center self-tapers (distance term shrinks); dead-center shoves straight down; result confined fully inside the visible frame and clear of App/Space bars (#242 clamp).
- Rides the existing relayout DisplayLink animation (shared duration + easing).
- **Default ON, Lua-only** (`set_float_nudge`), no GUI surface.
- Gated `floating && !wasFloating` — covers `make_floating` + `toggle_floating`, excludes `make_tiled`/`make_auto`/already-floating.

## Files

- `Tiling/FloatNudge.swift` — pure geometry (`FloatNudge.target(frame:visible:)`), no AX, unit-tested.
- `App/KiwiCore+FloatNudge.swift` — orchestration: snapshots cached frame + screen, bar-clamps, `applyFrame`.
- `Commands/KiwiCore+Commands.swift` — wired in `setFocusedFloating`.
- `Commands/KiwiCore+GapCommands.swift` + `APIReference.swift` — `set_float_nudge` verb.
- `Tiling/TilingSettings.swift` (+Coding/+Encoding) — `floatNudge` bool, JSON key `float_nudge`.
- Tests: `FloatNudgeTests.swift` (5 geometry cases), `SettingsCodingTests.swift`.
- Docs: `lua-reference.md`, `cli.md`, `design-decisions.md`.

## Verification

Debug + full test suite + lint + release build + site build all green. code-reviewer + architect-reviewer clean (only finding — a doc exclusion — fixed). Motion eye-confirmed on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)