### PR TITLE
test(scrolling): make floatingFocusEndToEnd hermetic (#450)

### DIFF
--- a/Tests/KiwiDeskCoreTests/ScrollingFloatingFocusTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingFloatingFocusTests.swift
@@ -88,7 +88,10 @@ struct ScrollingFloatingFocusTests {
                 "kiwidesk-tests-\(UUID().uuidString)"
             )
         let core = KiwiCore(configDirectory: directory)
-        for id in 1...5 {
+        // Twenty windows so the row overflows every display width:
+        // the offset then stays scrolled on any host, single- or
+        // multi-monitor (see the assertion note below, #450).
+        for id in 1...20 {
             core.state.apply(
                 .windowCreated(
                     ManagedWindow(
@@ -108,11 +111,10 @@ struct ScrollingFloatingFocusTests {
             "scroll.set_slot_size",
             args: [.number(800)]
         )
-        // Scroll far, then back to w2: the offset rests at
-        // w2's left-visible edge — scrolled, but well inside
-        // the boundary of the row even after one slot floats
-        // out of it, so only the #141 bug could move it.
-        core.state.workspaces.focus(WindowID(5), in: space)
+        // Scroll to the far end, then back to w2: the offset
+        // rests scrolled (negative). Once w2 floats it must keep
+        // a scrolled position; only the #141 bug would pan it home.
+        core.state.workspaces.focus(WindowID(20), in: space)
         core.retile(animated: false)
         core.state.workspaces.focus(w2, in: space)
         core.retile(animated: false)
@@ -120,8 +122,18 @@ struct ScrollingFloatingFocusTests {
         #expect(scrolled != nil && scrolled! < 0)
         core.execute("make_floating")
         core.retile(animated: false)
-        // Pre-#141 the slot-0 fallback panned the viewport
-        // home and persisted 0 — the tiled row visibly jumped.
-        #expect(core.activeSpace?.scrollOffset == scrolled)
+        // The floating focus has no slot, so the viewport keeps a
+        // boundary-clamped scrolled position instead of the pre-#141
+        // slot-0 pan home (which reset the offset to 0 and jumped
+        // the row). Asserted as the sign-stable invariant, not the
+        // exact pre-float value: floating drops a slot, so on a
+        // viewport that leaves the old offset past the shortened
+        // row's boundary it legitimately re-clamps by up to one
+        // slot. Pinning the exact value coupled the test to
+        // NSScreen.main and failed on multi-monitor hosts (#450);
+        // the 20-window row overflows any display, so "still
+        // scrolled" holds everywhere.
+        let afterFloat = core.activeSpace?.scrollOffset
+        #expect(afterFloat != nil && afterFloat! < 0)
     }
 }


### PR DESCRIPTION
## Problem

`ScrollingFloatingFocusTests.floatingFocusEndToEnd` passed on single-monitor hosts but failed deterministically on 2-monitor hosts:

```
Expectation failed: (scrollOffset → -722.0) == (scrolled → -810.0)
```

The end-to-end test injected no viewport, so it rode `NSScreen.main`. The scrolling clamp boundary is `along - rowLength` (`ScrollingLayout.swift:271`), where `along` is the live display's `visibleFrame` width. On a 2-monitor host `NSScreen.main` is whichever screen has focus — a different width — so after `make_floating` drops a slot from the row, the offset legitimately re-clamps and the exact-equality assertion tripped. **The product's clamp math is correct on any monitor count**; only the test was host-coupled.

## Fix

No faking of `NSScreen` (not feasible in a unit test). Instead:
- Seed 20 windows so the row overflows **every** display width — the offset then stays scrolled on any host.
- Assert the **sign-stable invariant**: after floating, the offset stays scrolled (`< 0`), i.e. did *not* pan home to slot 0 (the #141 bug) — rather than the exact pre-float value, which re-clamps by up to one slot on a differently-sized viewport.

The pure sibling tests in the same file already pin exact offsets via a fixed `1920×1080` `makeContext`; this only de-couples the one end-to-end case.

## Verification

Full `swift test` passes clean (1745 tests, 0 issues) on a 2-monitor host where the old test failed; `swift build -c release` + `scripts/lint.sh` green.

Fixes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)