### PR TITLE
feat(keybindings): re-pick defaults onto Control+Option + fix first-run space coverage (#270)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
@@ -151,11 +151,10 @@ extension KiwiCore {
     /// a single binding — a fresh install, or an `init.lua`
     /// that declares none — the base `default` mode gets the
     /// starter set so a new user can drive KiwiDesk
-    /// immediately. Per-space rows generate from the model's
-    /// final space list (live-derived, after the empty-state
-    /// fallback), so no dead row targeting a nonexistent space
-    /// is authored. Never fires once a user (or Lua) authored
-    /// any binding, in any mode — idempotent by that guard.
+    /// immediately. Never fires once a user (or Lua) authored
+    /// any binding, in any mode — idempotent by that guard, so
+    /// the space padding below is a first-run-only effect and
+    /// never pollutes a Lua-managed user's space list.
     private func seedDefaultShortcuts(
         _ config: inout GuiConfig
     ) {
@@ -165,6 +164,20 @@ extension KiwiCore {
                 where: { $0.isDefault }
             )
         else { return }
+        // First run reports only the ACTIVE Space (#270): the live
+        // list is a single numbered space (usually ["1"]), which
+        // would seed only ⌃⌥1. Pad just that bare signature to the
+        // five-space starter set the empty state already uses, so
+        // ⌃⌥1…5 all work out of the box. A named or multi-space
+        // list is a configured setup — left exactly as discovered
+        // so the seed never invents spaces the user didn't (dedup
+        // keeps the live space first, #75).
+        if config.spaces.count == 1,
+            Int(config.spaces[0].raw) != nil {
+            config.spaces = SpaceID.deduplicated(
+                config.spaces + (1...5).map { SpaceID($0) }
+            )
+        }
         config.modes[index].bindings =
             DefaultKeybindings.bindings(
                 spaces: config.spaces,

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
@@ -110,6 +110,13 @@ extension KiwiCore {
         }
     }
 
+    /// The starter space set a fresh install gets — five numbered
+    /// spaces — so ⌃⌥1…5 all bind out of the box (#270). One
+    /// constant behind both first-run pads (empty list and the
+    /// single-space signature) so the count can't drift between
+    /// them.
+    static let starterSpaces = (1...5).map { SpaceID($0) }
+
     /// Builds an editable model from the running configuration.
     /// Keybindings and mode icons are recovered from the source
     /// file via `recoverKeybindings` (#4); the sidecar owns them
@@ -136,7 +143,7 @@ extension KiwiCore {
             defined + Array(modes.keys)
         )
         if config.spaces.isEmpty {
-            config.spaces = (1...5).map { SpaceID($0) }
+            config.spaces = Self.starterSpaces
         }
         var bindings: [Int: String] = [:]
         for (number, name) in nativeSpaceBindings {
@@ -150,11 +157,14 @@ extension KiwiCore {
     /// First-run starter shortcuts (#91): when no mode carries
     /// a single binding — a fresh install, or an `init.lua`
     /// that declares none — the base `default` mode gets the
-    /// starter set so a new user can drive KiwiDesk
-    /// immediately. Never fires once a user (or Lua) authored
-    /// any binding, in any mode — idempotent by that guard, so
-    /// the space padding below is a first-run-only effect and
-    /// never pollutes a Lua-managed user's space list.
+    /// starter set so a new user can drive KiwiDesk immediately.
+    /// Also pads `config.spaces` on the bare first-run signature
+    /// (see below) — a deliberate second effect, kept here rather
+    /// than in `guiConfigSeed` because it depends on this same
+    /// no-binding guard. Never fires once a user (or Lua) authored
+    /// any binding, in any mode — idempotent by that guard, so the
+    /// space padding is a first-run-only effect and never pollutes
+    /// a Lua-managed user's space list.
     private func seedDefaultShortcuts(
         _ config: inout GuiConfig
     ) {
@@ -175,7 +185,7 @@ extension KiwiCore {
         if config.spaces.count == 1,
             Int(config.spaces[0].raw) != nil {
             config.spaces = SpaceID.deduplicated(
-                config.spaces + (1...5).map { SpaceID($0) }
+                config.spaces + Self.starterSpaces
             )
         }
         config.modes[index].bindings =

--- a/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
+++ b/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
@@ -5,6 +5,15 @@ import Foundation
 /// a fresh install, or a config whose Lua declares none — so a
 /// new user can focus, move, and navigate windows immediately.
 ///
+/// Modifier scheme (#270): every default is built on **Control+
+/// Option**, escalating ⌃⌥ → ⌃⌥⇧ → ⌃⌥⌘. Bare Option is the
+/// macOS special-character (AltGr) modifier, so a global
+/// `option+<key>` hotkey swallows characters on international
+/// Apple keyboards (⌥L = @, ⌥5 = [ …); adding Control or Command
+/// suppresses that composition, so ⌃⌥ is the lightest text-safe
+/// chord. Directions bind the **arrow keys**, which are layout-
+/// stable and never compose a character.
+///
 /// The Lua and canonical labels mirror what
 /// `KeybindingCatalog` (GUI target) authors for the same
 /// spaces and resize step — byte-for-byte, or the import
@@ -13,19 +22,22 @@ import Foundation
 /// (GUI tests), which iterates every seeded row and matches
 /// it against the catalog's output.
 ///
-/// Per-space rows are position-based (`option+1` targets the
-/// FIRST space in display order, whatever its name), generated
-/// only for the spaces that exist at seed time and capped at
-/// nine — so no dead row targeting a nonexistent space is ever
-/// authored (#91).
+/// Per-space rows are position-based (`control+option+1` targets
+/// the FIRST space in display order, whatever its name),
+/// generated only for the spaces that exist at seed time and
+/// capped at nine — so no dead row targeting a nonexistent space
+/// is ever authored (#91).
 public enum DefaultKeybindings {
-    /// Key ↔ direction ↔ canonical label phrase, in the
-    /// catalog's order (left, down, up, right — vim h/j/k/l).
+    /// Direction ↔ canonical label phrase, in the catalog's
+    /// order (left, down, up, right). The arrow key that drives
+    /// each binding is the direction itself — `control+option+
+    /// left` focuses left — so one token serves both the combo
+    /// and the Lua argument.
     private static let directions = [
-        ("h", "left", "to the left"),
-        ("j", "down", "below"),
-        ("k", "up", "above"),
-        ("l", "right", "to the right"),
+        ("left", "to the left"),
+        ("down", "below"),
+        ("up", "above"),
+        ("right", "to the right"),
     ]
 
     /// The starter rows for the base `default` mode.
@@ -34,10 +46,11 @@ public enum DefaultKeybindings {
         resizeStep: Int
     ) -> [KeyBinding] {
         var rows: [KeyBinding] = []
-        for (key, dir, phrase) in directions {
+        // Tier 1 — ⌃⌥: focus a window, go to a space.
+        for (dir, phrase) in directions {
             rows.append(
                 KeyBinding(
-                    combo: "option+\(key)",
+                    combo: "control+option+\(dir)",
                     lua: "KiwiDesk.focus(\"\(dir)\")",
                     kind: .navigation,
                     label: "Focus window \(phrase)"
@@ -47,7 +60,7 @@ public enum DefaultKeybindings {
         for (offset, space) in numbered(spaces) {
             rows.append(
                 KeyBinding(
-                    combo: "option+\(offset)",
+                    combo: "control+option+\(offset)",
                     lua: "KiwiDesk.focus_space"
                         + "(\(SpaceLuaArg.quote(space.raw)))",
                     kind: .navigation,
@@ -55,10 +68,11 @@ public enum DefaultKeybindings {
                 )
             )
         }
-        for (key, dir, phrase) in directions {
+        // Tier 2 — ⌃⌥⇧: swap a window, move it to a space.
+        for (dir, phrase) in directions {
             rows.append(
                 KeyBinding(
-                    combo: "option+shift+\(key)",
+                    combo: "control+option+shift+\(dir)",
                     lua: "KiwiDesk.swap(\"\(dir)\")",
                     kind: .navigation,
                     label: "Swap with window \(phrase)"
@@ -68,7 +82,7 @@ public enum DefaultKeybindings {
         for (offset, space) in numbered(spaces) {
             rows.append(
                 KeyBinding(
-                    combo: "option+shift+\(offset)",
+                    combo: "control+option+shift+\(offset)",
                     lua: "KiwiDesk.move_to_space"
                         + "(\(SpaceLuaArg.quote(space.raw)))",
                     kind: .navigation,
@@ -76,47 +90,79 @@ public enum DefaultKeybindings {
                 )
             )
         }
-        rows.append(
-            KeyBinding(
-                combo: "option+minus",
-                lua: "KiwiDesk.resize(\"x\", -\(resizeStep))",
-                kind: .navigation,
-                label: "Shrink width"
+        // Tier 3 — ⌃⌥⌘: resize, move-to-space-and-follow.
+        rows.append(contentsOf: resizeRows(step: resizeStep))
+        for (offset, space) in numbered(spaces) {
+            rows.append(
+                KeyBinding(
+                    combo: "control+option+command+\(offset)",
+                    lua: "KiwiDesk.move_to_space_and_follow"
+                        + "(\(SpaceLuaArg.quote(space.raw)))",
+                    kind: .navigation,
+                    label: "Move to Space \(space.raw) & follow"
+                )
             )
-        )
+        }
+        // Toggles — mnemonic letters. Display sticky is the more
+        // frequent scope, so it takes the lighter ⌃⌥ chord; the
+        // broader global sticky escalates to ⌃⌥⇧.
         rows.append(
             KeyBinding(
-                combo: "option+equal",
-                lua: "KiwiDesk.resize(\"x\", \(resizeStep))",
-                kind: .navigation,
-                label: "Grow width"
-            )
-        )
-        rows.append(
-            KeyBinding(
-                combo: "option+shift+minus",
-                lua: "KiwiDesk.resize(\"y\", -\(resizeStep))",
-                kind: .navigation,
-                label: "Shrink height"
-            )
-        )
-        rows.append(
-            KeyBinding(
-                combo: "option+shift+equal",
-                lua: "KiwiDesk.resize(\"y\", \(resizeStep))",
-                kind: .navigation,
-                label: "Grow height"
-            )
-        )
-        rows.append(
-            KeyBinding(
-                combo: "option+t",
+                combo: "control+option+f",
                 lua: "KiwiDesk.toggle_floating()",
                 kind: .navigation,
                 label: "Toggle floating"
             )
         )
+        rows.append(
+            KeyBinding(
+                combo: "control+option+s",
+                lua: "KiwiDesk.toggle_display_sticky()",
+                kind: .navigation,
+                label: "Toggle display sticky"
+            )
+        )
+        rows.append(
+            KeyBinding(
+                combo: "control+option+shift+s",
+                lua: "KiwiDesk.toggle_sticky()",
+                kind: .navigation,
+                label: "Toggle sticky"
+            )
+        )
         return rows
+    }
+
+    /// The four ⌃⌥⌘ + arrow resize rows: the arrow points the
+    /// change — →/← grow/shrink width, ↑/↓ grow/shrink height —
+    /// by the configurable `resize.step` (#58).
+    private static func resizeRows(step: Int) -> [KeyBinding] {
+        [
+            KeyBinding(
+                combo: "control+option+command+right",
+                lua: "KiwiDesk.resize(\"x\", \(step))",
+                kind: .navigation,
+                label: "Grow width"
+            ),
+            KeyBinding(
+                combo: "control+option+command+left",
+                lua: "KiwiDesk.resize(\"x\", -\(step))",
+                kind: .navigation,
+                label: "Shrink width"
+            ),
+            KeyBinding(
+                combo: "control+option+command+up",
+                lua: "KiwiDesk.resize(\"y\", \(step))",
+                kind: .navigation,
+                label: "Grow height"
+            ),
+            KeyBinding(
+                combo: "control+option+command+down",
+                lua: "KiwiDesk.resize(\"y\", -\(step))",
+                kind: .navigation,
+                label: "Shrink height"
+            ),
+        ]
     }
 
     /// The first nine spaces paired with their 1-based display

--- a/Tests/KiwiDeskCoreTests/DefaultKeybindingsTests.swift
+++ b/Tests/KiwiDeskCoreTests/DefaultKeybindingsTests.swift
@@ -63,7 +63,9 @@ struct DefaultKeybindingsTests {
         }
         #expect(goTo.count == 9)
         #expect(move.count == 9)
-        #expect(!rows.contains { $0.combo == "option+10" })
+        #expect(
+            !rows.contains { $0.combo == "control+option+10" }
+        )
     }
 
     @Test("per-space combos are position-based, not name-based")
@@ -79,8 +81,8 @@ struct DefaultKeybindingsTests {
         let web = rows.first {
             $0.lua == "KiwiDesk.focus_space(\"web\")"
         }
-        #expect(mail?.combo == "option+1")
-        #expect(web?.combo == "option+2")
+        #expect(mail?.combo == "control+option+1")
+        #expect(web?.combo == "control+option+2")
     }
 
     @Test("space names quote through the canonical escaper")

--- a/Tests/KiwiDeskCoreTests/FirstRunSeedTests.swift
+++ b/Tests/KiwiDeskCoreTests/FirstRunSeedTests.swift
@@ -197,4 +197,29 @@ struct FirstRunSeedTests {
             }
         )
     }
+
+    /// #270: at first run macOS reports only the active Space, so
+    /// the live list is just ["1"] — not empty, so the empty-state
+    /// pad is skipped. The seed pads to a five-space starter set
+    /// anyway, so ⌃⌥1…5 all bind out of the box rather than only
+    /// ⌃⌥1.
+    @Test("partial first-run discovery still seeds spaces 1-5")
+    func partialDiscoveryPadsToFive() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace(SpaceID("1"))
+
+        let seed = core.guiConfigSeed()
+        let spaces = Set(seed.spaces.map(\.raw))
+        for n in 1...5 {
+            #expect(spaces.contains("\(n)"), "missing space \(n)")
+        }
+        let base = seed.modes.first { $0.isDefault }
+        #expect(
+            (base?.bindings ?? []).contains {
+                $0.combo == "control+option+5"
+                    && $0.lua == "KiwiDesk.focus_space(\"5\")"
+            },
+            "⌃⌥5 not seeded despite only space 1 discovered"
+        )
+    }
 }

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1112,13 +1112,27 @@ view literals but missed catalog-defined strings).
 into emptiness.** A fresh install used to boot with zero
 shortcuts (the default mode existed but was empty): a GUI-first
 user had no way to focus or move a window until they authored
-every combo. Now `Core.DefaultKeybindings` seeds a starter set
-(⌥HJKL focus, ⌥⇧HJKL swap, ⌥digit / ⌥⇧digit per-space, ⌥-/⌥=
-width resize, ⌥⇧-/⌥⇧= height resize, ⌥T float) with one
-guard everywhere: **only when no
-mode carries a single binding** — a user- or Lua-authored
+every combo. Now `Core.DefaultKeybindings` seeds a starter set on an
+**escalating Control-Option scheme** (#270): `⌃⌥` arrows focus /
+`⌃⌥⇧` arrows swap, `⌃⌥` / `⌃⌥⇧` / `⌃⌥⌘` digit per-space go / move
+/ move-and-follow, `⌃⌥⌘` arrows resize, `⌃⌥F` float, `⌃⌥S` display
+sticky, `⌃⌥⇧S` global sticky — with one guard everywhere: **only
+when no mode carries a single binding** — a user- or Lua-authored
 binding anywhere blocks the seed, making it idempotent and
-never destructive. The set lives in the **base `gui.json`
+never destructive.
+
+**Why Control-Option, not bare Option (#270).** On macOS Option is
+the special-character (AltGr) modifier, so a *global* `⌥`+key
+hotkey swallows text entry on international Apple keyboards
+(`⌥L`=@, `⌥5`=[, `⌥8`={ …). macOS composes those characters only
+when the modifier is exactly `⌥` or `⌥⇧`; adding Control (or
+Command) suppresses it, so `⌃⌥` is the lightest text-safe chord
+(the earlier bare-`⌥` set, and Amethyst's `⌥⇧`, are not). Its only
+overlap is VoiceOver's `⌃⌥` modifier, inert unless VoiceOver is on
+and remappable to Caps Lock; `⌘⌥` was rejected because it collides
+with always-on system shortcuts (Force Quit, Dock, Hide/Minimize).
+Directions bind the arrow keys, which never compose a character on
+any layout. The set lives in the **base `gui.json`
 modes**, never a profile override (profiles stay
 tiling-plus-sparse-behavior, #55): on first launch the seeded
 model is persisted so the very first boot is GUI-managed and the
@@ -1142,11 +1156,13 @@ declares tiling settings of its own stays Lua-owned (no seed —
 seeding would let the GUI defaults overwrite its Lua tiling) and
 is offered the **Adopt** path instead. With a settings-free
 `init.lua` the seed appears in the editable model and persists on
-the first Save. Per-space rows are
-**position-based** (⌥3 = third space in display order,
-whatever its name), generated only for spaces that exist at
-seed time and capped at nine — no dead rows targeting
-nonexistent spaces. The seeded Lua and labels mirror
+the first Save. Per-space rows number the digits
+by display position but bind each to its space **by name**
+(`⌃⌥3` → the third space's name at seed time; a later rename
+rewrites the binding to follow it, so it survives). The first run
+pads the discovered list to a **five-space starter set** so
+`⌃⌥1`–`⌃⌥5` seed even though a fresh macOS reports only the active
+Space (#270), and the set still caps at nine. The seeded Lua and labels mirror
 `KeybindingCatalog` byte-for-byte (guarded by
 `DefaultSeedCatalogParityTests`) so the rows stay presets, not
 Custom (#4). (#91)

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -2873,7 +2873,7 @@ vice versa. Like `make_floating`/`make_tiled`, it writes an
 explicit manual override (which survives close/reopen); it never
 produces the `auto` state, so `make_auto` stays the way back to
 detection control. This is the everyday float shortcut (bound to
-`option+t` by default and the only float verb offered in the
+`control+option+f` by default and the only float verb offered in the
 Settings shortcut list); the explicit `make_*` verbs remain for
 scripts that need a specific direction.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1281,18 +1281,30 @@ you can drive KiwiDesk before configuring anything:
 
 | Action | Shortcut |
 | --- | --- |
-| Focus window left / down / up / right | `⌥H` `⌥J` `⌥K` `⌥L` |
-| Go to space 1–9 | `⌥1` … `⌥9` |
-| Swap with window left / down / up / right | `⌥⇧H` `⌥⇧J` `⌥⇧K` `⌥⇧L` |
-| Move to space 1–9 | `⌥⇧1` … `⌥⇧9` |
-| Shrink / Grow width | `⌥-` / `⌥=` |
-| Shrink / Grow height | `⌥⇧-` / `⌥⇧=` |
-| Toggle floating | `⌥T` |
+| Focus window left / down / up / right | `⌃⌥←` `⌃⌥↓` `⌃⌥↑` `⌃⌥→` |
+| Go to space 1–9 | `⌃⌥1` … `⌃⌥9` |
+| Swap with window left / down / up / right | `⌃⌥⇧←` `⌃⌥⇧↓` `⌃⌥⇧↑` `⌃⌥⇧→` |
+| Move to space 1–9 | `⌃⌥⇧1` … `⌃⌥⇧9` |
+| Move to space 1–9 and follow | `⌃⌥⌘1` … `⌃⌥⌘9` |
+| Grow / Shrink width | `⌃⌥⌘→` / `⌃⌥⌘←` |
+| Grow / Shrink height | `⌃⌥⌘↑` / `⌃⌥⌘↓` |
+| Toggle floating | `⌃⌥F` |
+| Toggle display sticky | `⌃⌥S` |
+| Toggle sticky (all spaces) | `⌃⌥⇧S` |
 
-The digits are display-order positions: `⌥3` targets the *third*
-space in your Spaces list, whatever its name. A row is generated
-only for spaces that exist when the set is seeded (at most nine),
-so no shortcut ever targets a space that isn't there.
+Every default is built on **Control-Option** (`⌃⌥`), escalating to
+`⌃⌥⇧` and `⌃⌥⌘`. On macOS the Option key by itself types special
+characters — on many layouts `⌥L` is `@` and `⌥5` is `[` — so a
+global `⌥`-only shortcut would swallow them; adding Control keeps
+every default clear of both macOS system shortcuts and text entry.
+Directions use the arrow keys, which are identical on every layout.
+
+Each space digit is bound to a space *by name*: `⌃⌥3` goes to
+whichever space was third when the set was seeded. Renaming that
+space in Settings rewrites the shortcut to follow it, so the binding
+survives a rename. At least `⌃⌥1`…`⌃⌥5` are seeded on a fresh
+install — even before you have created five spaces — so the digits
+work out of the box.
 
 The set is seeded only while **no** shortcut is bound anywhere —
 into `gui.json` at first launch on a fresh install, or into the
@@ -1423,7 +1435,7 @@ under Custom Bindings.
 
 The per-space rows above render one row per space in the current
 space list. A bound shortcut whose target space is *not* in that
-list — say `⌥6 → Go to Space 6` after switching from an 8-space
+list — say `⌃⌥6 → Go to Space 6` after switching from an 8-space
 to a 4-space profile — appears in a dimmed **Inactive shortcuts**
 section at the bottom instead of disappearing. Such a shortcut:
 


### PR DESCRIPTION
Closes #270.

## Why

Every shipped default was bare `option+<key>`. On macOS **Option is the special-character (AltGr) modifier**, so a *global* `option+<key>` hotkey swallows text entry on international Apple keyboards — `⌥L`=@, `⌥5`=[, `⌥8`={ … — and `option+digit` shadowed typing brackets/braces. macOS composes those characters only when the modifier is exactly `⌥` or `⌥⇧`; adding Control (or Command) suppresses it, so **⌃⌥ is the lightest text-safe chord**.

## What

**Re-chord the default seed onto an escalating ⌃⌥ scheme** (chords only — no lua/label changes, so the catalog parity mirror is untouched):

| Tier | Chord | Commands |
|---|---|---|
| 1 | `⌃⌥` | Focus ←↓↑→ (arrows) · Go to Space 1–9 · Toggle floating `F` · Toggle **display** sticky `S` |
| 2 | `⌃⌥⇧` | Swap/move window ←↓↑→ · Move to Space 1–9 · Toggle **global** sticky `S` |
| 3 | `⌃⌥⌘` | Resize (→/← width, ↑/↓ height) · Move to Space 1–9 **and follow** |

Directions bind the **arrow keys** (layout-stable, never compose a character) instead of hjkl. The only overlap is VoiceOver's `⌃⌥` (inert unless VoiceOver is on, remappable to Caps Lock); `⌘⌥` was rejected — it collides with always-on system shortcuts (Force Quit, Dock, Hide/Minimize). Space digits stay **name-based** and survive a rename (the rename path rewrites the binding).

**Fix the first-run "only Space 1 bound" bug.** A fresh macOS reports only the *active* Space, so first-run synthesis saw `spaces == ["1"]` — not empty — and the existing "pad to 1–5 when empty" fallback was skipped, seeding only `⌃⌥1`. Now `seedDefaultShortcuts` pads the single-numeric-space signature to the five-space starter set (gated by the no-binding seed guard, so Lua-managed and named/multi-space configs are never touched), so `⌃⌥1…5` bind out of the box.

## Verification

`swift build` (debug + release), `scripts/lint.sh`, and `site/ npm run build` pass; full `swift test` passes except the pre-existing `ScrollingFloatingFocus` flake (#450, fixed on its own branch/PR #452). New tests: `FirstRunSeedTests.partialDiscoveryPadsToFive`, updated seed-combo assertions.

## Review

`code-reviewer` + `architect-reviewer` (fresh, parallel) — no blocking issues. Both architect nits (hoist the starter-set constant, doc the dual effect of the pad) addressed in the final commit.

## Docs

`docs/user-guide.md` (Default Shortcuts table + rationale), `docs/lua-reference.md`, `docs/design-decisions.md` (the ⌃⌥ decision record + name-based/pad-to-5 behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)