### PR TITLE
fix(settings): keep unsaved shortcut edits when Settings reopens (#455)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderChrome.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderChrome.swift
@@ -90,7 +90,10 @@ struct LiveApplyCaption: View {
     private var text: String {
         switch feedback.status {
         case .applied:
-            L("key_recorder.live_applied", "Active now")
+            L(
+                "key_recorder.live_applied",
+                "Active now — Save to keep it"
+            )
         case .inactiveMode(let mode):
             L(
                 "key_recorder.live_inactive_mode",

--- a/Sources/KiwiDesk/Settings/SettingsWindowController.swift
+++ b/Sources/KiwiDesk/Settings/SettingsWindowController.swift
@@ -52,9 +52,21 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     }
 
     /// Shows the dashboard, refreshing from the backend so the
-    /// active profile and any external config edits are current.
+    /// active profile and any external config edits are current —
+    /// except when the model holds unsaved edits.
     func show() {
-        model.reload()
+        // Reopening must not discard an unsaved edit (#455). The
+        // model is retained across close with its staged `config`
+        // and its live-registered hotkeys intact; reseeding it from
+        // `gui.json` here would drop the edit, clear the "Unsaved
+        // changes" state, and roll the live hotkey back — the
+        // "reopen loses my new shortcut" bug. Only a clean model
+        // reloads, to pick up external edits (a profile switch, an
+        // outside `gui.json` write). Mirrors the non-destructive
+        // `refreshProfiles` / `refreshLayoutDrift` above.
+        if !model.isDirty {
+            model.reload()
+        }
         // Promote on every open, not just the first — closing
         // the window demotes to `.accessory`, so a reused
         // window must re-raise to get its Dock icon back.

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -248,7 +248,7 @@
   "key_recorder.dismiss_conflict": "Dismiss shortcut conflict",
   "key_recorder.go_to": "Go to",
   "key_recorder.help_press": "A shortcut is one key plus any of ⌃ Control, ⌥ Option, ⇧ Shift, and ⌘ Command — it locks in the moment you press the key. For more shortcut layers, add Modes.",
-  "key_recorder.live_applied": "Active now",
+  "key_recorder.live_applied": "Active now — Save to keep it",
   "key_recorder.live_apply_failed": "The shortcut change was recorded but couldn't be applied live. Save or Revert to retry.",
   "key_recorder.live_compile_failed": "Recorded — the action couldn't compile",
   "key_recorder.live_denied": "Recorded — the system didn't grant it",


### PR DESCRIPTION
Closes #455.

## Problem
A keyboard shortcut recorded in Settings live-applies immediately but only persists to `gui.json` on an explicit **Save**. Reopening the Settings window called `model.reload()` **unconditionally** — reseeding `config` from `gui.json` (discarding the unsaved edit and the "Unsaved changes" pill) and rolling the live hotkey back. So a just-added shortcut disappeared from the list on reopen.

## Fix (B + C)

**B — non-destructive reopen.** `SettingsWindowController.show()` now skips the reseeding `reload()` when `model.isDirty`, so the retained staged `config` and its live-registered hotkeys survive a close/reopen. A clean model still reloads (to pick up an external `gui.json` write or a profile switch). This mirrors the already-established non-destructive `refreshProfiles()` / `refreshLayoutDrift()` pattern in the same controller.

*Rejected alternative:* reading bindings from the live registry on open — it's the **resolved** base+profile set, so reading it back would collapse the `gui.json`-base / profile-override layering and the next Save would corrupt `gui.json`.

**C — clarity.** The inline recorder caption (`LiveApplyCaption`) already states the save caveat on four of its five branches ("Recorded — Save to activate", …); only the common `.applied` path was silent ("Active now"). It now reads **"Active now — Save to keep it"**, matching the sibling idiom. Placement/timing/color unchanged (ui-designer: the existing inline caption is the right surface — no new affordance). The key's English meaning changed, so it regenerates via `extract-keys` (it carried no shipped translations to drop).

## Verification
`swift build` (debug + release), `scripts/lint.sh` (incl. `extract-keys --check`) pass; full `swift test` passes except the pre-existing `ScrollingFloatingFocus` flake (#450, fixed on PR #452).

## Needs device QA
Confirm a live-applied shortcut both **stays listed** and **keeps firing** across a Settings close/reopen. (The investigation flagged that reopen was *supposed* to roll the live hotkey back to saved — this fix intentionally keeps it, so the applied-but-unsaved shortcut stays active for the session.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)