### PR TITLE
feat: session-scoped per-space layer for interactive resizes (#458)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
@@ -151,6 +151,11 @@ extension KiwiCore {
         tiler.settings.placementOverride = [:]
         tiler.settings.spaceIcons = [:]
         fallbackSpace = nil
+        // The session resize layer reseeds on reload (#458):
+        // the config about to apply is the new truth, and a
+        // shadowing session value would make an edited ratio
+        // visibly do nothing (§5 forced-retile rationale).
+        clearSessionRatios { $0 = SessionRatios() }
         for space in state.workspaces.allSpaces
         where space.mode != .bsp {
             state.workspaces.setMode(space.id, .bsp)

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -118,6 +118,10 @@ extension KiwiCore {
         // animates at the incoming duration, not a stale one
         // (#51 review).
         tiler.settings = config.settings
+        // A GUI save is an explicit apply (§5): reseed the
+        // session resize layer so an edited Layout Defaults
+        // ratio visibly applies on every space (#458).
+        clearSessionRatios { $0 = SessionRatios() }
         // Ensure spaces in display order first (config.spaces
         // is the authoritative list, so insertion order matches
         // the user's chosen Spaces ordering). Any extras that

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+BspCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+BspCommands.swift
@@ -21,10 +21,14 @@ extension KiwiCore {
             guard let ratio = Self.parseSplitRatio(args.first)
             else { return Self.ratioError }
             tiler.settings.bsp.splitRatioH = ratio
+            // An explicit global write must show everywhere:
+            // drop the session shadow (#458).
+            clearSessionRatios { $0.splitRatioH = nil }
         case "bsp.set_ratio_v":
             guard let ratio = Self.parseSplitRatio(args.first)
             else { return Self.ratioError }
             tiler.settings.bsp.splitRatioV = ratio
+            clearSessionRatios { $0.splitRatioV = nil }
         case "bsp.set_new_window_placement":
             guard let placement = parsePlacement(args) else {
                 return placementError

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Resize.swift
@@ -142,7 +142,7 @@ extension KiwiCore {
         space: Space
     ) -> CommandResponse {
         let scrolling =
-            tiler.settings.resolvedScrolling(for: space.id)
+            tiler.settings.resolvedScrolling(for: space)
         let horizontal = scrolling.axisIsHorizontal
         let screen = TilingEngine.screen(
             for: space.id,
@@ -154,7 +154,7 @@ extension KiwiCore {
         let along = horizontal ? bounds.width : bounds.height
         let current = scrolling.slotSize
             .editablePoints(along: along, horizontal: horizontal)
-        tiler.settings.setSlotSize(
+        writeSlotSize(
             .points(clamping: current + CGFloat(delta)),
             for: space.id
         )

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeBsp.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeBsp.swift
@@ -18,7 +18,7 @@ extension KiwiCore {
         span: Double,
         space: Space
     ) -> CommandResponse {
-        let bsp = tiler.settings.resolvedBsp(for: space.id)
+        let bsp = tiler.settings.resolvedBsp(for: space)
         let signed =
             bspFocusSign(axis: axis, space: space)
             * delta
@@ -36,7 +36,7 @@ extension KiwiCore {
                 available: span,
                 minSize: minSize
             )
-            tiler.settings.setSplitRatioH(
+            writeSplitRatioH(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )
@@ -47,7 +47,7 @@ extension KiwiCore {
                 available: span,
                 minSize: minSize
             )
-            tiler.settings.setSplitRatioV(
+            writeSplitRatioV(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeStack.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeStack.swift
@@ -22,7 +22,7 @@ extension KiwiCore {
         span: Double,
         space: Space
     ) -> CommandResponse {
-        let stack = tiler.settings.resolvedStack(for: space.id)
+        let stack = tiler.settings.resolvedStack(for: space)
         let tiled = state.effectiveTiledMembers(
             of: space,
             activeSpace: activeSpace?.id
@@ -51,7 +51,7 @@ extension KiwiCore {
                 available: span,
                 minSize: Double(tiler.settings.minWindowSize)
             )
-            tiler.settings.setMasterRatio(
+            writeMasterRatio(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+ScrollCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+ScrollCommands.swift
@@ -15,6 +15,8 @@ extension KiwiCore {
                 return Self.slotSizeError
             }
             tiler.settings.scrolling.slotSize = size
+            // Explicit global write shows everywhere (#458).
+            clearSessionRatios { $0.slotSize = nil }
         case "scroll.set_anchor":
             guard
                 let anchor = Self.parseAnchor(args.first?.stringValue)

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+StackCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+StackCommands.swift
@@ -20,6 +20,8 @@ extension KiwiCore {
             guard let ratio = Self.parseMasterRatio(args.first)
             else { return Self.masterRatioError }
             tiler.settings.stack.masterRatio = ratio
+            // Explicit global write shows everywhere (#458).
+            clearSessionRatios { $0.masterRatio = nil }
         case "stack.set_overflow_style":
             guard
                 let style = Self.parseOverflowStyle(

--- a/Sources/KiwiDeskCore/Models/SessionRatios.swift
+++ b/Sources/KiwiDeskCore/Models/SessionRatios.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Interactive-resize values for a space that has NO authored
+/// config override of the field (#458). Before this layer, a
+/// resize on such a space wrote the GLOBAL ratio, visibly
+/// resizing every other no-override space (obvious with two
+/// monitors showing two spaces). Session-only, like
+/// `stackWeights`: config layers stay untouched — the #290
+/// override editor never fills with overrides the user did not
+/// author — and the value dies with the space, an actual mode
+/// change (`setMode`), or a config reload.
+///
+/// Read precedence is enforced structurally in
+/// `TilingSettings.resolvedBsp/Stack/Scrolling(for: Space)`:
+/// authored override field > session value > global. A space
+/// whose override carries the field routes interactive writes
+/// into that override (pre-#458 behavior), so its session slot
+/// stays empty. Known edge, accepted: removing an override
+/// field mid-session can resurface an older session value
+/// until the next mode change or reload.
+public struct SessionRatios: Sendable, Equatable {
+    /// BSP side-by-side split (`resize("x")`).
+    public var splitRatioH: Double?
+    /// BSP stacked split (`resize("y")`).
+    public var splitRatioV: Double?
+    /// Stack master/stack split along the split axis.
+    public var masterRatio: Double?
+    /// Scrolling slot extent along the scroll axis.
+    public var slotSize: ScrollSize?
+
+    public init() {}
+}

--- a/Sources/KiwiDeskCore/Models/SpaceModel.swift
+++ b/Sources/KiwiDeskCore/Models/SpaceModel.swift
@@ -192,6 +192,14 @@ public struct Space: Sendable, Equatable {
     /// Session-only like `stackWeights`; travels with the break
     /// marker.
     public var trackWeights: [WindowID: Double]
+    /// Interactive-resize ratio layer (#458): the value a
+    /// resize wrote for THIS space when no config override of
+    /// the field exists — so resizing a no-override space no
+    /// longer moves every other no-override space through the
+    /// global. Session-only like `stackWeights` (never
+    /// persisted); cleared on an actual mode change and on
+    /// config reload. See `SessionRatios`.
+    public var sessionRatios: SessionRatios
 
     public init(
         id: SpaceID,
@@ -201,7 +209,8 @@ public struct Space: Sendable, Equatable {
         stackWeights: [WindowID: Double] = [:],
         scrollOffset: CGFloat? = nil,
         trackBreaks: Set<WindowID> = [],
-        trackWeights: [WindowID: Double] = [:]
+        trackWeights: [WindowID: Double] = [:],
+        sessionRatios: SessionRatios = SessionRatios()
     ) {
         self.id = id
         self.mode = mode
@@ -211,6 +220,7 @@ public struct Space: Sendable, Equatable {
         self.scrollOffset = scrollOffset
         self.trackBreaks = trackBreaks
         self.trackWeights = trackWeights
+        self.sessionRatios = sessionRatios
     }
 
     /// Appends a window if it is not already present.

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
@@ -33,6 +33,16 @@ extension KiwiCore {
         // The engine's cached durations sync via
         // `TilingEngine.settings.didSet` (#51).
         tiler.settings = profile.settings
+        // An EXPLICIT apply reseeds the session resize layer
+        // (#458): the incoming settings are the new truth, and
+        // a session shadow would make the profile's ratios
+        // visibly do nothing (§5 forced-retile rationale).
+        // Event-driven applies (monitor change, native-space
+        // binding) keep it — a display reconnect must not eat
+        // the user's interactive resizes.
+        if forceRetile {
+            clearSessionRatios { $0 = SessionRatios() }
+        }
         let declared = profile.declaredSpaces
         // Seed live order from the profile's stored list so
         // creation order matches display order. Using
@@ -157,6 +167,10 @@ extension KiwiCore {
         forceRetile: Bool
     ) {
         tiler.settings = composed.settings
+        // Same explicit-apply reseed as `apply(profile:)`.
+        if forceRetile {
+            clearSessionRatios { $0 = SessionRatios() }
+        }
         for space in composed.spaces {
             state.workspaces.ensureSpace(space)
             state.workspaces.setMode(

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
@@ -24,7 +24,9 @@ extension KiwiCore {
     /// Growth threshold (review 2026-07): two classification
     /// Bools is the ceiling. A THIRD would be the point to
     /// fold them into one apply-intent value (.userExplicit /
-    /// .hardwareEvent) — do not add Bool #3.
+    /// .hardwareEvent) — do not add Bool #3. The session
+    /// ratio-layer clear (#458) rides this same classification;
+    /// an eventual fold carries it along.
     func apply(
         profile: Profile,
         pruneStaleSpaces: Bool = false,

--- a/Sources/KiwiDeskCore/State/WorkspaceManager.swift
+++ b/Sources/KiwiDeskCore/State/WorkspaceManager.swift
@@ -86,6 +86,9 @@ public struct WorkspaceManager: Sendable {
         guard spaces[id]?.mode != mode else { return }
         spaces[id]?.mode = mode
         spaces[id]?.scrollOffset = nil
+        // The session resize layer (#458) is a stint value like
+        // the offset: a fresh mode stint reseeds from config.
+        spaces[id]?.sessionRatios = SessionRatios()
         // Track boundaries follow the same rule (#128): a
         // fresh track stint never resumes markers minted for a
         // different stint. Entering track seeds every window

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
@@ -109,7 +109,7 @@ extension KiwiCore {
         switch adjustment {
         case .bspRatioH(let delta):
             let base =
-                tiler.settings.resolvedBsp(for: space.id)
+                tiler.settings.resolvedBsp(for: space)
                 .splitRatioH
             // Cap at the display's effective range (#383): no
             // invisible ratchet past the min-size cliff, matching
@@ -120,13 +120,13 @@ extension KiwiCore {
                 available: Double(bounds.width),
                 minSize: Double(tiler.settings.minWindowSize)
             )
-            tiler.settings.setSplitRatioH(
+            writeSplitRatioH(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )
         case .bspRatioV(let delta):
             let base =
-                tiler.settings.resolvedBsp(for: space.id)
+                tiler.settings.resolvedBsp(for: space)
                 .splitRatioV
             let value = SplitDomain.cappedRatioWrite(
                 base + Double(delta),
@@ -134,13 +134,13 @@ extension KiwiCore {
                 available: Double(bounds.height),
                 minSize: Double(tiler.settings.minWindowSize)
             )
-            tiler.settings.setSplitRatioV(
+            writeSplitRatioV(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )
         case .masterRatio(let delta):
             let stack =
-                tiler.settings.resolvedStack(for: space.id)
+                tiler.settings.resolvedStack(for: space)
             let base = stack.masterRatio
             // The ratio lives on the split axis (#222), so the
             // cap's available span follows it too.
@@ -155,7 +155,7 @@ extension KiwiCore {
                 available: Double(available),
                 minSize: Double(tiler.settings.minWindowSize)
             )
-            tiler.settings.setMasterRatio(
+            writeMasterRatio(
                 min(max(value, 0.1), 0.9),
                 for: space.id
             )
@@ -164,12 +164,12 @@ extension KiwiCore {
             // magnitude (a stored pt as-is; auto/% seeded against
             // the scroll axis), add the delta, store as points.
             let scrolling =
-                tiler.settings.resolvedScrolling(for: space.id)
+                tiler.settings.resolvedScrolling(for: space)
             let horizontal = scrolling.axisIsHorizontal
             let along = horizontal ? bounds.width : bounds.height
             let current = scrolling.slotSize
                 .editablePoints(along: along, horizontal: horizontal)
-            tiler.settings.setSlotSize(
+            writeSlotSize(
                 .points(clamping: current + delta),
                 for: space.id
             )

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+SessionRatioWrite.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+SessionRatioWrite.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// The interactive-resize ratio write seam (#458): an authored
+/// config override of the field takes the write (pre-#458
+/// behavior — the #290 editor's value stays live); otherwise
+/// the value lands in the space's session layer, never the
+/// global. Both the keyboard `resize` verb and the mouse-drag
+/// drop (`applyResizeAdjustment`) route here.
+extension KiwiCore {
+    func writeSplitRatioH(_ value: Double, for space: SpaceID) {
+        if tiler.settings.setSplitRatioH(value, for: space) {
+            return
+        }
+        state.workspaces.withSpace(space) {
+            $0.sessionRatios.splitRatioH = value
+        }
+    }
+
+    func writeSplitRatioV(_ value: Double, for space: SpaceID) {
+        if tiler.settings.setSplitRatioV(value, for: space) {
+            return
+        }
+        state.workspaces.withSpace(space) {
+            $0.sessionRatios.splitRatioV = value
+        }
+    }
+
+    func writeMasterRatio(_ value: Double, for space: SpaceID) {
+        if tiler.settings.setMasterRatio(value, for: space) {
+            return
+        }
+        state.workspaces.withSpace(space) {
+            $0.sessionRatios.masterRatio = value
+        }
+    }
+
+    func writeSlotSize(_ value: ScrollSize, for space: SpaceID) {
+        if tiler.settings.setSlotSize(value, for: space) {
+            return
+        }
+        state.workspaces.withSpace(space) {
+            $0.sessionRatios.slotSize = value
+        }
+    }
+
+    /// Clears one session field on every space — the explicit
+    /// global setters (`bsp.set_ratio_h`, `stack.set_master_
+    /// ratio`, `scroll.set_slot_size`) call this so an explicit
+    /// config write visibly applies everywhere instead of being
+    /// shadowed by earlier interactive resizes (the #383
+    /// "visibly did nothing" trap, session-layer edition).
+    func clearSessionRatios(
+        _ clear: (inout SessionRatios) -> Void
+    ) {
+        for space in state.workspaces.allSpaces {
+            state.workspaces.withSpace(space.id) {
+                clear(&$0.sessionRatios)
+            }
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Resolution.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Resolution.swift
@@ -58,62 +58,113 @@ extension TilingSettings {
             .resolved(onto: track)
     }
 
+    // MARK: - Session-aware resolution (#458)
+
+    /// `resolvedBsp` with the space's session resize layer
+    /// overlaid — authored override field > session > global —
+    /// so an interactive resize on a no-override space shows on
+    /// that space alone. Layout reads (`context`) and resize
+    /// current-value reads use these; readers of non-ratio
+    /// params may keep the id form.
+    public func resolvedBsp(for space: Space) -> BspParams {
+        var params = resolvedBsp(for: space.id)
+        let override = bsp.override[space.id]
+        if override?.splitRatioH == nil,
+            let value = space.sessionRatios.splitRatioH
+        {
+            params.splitRatioH = value
+        }
+        if override?.splitRatioV == nil,
+            let value = space.sessionRatios.splitRatioV
+        {
+            params.splitRatioV = value
+        }
+        return params
+    }
+
+    /// See `resolvedBsp(for: Space)`.
+    public func resolvedStack(for space: Space) -> StackParams {
+        var params = resolvedStack(for: space.id)
+        if stack.override[space.id]?.masterRatio == nil,
+            let value = space.sessionRatios.masterRatio
+        {
+            params.masterRatio = value
+        }
+        return params
+    }
+
+    /// See `resolvedBsp(for: Space)`.
+    public func resolvedScrolling(
+        for space: Space
+    ) -> ScrollingParams {
+        var params = resolvedScrolling(for: space.id)
+        if scrolling.override[space.id]?.slotSize == nil,
+            let value = space.sessionRatios.slotSize
+        {
+            params.slotSize = value
+        }
+        return params
+    }
+
     // MARK: - Per-space writes (interactive resize)
     //
     // Only the interactive-resize path routes here — Lua `set_*`
     // and the GUI per-space bindings write the global params or
-    // the override map directly. These helpers exist so a resize
-    // edits the value the space displays without knowing whether
-    // that value is overridden.
+    // the override map directly. Since #458 these write ONLY an
+    // authored override field; a no-override space returns
+    // false and the caller (`KiwiCore.writeSplitRatioH` family)
+    // stores the value in the space's session layer instead —
+    // never the global, which would visibly resize every other
+    // no-override space.
 
-    /// Writes a resize-adjusted value for `space`: into the
-    /// space's override when it already overrides that field,
-    /// else into the global params. So resizing a window edits
-    /// exactly the value the space currently displays — its
-    /// override when it has one, the global otherwise (the
-    /// pre-#17 behavior) — never silently shifting other spaces.
+    /// Writes into the space's override when it already
+    /// overrides the field; returns whether it did.
+    @discardableResult
     public mutating func setSplitRatioH(
         _ value: Double,
         for space: SpaceID
-    ) {
-        if bsp.override[space]?.splitRatioH != nil {
-            bsp.override[space]?.splitRatioH = value
-        } else {
-            bsp.splitRatioH = value
+    ) -> Bool {
+        guard bsp.override[space]?.splitRatioH != nil else {
+            return false
         }
+        bsp.override[space]?.splitRatioH = value
+        return true
     }
 
+    @discardableResult
     public mutating func setSplitRatioV(
         _ value: Double,
         for space: SpaceID
-    ) {
-        if bsp.override[space]?.splitRatioV != nil {
-            bsp.override[space]?.splitRatioV = value
-        } else {
-            bsp.splitRatioV = value
+    ) -> Bool {
+        guard bsp.override[space]?.splitRatioV != nil else {
+            return false
         }
+        bsp.override[space]?.splitRatioV = value
+        return true
     }
 
+    @discardableResult
     public mutating func setMasterRatio(
         _ value: Double,
         for space: SpaceID
-    ) {
-        if stack.override[space]?.masterRatio != nil {
-            stack.override[space]?.masterRatio = value
-        } else {
-            stack.masterRatio = value
+    ) -> Bool {
+        guard stack.override[space]?.masterRatio != nil else {
+            return false
         }
+        stack.override[space]?.masterRatio = value
+        return true
     }
 
+    @discardableResult
     public mutating func setSlotSize(
         _ value: ScrollSize,
         for space: SpaceID
-    ) {
-        if scrolling.override[space]?.slotSize != nil {
-            scrolling.override[space]?.slotSize = value
-        } else {
-            scrolling.slotSize = value
+    ) -> Bool {
+        guard scrolling.override[space]?.slotSize != nil else {
+            return false
         }
+        scrolling.override[space]?.slotSize = value
+        return true
     }
 
     /// True while the Space Bar and at least one *enabled*
@@ -175,9 +226,9 @@ extension TilingSettings {
             trackBreaks: space.trackBreaks,
             trackWeights: space.trackWeights,
             sticky: sticky,
-            bsp: resolvedBsp(for: space.id),
-            stack: resolvedStack(for: space.id),
-            scrolling: resolvedScrolling(for: space.id),
+            bsp: resolvedBsp(for: space),
+            stack: resolvedStack(for: space),
+            scrolling: resolvedScrolling(for: space),
             grid: resolvedGrid(for: space.id),
             monocle: resolvedMonocle(for: space.id),
             track: resolvedTrack(for: space.id),

--- a/Tests/KiwiDeskCoreTests/BspFocusResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/BspFocusResizeTests.swift
@@ -48,14 +48,26 @@ struct BspFocusResizeTests {
         }
     }
 
+    /// The session-resolved ratios of space "1" (#458): an
+    /// interactive resize on a no-override space lands in the
+    /// session layer, so tests read the resolved value, and the
+    /// stored globals must stay untouched.
+    private func resolvedBsp(_ core: KiwiCore) -> BspParams {
+        core.tiler.settings.resolvedBsp(
+            for: core.state.workspaces[SpaceID("1")]!
+        )
+    }
+
     @Test("x with the left window focused raises the H ratio")
     func leftFocusGrowsLeft() {
         let core = makeCore()
         bspSpace(core)
         core.state.apply(.windowFocused(WindowID(1)))
-        let before = core.tiler.settings.bsp.splitRatioH
+        let before = resolvedBsp(core).splitRatioH
         core.execute("resize", args: [.string("x"), .number(200)])
-        #expect(core.tiler.settings.bsp.splitRatioH > before)
+        #expect(resolvedBsp(core).splitRatioH > before)
+        // The global never moves for a no-override space (#458).
+        #expect(core.tiler.settings.bsp.splitRatioH == before)
     }
 
     @Test("x with the right window focused lowers the H ratio")
@@ -63,11 +75,11 @@ struct BspFocusResizeTests {
         let core = makeCore()
         bspSpace(core)
         core.state.apply(.windowFocused(WindowID(2)))
-        let before = core.tiler.settings.bsp.splitRatioH
+        let before = resolvedBsp(core).splitRatioH
         core.execute("resize", args: [.string("x"), .number(200)])
         // +delta grows the FOCUSED window: the right region
         // widens, so the shared H ratio drops (#122).
-        #expect(core.tiler.settings.bsp.splitRatioH < before)
+        #expect(resolvedBsp(core).splitRatioH < before)
     }
 
     @Test("y with the top window focused raises the V ratio")
@@ -77,9 +89,9 @@ struct BspFocusResizeTests {
         // [1, 2, 3]: w1 left; the right region stacks w2 over
         // w3 (alternating → vertical at depth 1).
         core.state.apply(.windowFocused(WindowID(2)))
-        let before = core.tiler.settings.bsp.splitRatioV
+        let before = resolvedBsp(core).splitRatioV
         core.execute("resize", args: [.string("y"), .number(200)])
-        #expect(core.tiler.settings.bsp.splitRatioV > before)
+        #expect(resolvedBsp(core).splitRatioV > before)
     }
 
     @Test("y with the bottom window focused lowers the V ratio")
@@ -87,9 +99,9 @@ struct BspFocusResizeTests {
         let core = makeCore()
         bspSpace(core, count: 3)
         core.state.apply(.windowFocused(WindowID(3)))
-        let before = core.tiler.settings.bsp.splitRatioV
+        let before = resolvedBsp(core).splitRatioV
         core.execute("resize", args: [.string("y"), .number(200)])
-        #expect(core.tiler.settings.bsp.splitRatioV < before)
+        #expect(resolvedBsp(core).splitRatioV < before)
     }
 
     @Test("a huge x resize caps at the effective range (#383)")
@@ -114,7 +126,7 @@ struct BspFocusResizeTests {
         )!.upperBound
         let expected = min(max(bound, 0.1), 0.9)
         core.execute("resize", args: [.string("x"), .number(9000)])
-        #expect(abs(core.tiler.settings.bsp.splitRatioH - expected) < 1e-9)
+        #expect(abs(resolvedBsp(core).splitRatioH - expected) < 1e-9)
     }
 
     @Test("x with a floating focused window resizes the float")
@@ -125,13 +137,13 @@ struct BspFocusResizeTests {
         // shared ratio must not move, in either direction.
         core.state.apply(.windowFocused(WindowID(2)))
         core.state.setFloating(WindowID(2), true)
-        let before = core.tiler.settings.bsp.splitRatioH
+        let before = resolvedBsp(core).splitRatioH
         let response = core.execute(
             "resize",
             args: [.string("x"), .number(200)]
         )
         #expect(response.isSuccess)
-        #expect(core.tiler.settings.bsp.splitRatioH == before)
+        #expect(resolvedBsp(core).splitRatioH == before)
     }
 
     @Test("right focus writes the space's own override (#17)")

--- a/Tests/KiwiDeskCoreTests/MouseResizeApplyTests.swift
+++ b/Tests/KiwiDeskCoreTests/MouseResizeApplyTests.swift
@@ -38,6 +38,14 @@ struct MouseResizeApplyTests {
         return core.state.workspaces[SpaceID("1")]!
     }
 
+    /// Session-resolved params of space "1" (#458): mouse
+    /// drops on a no-override space land in the session layer.
+    private func resolvedBsp(_ core: KiwiCore) -> BspParams {
+        core.tiler.settings.resolvedBsp(
+            for: core.state.workspaces[SpaceID("1")]!
+        )
+    }
+
     @Test("bspRatioH writes only the H ratio")
     func hAppliesToH() {
         let core = makeCore()
@@ -47,9 +55,11 @@ struct MouseResizeApplyTests {
             in: space,
             bounds: bounds
         )
-        let bsp = core.tiler.settings.bsp
+        let bsp = resolvedBsp(core)
         #expect(abs(bsp.splitRatioH - 0.6) < 1e-9)
         #expect(bsp.splitRatioV == 0.5)
+        // The stored global is untouched (#458).
+        #expect(core.tiler.settings.bsp.splitRatioH == 0.5)
     }
 
     @Test("bspRatioV writes only the V ratio")
@@ -61,7 +71,7 @@ struct MouseResizeApplyTests {
             in: space,
             bounds: bounds
         )
-        let bsp = core.tiler.settings.bsp
+        let bsp = resolvedBsp(core)
         #expect(abs(bsp.splitRatioV - 0.6) < 1e-9)
         #expect(bsp.splitRatioH == 0.5)
     }
@@ -79,7 +89,7 @@ struct MouseResizeApplyTests {
             in: space,
             bounds: bounds
         )
-        #expect(abs(core.tiler.settings.bsp.splitRatioH - 0.7) < 1e-9)
+        #expect(abs(resolvedBsp(core).splitRatioH - 0.7) < 1e-9)
     }
 
     @Test("bspRatioV drag caps at the effective range (#383)")
@@ -92,7 +102,7 @@ struct MouseResizeApplyTests {
             in: space,
             bounds: bounds
         )
-        #expect(abs(core.tiler.settings.bsp.splitRatioV - 0.625) < 1e-9)
+        #expect(abs(resolvedBsp(core).splitRatioV - 0.625) < 1e-9)
     }
 
     @Test("masterRatio applies onto the resolved base")
@@ -104,7 +114,9 @@ struct MouseResizeApplyTests {
             in: space,
             bounds: bounds
         )
-        let stack = core.tiler.settings.stack
+        let stack = core.tiler.settings.resolvedStack(
+            for: core.state.workspaces[SpaceID("1")]!
+        )
         #expect(abs(stack.masterRatio - 0.5) < 1e-9)
     }
 
@@ -120,7 +132,9 @@ struct MouseResizeApplyTests {
             in: space,
             bounds: bounds
         )
-        let stack = core.tiler.settings.stack
+        let stack = core.tiler.settings.resolvedStack(
+            for: core.state.workspaces[SpaceID("1")]!
+        )
         #expect(abs(stack.masterRatio - 0.7) < 1e-9)
     }
 
@@ -138,7 +152,9 @@ struct MouseResizeApplyTests {
             in: space,
             bounds: bounds
         )
-        let after = core.tiler.settings.scrolling.slotSize
+        let after = core.tiler.settings.resolvedScrolling(
+            for: core.state.workspaces[SpaceID("1")]!
+        ).slotSize
             .editablePoints(along: bounds.width, horizontal: true)
         #expect(abs(after - before - 100) < 0.5)
     }

--- a/Tests/KiwiDeskCoreTests/PerSpaceResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/PerSpaceResizeTests.swift
@@ -58,15 +58,26 @@ struct PerSpaceResizeTests {
         #expect(core.tiler.settings.stack.masterRatio == globalBefore)
     }
 
-    @Test("Resize in an unoverridden space edits the global")
-    func resizeHitsGlobalWhenUnoverridden() {
+    @Test("Resize in an unoverridden space edits its session layer")
+    func resizeHitsSessionWhenUnoverridden() {
         let core = makeCore()
         stackSpace(core)
         let before = core.tiler.settings.stack.masterRatio
         core.execute("resize", args: [.string("x"), .number(500)])
-        #expect(core.tiler.settings.stack.masterRatio != before)
-        // No override was created for a space that had none.
+        // #458: the global no longer moves — every other
+        // no-override space stays put — and no override is
+        // silently authored either; the value lives in the
+        // space's session layer.
+        #expect(core.tiler.settings.stack.masterRatio == before)
         #expect(core.tiler.settings.stack.override.isEmpty)
+        let space = core.state.workspaces[SpaceID("1")]
+        #expect(space?.sessionRatios.masterRatio != nil)
+        if let space {
+            #expect(
+                core.tiler.settings.resolvedStack(for: space)
+                    .masterRatio != before
+            )
+        }
     }
 
     @Test("Resize base is the resolved value, not the global")
@@ -118,10 +129,14 @@ struct PerSpaceResizeTests {
             "set_mode",
             args: [.string("1"), .string("bsp")]
         )
-        let hBefore = core.tiler.settings.bsp.splitRatioH
         core.execute("resize", args: [.string("y"), .number(500)])
-        // The V ratio moved; the H ratio is untouched.
-        #expect(core.tiler.settings.bsp.splitRatioV != 0.5)
-        #expect(core.tiler.settings.bsp.splitRatioH == hBefore)
+        // The V ratio moved (in the session layer, #458); the H
+        // ratio is untouched on every layer.
+        let session =
+            core.state.workspaces[SpaceID("1")]?.sessionRatios
+        #expect(session?.splitRatioV != nil)
+        #expect(session?.splitRatioH == nil)
+        #expect(core.tiler.settings.bsp.splitRatioV == 0.5)
+        #expect(core.tiler.settings.bsp.splitRatioH == 0.5)
     }
 }

--- a/Tests/KiwiDeskCoreTests/SessionRatioTests.swift
+++ b/Tests/KiwiDeskCoreTests/SessionRatioTests.swift
@@ -212,6 +212,47 @@ struct SessionRatioTests {
         )
     }
 
+    @Test("A composed (preset) apply follows the same rule")
+    func composedApplyReseeds() {
+        let core = makeCore()
+        core.execute("resize", args: [.string("x"), .number(500)])
+        let composed = ProfileComposition.Composed(
+            sourceName: "standard",
+            spaces: ["1"],
+            spaceModes: ["1": .bsp],
+            assignment: [:],
+            settings: core.tiler.settings
+        )
+        core.apply(composed: composed, forceRetile: false)
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.splitRatioH != nil
+        )
+        core.apply(composed: composed, forceRetile: true)
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios == SessionRatios()
+        )
+    }
+
+    @Test("The GUI save apply always reseeds")
+    func guiSaveApplyReseeds() {
+        let core = makeCore()
+        core.execute("resize", args: [.string("x"), .number(500)])
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.splitRatioH != nil
+        )
+        var config = GuiConfig()
+        config.settings = core.tiler.settings
+        config.spaces = ["1"]
+        core.applyProfileScopedState(from: config)
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios == SessionRatios()
+        )
+    }
+
     @Test("reload_config reseeds the layer")
     func reloadReseeds() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/SessionRatioTests.swift
+++ b/Tests/KiwiDeskCoreTests/SessionRatioTests.swift
@@ -1,0 +1,149 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The session resize layer (#458): interactive resizes on a
+/// space with no authored override live in per-space runtime
+/// state — config layers untouched, other spaces unmoved —
+/// with authored override > session > global precedence, and
+/// reseeding on mode change and explicit global writes.
+@Suite("Session resize layer (#458)", .serialized)
+@MainActor
+struct SessionRatioTests {
+    private func makeCore() -> KiwiCore {
+        KiwiCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-session-\(UUID().uuidString)"
+                )
+        )
+    }
+
+    @Test("BSP resize moves only the resized space")
+    func bspIsolation() {
+        let core = makeCore()
+        core.state.workspaces.ensureSpace("2")
+        core.execute("resize", args: [.string("x"), .number(500)])
+        // The resized space resolves its session value…
+        let one = core.state.workspaces[SpaceID("1")]
+        #expect(one?.sessionRatios.splitRatioH != nil)
+        if let one {
+            #expect(
+                core.tiler.settings.resolvedBsp(for: one)
+                    .splitRatioH != 0.5
+            )
+        }
+        // …while the other no-override space still resolves
+        // the untouched global.
+        let two = core.state.workspaces[SpaceID("2")]
+        if let two {
+            #expect(
+                core.tiler.settings.resolvedBsp(for: two)
+                    .splitRatioH == 0.5
+            )
+        }
+        #expect(core.tiler.settings.bsp.splitRatioH == 0.5)
+    }
+
+    @Test("An authored override wins over a stale session value")
+    func overrideBeatsSession() {
+        let core = makeCore()
+        core.execute("resize", args: [.string("x"), .number(500)])
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.splitRatioH != nil
+        )
+        core.execute(
+            "bsp.set_ratio_h_override",
+            args: [.string("1"), .number(0.3)]
+        )
+        if let space = core.state.workspaces[SpaceID("1")] {
+            #expect(
+                core.tiler.settings.resolvedBsp(for: space)
+                    .splitRatioH == 0.3
+            )
+        }
+    }
+
+    @Test("A real mode change reseeds; a same-mode set keeps")
+    func modeChangeReseeds() {
+        let core = makeCore()
+        core.execute("resize", args: [.string("x"), .number(500)])
+        // Dense same-mode applies (profile/GUI) must not wipe.
+        core.state.workspaces.setMode(SpaceID("1"), .bsp)
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.splitRatioH != nil
+        )
+        core.state.workspaces.setMode(SpaceID("1"), .stack)
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios == SessionRatios()
+        )
+    }
+
+    @Test("An explicit global setter drops the session shadow")
+    func explicitGlobalClearsShadow() {
+        let core = makeCore()
+        core.execute("resize", args: [.string("x"), .number(500)])
+        core.execute("resize", args: [.string("y"), .number(500)])
+        #expect(
+            core.execute(
+                "bsp.set_ratio_h",
+                args: [.number(0.4)]
+            ).isSuccess
+        )
+        let session =
+            core.state.workspaces[SpaceID("1")]?.sessionRatios
+        // Only the written field is cleared; the V value is a
+        // different knob and survives.
+        #expect(session?.splitRatioH == nil)
+        #expect(session?.splitRatioV != nil)
+        if let space = core.state.workspaces[SpaceID("1")] {
+            #expect(
+                core.tiler.settings.resolvedBsp(for: space)
+                    .splitRatioH == 0.4
+            )
+        }
+    }
+
+    @Test("Scrolling slot resize stays per-space too")
+    func scrollingSlotSession() {
+        let core = makeCore()
+        let globalBefore = core.tiler.settings.scrolling.slotSize
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("scrolling")]
+        )
+        core.execute("resize", args: [.string("x"), .number(50)])
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.slotSize != nil
+        )
+        #expect(
+            core.tiler.settings.scrolling.slotSize == globalBefore
+        )
+    }
+
+    @Test("The mouse drop path writes the same session layer")
+    func mouseAdjustmentSession() {
+        let core = makeCore()
+        guard let space = core.state.workspaces[SpaceID("1")]
+        else {
+            Issue.record("active space missing")
+            return
+        }
+        core.applyResizeAdjustment(
+            .bspRatioH(0.1),
+            in: space,
+            bounds: CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        )
+        let session =
+            core.state.workspaces[SpaceID("1")]?.sessionRatios
+        #expect(session?.splitRatioH != nil)
+        #expect(core.tiler.settings.bsp.splitRatioH == 0.5)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/SessionRatioTests.swift
+++ b/Tests/KiwiDeskCoreTests/SessionRatioTests.swift
@@ -110,6 +110,135 @@ struct SessionRatioTests {
         }
     }
 
+    @Test("Every explicit global setter drops its own shadow")
+    func allExplicitSettersClearTheirField() {
+        let core = makeCore()
+        core.execute("resize", args: [.string("y"), .number(500)])
+        #expect(
+            core.execute(
+                "bsp.set_ratio_v",
+                args: [.number(0.4)]
+            ).isSuccess
+        )
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.splitRatioV == nil
+        )
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("stack")]
+        )
+        core.execute("resize", args: [.string("x"), .number(500)])
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.masterRatio != nil
+        )
+        #expect(
+            core.execute(
+                "stack.set_master_ratio",
+                args: [.number(0.55)]
+            ).isSuccess
+        )
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.masterRatio == nil
+        )
+        core.execute(
+            "set_mode",
+            args: [.string("1"), .string("scrolling")]
+        )
+        core.execute("resize", args: [.string("x"), .number(50)])
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.slotSize != nil
+        )
+        #expect(
+            core.execute(
+                "scroll.set_slot_size",
+                args: [.number(700)]
+            ).isSuccess
+        )
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.slotSize == nil
+        )
+    }
+
+    @Test("Consecutive resizes accumulate on the session base")
+    func consecutiveResizesAccumulate() {
+        let core = makeCore()
+        core.execute("resize", args: [.string("x"), .number(100)])
+        let first = core.state.workspaces[SpaceID("1")]?
+            .sessionRatios.splitRatioH
+        core.execute("resize", args: [.string("x"), .number(100)])
+        let second = core.state.workspaces[SpaceID("1")]?
+            .sessionRatios.splitRatioH
+        // A read regressed to the config-only resolver would
+        // recompute global+delta each time: the second resize
+        // would land on the same value and the window would
+        // visibly stick after one step.
+        if let first, let second {
+            #expect(second > first)
+        } else {
+            Issue.record("session ratio missing")
+        }
+    }
+
+    @Test("An explicit profile apply reseeds the layer")
+    func explicitProfileApplyReseeds() {
+        let core = makeCore()
+        core.execute("resize", args: [.string("x"), .number(500)])
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.splitRatioH != nil
+        )
+        let profile = Profile(
+            name: "p",
+            monitorSets: [MonitorSet(monitors: ["A:1x1"])],
+            spaceModes: ["1": .bsp],
+            settings: core.tiler.settings
+        )
+        core.apply(profile: profile, forceRetile: true)
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios == SessionRatios()
+        )
+        // An event-driven (un-forced) apply keeps the layer.
+        core.execute("resize", args: [.string("x"), .number(500)])
+        core.apply(profile: profile, forceRetile: false)
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.splitRatioH != nil
+        )
+    }
+
+    @Test("reload_config reseeds the layer")
+    func reloadReseeds() {
+        let core = makeCore()
+        core.execute("resize", args: [.string("x"), .number(500)])
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios.splitRatioH != nil
+        )
+        core.loadConfig()
+        #expect(
+            core.state.workspaces[SpaceID("1")]?
+                .sessionRatios == SessionRatios()
+        )
+    }
+
+    /// The #458 mirror net (§5 parity rule): the SessionRatios
+    /// field list is hand-mirrored at the overlay funcs
+    /// (`TilingSettings+Resolution`), the write wrappers and
+    /// clears (`KiwiCore+SessionRatioWrite`, the three command
+    /// files), and this suite. Adding a field must fail here
+    /// until every site — and a behavioral test — is updated.
+    @Test("SessionRatios carries exactly the mirrored fields")
+    func fieldCountPinsTheMirrors() {
+        let mirror = Mirror(reflecting: SessionRatios())
+        #expect(mirror.children.count == 4)
+    }
+
     @Test("Scrolling slot resize stays per-space too")
     func scrollingSlotSession() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/StackArrangementResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/StackArrangementResizeTests.swift
@@ -50,9 +50,16 @@ struct StackArrangementResizeTests {
         let core = makeCore()
         topStackSpace(core)
         core.state.apply(.windowFocused(WindowID(3)))
-        let before = core.tiler.settings.stack.masterRatio
+        let before = core.tiler.settings.resolvedStack(
+            for: core.state.workspaces[SpaceID("1")]!
+        ).masterRatio
         core.execute("resize", args: [.string("y"), .number(300)])
-        #expect(core.tiler.settings.stack.masterRatio > before)
+        // #458: the write lands in the session layer.
+        #expect(
+            core.tiler.settings.resolvedStack(
+                for: core.state.workspaces[SpaceID("1")]!
+            ).masterRatio > before
+        )
     }
 
     @Test("x bumps a horizontal stack row's weight")

--- a/Tests/KiwiDeskCoreTests/StackFocusResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/StackFocusResizeTests.swift
@@ -40,14 +40,23 @@ struct StackFocusResizeTests {
         }
     }
 
+    /// Session-resolved master ratio of space "1" (#458).
+    private func resolvedMaster(_ core: KiwiCore) -> Double {
+        core.tiler.settings.resolvedStack(
+            for: core.state.workspaces[SpaceID("1")]!
+        ).masterRatio
+    }
+
     @Test("x with the master focused grows the master ratio")
     func masterFocusGrowsMaster() {
         let core = makeCore()
         stackSpace(core)
         core.state.apply(.windowFocused(WindowID(3)))
-        let before = core.tiler.settings.stack.masterRatio
+        let before = resolvedMaster(core)
         core.execute("resize", args: [.string("x"), .number(500)])
-        #expect(core.tiler.settings.stack.masterRatio > before)
+        #expect(resolvedMaster(core) > before)
+        // The global never moves for a no-override space (#458).
+        #expect(core.tiler.settings.stack.masterRatio == before)
     }
 
     @Test("x with a stack window focused lowers the master ratio")
@@ -55,11 +64,11 @@ struct StackFocusResizeTests {
         let core = makeCore()
         stackSpace(core)
         core.state.apply(.windowFocused(WindowID(1)))
-        let before = core.tiler.settings.stack.masterRatio
+        let before = resolvedMaster(core)
         core.execute("resize", args: [.string("x"), .number(500)])
         // +delta grows the FOCUSED window: the stack column
         // widens, so the master ratio drops (#67).
-        #expect(core.tiler.settings.stack.masterRatio < before)
+        #expect(resolvedMaster(core) < before)
     }
 
     @Test("y bumps the focused stack window's weight only")

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -375,6 +375,33 @@ two-axis layout's wire keys are named follows the
 geometric-wire rule in
 [Settings UI patterns](ui-patterns.md#labels--wire-names).
 
+**Interactive resizes are session-scoped per space; the config
+layers never move underneath them (#458).** Before, a resize on
+a space with no authored override wrote the *global* ratio —
+coherent under the #17 layered model ("you resized the
+default") but visibly wrong the moment two monitors show two
+no-override spaces: resizing one resized both. The two rejected
+alternatives: keeping as-is (documented confusion), and
+materializing a per-space override on first resize (silently
+pins the space, decouples it from Layout Defaults, and fills
+the #290 override editor with overrides the user never
+authored). Chosen: a **session ratio layer** on the `Space`
+(`SessionRatios`), the `stackWeights` precedent — interactive
+writes land there when no authored override carries the field,
+config stays untouched, and the layer reseeds on a real mode
+change or `reload_config`. Read precedence is authored override
+> session > global, and an **explicit global setter**
+(`bsp.set_ratio_h`, `stack.set_master_ratio`,
+`scroll.set_slot_size`) drops its field's session shadow
+everywhere so an explicit write always visibly applies (the
+#383 "visibly did nothing" rationale). Covers the BSP split
+ratios, stack master ratio, and scrolling slot size — the same
+shape for all three, per the #458 scope note. Accepted edges: a
+GUI Layout Defaults slider edit (a direct global write, no
+session clear) stays shadowed on session-resized spaces until a
+reload or mode change, and removing an override field
+mid-session can resurface an older session value until then.
+
 **Resize is truly 2-axis via two per-space BSP ratios; per-node
 ratios are rejected.** `resize("x")` and `resize("y")` used to
 write the *same* scalar (one `splitRatio` for every BSP split, one

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -390,17 +390,20 @@ authored). Chosen: a **session ratio layer** on the `Space`
 writes land there when no authored override carries the field,
 config stays untouched, and the layer reseeds on a real mode
 change or `reload_config`. Read precedence is authored override
-> session > global, and an **explicit global setter**
+> session > global, and every **explicit config write** drops
+the session shadow so it always visibly applies (the #383
+"visibly did nothing" rationale): a global setter
 (`bsp.set_ratio_h`, `stack.set_master_ratio`,
-`scroll.set_slot_size`) drops its field's session shadow
-everywhere so an explicit write always visibly applies (the
-#383 "visibly did nothing" rationale). Covers the BSP split
-ratios, stack master ratio, and scrolling slot size — the same
-shape for all three, per the #458 scope note. Accepted edges: a
-GUI Layout Defaults slider edit (a direct global write, no
-session clear) stays shadowed on session-resized spaces until a
-reload or mode change, and removing an override field
-mid-session can resurface an older session value until then.
+`scroll.set_slot_size`) clears its own field everywhere, and an
+explicit apply — `load_profile`, a preset, a GUI save — clears
+the whole layer, riding the same `forceRetile` classification
+those applies already carry (§5); event-driven applies (monitor
+change, native-space binding) keep it, so a display reconnect
+never eats an interactive resize. Covers the BSP split ratios,
+stack master ratio, and scrolling slot size — the same shape
+for all three, per the #458 scope note. Accepted edge: removing
+an override field mid-session can resurface an older session
+value until the next reseed.
 
 **Resize is truly 2-axis via two per-space BSP ratios; per-node
 ratios are rejected.** `resize("x")` and `resize("y")` used to

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -3290,7 +3290,8 @@ space no longer visibly resizes every other no-override space,
 and no override is silently authored on your behalf. Session
 values behave like the stack's per-window weights: never saved
 to a profile, gone on restart, reseeded from config on a real
-mode change or `reload_config`, and dropped for a field the
+mode change, `reload_config`, `load_profile` (or any other
+explicit profile/preset/GUI apply), and dropped for a field the
 moment you set its global explicitly (`bsp.set_ratio_h`,
 `stack.set_master_ratio`, `scroll.set_slot_size` — an explicit
 write always shows everywhere). This covers the BSP split

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -3281,6 +3281,22 @@ callers never hear it, they read the error JSON. What the
   track cannot trade cross-axis space, and a window alone in
   its track has no share to grow; both report an error.
 
+**Where the ratio write lands (#458):** a space with an authored
+per-space override of the field (`bsp.set_ratio_h_override`, the
+Settings override editor) keeps editing that override. A space
+*without* one stores the value in a **session layer scoped to
+that space** — the shared global never moves, so resizing one
+space no longer visibly resizes every other no-override space,
+and no override is silently authored on your behalf. Session
+values behave like the stack's per-window weights: never saved
+to a profile, gone on restart, reseeded from config on a real
+mode change or `reload_config`, and dropped for a field the
+moment you set its global explicitly (`bsp.set_ratio_h`,
+`stack.set_master_ratio`, `scroll.set_slot_size` — an explicit
+write always shows everywhere). This covers the BSP split
+ratios, the stack master ratio, and the scrolling slot size —
+the three interactive-resize knobs — consistently.
+
 **Example:**
 
 ```lua


### PR DESCRIPTION
## Description

Interactive resizes (keyboard `resize` verb and mouse drop) on a space with no authored config override used to write the **global** ratio — with two monitors showing two no-override spaces, resizing one visibly resized both. Option 3 from the issue (the `stackWeights` precedent):

- New sparse **`SessionRatios`** on `Space` (BSP `splitRatioH/V`, stack `masterRatio`, scrolling `slotSize`) — session-only, snapshot-excluded, dies with the space.
- **Precedence: authored override > session > global**, enforced structurally in new `resolvedBsp/Stack/Scrolling(for: Space)` overloads; `context()` and both resize paths read them. A space with an authored override keeps writing that override, so the #290 editor stays live and never fills with unauthored entries.
- `TilingSettings` per-space setters became override-only (`-> Bool`); `KiwiCore` wrappers fall through to the session layer. Mouse drag inherits via `applyResizeAdjustment`.
- **Reseeds** — the layer is a stint value: a real `set_mode` change, `reload_config`, and every **explicit apply** (`load_profile`, preset/composed apply, GUI save — riding the existing `forceRetile` classification) clear it; event-driven applies (monitor change, native-space binding) keep it, so a display reconnect never eats a resize. An explicit global setter (`bsp.set_ratio_h/v`, `stack.set_master_ratio`, `scroll.set_slot_size`) drops its own field's shadow everywhere.

Docs: design-decisions settled-decision paragraph (option 3 vs the two rejected alternatives, remaining accepted edge: removing an override field mid-session can resurface an older session value until the next reseed), lua-reference `resize` section.

## Related Issue(s)

Fixes #458

## Checklist

- [x] I understand what this change does (on-device QA pending — see below)
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested (SessionRatioTests incl. Mirror field-count parity net; PerSpaceResize/BspFocusResize/StackFocusResize/StackArrangementResize/MouseResizeApply suites updated to session-resolved reads)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes (1766 tests / 301 suites)
- [x] Release build passes: `swift build -c release`
- [x] PR is focused

## How I verified

Full verify gate per AGENTS.md §3 after each commit; site build green. On-device QA is the merge gate (owner runs it):

1. Two monitors, two no-override BSP spaces visible: resize splits on one — the other must not move. Same for stack master ratio and scrolling slot size.
2. A space with an authored override (override editor) still resizes its override; the override editor value follows.
3. `load_profile` / GUI save after an interactive resize: the incoming ratios visibly apply (no stale session shadow).
4. `bsp.set_ratio_h 0.5` after resizing several spaces: all spaces adopt 0.5.

## Notes for Reviewer

Two-agent review per AGENTS §3 (parallel round 1, sequential re-review of the fix batch) — final verdicts "no major findings". Consciously dismissed with reasons on record: renaming the id-based `resolved*` forms to `configResolved*` (naming asymmetry vs the untouched grid/monocle/track family; write seam closed), and the SpaceModel file split (347/350 lines — planned at the next `Space` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)