### PR TITLE
feat(track): fill-then-spill new-window default (#437)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutHelp.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutHelp.swift
@@ -167,9 +167,9 @@ enum LayoutHelp {
     @MainActor static var trackPosition: String {
         L(
             "track.new_window_position.help",
-            "With \u{201C}Opens own track\u{201D}, where the "
+            "With \u{201C}Opens its own track\u{201D}, where the "
                 + "new track lands among the tracks; with "
-                + "\u{201C}Joins the focused track\u{201D}, "
+                + "\u{201C}Fills the focused track\u{201D}, "
                 + "where the window lands inside it: First, "
                 + "Last, or right before or after the focused "
                 + "one."

--- a/Sources/KiwiDesk/Settings/Components/Layouts/TrackEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/TrackEditor.swift
@@ -82,17 +82,17 @@ struct TrackEditor: View {
                 options: [
                     (
                         L(
-                            "track.new_window.own",
-                            "Opens its own track"
+                            "track.new_window.focused",
+                            "Fills the focused track"
                         ),
-                        TrackParams.NewWindowTrack.ownTrack
+                        TrackParams.NewWindowTrack.focusedTrack
                     ),
                     (
                         L(
-                            "track.new_window.focused",
-                            "Joins the focused track"
+                            "track.new_window.own",
+                            "Opens its own track"
                         ),
-                        .focusedTrack
+                        .ownTrack
                     ),
                 ]
             )

--- a/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
@@ -158,7 +158,7 @@ extension KiwiCore {
         clearSessionRatios { $0 = SessionRatios() }
         for space in state.workspaces.allSpaces
         where space.mode != .bsp {
-            state.workspaces.setMode(space.id, .bsp)
+            setSpaceMode(space.id, .bsp)
         }
     }
 

--- a/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
@@ -23,6 +23,17 @@ extension KiwiCore {
         ]
         state.spawnOverride = tiler.settings.placementOverride
         state.trackParams = tiler.settings.track
+        // Fill-then-spill needs each track space's capacity (#437),
+        // which is display geometry — resolve it here and mirror it
+        // in like `trackParams`, so a `focused_track` spawn reads a
+        // plain Int and the state core stays geometry-free. Only a
+        // window creation consumes it, so skip the per-space context
+        // builds on every other (higher-frequency) event.
+        if case .windowCreated = event {
+            state.trackCapacities = tiler.trackCapacities(
+                state: state
+            )
+        }
         let effects = state.apply(event)
         var newlyCreatedWindow: WindowID? = nil
         switch event {

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -160,7 +160,7 @@ extension KiwiCore {
             preferring: config.fallbackSpace
         )
         for space in state.workspaces.allSpaces {
-            state.workspaces.setMode(
+            setSpaceMode(
                 space.id,
                 config.spaceModes[space.id] ?? .bsp
             )

--- a/Sources/KiwiDeskCore/App/KiwiCore+TrackSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+TrackSeed.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Track-mode entry seeding (#437). When a space switches INTO the
+/// track layout under fill-then-spill (`focused_track`), its
+/// existing windows are packed into filled tracks — what
+/// window-by-window spawning would have built — instead of one
+/// column each. `own_track` keeps the every-window-its-own-track
+/// seed. The packing needs the display geometry the tiler holds,
+/// so it is resolved here and handed to the pure
+/// `WorkspaceManager.setMode`. Every `set_mode` path routes
+/// through `setSpaceMode`, so no entry can forget to seed.
+extension KiwiCore {
+    /// Sets a space's layout mode, seeding the track partition on a
+    /// real switch into track mode; a no-op seed otherwise. Reads
+    /// live `tiler.settings` for the rule and capacity, so a
+    /// config-apply caller must assign `tiler.settings` BEFORE its
+    /// `setSpaceMode` loop (both bulk-apply callers already do).
+    func setSpaceMode(_ id: SpaceID, _ mode: LayoutMode) {
+        // Compute the seed BEFORE the mutating `setMode` — reading
+        // `state.workspaces` inside it would overlap the exclusive
+        // access. Only on a genuine entry, so dense profile / config
+        // applies (mode unchanged) pay nothing.
+        let entering =
+            mode == .track
+            && state.workspaces[id]?.mode != .track
+        let seed = entering ? trackEntrySeed(for: id) : nil
+        state.workspaces.setMode(id, mode, trackSeed: seed)
+    }
+
+    /// The fill-then-spill seed for a space entering track mode:
+    /// its tiled windows packed into tracks of the display's
+    /// capacity (#437). `nil` under `own_track`, so `setMode` uses
+    /// the every-window-its-own-track default.
+    private func trackEntrySeed(
+        for id: SpaceID
+    ) -> Set<WindowID>? {
+        guard let space = state.workspaces[id],
+            tiler.settings.resolvedTrack(for: id).newWindow
+                == .focusedTrack
+        else { return nil }
+        let capacity = tiler.trackCapacity(for: space, state: state)
+        let tiled = space.windows.filter {
+            state.windows[$0]?.isFloating == false
+        }
+        return TrackLayout.fillSeed(
+            tiled: tiled,
+            capacity: capacity
+        )
+    }
+}

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
@@ -306,7 +306,7 @@ extension KiwiCore {
             return .fail("expected [space,] mode")
         }
         state.workspaces.ensureSpace(spaceID)
-        state.workspaces.setMode(spaceID, mode)
+        setSpaceMode(spaceID, mode)
         // Forced: an explicit config apply (AGENTS.md §5),
         // like the layoutCommand dispatch.
         retile(force: true)

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceCommands.swift
@@ -168,11 +168,17 @@ extension KiwiCore {
         }
         let params = tiler.settings.resolvedTrack(for: target)
         let windows = state.windows
+        // A traveler is an explicit placement (#437): it joins the
+        // focused track and piles if full — `spillCapacity: nil`
+        // suppresses the fill-then-spill, so the move is never
+        // second-guessed by relocating the window to a new track.
         state.workspaces.add(
             window,
             to: target,
             trackRule: params.newWindow,
             trackPosition: params.newWindowPosition,
+            spillCapacity: nil,
+            trackCap: params.trackCap,
             isTiled: { windows[$0]?.isFloating == false }
         )
     }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceLifecycleCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SpaceLifecycleCommands.swift
@@ -20,7 +20,7 @@ extension KiwiCore {
             guard let mode = LayoutMode(rawValue: modeRaw) else {
                 return .fail("unknown mode: \(modeRaw)")
             }
-            state.workspaces.setMode(space, mode)
+            setSpaceMode(space, mode)
         }
         // Give the new space a display (auto / main) so it can be
         // shown, then apply.

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+Domain.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+Domain.swift
@@ -125,6 +125,61 @@ extension TrackLayout {
         )
     }
 
+    /// How many min-size windows fit stacked inside ONE track
+    /// along its in-track axis (#437, fill-then-spill): the
+    /// orthogonal of `geometricCap` (which caps how many *tracks*
+    /// fit across the cross-axis). A vertical track (column)
+    /// stacks its windows down `usable.height` with the vertical
+    /// inner gap; a horizontal track (row) runs them along
+    /// `usable.width`. Independent of the track count — every
+    /// track spans the full in-track axis — so it is a stable
+    /// per-display capacity. At equal track weights it matches the
+    /// count at which `trackFrames` starts piling (both go through
+    /// `StackLayout.maxColumnTotal` / `fitCap`), so a spawn spills
+    /// about when the render would otherwise cascade — a min-size
+    /// heuristic, since a resized (non-uniform) track can diverge by
+    /// a window. At least
+    /// 1 (a track always holds one window before spilling);
+    /// `.max` when there is no minimum.
+    public static func trackCapacity(
+        for context: LayoutContext
+    ) -> Int {
+        let vertical = context.track.axis == .vertical
+        let gap =
+            vertical
+            ? context.gaps.inner.vertical
+            : context.gaps.inner.horizontal
+        let span =
+            vertical
+            ? context.usable.height : context.usable.width
+        let cap = fitCap(
+            crossSpan: span,
+            minSize: context.minWindowSize,
+            gap: gap
+        )
+        return cap == .max ? .max : max(1, cap)
+    }
+
+    /// The break-marker seed that packs a tiled window list into
+    /// tracks of `capacity` each (#437): a break every `capacity`
+    /// windows, so entering track mode under fill-then-spill lays
+    /// the existing windows out as filled tracks — what
+    /// window-by-window spawning would have built — instead of one
+    /// column each. `capacity <= 0` (no minimum) is one track
+    /// holding everything, matching the seed's "no markers" case.
+    public static func fillSeed(
+        tiled: [WindowID],
+        capacity: Int
+    ) -> Set<WindowID> {
+        guard capacity > 0 else { return [] }
+        var breaks: Set<WindowID> = []
+        for (index, id) in tiled.enumerated()
+        where index % capacity == 0 {
+            breaks.insert(id)
+        }
+        return breaks
+    }
+
     /// Resolves the marker-track count against the two caps the
     /// layout applies — `normalCap` (the fixed `count`, or
     /// `.max` when `auto_tracks` is on) and `geoCap` (how many

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+Insert.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+Insert.swift
@@ -7,19 +7,34 @@ import Foundation
 /// over the flat array — no geometry; the layout renders overflow.
 extension Space {
     /// Inserts a window per the track layout's `new_window` rule
-    /// (#128) and `new_window_position` (#188): it either opens
-    /// its own new track or joins the focused track, and
-    /// `position` places it — for a new track, among the tracks;
-    /// for a join, among that track's windows. `ownTrack` ALWAYS
-    /// opens a new track (#192): the overflow track is a read-time
-    /// view, so spawn never caps — the far-edge surplus folds into
-    /// the overflow track when the layout renders. `isTiled`
-    /// supplies the float knowledge the space itself does not hold
-    /// — the partition only spans tiled windows.
+    /// (#128, #437) and `new_window_position` (#188). `ownTrack`
+    /// ALWAYS opens its own new track (#192): the overflow track is
+    /// a read-time view, so spawn never caps — the far-edge surplus
+    /// folds into it when the layout renders. `focusedTrack` is
+    /// fill-then-spill: the window joins the focused track (placed
+    /// by `position` among its windows) UNTIL that track already
+    /// holds `spillCapacity` windows — as many as fit at
+    /// `min_window_size` — and another track fits under `trackCap`,
+    /// when it opens a NEW track beside the focused one instead
+    /// (#437). `spillCapacity == nil` disables the spill so the
+    /// window always joins-and-piles — the explicit-placement path
+    /// (`move_to_space` travelers), which must not be relocated.
+    /// `trackCap` is 0 (unlimited, `auto_tracks`) or the fixed
+    /// `count + 1`; at the cap there is no room to spill, so it
+    /// piles. `isTiled` supplies the float knowledge the space
+    /// itself does not hold — the partition only spans tiled
+    /// windows.
+    /// `spillCapacity`/`trackCap` default to the no-spill identity
+    /// (join-and-pile): production routes through
+    /// `WorkspaceManager.add`, which requires both so every spawn
+    /// path chooses, but the Space primitive's default keeps
+    /// position-only callers simple.
     public mutating func insertIntoTrack(
         _ window: WindowID,
         rule: TrackParams.NewWindowTrack,
         position: SpawnPlacement,
+        spillCapacity: Int? = nil,
+        trackCap: Int = 0,
         isTiled: (WindowID) -> Bool
     ) {
         guard !windows.contains(window) else { return }
@@ -52,6 +67,23 @@ extension Space {
             insertOwnTrack(
                 window,
                 position: position,
+                focusedTrack: track,
+                tiled: tiled,
+                ranges: ranges
+            )
+        } else if let capacity = spillCapacity,
+            counts[track] >= capacity,
+            trackCap == 0 || counts.count < trackCap
+        {
+            // Fill-then-spill (#437): the focused track can't fit
+            // another window at min size and another track fits, so
+            // open a NEW track immediately after the focused one.
+            // Focus follows it (the caller's `focus`), so the next
+            // window fills that track and spills again — the
+            // recursion needs no special-casing.
+            insertOwnTrack(
+                window,
+                position: .afterFocused,
                 focusedTrack: track,
                 tiled: tiled,
                 ranges: ranges

--- a/Sources/KiwiDeskCore/Layouts/TrackParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackParams.swift
@@ -19,17 +19,26 @@ public struct TrackParams: Sendable, Equatable, Codable {
         case horizontal
     }
 
-    /// Whether a new window opens its own track or joins the
-    /// focused one (#128 design decision 3). Where within that
-    /// choice it lands is the orthogonal `newWindowPosition`.
+    /// Whether a new window fills the focused track (spilling into
+    /// a new one when it is full) or opens its own track (#128,
+    /// redefined #437). Where within that choice it lands is the
+    /// orthogonal `newWindowPosition`.
     public enum NewWindowTrack: String, Sendable, Codable {
         /// The window opens its own new track; `newWindowPosition`
         /// places that track among the others. Falls back to
-        /// `focusedTrack` when the track cap is reached.
+        /// joining once the track cap is reached. The "one
+        /// full-width app per column" (ultrawide) choice.
         case ownTrack = "own_track"
-        /// The window joins the focused window's track;
-        /// `newWindowPosition` places it among that track's
-        /// windows.
+        /// Fill-then-spill (#437, the default): the window joins
+        /// the focused window's track, and `newWindowPosition`
+        /// places it among that track's windows — until the track
+        /// can't fit another window at `min_window_size`, when the
+        /// window instead spills into a NEW track beside the
+        /// focused one (focus follows it, so the next window fills
+        /// that track and spills again). With no other track to
+        /// spill to — a fixed `count` cap with no room, or a
+        /// traveler dropped by `move_to_space` — it piles in the
+        /// focused track instead (the overflow fallback).
         case focusedTrack = "focused_track"
     }
 
@@ -48,7 +57,7 @@ public struct TrackParams: Sendable, Equatable, Codable {
     /// `autoTracks` is on. The live partition is session state
     /// (`Space.trackBreaks`), like `stackWeights`.
     public var count: Int = 2
-    public var newWindow: NewWindowTrack = .ownTrack
+    public var newWindow: NewWindowTrack = .focusedTrack
     /// Where a new window lands within the `newWindow` choice,
     /// reusing the shared `SpawnPlacement` vocabulary. For
     /// `own_track` it positions the new track among the others
@@ -145,7 +154,7 @@ public struct TrackParams: Sendable, Equatable, Codable {
             try container.decodeIfPresent(
                 NewWindowTrack.self,
                 forKey: .newWindow
-            ) ?? .ownTrack
+            ) ?? .focusedTrack
         newWindowPosition =
             try container.decodeIfPresent(
                 SpawnPlacement.self,

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
@@ -77,7 +77,7 @@ extension KiwiCore {
         // sparse) profile doesn't declare reverts to bsp
         // instead of keeping the previous state's mode.
         for space in state.workspaces.allSpaces {
-            state.workspaces.setMode(
+            setSpaceMode(
                 space.id,
                 profile.spaceModes[space.id] ?? .bsp
             )
@@ -175,7 +175,7 @@ extension KiwiCore {
         }
         for space in composed.spaces {
             state.workspaces.ensureSpace(space)
-            state.workspaces.setMode(
+            setSpaceMode(
                 space,
                 composed.spaceModes[space] ?? .bsp
             )

--- a/Sources/KiwiDeskCore/Resources/Locales/de.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/de.json
@@ -387,7 +387,6 @@
   "track.count": "Spur-Limit",
   "track.count_caption": "Begrenzt durch die minimale Fenstergröße oben: mehr Spuren als passen, klappen in die Überlaufspur.",
   "track.new_window": "Neues Fenster",
-  "track.new_window.focused": "Reiht sich in die fokussierte Spur ein",
   "track.new_window.own": "Öffnet seine eigene Spur",
   "track.new_window_position": "Position",
   "track.wrap_focus": "Fokus umlaufen lassen"

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -752,9 +752,9 @@
   "track.count": "Track limit",
   "track.count_caption": "Bounded by the minimum window size above: more tracks than fit collapse into the overflow track.",
   "track.new_window": "New window",
-  "track.new_window.focused": "Joins the focused track",
+  "track.new_window.focused": "Fills the focused track",
   "track.new_window.own": "Opens its own track",
   "track.new_window_position": "Position",
-  "track.new_window_position.help": "With “Opens own track”, where the new track lands among the tracks; with “Joins the focused track”, where the window lands inside it: First, Last, or right before or after the focused one.",
+  "track.new_window_position.help": "With “Opens its own track”, where the new track lands among the tracks; with “Fills the focused track”, where the window lands inside it: First, Last, or right before or after the focused one.",
   "track.wrap_focus": "Wrap focus"
 }

--- a/Sources/KiwiDeskCore/State/StateCoordinator.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator.swift
@@ -47,6 +47,17 @@ public struct StateCoordinator: Sendable {
     /// every other mode.
     public var trackParams = TrackParams()
 
+    /// Per-space fill-then-spill capacity (#437), mirrored from the
+    /// tiler before each event like `trackParams`: how many windows
+    /// a track holds at `min_window_size` before a `focused_track`
+    /// spawn spills into a new track beside the focused one. The
+    /// number is geometry-derived (the space's display), computed
+    /// where the geometry lives (`TilingEngine.trackCapacities`) so
+    /// this state core stays pure. An absent entry (unknown display)
+    /// makes the spawn join-and-pile — the same safe fallback a
+    /// traveler takes.
+    public var trackCapacities: [SpaceID: Int] = [:]
+
     /// Last known space per window. Window ids are stable OS
     /// ids, so a "created" window with a remembered space is
     /// one coming back from another native macOS Space (or a
@@ -195,6 +206,8 @@ public struct StateCoordinator: Sendable {
                         to: target,
                         trackRule: params.newWindow,
                         trackPosition: params.newWindowPosition,
+                        spillCapacity: trackCapacities[target],
+                        trackCap: params.trackCap,
                         isTiled: { [windows] in
                             windows[$0]?.isFloating == false
                         }

--- a/Sources/KiwiDeskCore/State/WorkspaceManager.swift
+++ b/Sources/KiwiDeskCore/State/WorkspaceManager.swift
@@ -81,7 +81,8 @@ public struct WorkspaceManager: Sendable {
     /// home whenever an unrelated setting is edited.
     public mutating func setMode(
         _ id: SpaceID,
-        _ mode: LayoutMode
+        _ mode: LayoutMode,
+        trackSeed: Set<WindowID>? = nil
     ) {
         guard spaces[id]?.mode != mode else { return }
         spaces[id]?.mode = mode
@@ -89,15 +90,14 @@ public struct WorkspaceManager: Sendable {
         // The session resize layer (#458) is a stint value like
         // the offset: a fresh mode stint reseeds from config.
         spaces[id]?.sessionRatios = SessionRatios()
-        // Track boundaries follow the same rule (#128): a
-        // fresh track stint never resumes markers minted for a
-        // different stint. Entering track seeds every window
-        // as its own track (the dynamic default; a positive
-        // cap merges the surplus at read time).
+        // Track boundaries follow the same rule (#128). Entering
+        // track uses the caller's `trackSeed` (fill-then-spill
+        // packing, #437) or seeds every window as its own track.
         spaces[id]?.trackWeights = [:]
-        let seed =
+        let seed: Set<WindowID> =
             mode == .track
-            ? Set(spaces[id]?.windows ?? []) : Set()
+            ? (trackSeed ?? Set(spaces[id]?.windows ?? []))
+            : []
         spaces[id]?.trackBreaks = seed
     }
 
@@ -235,16 +235,16 @@ public struct WorkspaceManager: Sendable {
         spaces[id]?.insert(window, placement: placement)
     }
 
-    /// Adds a window to a track-mode space per the track
-    /// layout's `new_window` rule (#128), removing it from its
-    /// old space. The track twin of `add(_:to:placement:)`;
-    /// `isTiled` supplies the float knowledge the space does
-    /// not hold.
+    /// Adds a window to a track-mode space per `new_window` (#128,
+    /// #437), removing it from its old space; the track twin of
+    /// `add(_:to:placement:)`. `isTiled` supplies float knowledge.
     public mutating func add(
         _ window: WindowID,
         to id: SpaceID,
         trackRule: TrackParams.NewWindowTrack,
         trackPosition: SpawnPlacement,
+        spillCapacity: Int?,
+        trackCap: Int,
         isTiled: (WindowID) -> Bool
     ) {
         remove(window)
@@ -253,6 +253,8 @@ public struct WorkspaceManager: Sendable {
             window,
             rule: trackRule,
             position: trackPosition,
+            spillCapacity: spillCapacity,
+            trackCap: trackCap,
             isTiled: isTiled
         )
     }

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine+Layout.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine+Layout.swift
@@ -115,6 +115,49 @@ extension TilingEngine {
         return Array(byScreen.values)
     }
 
+    /// The fill-then-spill capacity (#437) of every track-mode
+    /// space, keyed by id: how many windows its focused track
+    /// holds before a spawn spills into a new track. It is
+    /// geometry-derived (the space's display, `min_window_size`,
+    /// inner gap, axis), so it lives here and is mirrored into the
+    /// pure `StateCoordinator` before each event — spawn then reads
+    /// a plain Int and no geometry leaks into the state core. Empty
+    /// (skipped) when no space is in track mode, the common case.
+    func trackCapacities(
+        state: StateCoordinator
+    ) -> [SpaceID: Int] {
+        var caps: [SpaceID: Int] = [:]
+        for space in state.workspaces.allSpaces
+        where space.mode == .track {
+            caps[space.id] = trackCapacity(for: space, state: state)
+        }
+        return caps
+    }
+
+    /// One space's fill-then-spill capacity, laid out on its own
+    /// display (multi-monitor), for the spawn mirror and the
+    /// track-entry seed (#437). Works before the mode flips — it
+    /// reads only the usable area, min size, gap, and resolved
+    /// axis, none of which depend on the current partition.
+    func trackCapacity(
+        for space: Space,
+        state: StateCoordinator
+    ) -> Int {
+        // No display at all → unbounded (never spill), a safe
+        // fall back to join-and-pile.
+        guard let screen = Self.screen(for: space.id, in: state)
+        else { return .max }
+        let bounds = settings.layoutBounds(
+            from: GeometryUtils.axVisibleFrame(of: screen)
+        )
+        let context = settings.context(
+            bounds: bounds,
+            space: space,
+            sticky: []
+        )
+        return TrackLayout.trackCapacity(for: context)
+    }
+
     /// The `NSScreen` a space lays out on: its assigned display's
     /// screen, else the main screen.
     static func screen(

--- a/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
@@ -146,7 +146,7 @@ struct LayoutParamsCodingParityTests {
         params.axis = .horizontal
         params.autoTracks = false
         params.count = 4
-        params.newWindow = .focusedTrack
+        params.newWindow = .ownTrack
         params.newWindowPosition = .last
         params.overflowStyle = .cascadeOverflow
         params.wrapFocus = true

--- a/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
+++ b/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
@@ -154,7 +154,7 @@ struct SettingsCodingTests {
         // (#178), on by default; `count` is the remembered cap.
         #expect(track["auto_tracks"] as? Bool == true)
         #expect(track["count"] as? Int == 2)
-        #expect(track["new_window"] as? String == "own_track")
+        #expect(track["new_window"] as? String == "focused_track")
         #expect(track["wrap_focus"] as? Bool == false)
         // SpaceID-keyed maps encode as objects, not arrays.
         let gap = try object(root["gap"])

--- a/Tests/KiwiDeskCoreTests/TrackCommandsTests.swift
+++ b/Tests/KiwiDeskCoreTests/TrackCommandsTests.swift
@@ -241,6 +241,13 @@ struct TrackCommandsTests {
         let space = core.state.workspaces.space(
             of: WindowID(1)
         )!
+        // own_track so the seed is deterministic (one window per
+        // track); the default fill-then-spill would pack by display
+        // capacity (#437).
+        core.execute(
+            "track.set_new_window",
+            args: [.string("own_track")]
+        )
         #expect(
             core.execute(
                 "set_mode",
@@ -304,6 +311,11 @@ struct TrackCommandsTests {
         let space = core.state.workspaces.space(
             of: WindowID(1)
         )!
+        // own_track for a deterministic one-per-track seed (#437).
+        core.execute(
+            "track.set_new_window",
+            args: [.string("own_track")]
+        )
         core.execute(
             "set_mode",
             args: [.string(space.raw), .string("track")]
@@ -334,6 +346,12 @@ struct TrackCommandsTests {
                 )
             )
         }
+        // own_track so a traveler opens its own track (the
+        // fill-then-spill default would join-and-pile — #437).
+        core.execute(
+            "track.set_new_window",
+            args: [.string("own_track")]
+        )
         // Move 2 and 3 to space "2", switch it to track.
         core.state.workspaces.focus(WindowID(2), in: "1")
         core.execute("move_to_space", args: [.string("2")])
@@ -344,8 +362,8 @@ struct TrackCommandsTests {
             args: [.string("2"), .string("track")]
         )
         // Now move window 1 (focused in space 1) into space 2:
-        // with own_track default it must open its own track,
-        // not silently join the last one.
+        // under own_track it must open its own track, not silently
+        // join the last one.
         core.state.workspaces.focus(WindowID(1), in: "1")
         #expect(
             core.execute("move_to_space", args: [.string("2")])

--- a/Tests/KiwiDeskCoreTests/TrackNavigateTests.swift
+++ b/Tests/KiwiDeskCoreTests/TrackNavigateTests.swift
@@ -33,6 +33,13 @@ private func makeTrackSpace(
         )
     }
     let space = core.state.workspaces.space(of: WindowID(1))!
+    // own_track so mode-entry seeds one window per track — the
+    // multi-track fixture these tests exercise. #437 flipped the
+    // default to fill-then-spill, whose seed would pack them.
+    core.execute(
+        "track.set_new_window",
+        args: [.string("own_track")]
+    )
     core.execute(
         "set_mode",
         args: [.string(space.raw), .string("track")]

--- a/Tests/KiwiDeskCoreTests/TrackResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/TrackResizeTests.swift
@@ -30,6 +30,13 @@ private func makeTrackSpace(
         )
     }
     let space = core.state.workspaces.space(of: WindowID(1))!
+    // own_track so mode-entry seeds one window per track — the
+    // multi-track fixture these tests exercise. #437 flipped the
+    // default to fill-then-spill, whose seed would pack them.
+    core.execute(
+        "track.set_new_window",
+        args: [.string("own_track")]
+    )
     core.execute(
         "set_mode",
         args: [.string(space.raw), .string("track")]

--- a/Tests/KiwiDeskCoreTests/TrackSpillTests.swift
+++ b/Tests/KiwiDeskCoreTests/TrackSpillTests.swift
@@ -1,0 +1,214 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Fill-then-spill spawning for the `focused_track` default
+/// (#437): a new window fills the focused track until it can't fit
+/// another at min size, then spills into a new track beside it;
+/// the pile survives only as the no-alternative fallback.
+private func ids(_ n: Int) -> [WindowID] {
+    (1...n).map { WindowID(UInt32($0)) }
+}
+
+private let allTiled: @Sendable (WindowID) -> Bool = { _ in true }
+
+private let zeroGaps = Gaps(
+    outer: Gaps.Outer(top: 0, bottom: 0, left: 0, right: 0),
+    inner: Gaps.Inner(horizontal: 0, vertical: 0)
+)
+
+@Suite("Track fill-then-spill (#437)")
+struct TrackSpillTests {
+    // MARK: Capacity & seed (pure geometry)
+
+    @Test("Capacity is fitCap on the in-track axis")
+    func capacityPicksInTrackAxis() {
+        // A vertical track (column) stacks down the height; a
+        // horizontal track (row) runs along the width. Zero gaps,
+        // min 200: height 600 → 3, width 1200 → 6.
+        var vTrack = TrackParams()
+        vTrack.axis = .vertical
+        let vertical = LayoutContext(
+            bounds: CGRect(x: 0, y: 0, width: 1200, height: 600),
+            gaps: zeroGaps,
+            minWindowSize: 200,
+            track: vTrack
+        )
+        #expect(TrackLayout.trackCapacity(for: vertical) == 3)
+
+        var hTrack = TrackParams()
+        hTrack.axis = .horizontal
+        let horizontal = LayoutContext(
+            bounds: CGRect(x: 0, y: 0, width: 1200, height: 600),
+            gaps: zeroGaps,
+            minWindowSize: 200,
+            track: hTrack
+        )
+        #expect(TrackLayout.trackCapacity(for: horizontal) == 6)
+    }
+
+    @Test("No minimum makes the track unbounded (never spills)")
+    func capacityUnboundedWithoutMinimum() {
+        let context = LayoutContext(
+            bounds: CGRect(x: 0, y: 0, width: 1200, height: 600),
+            gaps: zeroGaps,
+            minWindowSize: 0
+        )
+        #expect(TrackLayout.trackCapacity(for: context) == .max)
+    }
+
+    @Test("fillSeed packs the tiled list into tracks of capacity")
+    func fillSeedPacks() {
+        let w = ids(5)
+        // Capacity 2 → breaks at 0, 2, 4: [w0 w1][w2 w3][w4].
+        #expect(
+            TrackLayout.fillSeed(tiled: w, capacity: 2)
+                == Set([w[0], w[2], w[4]])
+        )
+    }
+
+    @Test("A capacity past the count seeds one track")
+    func fillSeedSingleTrack() {
+        let w = ids(3)
+        #expect(
+            TrackLayout.fillSeed(tiled: w, capacity: 9) == [w[0]]
+        )
+    }
+
+    // MARK: Spill on spawn (pure state)
+
+    @Test("Fills the focused track, then spills a new one")
+    func fillsThenSpills() {
+        let w = ids(3)
+        var space = Space(
+            id: "1",
+            mode: .track,
+            windows: [w[0]],
+            focused: w[0],
+            trackBreaks: [w[0]]
+        )
+        // Capacity 2, track holds 1 < 2 → w1 joins.
+        space.insertIntoTrack(
+            w[1],
+            rule: .focusedTrack,
+            position: .last,
+            spillCapacity: 2,
+            trackCap: 0,
+            isTiled: allTiled
+        )
+        space.focused = w[1]
+        #expect(space.trackBreaks == [w[0]])
+        // Track now holds 2 >= 2 → w2 spills into a NEW track.
+        space.insertIntoTrack(
+            w[2],
+            rule: .focusedTrack,
+            position: .last,
+            spillCapacity: 2,
+            trackCap: 0,
+            isTiled: allTiled
+        )
+        #expect(space.windows == [w[0], w[1], w[2]])
+        #expect(space.trackBreaks == [w[0], w[2]])
+    }
+
+    @Test("After a spill the new track fills next (recursion)")
+    func spillRecursion() {
+        let w = ids(4)
+        var space = Space(
+            id: "1",
+            mode: .track,
+            windows: [w[0], w[1]],
+            focused: w[1],
+            trackBreaks: [w[0]]
+        )
+        // Full track (2 >= 2) → w2 spills; focus follows it.
+        space.insertIntoTrack(
+            w[2],
+            rule: .focusedTrack,
+            position: .last,
+            spillCapacity: 2,
+            trackCap: 0,
+            isTiled: allTiled
+        )
+        space.focused = w[2]
+        #expect(space.trackBreaks == [w[0], w[2]])
+        // The new track holds 1 < 2 → w3 fills it, no spill.
+        space.insertIntoTrack(
+            w[3],
+            rule: .focusedTrack,
+            position: .last,
+            spillCapacity: 2,
+            trackCap: 0,
+            isTiled: allTiled
+        )
+        #expect(space.windows == [w[0], w[1], w[2], w[3]])
+        #expect(space.trackBreaks == [w[0], w[2]])
+    }
+
+    @Test("A fixed cap with no room piles instead of spilling")
+    func fixedCapPiles() {
+        let w = ids(3)
+        var space = Space(
+            id: "1",
+            mode: .track,
+            windows: [w[0], w[1]],
+            focused: w[1],
+            trackBreaks: [w[0]]
+        )
+        // Track full (2 >= 2) but trackCap 1 leaves no room for a
+        // new track → w2 joins and piles in the focused track.
+        space.insertIntoTrack(
+            w[2],
+            rule: .focusedTrack,
+            position: .last,
+            spillCapacity: 2,
+            trackCap: 1,
+            isTiled: allTiled
+        )
+        #expect(space.windows == [w[0], w[1], w[2]])
+        #expect(space.trackBreaks == [w[0]])
+    }
+
+    @Test("A traveler (nil capacity) always joins, never spills")
+    func nilCapacityJoins() {
+        let w = ids(3)
+        var space = Space(
+            id: "1",
+            mode: .track,
+            windows: [w[0], w[1]],
+            focused: w[1],
+            trackBreaks: [w[0]]
+        )
+        // No spill capacity → the explicit placement joins and
+        // piles, however full the track is.
+        space.insertIntoTrack(
+            w[2],
+            rule: .focusedTrack,
+            position: .last,
+            spillCapacity: nil,
+            trackCap: 0,
+            isTiled: allTiled
+        )
+        #expect(space.trackBreaks == [w[0]])
+    }
+
+    // MARK: Mode-entry seed
+
+    @Test("Entering track uses the caller's fill-then-spill seed")
+    func setModeUsesProvidedSeed() {
+        var manager = WorkspaceManager()
+        manager.ensureSpace("1")
+        let w = ids(4)
+        for id in w { manager.add(id, to: "1") }
+        // The KiwiCore layer packs the seed with the display
+        // capacity; here it is passed directly (capacity 2).
+        manager.setMode(
+            "1",
+            .track,
+            trackSeed: TrackLayout.fillSeed(tiled: w, capacity: 2)
+        )
+        #expect(manager["1"]?.trackBreaks == [w[0], w[2]])
+    }
+}

--- a/Tests/KiwiDeskCoreTests/TrackStateTests.swift
+++ b/Tests/KiwiDeskCoreTests/TrackStateTests.swift
@@ -255,6 +255,7 @@ struct TrackSpawnTests {
     func spawnOwnTrack() {
         var state = StateCoordinator(defaultSpace: "1")
         state.workspaces.setMode("1", .track)
+        state.trackParams.newWindow = .ownTrack
         // after_focused keeps a stable left-to-right order for
         // this partition assertion (the default `first` would
         // reverse it — covered by its own test below).
@@ -284,6 +285,7 @@ struct TrackSpawnTests {
     func spawnHonorsOverride() {
         var state = StateCoordinator(defaultSpace: "1")
         state.workspaces.setMode("1", .track)
+        state.trackParams.newWindow = .ownTrack
         state.trackParams.newWindowPosition = .afterFocused
         var over = TrackOverride()
         // A fixed cap needs automatic off (#178); count alone is

--- a/Tests/KiwiDeskCoreTests/TrackSwapTests.swift
+++ b/Tests/KiwiDeskCoreTests/TrackSwapTests.swift
@@ -32,6 +32,13 @@ private func makeTrackSpace(
         )
     }
     let space = core.state.workspaces.space(of: WindowID(1))!
+    // own_track so mode-entry seeds one window per track — the
+    // multi-track fixture these tests exercise. #437 flipped the
+    // default to fill-then-spill, whose seed would pack them.
+    core.execute(
+        "track.set_new_window",
+        args: [.string("own_track")]
+    )
     core.execute(
         "set_mode",
         args: [.string(space.raw), .string("track")]

--- a/Tests/KiwiDeskCoreTests/ZOrderScheduleTests.swift
+++ b/Tests/KiwiDeskCoreTests/ZOrderScheduleTests.swift
@@ -160,6 +160,13 @@ struct ZOrderScheduleTests {
     func trackSwapSchedulesRestore() {
         let core = makeCore()
         let space = makeSpace(core, windows: 8)
+        // own_track seeds eight separate markers so the cap below
+        // folds them all into one pile; fill-then-spill (#437, the
+        // default) would pack them by display capacity instead.
+        _ = core.execute(
+            "track.set_new_window",
+            args: [.string("own_track")]
+        )
         setMode(core, space, "track")
         // Cap the space to one track: all eight windows pile into
         // it and cascade (cascade_all default), so a swap scrambles

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -370,8 +370,43 @@ and simply falls into the overflow track's slice at render time.
 `cascade_all`); every normal track's own overflow is always
 `cascade_overflow`. An earlier "overflow-aware spawn" idea —
 shifting windows into a new track at spawn based on available
-space — was rejected for putting geometry into state (it would
-make spawn outcomes monitor-dependent and non-deterministic).
+space — was rejected here for putting geometry into state (it
+would make spawn outcomes monitor-dependent and
+non-deterministic). **This was deliberately revisited for the
+`focused_track` default — see the next entry.**
+
+**Fill-then-spill is the track default; the spawn-geometry ban is
+relaxed for it (#437, 2026-07-23):** `focused_track` — now the
+default (`own_track` demoted to the ultrawide "one app per column"
+opt-in) — fills the focused track and, when it can't fit another
+window at `min_window_size`, spills the next window into a new
+track beside it (focus follows, so the recursion needs no
+special-casing). The unbounded within-track pile the old
+`focused_track` produced was never a chosen feature — it was the
+overflow fallback moonlighting as primary behavior. Getting the
+shelf-like "fill the column you're at first" feel **requires**
+the geometry #192 kept out of spawn: the spill boundary is "how
+many fit at `min_window_size`," a display-dependent count. So the
+ban is relaxed *for this one decision*, with the cost #192 named
+accepted: spawn outcomes are monitor-dependent (a set of windows
+packs into fewer tracks on a larger display, and moving to a
+bigger display does not un-spill an already-spilled window). The
+containment that keeps it honest: the geometry is computed only
+where it already lives (`TilingEngine.trackCapacity`, the same
+`fitCap` the render piles by) and **mirrored into the pure state
+core as a plain per-space `Int`** (`StateCoordinator.trackCapacities`,
+like `trackParams`), so `Space.insertIntoTrack` stays a pure
+function of the flat array plus that number — no `LayoutContext`
+reaches the state layer. The pile survives only as the
+no-alternative fallback (a fixed `count` cap with no room, or a
+`move_to_space` traveler an explicit placement mustn't relocate),
+so it never contradicts the spill. Entering track mode seeds the
+same way: `focused_track` packs the existing windows into filled
+tracks (`TrackLayout.fillSeed`), `own_track` gives each its own —
+the seed mirrors what incoming windows would do. Navigation and
+the overflow-pile classification are unchanged (the pile is still
+the array-order Track model's fallback), so the table above keeps
+its Track row as-is.
 
 ### Layout and resize behavior
 

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1264,21 +1264,38 @@ track.set_auto_tracks(false)
 
 ### track.set_new_window
 
-**Expects:** `"own_track"` (default) or `"focused_track"`.
+**Expects:** `"focused_track"` (default) or `"own_track"`.
 
-**Does:** decides whether a new window opens its **own** new
-track or **joins** the focused window's track. Where within that
-choice it lands is the separate
-[`track.set_new_window_position`](#track_set_new_window_position).
-`own_track` falls back to joining once `track.set_count` is
-reached. Track spaces use this pair instead of the flat
+**Does:** decides where a new window lands in a track space.
+
+- `focused_track` (**fill-then-spill**, the default): the window
+  **joins** the focused window's track — placed among its windows
+  by [`track.set_new_window_position`](#track_set_new_window_position)
+  — until that track can't fit another window at
+  `min_window_size`, when the window instead **spills into a new
+  track** immediately beside the focused one. Focus follows the
+  new window, so the next one fills that track and spills again.
+  With no other track to spill to it piles in the focused track
+  instead: under a fixed [`track.set_count`](#track_set_count) cap
+  with no room for another track, or for a window an explicit
+  `move_to_space` drops onto a full track (an explicit placement,
+  never relocated).
+- `own_track`: each new window opens its **own** new track,
+  positioned among the others by
+  [`track.set_new_window_position`](#track_set_new_window_position)
+  — the "one full-width app per column" (ultrawide) choice. Falls
+  back to joining once `track.set_count` is reached.
+
+Track spaces use this pair instead of the flat
 `new_window_placement` vocabulary — a flat index cannot say "own
-track".
+track". The fill-then-spill boundary is display-dependent (how
+many windows fit at `min_window_size`), so the same window count
+spills sooner on a smaller display.
 
 **Example:**
 
 ```lua
-track.set_new_window("focused_track")
+track.set_new_window("own_track")
 ```
 
 ### track.set_new_window_position

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -462,12 +462,16 @@ Adjust each mode's defaults:
 - **Track**: a somewhat more advanced layout (a caption at the
   top of the section says so) where several windows can share
   one track. **Arrange** (Columns = tracks side by side, Rows =
-  tracks stacked); **New window** — whether it opens its own
-  track or
-  joins the focused one — with a **Position** picker for where
-  within that choice it lands (first, last, before or after the
-  focused track/window; defaults to **first** so a new window
-  isn't buried in the overflow); **Automatic tracks** (on by
+  tracks stacked); **New window** — **Fills the focused track**
+  (the default) fills the track you're in and spills the next
+  window into a new track beside it once it's full (shelf-like:
+  fill the column you're at before reaching for a new one), while
+  **Opens its own track** gives every new window its own column
+  (the ultrawide "one app per column" choice) — with a
+  **Position** picker for where within that choice it lands (first,
+  last, before or after the focused track/window; defaults to
+  **first** so a new window isn't buried in the overflow);
+  **Automatic tracks** (on by
   default — tracks open and collapse as windows come and go;
   turn it off to pin a fixed **Track limit**, which greys out
   while automatic is on — the limit counts *normal* tracks, so a


### PR DESCRIPTION
Fixes #437.

## What

Redefines the track layout's `focused_track` new-window rule as **fill-then-spill** and makes it the **default**; demotes `own_track` to the ultrawide "one app per column" opt-in.

A new window joins the focused track until it can't fit another at `min_window_size`, then **spills into a new track** beside the focused one. Focus follows the new window, so the next one fills that track and spills again — the recursion needs no special-casing. The within-track pile survives only as the no-alternative fallback:
- a fixed `track.set_count` cap with no room for another track, or
- a `move_to_space` traveler (an explicit placement, never relocated → `spillCapacity: nil`).

## The architectural call

Fill-then-spill needs the "how many fit at min size" count that #192 deliberately kept out of spawn. This PR relaxes that ban **for this default only**, with the cost #192 named accepted (monitor-dependent spawn; a bigger display packs into fewer tracks and doesn't un-spill). `docs/design-decisions.md` records the reversal.

The containment that keeps the state core pure:
- geometry is computed only in `TilingEngine.trackCapacity` (the same `fitCap` the render piles by),
- **mirrored into the pure `StateCoordinator` as a per-space `Int`** (`trackCapacities`, like `trackParams`), populated only on `.windowCreated`,
- so `Space.insertIntoTrack` stays a pure function of the flat array + that Int. No `LayoutContext`/`NSScreen` reaches the state/layout-pure layers.

Entering track mode seeds the same way: `focused_track` packs existing windows into filled tracks (`TrackLayout.fillSeed`), `own_track` gives each its own — all `set_mode` paths route through one `KiwiCore.setSpaceMode` choke point.

## Verify

`swift build && swift test && scripts/lint.sh` and `swift build -c release` all pass (the lone full-suite failure is the known `SpaceBarDropCoordinator` async flake — passes in isolation, unrelated).

New `TrackSpillTests` cover capacity, the seed, the spill, the fixed-cap and traveler pile fallbacks, and the recursion; existing track tests updated for the flipped default.

Reviewed by `code-reviewer` + `architect-reviewer` (no correctness findings; copy/comment polish applied).

## QA notes

Exercise a track space through **spawn** (fill one track, watch it spill into a new one), **move_to_space** (traveler joins-and-piles, no spill), and **cap overflow** (fixed `count` with no room piles). Docs: `lua-reference` (`track.set_new_window`), `user-guide`, `design-decisions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)