### PR TITLE
fix(space-bar): symmetric front divider + pin front app on scroll (#409)

### DIFF
--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+BoxGlass.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+BoxGlass.swift
@@ -85,8 +85,13 @@ extension SpaceBarOverlay {
             return
         }
         frontGlass = glass
-        if glass.superview !== itemContainer {
-            itemContainer.addSubview(
+        // Follow the loose front views to their host (#409): the
+        // clipping viewport as the run's tail, or the panel content
+        // while pinned. Kept just below the divider so the segment's
+        // real views paint over the frosted backdrop.
+        let host = frontHost ?? itemContainer
+        if glass.superview !== host {
+            host.addSubview(
                 glass,
                 positioned: .below,
                 relativeTo: frontDivider
@@ -94,7 +99,8 @@ extension SpaceBarOverlay {
             // A backdrop glass renders flat without a contentView;
             // a throwaway empty view makes it frost as true glass,
             // and the segment's real views paint over it (they sit
-            // above in z, laid out in `itemContainer`).
+            // above in z, in the same `frontHost` — the viewport, or
+            // the panel content while pinned, #409).
             GlassPlate.setContent(glass, NSView())
         }
         glass.isHidden = false

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
@@ -12,7 +12,7 @@ extension SpaceBarOverlay {
         _ app: SpaceBarItemView.App?,
         after cursor: CGFloat,
         strip: CGRect,
-        viewport: CGFloat,
+        nameBound: CGFloat,
         style: SpaceBarStyle,
         horizontal: Bool
     ) {
@@ -50,7 +50,7 @@ extension SpaceBarOverlay {
             app,
             at: offset,
             depth: depth,
-            viewport: viewport,
+            viewport: nameBound,
             horizontal: horizontal,
             accent: accent,
             style: style
@@ -149,8 +149,14 @@ extension SpaceBarOverlay {
         guard let app else { return 0 }
         let pad = SpaceBarItemView.pad
         let cell = max(depth - pad * 2, 8)
+        // Mirror the placement (#409): leading gap, rule, symmetric
+        // `boxGap` right gap, glyph cell, plus the chip's `pad`
+        // inset each side — which also reserves the pinned band.
+        let chip = style.hasBox || wantsBoxGlass(style)
+        let inset = chip ? pad : 0
         var extent =
-            style.boxGap + BarDivider.sectionThickness + pad + cell
+            style.boxGap + BarDivider.sectionThickness
+            + style.boxGap + inset + cell + inset
         if horizontal {
             extent += pad
             let size =
@@ -171,12 +177,14 @@ extension SpaceBarOverlay {
     }
 
     private func attachFrontViewsIfNeeded() {
-        // The segment lives inside the clipping viewport so it
-        // scrolls (and clips) with the items — the tail of one
-        // run (#385). Re-added every render so it stays ABOVE item
-        // views created later (`syncItemViewCount` appends on
-        // top) — otherwise a long item row paints over it.
-        let content = itemContainer
+        // The segment hosts in the clipping viewport (run tail) or,
+        // while pinned, in the panel content outside it (#409) — see
+        // `frontHost`. Re-added every render so it stays ABOVE item
+        // views created later (`syncItemViewCount` appends on top,
+        // and pinned it must sit over the plate) — otherwise a long
+        // item row paints over it. Moving hosts also detaches it
+        // from the previous parent (a plain `addSubview` reparents).
+        let content = frontHost ?? itemContainer
         // frontBox first so it lands beneath the divider/glyph/
         // name added above it — the box is the chip behind them.
         for view in [
@@ -215,7 +223,14 @@ extension SpaceBarOverlay {
             thickness: BarDivider.sectionThickness,
             fullDepth: true
         )
-        return BarDivider.sectionThickness + SpaceBarItemView.pad
+        // Symmetric gap (#409): `boxGap` on the rule's right to
+        // match the `boxGap` the run cursor already left on its
+        // left. Under a chip (Boxed / per-box glass) the content is
+        // `pad`-inset, so the chip EDGE lands `boxGap` out; Plain
+        // has no chip, so the bare glyph sits `boxGap` out.
+        let chip = style.hasBox || wantsBoxGlass(style)
+        return BarDivider.sectionThickness + style.boxGap
+            + (chip ? SpaceBarItemView.pad : 0)
     }
 
     /// The focused app's glyph (App Font ligature or image);

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Metrics.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Metrics.swift
@@ -181,19 +181,22 @@ extension SpaceBarOverlay {
         at local: CGPoint,
         strip: CGRect,
         inset: CGFloat,
+        trailingAxis: CGFloat,
         horizontal: Bool
     ) -> ScrollArrow? {
         guard inset > 0 else { return nil }
         let axisPos = horizontal ? local.x : local.y
-        let axisLen = horizontal ? strip.width : strip.height
         let crossPos = horizontal ? local.y : local.x
         let crossLen = horizontal ? strip.height : strip.width
+        // The forward zone ends at `trailingAxis` — the Spaces
+        // region's trailing edge — not the strip rim, so a point in
+        // the pinned front band past it is not a scroll zone (#409).
         guard crossPos >= 0, crossPos <= crossLen,
-            axisPos >= 0, axisPos <= axisLen
+            axisPos >= 0, axisPos <= trailingAxis
         else { return nil }
         let zone = BarArrowView.zone
         if axisPos < zone { return .back }
-        if axisPos > axisLen - zone { return .forward }
+        if axisPos > trailingAxis - zone { return .forward }
         return nil
     }
 }

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Panel.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Panel.swift
@@ -128,6 +128,7 @@ extension SpaceBarOverlay {
         frames: [CGRect],
         viewport: CGRect,
         plateFrame: CGRect,
+        pinnedFront: Bool,
         style: SpaceBarStyle,
         depth: CGFloat
     ) {
@@ -144,6 +145,7 @@ extension SpaceBarOverlay {
                 viewport: viewport,
                 plateFrame: plateFrame,
                 overflow: mode == .plainGlassSpan,
+                pinnedFront: pinnedFront,
                 style: style,
                 depth: depth
             )

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+PlainGlass.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+PlainGlass.swift
@@ -12,6 +12,7 @@ extension SpaceBarOverlay {
         viewport: CGRect,
         plateFrame: CGRect,
         overflow: Bool,
+        pinnedFront: Bool,
         style: SpaceBarStyle,
         depth: CGFloat
     ) {
@@ -28,7 +29,22 @@ extension SpaceBarOverlay {
         }
         plate.isHidden = false
         let radius = style.resolvedCornerRadius(forThickness: depth)
-        if overflow {
+        if overflow && pinnedFront {
+            // The front segment is pinned OUTSIDE the scrolling
+            // viewport (#409), so the plate can't just host the item
+            // viewport — it would leave the pinned app on bare panel.
+            // Span the whole strip as a frosted backdrop under BOTH
+            // the scrolling items and the pinned segment (siblings
+            // above it), so the app sits on one continuous plate.
+            spanBackdrop(
+                plate: plate,
+                content: content,
+                viewport: viewport,
+                plateFrame: plateFrame,
+                radius: radius,
+                style: style
+            )
+        } else if overflow {
             spanViewport(
                 plate: plate,
                 viewport: viewport,
@@ -79,6 +95,54 @@ extension SpaceBarOverlay {
         applyPlateTint(
             plate: plate,
             frame: viewport,
+            radius: radius,
+            hex: style.fillColor
+        )
+    }
+
+    /// Pinned overflow (#409): the plate spans the WHOLE strip as a
+    /// frosted backdrop (empty content frosts as true glass — the
+    /// `frontGlass` precedent), sitting below both the scrolling
+    /// item viewport and the pinned front segment (siblings above
+    /// it), so the pinned app rides one continuous plate instead of
+    /// bare panel. It does NOT host the items: a hosted view is
+    /// auto-sized to the glass bounds, which would break the scroll
+    /// clip. The items keep their own `itemContainer`.
+    private func spanBackdrop(
+        plate: NSView,
+        content: NSView,
+        viewport: CGRect,
+        plateFrame: CGRect,
+        radius: CGFloat,
+        style: SpaceBarStyle
+    ) {
+        returnRunToContainer()
+        // Release the item viewport back to a plain sibling if a
+        // prior render hosted it (leaving span/hug hosting).
+        if GlassPlate.holds(plate, itemContainer) {
+            GlassPlate.detach(plate)
+            content.addSubview(
+                itemContainer,
+                positioned: .below,
+                relativeTo: backArrow
+            )
+            itemContainer.frame = viewport
+        }
+        GlassPlate.setContent(plate, glassBackdropFiller)
+        content.addSubview(
+            plate,
+            positioned: .below,
+            relativeTo: itemContainer
+        )
+        GlassPlate.update(
+            plate,
+            frame: plateFrame,
+            cornerRadius: radius,
+            tintHex: style.fillColor
+        )
+        applyPlateTint(
+            plate: plate,
+            frame: plateFrame,
             radius: radius,
             hex: style.fillColor
         )

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Render.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Render.swift
@@ -1,0 +1,233 @@
+import AppKit
+
+/// The Space Bar's one layout pass. Split from `SpaceBarOverlay`
+/// for file size (§2): the stored views/state and the show/hide
+/// surface stay in the main file; the render composition — item
+/// run, scroll viewport, the pinned front segment (#409), the
+/// glass hosting, and the arrows — lives here.
+extension SpaceBarOverlay {
+    /// One layout pass over the last shown state. `show()`
+    /// follows the active Space into view; a manual arrow or
+    /// autoscroll re-renders without that adjustment so it isn't
+    /// snapped straight back (the App Bar's `followingFocus`).
+    func render(followingActive: Bool) {
+        guard let state = lastShown else { return }
+        let (items, frontApp, strip, style, stateMarkColors) = state
+        let panel = self.panel ?? makePanel()
+        self.panel = panel
+        styleContainer(panel, style: style, strip: strip)
+        syncItemViewCount(items.count)
+        let horizontal = style.edge.isHorizontal
+        let depth = horizontal ? strip.height : strip.width
+        let axis = horizontal ? strip.width : strip.height
+        let gap = style.boxGap
+        let lengths = items.map { item in
+            style.boxSize > 0
+                ? style.boxSize
+                : SpaceBarItemView.autoLength(
+                    appCount: item.apps.count,
+                    overflow: item.overflow,
+                    depth: depth
+                )
+        }
+        // While the whole run fits, items plus the trailing front
+        // segment align as ONE run (an end-aligned bar ends at the
+        // rim including the segment) — the segment is the run's
+        // tail, unchanged. When the run OVERFLOWS, the segment is
+        // pinned to the trailing rim in a fixed band and only the
+        // Spaces scroll behind the arrows (#409), so the front app
+        // never scrolls out of view. The overflow threshold still
+        // weighs items + segment together, so the bar starts
+        // scrolling at exactly the same width as before.
+        let front = frontExtent(
+            frontApp,
+            depth: depth,
+            horizontal: horizontal,
+            style: style
+        )
+        let total = Self.runTotal(
+            lengths: lengths,
+            gap: gap,
+            frontExtent: front
+        )
+        // Pin only when the trailing band still leaves the Spaces a
+        // real viewport (room for both arrow zones); a pathological
+        // near-full-width app name falls back to scrolling with the
+        // run rather than collapsing the Spaces to nothing.
+        let arrowRoom = 2 * (BarArrowView.zone + gap)
+        let pinFront =
+            total > axis && frontApp != nil
+            && front < axis - arrowRoom
+        // Pinned: the segment owns the trailing `front` band, so the
+        // Spaces scroll in the axis that remains and the segment
+        // leaves the scrolled run. Not pinned: the segment rides the
+        // run as its tail, exactly as before.
+        let scrolledFront = pinFront ? 0 : front
+        let spacesAxis = pinFront ? axis - front : axis
+        let scrolledTotal = Self.runTotal(
+            lengths: lengths,
+            gap: gap,
+            frontExtent: scrolledFront
+        )
+        let (inset, viewport) = Self.scrollViewport(
+            axis: spacesAxis,
+            total: scrolledTotal,
+            gap: gap
+        )
+        scrollOffset = Self.scrollOffset(
+            current: scrollOffset,
+            lengths: lengths,
+            gap: gap,
+            frontExtent: scrolledFront,
+            activeIndex: followingActive ? activeIndex(items) : nil,
+            viewport: viewport,
+            margin: gap
+        )
+        let viewportRect = placeItemContainer(
+            inset: inset,
+            viewport: viewport,
+            strip: strip,
+            horizontal: horizontal
+        )
+        let metrics = Self.runMetrics(
+            lengths: lengths,
+            gap: gap,
+            frontExtent: scrolledFront,
+            strip: strip,
+            viewport: viewport,
+            horizontal: horizontal,
+            alignment: style.alignment,
+            pad: SpaceBarItemView.pad,
+            scrollOffset: scrollOffset
+        )
+        // The shared plate (plain fill / glass) hugs or spans
+        // per `tab_background_fit`. With no arrow inset the
+        // viewport is the strip, so viewport-local run
+        // coordinates are already strip-local; while inset > 0
+        // the plate is full anyway.
+        let runStart: CGFloat
+        if let first = metrics.itemFrames.first {
+            runStart = horizontal ? first.minX : first.minY
+        } else {
+            runStart = metrics.frontStart
+        }
+        // A pinned segment (#409) means the run fills the strip
+        // (Spaces + arrows + segment), so the shared plate spans it
+        // — nothing to hug, and the pinned segment must sit on the
+        // same continuous plate as the Spaces.
+        let plateFrame =
+            pinFront
+            ? CGRect(
+                x: 0,
+                y: 0,
+                width: strip.width,
+                height: strip.height
+            )
+            : BarPlate.frame(
+                strip: strip,
+                runStart: runStart,
+                runTotal: total,
+                inset: inset,
+                gap: gap,
+                horizontal: horizontal,
+                fit: style.tabBackgroundFit
+            )
+        // The one hosting mode for this render (#407): prepared
+        // (non-target teardown) here, then installed post-passes
+        // once the item frames are laid out.
+        let hosting = glassHosting(style, overflow: inset > 0)
+        prepareGlassHosting(
+            hosting,
+            panel: panel,
+            style: style,
+            strip: strip,
+            plateFrame: plateFrame,
+            viewport: viewportRect
+        )
+        recordHitFrames(
+            items: items,
+            frames: metrics.itemFrames,
+            strip: strip
+        )
+        for (index, item) in items.enumerated() {
+            let view = itemViews[index]
+            view.frame = metrics.itemFrames[index]
+            view.configure(
+                space: item.space,
+                spaceGlyph: item.spaceGlyph,
+                apps: item.apps,
+                active: item.active,
+                horizontal: horizontal,
+                style: style,
+                stateMarkColors: stateMarkColors,
+                overflow: item.overflow,
+                focusInOverflow: item.focusInOverflow
+            )
+            view.onSelect = { [weak self] space in
+                self?.onSelect(space)
+            }
+            // Only the run's outer items meet a rounded plate end.
+            // The trailing end is the front-app segment's when one
+            // trails, so the last Space item clips its trailing
+            // corner only without a front app.
+            view.isFirstInRun = index == 0
+            view.isLastInRun =
+                index == items.count - 1 && frontApp == nil
+        }
+        // Host the segment in the panel content (outside the
+        // clipping viewport) while pinned, so it stays put as the
+        // Spaces scroll; in the viewport as the run's tail while it
+        // fits. Pinned, its divider sits one `gap` past where the
+        // forward arrow ends (`spacesAxis`), mirroring the run-tail
+        // spacing; the name may still reach the strip rim.
+        frontHost = pinFront ? panel.contentView : itemContainer
+        renderFrontSegment(
+            frontApp,
+            after: pinFront ? spacesAxis + gap : metrics.frontStart,
+            strip: strip,
+            nameBound: pinFront ? axis : viewport,
+            style: style,
+            horizontal: horizontal
+        )
+        // Install the target hosting from the now-laid-out item
+        // frames (per-box glass and the plain-glass run both position
+        // from them, so this runs after the item + front passes).
+        // #407: one dispatch, no per-mode branching at the call site.
+        installGlassHosting(
+            hosting,
+            panel: panel,
+            frames: metrics.itemFrames,
+            viewport: viewportRect,
+            plateFrame: plateFrame,
+            pinnedFront: pinFront,
+            style: style,
+            depth: horizontal ? strip.height : strip.width
+        )
+        layoutArrows(
+            strip: strip,
+            inset: inset,
+            viewport: viewport,
+            total: scrolledTotal,
+            trailingAxis: spacesAxis,
+            lengths: lengths,
+            gap: gap,
+            horizontal: horizontal,
+            style: style
+        )
+        panel.setFrame(
+            GeometryUtils.flip(
+                strip,
+                primaryHeight: GeometryUtils.primaryHeight
+            ),
+            display: true
+        )
+        if !panel.isVisible {
+            panel.orderFrontRegardless()
+        }
+    }
+
+    /// The index of the active Space, for scroll-follow.
+    private func activeIndex(_ items: [Item]) -> Int? {
+        items.firstIndex(where: \.active)
+    }
+}

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Scroll.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Scroll.swift
@@ -21,6 +21,11 @@ extension SpaceBarOverlay {
         let step: CGFloat
         /// The largest valid scroll offset (`total − viewport`).
         let maxOffset: CGFloat
+        /// The Spaces region's trailing edge along the axis (#409):
+        /// the strip length, or `strip − front band` while the front
+        /// segment is pinned. The forward arrow sits one zone inside
+        /// it, and `arrowHit` bounds the forward zone by it.
+        let trailingAxis: CGFloat
     }
 
     /// Quiet dwell over an arrow before the first autoscroll tick,
@@ -40,6 +45,7 @@ extension SpaceBarOverlay {
         inset: CGFloat,
         viewport: CGFloat,
         total: CGFloat,
+        trailingAxis: CGFloat,
         lengths: [CGFloat],
         gap: CGFloat,
         horizontal: Bool,
@@ -55,17 +61,20 @@ extension SpaceBarOverlay {
             horizontal
             ? CGRect(x: 0, y: 0, width: zone, height: strip.height)
             : CGRect(x: 0, y: 0, width: strip.width, height: zone)
+        // The forward arrow sits at the Spaces region's trailing
+        // edge — the strip rim, or one front band in while the front
+        // segment is pinned there (#409).
         forwardArrow.frame =
             horizontal
             ? CGRect(
-                x: strip.width - zone,
+                x: trailingAxis - zone,
                 y: 0,
                 width: zone,
                 height: strip.height
             )
             : CGRect(
                 x: 0,
-                y: strip.height - zone,
+                y: trailingAxis - zone,
                 width: strip.width,
                 height: zone
             )
@@ -96,7 +105,8 @@ extension SpaceBarOverlay {
             inset: inset,
             horizontal: horizontal,
             step: step,
-            maxOffset: maxOffset
+            maxOffset: maxOffset,
+            trailingAxis: trailingAxis
         )
     }
 
@@ -133,6 +143,7 @@ extension SpaceBarOverlay {
             at: local,
             strip: geom.strip,
             inset: geom.inset,
+            trailingAxis: geom.trailingAxis,
             horizontal: geom.horizontal
         )
         // Only a direction that still has hidden items counts —

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
@@ -28,7 +28,9 @@ public final class SpaceBarOverlay {
     /// Click-to-focus hook; wired to `KiwiCore.focusSpace`.
     public var onSelect: @MainActor (SpaceID) -> Void = { _ in }
 
-    private var panel: NSPanel?
+    // Internal (not private): `render()` in the +Render extension
+    // reads and lazily creates the panel.
+    var panel: NSPanel?
     var itemViews: [SpaceBarItemView] = []
     /// The clipping item viewport (#385): items and the trailing
     /// front segment render inside it, inset by an arrow zone at
@@ -38,6 +40,15 @@ public final class SpaceBarOverlay {
     let itemContainer = AppBarOverlay.FlippedView()
     let backArrow = BarArrowView()
     let forwardArrow = BarArrowView()
+    /// Where the front-app segment's views (and its glass backdrop)
+    /// are hosted this render (#409): `itemContainer` while the run
+    /// fits, so the segment is the run's tail as before; the panel
+    /// content (outside the clipping viewport) while the run
+    /// overflows, so the segment stays pinned to the trailing rim
+    /// while only the Spaces scroll behind the arrows. Set by
+    /// `render()` before the front pass; read by
+    /// `attachFrontViewsIfNeeded` and `updateFrontGlass`.
+    weak var frontHost: NSView?
     /// The Liquid Glass plate under the items when `tabBackground`
     /// resolves to `material` (#390); nil otherwise / below macOS
     /// 26. Stored as a plain view — the concrete type is 26-only.
@@ -58,6 +69,12 @@ public final class SpaceBarOverlay {
     var frontTint: NSView?
     /// Colored backdrop behind the single glass plate (#408).
     var glassTint: NSView?
+    /// Throwaway content view that turns the shared plate into a
+    /// bare frosted backdrop when the front app is pinned over an
+    /// overflowing run (#409) — an empty content view frosts as
+    /// true glass (the `frontGlass` precedent), letting the plate
+    /// span the strip under both the items and the pinned segment.
+    let glassBackdropFiller = NSView()
     /// Under plain + glass when the run fits, the glass hosts this
     /// flipped run wrapper at the hugged plate frame with the run
     /// (items + front segment) placed run-local — so the frosted
@@ -101,7 +118,9 @@ public final class SpaceBarOverlay {
         return tf
     }()
     let frontName = NSTextField(labelWithString: "")
-    private var lastShown:
+    // Internal (not private): read by `render()` in the +Render
+    // extension.
+    var lastShown:
         (
             items: [Item],
             frontApp: SpaceBarItemView.App?,
@@ -150,184 +169,8 @@ public final class SpaceBarOverlay {
 
     // MARK: - Rendering
 
-    /// One layout pass over the last shown state. `show()`
-    /// follows the active Space into view; a manual arrow or
-    /// autoscroll re-renders without that adjustment so it isn't
-    /// snapped straight back (the App Bar's `followingFocus`).
-    func render(followingActive: Bool) {
-        guard let state = lastShown else { return }
-        let (items, frontApp, strip, style, stateMarkColors) = state
-        let panel = self.panel ?? makePanel()
-        self.panel = panel
-        styleContainer(panel, style: style, strip: strip)
-        syncItemViewCount(items.count)
-        let horizontal = style.edge.isHorizontal
-        let depth = horizontal ? strip.height : strip.width
-        let axis = horizontal ? strip.width : strip.height
-        let gap = style.boxGap
-        let lengths = items.map { item in
-            style.boxSize > 0
-                ? style.boxSize
-                : SpaceBarItemView.autoLength(
-                    appCount: item.apps.count,
-                    overflow: item.overflow,
-                    depth: depth
-                )
-        }
-        // Items plus the trailing front segment align as ONE run
-        // (an end-aligned bar ends at the rim including the
-        // segment) — and scroll as one when the run overflows.
-        let front = frontExtent(
-            frontApp,
-            depth: depth,
-            horizontal: horizontal,
-            style: style
-        )
-        let total = Self.runTotal(
-            lengths: lengths,
-            gap: gap,
-            frontExtent: front
-        )
-        let (inset, viewport) = Self.scrollViewport(
-            axis: axis,
-            total: total,
-            gap: gap
-        )
-        scrollOffset = Self.scrollOffset(
-            current: scrollOffset,
-            lengths: lengths,
-            gap: gap,
-            frontExtent: front,
-            activeIndex: followingActive ? activeIndex(items) : nil,
-            viewport: viewport,
-            margin: gap
-        )
-        let viewportRect = placeItemContainer(
-            inset: inset,
-            viewport: viewport,
-            strip: strip,
-            horizontal: horizontal
-        )
-        let metrics = Self.runMetrics(
-            lengths: lengths,
-            gap: gap,
-            frontExtent: front,
-            strip: strip,
-            viewport: viewport,
-            horizontal: horizontal,
-            alignment: style.alignment,
-            pad: SpaceBarItemView.pad,
-            scrollOffset: scrollOffset
-        )
-        // The shared plate (plain fill / glass) hugs or spans
-        // per `tab_background_fit`. With no arrow inset the
-        // viewport is the strip, so viewport-local run
-        // coordinates are already strip-local; while inset > 0
-        // the plate is full anyway.
-        let runStart: CGFloat
-        if let first = metrics.itemFrames.first {
-            runStart = horizontal ? first.minX : first.minY
-        } else {
-            runStart = metrics.frontStart
-        }
-        let plateFrame = BarPlate.frame(
-            strip: strip,
-            runStart: runStart,
-            runTotal: total,
-            inset: inset,
-            gap: gap,
-            horizontal: horizontal,
-            fit: style.tabBackgroundFit
-        )
-        // The one hosting mode for this render (#407): prepared
-        // (non-target teardown) here, then installed post-passes
-        // once the item frames are laid out.
-        let hosting = glassHosting(style, overflow: inset > 0)
-        prepareGlassHosting(
-            hosting,
-            panel: panel,
-            style: style,
-            strip: strip,
-            plateFrame: plateFrame,
-            viewport: viewportRect
-        )
-        recordHitFrames(
-            items: items,
-            frames: metrics.itemFrames,
-            strip: strip
-        )
-        for (index, item) in items.enumerated() {
-            let view = itemViews[index]
-            view.frame = metrics.itemFrames[index]
-            view.configure(
-                space: item.space,
-                spaceGlyph: item.spaceGlyph,
-                apps: item.apps,
-                active: item.active,
-                horizontal: horizontal,
-                style: style,
-                stateMarkColors: stateMarkColors,
-                overflow: item.overflow,
-                focusInOverflow: item.focusInOverflow
-            )
-            view.onSelect = { [weak self] space in
-                self?.onSelect(space)
-            }
-            // Only the run's outer items meet a rounded plate end.
-            // The trailing end is the front-app segment's when one
-            // trails, so the last Space item clips its trailing
-            // corner only without a front app.
-            view.isFirstInRun = index == 0
-            view.isLastInRun =
-                index == items.count - 1 && frontApp == nil
-        }
-        renderFrontSegment(
-            frontApp,
-            after: metrics.frontStart,
-            strip: strip,
-            viewport: viewport,
-            style: style,
-            horizontal: horizontal
-        )
-        // Install the target hosting from the now-laid-out item
-        // frames (per-box glass and the plain-glass run both position
-        // from them, so this runs after the item + front passes).
-        // #407: one dispatch, no per-mode branching at the call site.
-        installGlassHosting(
-            hosting,
-            panel: panel,
-            frames: metrics.itemFrames,
-            viewport: viewportRect,
-            plateFrame: plateFrame,
-            style: style,
-            depth: horizontal ? strip.height : strip.width
-        )
-        layoutArrows(
-            strip: strip,
-            inset: inset,
-            viewport: viewport,
-            total: total,
-            lengths: lengths,
-            gap: gap,
-            horizontal: horizontal,
-            style: style
-        )
-        panel.setFrame(
-            GeometryUtils.flip(
-                strip,
-                primaryHeight: GeometryUtils.primaryHeight
-            ),
-            display: true
-        )
-        if !panel.isVisible {
-            panel.orderFrontRegardless()
-        }
-    }
-
-    /// The index of the active Space, for scroll-follow.
-    private func activeIndex(_ items: [Item]) -> Int? {
-        items.firstIndex(where: \.active)
-    }
+    // `render(followingActive:)` and `activeIndex` live in
+    // `SpaceBarOverlay+Render.swift` (file size, §2).
 
     /// Axis start of the content run per `alignment` (#293
     /// QA). `pad` keeps the run off the strip's rim and floors

--- a/Tests/KiwiDeskCoreTests/SpaceBarScrollTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarScrollTests.swift
@@ -119,6 +119,7 @@ struct SpaceBarScrollTests {
                 at: CGPoint(x: 10, y: 16),
                 strip: strip,
                 inset: zone + 6,
+                trailingAxis: 200,
                 horizontal: true
             ) == .back
         )
@@ -127,6 +128,7 @@ struct SpaceBarScrollTests {
                 at: CGPoint(x: 195, y: 16),
                 strip: strip,
                 inset: zone + 6,
+                trailingAxis: 200,
                 horizontal: true
             ) == .forward
         )
@@ -135,8 +137,38 @@ struct SpaceBarScrollTests {
                 at: CGPoint(x: 100, y: 16),
                 strip: strip,
                 inset: zone + 6,
+                trailingAxis: 200,
                 horizontal: true
             ) == nil
+        )
+    }
+
+    @Test(
+        "Forward zone tracks the pinned front band, not the rim"
+    )
+    func arrowHitPinnedFrontBand() {
+        // The front segment holds the trailing 60pt; the Spaces
+        // region (and its forward arrow) ends at trailingAxis 140.
+        let strip = CGRect(x: 0, y: 0, width: 200, height: 32)
+        // A point in the pinned band past trailingAxis is inert.
+        #expect(
+            SpaceBarOverlay.arrowHit(
+                at: CGPoint(x: 180, y: 16),
+                strip: strip,
+                inset: zone + 6,
+                trailingAxis: 140,
+                horizontal: true
+            ) == nil
+        )
+        // The forward arrow now sits just inside trailingAxis.
+        #expect(
+            SpaceBarOverlay.arrowHit(
+                at: CGPoint(x: 135, y: 16),
+                strip: strip,
+                inset: zone + 6,
+                trailingAxis: 140,
+                horizontal: true
+            ) == .forward
         )
     }
 
@@ -148,6 +180,7 @@ struct SpaceBarScrollTests {
                 at: CGPoint(x: 10, y: 16),
                 strip: strip,
                 inset: 0,
+                trailingAxis: 200,
                 horizontal: true
             ) == nil
         )
@@ -161,6 +194,7 @@ struct SpaceBarScrollTests {
                 at: CGPoint(x: 10, y: 40),
                 strip: strip,
                 inset: zone + 6,
+                trailingAxis: 200,
                 horizontal: true
             ) == nil
         )
@@ -174,6 +208,7 @@ struct SpaceBarScrollTests {
                 at: CGPoint(x: 16, y: 10),
                 strip: strip,
                 inset: zone + 6,
+                trailingAxis: 200,
                 horizontal: false
             ) == .back
         )
@@ -182,6 +217,7 @@ struct SpaceBarScrollTests {
                 at: CGPoint(x: 16, y: 195),
                 strip: strip,
                 inset: zone + 6,
+                trailingAxis: 200,
                 horizontal: false
             ) == .forward
         )

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -917,9 +917,10 @@ their size; small chevrons appear at the ends toward the hidden
 Spaces, and the bar follows the active Space into view. Click a
 chevron to scroll, or — while dragging a window — hold the cursor
 over a chevron and the bar autoscrolls so you can drop onto a
-Space that started off-screen. The front-app segment scrolls with
-the row (it's the row's tail), so it's at the far end when you
-scroll there.
+Space that started off-screen. The front-app segment stays
+pinned at the trailing end — only the Spaces scroll behind the
+chevrons — so the focused app is always in view; while the bar
+fits it sits at the row's tail as before.
 
 The editor's order matches the App Bar editor's: preview,
 **Show Space Bar**, **Position** (any of the four screen edges


### PR DESCRIPTION
Fixes #409.

Two front-app-segment polish fixes.

## 1. Symmetric divider spacing
The section divider before the front-app segment now takes an equal `boxGap` (6pt) on both sides instead of `boxGap` left / `pad` (4pt) right (flush against the chip in Boxed). One reused token — `layoutDivider` returns `sectionThickness + boxGap + (chip ? pad : 0)`, mirrored in `frontExtent`.

## 2. Pin the front app when the bar overflows
When the run overflows, the front-app segment is pinned to the trailing rim and only the Spaces scroll behind the arrows, so the focused app never scrolls out of view. When the run fits, it's the run's tail exactly as before.

- Front views reparent out of the clipping `itemContainer` into panel content (`frontHost`); forward arrow + `arrowHit` shift in by the front band (`trailingAxis`).
- Pinned only when the trailing band still leaves the Spaces a real (arrow-bearing) viewport, else it falls back to scrolling with the run.
- Under **Plain+Glass / Material**, the shared frosted plate spans the whole strip as a backdrop below both the items and the pinned segment (`spanBackdrop`), so the pinned app sits on one continuous plate — caught in review.
- `render()`/`activeIndex` moved to `SpaceBarOverlay+Render.swift` for file size.

## Verify
`swift build && swift test && scripts/lint.sh` and `swift build -c release` all pass (full suite green). New `arrowHit` pinned-band test; existing scroll geometry tests updated.

Reviewed by `code-reviewer` + `architect-reviewer` (round 1) plus a focused re-review confirming the glass-backdrop fix and the degenerate-name clamp. Divider spacing eye-confirmed on-device.

Note (follow-up, not blocking): `SpaceBarOverlay+FrontApp.swift` sits at 349/350 — the next front-segment edit should split the `layoutFront*` helpers into a `+FrontLayout.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)