### PR TITLE
feat(profiles): first-run beginner ladder — five spaces per display (#466)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
@@ -128,10 +128,11 @@ extension KiwiCore {
         // once against the FINAL effective rules. Without this,
         // verdicts stay stale until an unrelated AX event (#164).
         eventLoop.reconcileAll()
-        // Displays are now known: author the beginner ladder's
-        // "Starter" profile (modes, pins, tuning) before the event
-        // loop's first monitor change, which then matches and keeps
-        // it (#466). First-run-only.
+        // Author the beginner ladder's "Starter" profile (modes,
+        // pins, tuning). It reads displays from NSScreen itself
+        // (the event loop hasn't published them yet) and runs
+        // before the loop's first monitor change, which then
+        // matches and keeps it (#466). First-run-only.
         if seedStarterProfile {
             seedFirstRunStarterProfile()
         }

--- a/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Config.swift
@@ -55,9 +55,21 @@ extension KiwiCore {
         // all-comment starter template (which declares nothing).
         let luaOwnsSettings = configDeclaresManagedSettings
         ensureDefaultConfig()
-        if !guiConfigStore.exists, !luaOwnsSettings {
+        // No sidecar yet and no Lua-owned settings: seed gui.json
+        // (space list + scaled shortcuts). Unchanged from before —
+        // this also re-seeds on a reload of a Lua config that has
+        // no gui.json, which is harmless.
+        let seedGuiConfig = !guiConfigStore.exists && !luaOwnsSettings
+        if seedGuiConfig {
             try? guiConfigStore.save(guiConfigSeed())
         }
+        // The beginner ladder's profile-scoped half is materialized
+        // (once displays are known, below) only on a TRULY fresh
+        // install — no profile of any kind exists yet — so a Lua
+        // config that already saved a profile keeps it and is never
+        // handed a Starter profile (#466).
+        let seedStarterProfile =
+            seedGuiConfig && profiles.list().isEmpty
         // Typo-guard hits are recorded only for the chunk run:
         // a guarded unknown call is non-fatal, so it must land
         // here as an issue to stay visible (#39).
@@ -116,6 +128,13 @@ extension KiwiCore {
         // once against the FINAL effective rules. Without this,
         // verdicts stay stale until an unrelated AX event (#164).
         eventLoop.reconcileAll()
+        // Displays are now known: author the beginner ladder's
+        // "Starter" profile (modes, pins, tuning) before the event
+        // loop's first monitor change, which then matches and keeps
+        // it (#466). First-run-only.
+        if seedStarterProfile {
+            seedFirstRunStarterProfile()
+        }
         retile()
         // Publish what this load could not apply (#68): the
         // Lua/sidecar problems above plus any profile JSON

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 /// The "seed / overlay a `GuiConfig` from live or stored-profile
@@ -110,13 +111,32 @@ extension KiwiCore {
         }
     }
 
-    /// The starter space set a fresh install gets — nine numbered
-    /// spaces, so every digit key ⌃⌥1…9 binds out of the box even
-    /// on a multi-monitor first run where more spaces are likely
-    /// (#270). One constant behind both first-run pads (empty list
-    /// and the single-space signature) so the count can't drift
-    /// between them.
-    static let starterSpaces = (1...9).map { SpaceID($0) }
+    /// The starter space set a fresh install gets — the beginner
+    /// ladder sized to the connected displays: five spaces per
+    /// display (#466, superseding the flat nine of #270). One
+    /// generator behind both first-run pads (empty list and the
+    /// single-space signature) so the count can't drift between
+    /// them; the ladder's per-space MODES and pins are applied and
+    /// persisted separately by `seedFirstRunStarterProfile()`,
+    /// since `gui.json` carries only the space list and shortcuts.
+    func starterSpaces() -> [SpaceID] {
+        StarterLadder.spaces(displayCount: firstRunDisplayCount())
+    }
+
+    /// Connected-display count for first-run seeding. Prefers live
+    /// workspace state, but `guiConfigSeed()` runs in `loadConfig`
+    /// *before* the event loop reconciles displays, so it falls
+    /// back to a direct `NSScreen` read (floored at one — a Mac
+    /// always drives a screen). Tests seed displays into state to
+    /// drive this deterministically.
+    func firstRunDisplayCount() -> Int {
+        let live = state.workspaces.allDisplays.count
+        if live > 0 { return live }
+        let screens = NSScreen.screens
+            .compactMap { $0.kiwiDisplay }
+            .count
+        return max(1, screens)
+    }
 
     /// Builds an editable model from the running configuration.
     /// Keybindings and mode icons are recovered from the source
@@ -144,7 +164,7 @@ extension KiwiCore {
             defined + Array(modes.keys)
         )
         if config.spaces.isEmpty {
-            config.spaces = Self.starterSpaces
+            config.spaces = starterSpaces()
         }
         var bindings: [Int: String] = [:]
         for (number, name) in nativeSpaceBindings {
@@ -178,8 +198,9 @@ extension KiwiCore {
         // First run reports only the ACTIVE Space (#270): the live
         // list is a single numbered space (usually ["1"]), which
         // would seed only ⌃⌥1. Pad just that bare signature to the
-        // nine-space starter set the empty state already uses, so
-        // ⌃⌥1…9 all work out of the box. A named or multi-space
+        // per-display ladder the empty state already uses, so the
+        // scaled digit shortcuts (⌃⌥1–5 on one display, …+0 on two)
+        // all work out of the box (#466). A named or multi-space
         // list is a configured setup — left exactly as discovered
         // so the seed never invents spaces the user didn't (dedup
         // keeps the live space first, #75).
@@ -187,7 +208,7 @@ extension KiwiCore {
             Int(config.spaces[0].raw) != nil
         {
             config.spaces = SpaceID.deduplicated(
-                config.spaces + Self.starterSpaces
+                config.spaces + starterSpaces()
             )
         }
         config.modes[index].bindings =

--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfigSeed.swift
@@ -123,19 +123,25 @@ extension KiwiCore {
         StarterLadder.spaces(displayCount: firstRunDisplayCount())
     }
 
-    /// Connected-display count for first-run seeding. Prefers live
-    /// workspace state, but `guiConfigSeed()` runs in `loadConfig`
-    /// *before* the event loop reconciles displays, so it falls
-    /// back to a direct `NSScreen` read (floored at one — a Mac
-    /// always drives a screen). Tests seed displays into state to
-    /// drive this deterministically.
+    /// Connected displays for first-run seeding. `loadConfig` runs
+    /// before the event loop's first `publishDisplays`, so live
+    /// state is still empty on a genuine first launch — fall back
+    /// to the same `NSScreen` source `publishDisplays` reads.
+    /// Prefers live state when present (tests seed displays there
+    /// to drive this deterministically). The one accessor behind
+    /// both the `gui.json` space count and the Starter profile, so
+    /// the two can't size to different display counts.
+    func firstRunDisplays() -> [Display] {
+        let live = state.workspaces.allDisplays
+        if !live.isEmpty { return live }
+        return NSScreen.screens.compactMap { $0.kiwiDisplay }
+    }
+
+    /// `firstRunDisplays().count`, floored at one — a Mac always
+    /// drives at least one screen even if the read comes back
+    /// empty (headless CI).
     func firstRunDisplayCount() -> Int {
-        let live = state.workspaces.allDisplays.count
-        if live > 0 { return live }
-        let screens = NSScreen.screens
-            .compactMap { $0.kiwiDisplay }
-            .count
-        return max(1, screens)
+        max(1, firstRunDisplays().count)
     }
 
     /// Builds an editable model from the running configuration.

--- a/Sources/KiwiDeskCore/App/KiwiCore+StarterSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+StarterSeed.swift
@@ -32,8 +32,10 @@ extension KiwiCore {
             return
         }
         // Populate state so pins resolve and `buildProfile`
-        // captures a real monitor set. A no-op re-publish arrives
-        // later from the event loop.
+        // captures a real monitor set. The event loop re-publishes
+        // the same set later — an idempotent state re-apply, whose
+        // `handleMonitorChange` is then the step that matches and
+        // keeps this profile.
         state.apply(.displaysChanged(displays))
         do {
             try applyStandard(

--- a/Sources/KiwiDeskCore/App/KiwiCore+StarterSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+StarterSeed.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// First-run materialization of the beginner ladder (#466).
+extension KiwiCore {
+    /// Materializes the beginner ladder as a real, adopted
+    /// "Starter" profile on a fresh first run — the only durable
+    /// home for the per-space modes, monitor pins, and tuning that
+    /// `gui.json` (globals only) can't carry. The `gui.json` seed
+    /// already wrote the matching space list and scaled shortcuts;
+    /// this lays the profile-scoped half on top and persists it.
+    ///
+    /// Runs from `loadConfig` after `reconcileAll` has populated
+    /// displays, so `allDisplays` is authoritative — and before
+    /// the event loop's first `handleMonitorChange`, which then
+    /// finds this profile as an exact match and keeps it. Saving
+    /// adopts it (`currentName`), so every later reload re-applies
+    /// it via `reapplyActiveProfileState`. First-run-only: the
+    /// caller gates it on the same signal as the `gui.json` seed,
+    /// so a monitor added later never re-seeds.
+    func seedFirstRunStarterProfile() {
+        let ordered = PositionalDisplays.ordered(
+            state.workspaces.allDisplays,
+            mainID: PositionalDisplays.liveMainID
+        )
+        let count = max(1, ordered.count)
+        let spaces = StarterLadder.spaces(displayCount: count)
+        for space in spaces {
+            state.workspaces.ensureSpace(space)
+        }
+        state.workspaces.reorder(matching: spaces)
+
+        // Per-space modes (sparse map ⇒ bsp fallback).
+        let modes = StarterLadder.spaceModes(displayCount: count)
+        for space in spaces {
+            setSpaceMode(space, modes[space] ?? .bsp)
+        }
+
+        // Pin each display's block to its ordered fingerprint; the
+        // main block takes the Main role. A block whose display
+        // isn't connected (can't happen at seed time, defensive)
+        // falls back to Main.
+        var pins: [SpaceID: String] = [:]
+        var mains: Set<SpaceID> = []
+        for space in spaces {
+            let screen = StarterLadder.screen(of: space)
+            if screen >= 1, screen < ordered.count {
+                pins[space] = ordered[screen].fingerprint
+            } else {
+                mains.insert(space)
+            }
+        }
+        spacePins = pins
+        mainSpaces = mains
+
+        // Wholesale, so the seeded profile's settings match exactly
+        // what applying the Starter preset would produce (on a
+        // fresh run the live settings are still the defaults).
+        tiler.settings = StarterLadder.settings()
+
+        resolveSpaceDisplays()
+
+        // Durable + adopted: `save` writes the JSON and sets
+        // `currentName`, so `reapplyActiveProfileState` reloads it.
+        do {
+            try profiles.save(
+                buildProfile(name: profiles.freeName(base: "Starter"))
+            )
+        } catch {
+            onLog(
+                "first run: could not save the Starter profile: "
+                    + "\(error)"
+            )
+        }
+        retile(force: true)
+        emitSpaceChange()
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore+StarterSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+StarterSeed.swift
@@ -9,69 +9,43 @@ extension KiwiCore {
     /// already wrote the matching space list and scaled shortcuts;
     /// this lays the profile-scoped half on top and persists it.
     ///
-    /// Runs from `loadConfig` after `reconcileAll` has populated
-    /// displays, so `allDisplays` is authoritative — and before
-    /// the event loop's first `handleMonitorChange`, which then
-    /// finds this profile as an exact match and keeps it. Saving
-    /// adopts it (`currentName`), so every later reload re-applies
-    /// it via `reapplyActiveProfileState`. First-run-only: the
-    /// caller gates it on the same signal as the `gui.json` seed,
-    /// so a monitor added later never re-seeds.
+    /// `loadConfig` runs before the event loop's first
+    /// `publishDisplays`, so displays aren't in state yet — the
+    /// ladder needs them for its pins and for a non-empty monitor
+    /// set (without which the first `handleMonitorChange` couldn't
+    /// match the profile and would drop it for a composed
+    /// Standard). So it reads the same `NSScreen` source and
+    /// populates state first, then applies through the one
+    /// canonical path — `applyStandard` — which composes, sets
+    /// modes/pins/tuning, adopts, and saves (setting `currentName`,
+    /// so every later reload re-applies it via
+    /// `reapplyActiveProfileState`). First-run-only: the caller
+    /// gates it on the same signal as the `gui.json` seed plus an
+    /// empty profile list, so an existing setup is never touched.
     func seedFirstRunStarterProfile() {
-        let ordered = PositionalDisplays.ordered(
-            state.workspaces.allDisplays,
-            mainID: PositionalDisplays.liveMainID
-        )
-        let count = max(1, ordered.count)
-        let spaces = StarterLadder.spaces(displayCount: count)
-        for space in spaces {
-            state.workspaces.ensureSpace(space)
+        let displays = firstRunDisplays()
+        guard !displays.isEmpty else {
+            onLog(
+                "first run: no displays detected; skipped the "
+                    + "Starter profile seed"
+            )
+            return
         }
-        state.workspaces.reorder(matching: spaces)
-
-        // Per-space modes (sparse map ⇒ bsp fallback).
-        let modes = StarterLadder.spaceModes(displayCount: count)
-        for space in spaces {
-            setSpaceMode(space, modes[space] ?? .bsp)
-        }
-
-        // Pin each display's block to its ordered fingerprint; the
-        // main block takes the Main role. A block whose display
-        // isn't connected (can't happen at seed time, defensive)
-        // falls back to Main.
-        var pins: [SpaceID: String] = [:]
-        var mains: Set<SpaceID> = []
-        for space in spaces {
-            let screen = StarterLadder.screen(of: space)
-            if screen >= 1, screen < ordered.count {
-                pins[space] = ordered[screen].fingerprint
-            } else {
-                mains.insert(space)
-            }
-        }
-        spacePins = pins
-        mainSpaces = mains
-
-        // Wholesale, so the seeded profile's settings match exactly
-        // what applying the Starter preset would produce (on a
-        // fresh run the live settings are still the defaults).
-        tiler.settings = StarterLadder.settings()
-
-        resolveSpaceDisplays()
-
-        // Durable + adopted: `save` writes the JSON and sets
-        // `currentName`, so `reapplyActiveProfileState` reloads it.
+        // Populate state so pins resolve and `buildProfile`
+        // captures a real monitor set. A no-op re-publish arrives
+        // later from the event loop.
+        state.apply(.displaysChanged(displays))
         do {
-            try profiles.save(
-                buildProfile(name: profiles.freeName(base: "Starter"))
+            try applyStandard(
+                StarterLadder.standardLayout(
+                    displayCount: displays.count
+                )
             )
         } catch {
             onLog(
-                "first run: could not save the Starter profile: "
+                "first run: could not seed the Starter profile: "
                     + "\(error)"
             )
         }
-        retile(force: true)
-        emitSpaceChange()
     }
 }

--- a/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
+++ b/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
@@ -25,8 +25,9 @@ import Foundation
 /// Per-space rows are position-based (`control+option+1` targets
 /// the FIRST space in display order, whatever its name),
 /// generated only for the spaces that exist at seed time and
-/// capped at nine — so no dead row targeting a nonexistent space
-/// is ever authored (#91).
+/// capped at ten — positions 1…9 then ⌃⌥0 for the tenth (#466) —
+/// so no dead row targeting a nonexistent space is ever authored
+/// (#91).
 public enum DefaultKeybindings {
     /// Direction ↔ canonical label phrase, in the catalog's
     /// order (left, down, up, right). The arrow key that drives
@@ -57,10 +58,10 @@ public enum DefaultKeybindings {
                 )
             )
         }
-        for (offset, space) in numbered(spaces) {
+        for (digit, space) in numbered(spaces) {
             rows.append(
                 KeyBinding(
-                    combo: "control+option+\(offset)",
+                    combo: "control+option+\(digit)",
                     lua: "KiwiDesk.focus_space"
                         + "(\(SpaceLuaArg.quote(space.raw)))",
                     kind: .navigation,
@@ -79,10 +80,10 @@ public enum DefaultKeybindings {
                 )
             )
         }
-        for (offset, space) in numbered(spaces) {
+        for (digit, space) in numbered(spaces) {
             rows.append(
                 KeyBinding(
-                    combo: "control+option+shift+\(offset)",
+                    combo: "control+option+shift+\(digit)",
                     lua: "KiwiDesk.move_to_space"
                         + "(\(SpaceLuaArg.quote(space.raw)))",
                     kind: .navigation,
@@ -92,10 +93,10 @@ public enum DefaultKeybindings {
         }
         // Tier 3 — ⌃⌥⌘: resize, move-to-space-and-follow.
         rows.append(contentsOf: resizeRows(step: resizeStep))
-        for (offset, space) in numbered(spaces) {
+        for (digit, space) in numbered(spaces) {
             rows.append(
                 KeyBinding(
-                    combo: "control+option+command+\(offset)",
+                    combo: "control+option+command+\(digit)",
                     lua: "KiwiDesk.move_to_space_and_follow"
                         + "(\(SpaceLuaArg.quote(space.raw)))",
                     kind: .navigation,
@@ -165,11 +166,17 @@ public enum DefaultKeybindings {
         ]
     }
 
-    /// The first nine spaces paired with their 1-based display
-    /// position — the digit each per-space combo uses.
+    /// The first ten spaces paired with the digit key each
+    /// per-space combo uses: positions 1…9 map to `"1"`…`"9"`, and
+    /// the tenth to `"0"` (⌃⌥0 = space 10, the top-row order). Ten
+    /// is the hard cap — the number row has no eleventh digit — so
+    /// spaces past the tenth ship unbound by default (#466);
+    /// they stay bindable in the Keybindings editor.
     private static func numbered(
         _ spaces: [SpaceID]
-    ) -> [(Int, SpaceID)] {
-        spaces.prefix(9).enumerated().map { ($0 + 1, $1) }
+    ) -> [(String, SpaceID)] {
+        spaces.prefix(10).enumerated().map { index, space in
+            (index == 9 ? "0" : String(index + 1), space)
+        }
     }
 }

--- a/Sources/KiwiDeskCore/Profiles/StandardProfiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/StandardProfiles.swift
@@ -60,21 +60,9 @@ public enum StandardProfiles {
         screens: Int,
         summary: String
     ) -> StandardLayout {
-        StandardLayout(
-            name: "Starter",
-            summary: summary,
-            screenCount: screens,
-            spaceCount: StarterLadder.spaceCount(
-                displayCount: screens
-            ),
-            spaceModes: StarterLadder.spaceModes(
-                displayCount: screens
-            ),
-            spaceScreens: StarterLadder.spaceScreens(
-                displayCount: screens
-            ),
-            isStandard: false,
-            settings: StarterLadder.settings()
+        StarterLadder.standardLayout(
+            displayCount: screens,
+            summary: summary
         )
     }
 

--- a/Sources/KiwiDeskCore/Profiles/StandardProfiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/StandardProfiles.swift
@@ -25,12 +25,58 @@ public struct StandardLayout: Sendable, Equatable {
 /// The shipped per-count layouts. Never deletable; a count with
 /// no saved user profile falls back to its Standard.
 public enum StandardProfiles {
-    /// The catalog, ordered by screen count, Standards first.
+    /// The catalog, ordered by screen count. The beginner
+    /// `Starter` ladder leads each count (the "start here" preset,
+    /// #466); the workflow layouts follow, silent-fallback
+    /// Standard among them.
     public static let all: [StandardLayout] = [
-        developer, minimalist, focusStack,
-        dualDeveloper, coderAndMonitor,
-        commandCenter, visualCreative,
+        starterOne, developer, minimalist, focusStack,
+        starterTwo, dualDeveloper, coderAndMonitor,
+        starterThree, commandCenter, visualCreative,
     ]
+
+    /// The beginner ladder as an applyable preset per screen
+    /// count (#466) — the same `StarterLadder` generator the
+    /// first-run seed uses, so the two never drift. Never the
+    /// silent `isStandard` fallback: a demo layout of empty modes
+    /// is a poor thing to land in silently on a monitor change.
+    static let starterOne = starter(
+        screens: 1,
+        summary: "One space per layout mode — track, stack, "
+            + "bsp, grid, and floating."
+    )
+    static let starterTwo = starter(
+        screens: 2,
+        summary: "The five-mode set repeated on each display, "
+            + "track through floating."
+    )
+    static let starterThree = starter(
+        screens: 3,
+        summary: "The five-mode set on all three displays, "
+            + "track through floating."
+    )
+
+    private static func starter(
+        screens: Int,
+        summary: String
+    ) -> StandardLayout {
+        StandardLayout(
+            name: "Starter",
+            summary: summary,
+            screenCount: screens,
+            spaceCount: StarterLadder.spaceCount(
+                displayCount: screens
+            ),
+            spaceModes: StarterLadder.spaceModes(
+                displayCount: screens
+            ),
+            spaceScreens: StarterLadder.spaceScreens(
+                displayCount: screens
+            ),
+            isStandard: false,
+            settings: StarterLadder.settings()
+        )
+    }
 
     /// The layouts planning for exactly `count` screens.
     public static func layouts(

--- a/Sources/KiwiDeskCore/Profiles/StarterLadder.swift
+++ b/Sources/KiwiDeskCore/Profiles/StarterLadder.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// The beginner "ladder" seeded on a fresh install (#466): five
+/// spaces per display, each demoing a different layout mode so a
+/// newcomer meets the whole range at once. The block repeats
+/// per display — spaces 1–5 on the main, 6–10 on the second, …
+///
+/// | Position in block | Mode | Shown off |
+/// |---|---|---|
+/// | 1 | track | new window → its own new track |
+/// | 2 | stack | single master, 80/20 split |
+/// | 3 | bsp | the default binary layout |
+/// | 4 | grid | a 3×2 grid |
+/// | 5 | floating | untiled |
+///
+/// One pure generator behind BOTH callers — the first-run seed
+/// (arbitrary live display count) and the fixed 1/2/3-screen
+/// `StandardLayout` presets — so the ladder is defined once, not
+/// hand-mirrored (`.claude/rules/parity-tests.md`, at the logic
+/// level).
+public enum StarterLadder {
+    /// Spaces each display's block contributes.
+    public static let spacesPerDisplay = 5
+
+    /// The mode for each 1-based position within a block; `.bsp`
+    /// is the array-index-2 rung and, being the fallback, is
+    /// omitted from the sparse `spaceModes` map below.
+    private static let blockModes: [LayoutMode] = [
+        .track, .stack, .bsp, .grid, .floating,
+    ]
+
+    /// Total spaces for `displayCount` displays (floored at one —
+    /// a machine always drives at least one screen).
+    public static func spaceCount(displayCount: Int) -> Int {
+        max(1, displayCount) * spacesPerDisplay
+    }
+
+    /// The ladder's spaces, ids `"1"`…`"5N"`, in display order.
+    public static func spaces(displayCount: Int) -> [SpaceID] {
+        (1...spaceCount(displayCount: displayCount))
+            .map { SpaceID($0) }
+    }
+
+    /// Sparse per-space modes — `.bsp` positions are omitted (they
+    /// resolve to the fallback), matching `StandardLayout`'s
+    /// sparse convention.
+    public static func spaceModes(
+        displayCount: Int
+    ) -> [SpaceID: LayoutMode] {
+        var modes: [SpaceID: LayoutMode] = [:]
+        for number in 1...spaceCount(displayCount: displayCount) {
+            let mode = blockModes[(number - 1) % spacesPerDisplay]
+            if mode != .bsp { modes[SpaceID(number)] = mode }
+        }
+        return modes
+    }
+
+    /// Sparse positional screen per space (0 = main). Main-display
+    /// spaces are omitted (unlisted ⇒ main), so only the second
+    /// display's block onward is named.
+    public static func spaceScreens(
+        displayCount: Int
+    ) -> [SpaceID: Int] {
+        var screens: [SpaceID: Int] = [:]
+        for number in 1...spaceCount(displayCount: displayCount) {
+            let screen = (number - 1) / spacesPerDisplay
+            if screen >= 1 { screens[SpaceID(number)] = screen }
+        }
+        return screens
+    }
+
+    /// The positional display index a space's block sits on
+    /// (0 = main) — the seed's `spaceScreens` twin for live pins.
+    public static func screen(of space: SpaceID) -> Int {
+        guard let number = Int(space.raw) else { return 0 }
+        return (number - 1) / spacesPerDisplay
+    }
+
+    /// The beginner tuning the ladder ships with: a comfortable
+    /// gap, the stack's single-master 80/20 split, and track's
+    /// new-window-opens-its-own-track. Grid's 3×2 is already the
+    /// default, so it needs no override here.
+    public static func settings(gap: Double = 8) -> TilingSettings {
+        var settings = TilingSettings()
+        settings.gapsGlobal = .uniform(gap)
+        settings.stack.masterRatio = 0.8
+        settings.track.newWindow = .ownTrack
+        return settings
+    }
+}

--- a/Sources/KiwiDeskCore/Profiles/StarterLadder.swift
+++ b/Sources/KiwiDeskCore/Profiles/StarterLadder.swift
@@ -87,4 +87,26 @@ public enum StarterLadder {
         settings.track.newWindow = .ownTrack
         return settings
     }
+
+    /// The ladder packaged as a `StandardLayout` for a display
+    /// count — the single shape shared by the fixed 1/2/3-screen
+    /// presets (which pass a `summary`) and the first-run seed
+    /// (which composes and applies it through `applyStandard`, so
+    /// the seed rides the one canonical apply path rather than
+    /// re-implementing it).
+    public static func standardLayout(
+        displayCount: Int,
+        summary: String = ""
+    ) -> StandardLayout {
+        StandardLayout(
+            name: "Starter",
+            summary: summary,
+            screenCount: max(1, displayCount),
+            spaceCount: spaceCount(displayCount: displayCount),
+            spaceModes: spaceModes(displayCount: displayCount),
+            spaceScreens: spaceScreens(displayCount: displayCount),
+            isStandard: false,
+            settings: settings()
+        )
+    }
 }

--- a/Tests/KiwiDeskCoreTests/DefaultKeybindingsTests.swift
+++ b/Tests/KiwiDeskCoreTests/DefaultKeybindingsTests.swift
@@ -49,7 +49,7 @@ struct DefaultKeybindingsTests {
         }
     }
 
-    @Test("per-space rows cap at nine spaces")
+    @Test("per-space rows cap at ten spaces, tenth on ⌃⌥0")
     func spacesCapped() {
         let rows = DefaultKeybindings.bindings(
             spaces: spaces(12),
@@ -61,10 +61,21 @@ struct DefaultKeybindingsTests {
         let move = rows.filter {
             $0.lua.hasPrefix("KiwiDesk.move_to_space(")
         }
-        #expect(goTo.count == 9)
-        #expect(move.count == 9)
+        // Ten digit rows per tier — 1…9 then 0 for the tenth.
+        #expect(goTo.count == 10)
+        #expect(move.count == 10)
+        #expect(
+            rows.contains {
+                $0.combo == "control+option+0"
+                    && $0.lua == "KiwiDesk.focus_space(\"10\")"
+            }
+        )
+        // No dead digit past ten (there is no eleventh key).
         #expect(
             !rows.contains { $0.combo == "control+option+10" }
+        )
+        #expect(
+            !rows.contains { $0.combo == "control+option+11" }
         )
     }
 

--- a/Tests/KiwiDeskCoreTests/FirstRunSeedTests.swift
+++ b/Tests/KiwiDeskCoreTests/FirstRunSeedTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import Testing
 
@@ -17,6 +18,18 @@ struct FirstRunSeedTests {
                 .appendingPathComponent(
                     "kiwi-seed-\(UUID().uuidString)"
                 )
+        )
+    }
+
+    private func twoBySide(
+        _ id: UInt32,
+        name: String,
+        x: CGFloat
+    ) -> Display {
+        Display(
+            id: DisplayID(id),
+            name: name,
+            frame: CGRect(x: x, y: 0, width: 1920, height: 1080)
         )
     }
 
@@ -198,28 +211,35 @@ struct FirstRunSeedTests {
         )
     }
 
-    /// #270: at first run macOS reports only the active Space, so
-    /// the live list is just ["1"] — not empty, so the empty-state
-    /// pad is skipped. The seed pads to a nine-space starter set
-    /// anyway, so ⌃⌥1…9 all bind out of the box rather than only
-    /// ⌃⌥1.
-    @Test("partial first-run discovery still seeds spaces 1-9")
-    func partialDiscoveryPadsToNine() {
+    /// #270/#466: at first run macOS reports only the active
+    /// Space, so the live list is just ["1"] — not empty, so the
+    /// empty-state pad is skipped. The seed pads that bare
+    /// signature to the per-display ladder anyway, so with two
+    /// displays spaces 1–10 all exist and the top digit ⌃⌥0
+    /// (= space 10) binds out of the box rather than only ⌃⌥1.
+    @Test("partial first-run discovery pads to the ladder")
+    func partialDiscoveryPadsToLadder() {
         let core = makeCore()
+        core.state.apply(
+            .displaysChanged([
+                twoBySide(1, name: "Main", x: 0),
+                twoBySide(2, name: "Second", x: 1920),
+            ])
+        )
         core.state.workspaces.ensureSpace(SpaceID("1"))
 
         let seed = core.guiConfigSeed()
         let spaces = Set(seed.spaces.map(\.raw))
-        for n in 1...9 {
+        for n in 1...10 {
             #expect(spaces.contains("\(n)"), "missing space \(n)")
         }
         let base = seed.modes.first { $0.isDefault }
         #expect(
             (base?.bindings ?? []).contains {
-                $0.combo == "control+option+9"
-                    && $0.lua == "KiwiDesk.focus_space(\"9\")"
+                $0.combo == "control+option+0"
+                    && $0.lua == "KiwiDesk.focus_space(\"10\")"
             },
-            "⌃⌥9 not seeded despite only space 1 discovered"
+            "⌃⌥0 not seeded despite two displays discovered"
         )
     }
 }

--- a/Tests/KiwiDeskCoreTests/StarterLadderSeedTests.swift
+++ b/Tests/KiwiDeskCoreTests/StarterLadderSeedTests.swift
@@ -1,0 +1,200 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The beginner ladder (#466): the pure `StarterLadder` generator,
+/// its `Starter` preset faces, and the first-run seed that
+/// materializes it as an adopted profile scaled to the displays.
+@Suite("Starter ladder & first-run seed (#466)", .serialized)
+@MainActor
+struct StarterLadderSeedTests {
+    private func makeCore() -> KiwiCore {
+        KiwiCore(
+            configDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-starter-\(UUID().uuidString)"
+                )
+        )
+    }
+
+    private func display(
+        _ id: UInt32,
+        name: String,
+        x: CGFloat
+    ) -> Display {
+        Display(
+            id: DisplayID(id),
+            name: name,
+            frame: CGRect(x: x, y: 0, width: 1920, height: 1080)
+        )
+    }
+
+    private func seedDisplays(_ core: KiwiCore, count: Int) {
+        let displays = (0..<count).map {
+            display(
+                UInt32(10 + $0),
+                name: "D\($0)",
+                x: CGFloat($0) * 1920
+            )
+        }
+        core.state.apply(.displaysChanged(displays))
+    }
+
+    // MARK: - Pure generator
+
+    @Test("space count is five per display")
+    func spaceCountScales() {
+        #expect(StarterLadder.spaceCount(displayCount: 1) == 5)
+        #expect(StarterLadder.spaceCount(displayCount: 2) == 10)
+        #expect(StarterLadder.spaceCount(displayCount: 3) == 15)
+        // Floored at one screen.
+        #expect(StarterLadder.spaceCount(displayCount: 0) == 5)
+    }
+
+    @Test("modes ladder repeats per display, bsp omitted")
+    func modesLadder() {
+        let modes = StarterLadder.spaceModes(displayCount: 2)
+        // Block one.
+        #expect(modes[SpaceID("1")] == .track)
+        #expect(modes[SpaceID("2")] == .stack)
+        #expect(modes[SpaceID("3")] == nil)  // bsp ⇒ omitted
+        #expect(modes[SpaceID("4")] == .grid)
+        #expect(modes[SpaceID("5")] == .floating)
+        // Block two mirrors it.
+        #expect(modes[SpaceID("6")] == .track)
+        #expect(modes[SpaceID("7")] == .stack)
+        #expect(modes[SpaceID("8")] == nil)
+        #expect(modes[SpaceID("9")] == .grid)
+        #expect(modes[SpaceID("10")] == .floating)
+    }
+
+    @Test("screens are positional, main omitted")
+    func screensPositional() {
+        let screens = StarterLadder.spaceScreens(displayCount: 3)
+        #expect(screens[SpaceID("1")] == nil)  // main ⇒ omitted
+        #expect(screens[SpaceID("5")] == nil)
+        #expect(screens[SpaceID("6")] == 1)
+        #expect(screens[SpaceID("10")] == 1)
+        #expect(screens[SpaceID("11")] == 2)
+        #expect(screens[SpaceID("15")] == 2)
+        #expect(StarterLadder.screen(of: SpaceID("1")) == 0)
+        #expect(StarterLadder.screen(of: SpaceID("6")) == 1)
+        #expect(StarterLadder.screen(of: SpaceID("11")) == 2)
+    }
+
+    @Test("settings carry the beginner tuning")
+    func settingsTuning() {
+        let settings = StarterLadder.settings()
+        #expect(settings.stack.masterRatio == 0.8)
+        #expect(settings.track.newWindow == .ownTrack)
+    }
+
+    // MARK: - Preset faces
+
+    @Test("Starter leads each screen count, never the fallback")
+    func starterPreset() {
+        for count in 1...3 {
+            let layouts = StandardProfiles.layouts(for: count)
+            #expect(
+                layouts.first?.name == "Starter",
+                "Starter not first for \(count) screens"
+            )
+            let starter = layouts.first { $0.name == "Starter" }
+            #expect(starter?.isStandard == false)
+            #expect(starter?.spaceCount == count * 5)
+        }
+        // The silent per-count fallback stays a workflow layout.
+        #expect(StandardProfiles.standard(for: 1)?.name != "Starter")
+    }
+
+    @Test("Starter preset uses the shared generator")
+    func starterPresetSharesGenerator() {
+        let two = StandardProfiles.layouts(for: 2)
+            .first { $0.name == "Starter" }
+        #expect(
+            two?.spaceModes
+                == StarterLadder.spaceModes(displayCount: 2)
+        )
+        #expect(
+            two?.spaceScreens
+                == StarterLadder.spaceScreens(displayCount: 2)
+        )
+    }
+
+    // MARK: - First-run seed
+
+    @Test("gui.json seed scales spaces and digits to displays")
+    func seedScalesToDisplays() {
+        let core = makeCore()
+        seedDisplays(core, count: 2)
+        let config = core.guiConfigSeed()
+        #expect(
+            config.spaces.map(\.raw)
+                == (1...10).map { "\($0)" }
+        )
+        let base = config.modes.first { $0.isDefault }
+        let combos = Set((base?.bindings ?? []).map(\.combo))
+        // Tenth space binds ⌃⌥0; there is no ⌃⌥6-as-two-digits.
+        #expect(combos.contains("control+option+0"))
+        #expect(
+            (base?.bindings ?? []).contains {
+                $0.combo == "control+option+0"
+                    && $0.lua == "KiwiDesk.focus_space(\"10\")"
+            }
+        )
+    }
+
+    @Test("single display seeds only five spaces and ⌃⌥1-5")
+    func seedSingleDisplay() {
+        let core = makeCore()
+        seedDisplays(core, count: 1)
+        let config = core.guiConfigSeed()
+        #expect(config.spaces.count == 5)
+        let base = core.guiConfigSeed().modes.first { $0.isDefault }
+        let combos = Set((base?.bindings ?? []).map(\.combo))
+        #expect(combos.contains("control+option+5"))
+        #expect(!combos.contains("control+option+6"))
+        #expect(!combos.contains("control+option+0"))
+    }
+
+    @Test("first-run profile carries ladder modes, pins, tuning")
+    func seedProfileMaterialized() throws {
+        let core = makeCore()
+        seedDisplays(core, count: 2)
+        core.seedFirstRunStarterProfile()
+
+        // Ten live spaces with the ladder modes.
+        let modes = Dictionary(
+            uniqueKeysWithValues: core.state.workspaces.allSpaces
+                .map { ($0.id, $0.mode) }
+        )
+        #expect(modes[SpaceID("1")] == .track)
+        #expect(modes[SpaceID("2")] == .stack)
+        #expect(modes[SpaceID("3")] == .bsp)
+        #expect(modes[SpaceID("4")] == .grid)
+        #expect(modes[SpaceID("5")] == .floating)
+        #expect(modes[SpaceID("6")] == .track)
+
+        // Second block pinned to the second display; first block
+        // holds the Main role.
+        let secondFingerprint = display(11, name: "D1", x: 1920)
+            .fingerprint
+        #expect(core.spacePins[SpaceID("6")] == secondFingerprint)
+        #expect(core.spacePins[SpaceID("1")] == nil)
+        #expect(core.mainSpaces.contains(SpaceID("1")))
+
+        // Beginner tuning applied.
+        #expect(core.tiler.settings.stack.masterRatio == 0.8)
+        #expect(core.tiler.settings.track.newWindow == .ownTrack)
+
+        // Persisted and adopted, so a reload re-applies it.
+        #expect(core.profiles.currentName == "Starter")
+        let saved = try core.profiles.read(name: "Starter")
+        #expect(saved.spaceModes[SpaceID("2")] == .stack)
+        #expect(
+            saved.spaceModes[SpaceID("9")] == .grid
+        )
+    }
+}

--- a/Tests/KiwiDeskCoreTests/StarterLadderSeedTests.swift
+++ b/Tests/KiwiDeskCoreTests/StarterLadderSeedTests.swift
@@ -196,5 +196,28 @@ struct StarterLadderSeedTests {
         #expect(
             saved.spaceModes[SpaceID("9")] == .grid
         )
+        // The saved profile carries a real monitor set — both
+        // displays — or the first monitor change couldn't match
+        // it and would drop it for a composed Standard.
+        #expect(saved.monitorSets.first?.monitors.count == 2)
+    }
+
+    @Test("empty state falls back to NSScreen for the ladder")
+    func seedPopulatesDisplaysFromScreens() {
+        // The production path: state has no displays when the seed
+        // runs (loadConfig precedes the first publishDisplays).
+        // The seed must still populate them from NSScreen so the
+        // profile isn't saved with an empty monitor set.
+        let core = makeCore()
+        #expect(core.state.workspaces.allDisplays.isEmpty)
+        core.seedFirstRunStarterProfile()
+        // On any real display this authors the profile with a
+        // non-empty monitor set; on a headless runner it logs and
+        // skips. Either way it never saves an empty-monitor
+        // profile that a monitor change would discard.
+        if let saved = try? core.profiles.read(name: "Starter") {
+            #expect(saved.monitorSets.first?.monitors.isEmpty == false)
+            #expect(!core.state.workspaces.allDisplays.isEmpty)
+        }
     }
 }

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -106,6 +106,7 @@ planned escape hatch; it is not a wontfix dumping ground.
 | While a tiled-sticky traveler visits a **track space at index 0** (or at any track head slot), that track's custom width temporarily reverts to the default share, snapping back when the traveler leaves. | Track head weights are keyed by the head window, and the visiting traveler becomes the (implicit) head; its id carries no stored weight, and storing one under a non-member id would orphan (never pruned, recycled-id hazard #308) — so `resize` writes instead key the first local member, which applies once the traveler departs. A transient wobble, not data loss. | `Space.trackWeights` is keyed by the track's head window (#128), and injection is derived — the traveler is never a member whose entries the space could own or prune. | Resolve the head weight against the first local member at read time if the wobble ever matters in practice. |
 | `track.swap`'s overflow-block gauge can misjudge by one track at the edge while a tiled-sticky traveler visits a track space (the gauge reads the injected list, the mutation partitions the local array). | The mutation stays safe (membership guards; the focused window is always local), the mismatch surfaces only as an occasionally over- or under-cautious refusal at the folded-overflow boundary, and translating the gauge to the local array is the non-home-reorder non-goal's territory. | The gauge and the mutation deliberately consume different derivations: reads see the rendered (injected) space, writes own only the local array. | Re-derive the gauge from `localTiledMembers` if the edge ever bites in practice. |
 | `KiwiDesk.exec` (and `os.execute`) **dedups identical commands by default**: while one copy of the exact command string is in flight, a second `exec` of it is skipped — it returns `nil` and its callback never fires. | For the dominant use — per-event hook pokes to a receiver that re-queries full state (the sketchybar bridge) — a second poke while one is pending is redundant, and deduping is what caps a wedged receiver at one stuck child per command instead of thousands ([#467](https://github.com/hajiboy95/KiwiDesk/issues/467)). It edges past "Lua is open" (§2.7) only for the rare case of deliberately running two identical commands at once, which the opt-out covers. | The launcher tracks an in-flight count per exact command string and skips a dedup launch while it is non-zero (`ExecLauncher.inFlight`); the raw `launch` primitive defaults dedup off, the opinionated default-on lives at the Lua boundary (`KiwiCore+ExecAPI`). | Pass `dedup = false` (the 4th `exec` argument) to run identical commands in parallel; the callback then fires normally. |
+| The first-run beginner ladder seeds five spaces per display (10 on two monitors, 15 on three, and 5 × N for more), but only the first ten get a default digit shortcut — spaces 11+ ship with no `⌃⌥`/`⌃⌥⇧`/`⌃⌥⌘` binding. | The number row has exactly ten keys (`1`…`9`, `0`); there is no eleventh digit to bind, and inventing a two-key or lettered default for the overflow would be less predictable than leaving it to the user. Every space stays reachable and bindable — only the *default* shortcut is absent (#466, "approachable by default, powerful on demand"). | `DefaultKeybindings.numbered` caps the per-space rows at ten and maps the tenth to `⌃⌥0`; the ladder itself (`StarterLadder`) scales to any display count, so on 3+ monitors it out-runs the digit keys by design. | Reach spaces 11+ from the Space Bar, or bind them yourself in the Keybindings editor (any space is bindable, by name). |
 | If an Accessibility-permission revoke (`stop()`) fires while an exec child is *genuinely wedged* (a grandchild holds its output pipe past EOF), that child's bookkeeping — and its in-flight dedup tally — leaks for the process life, so that exact command string stays dedup-blocked even if its receiver later recovers. | The window is tiny (the stop must land in the interval a child holds the pipe past EOF) and clearing the entry would be *wrong*: a later EOF reap of that child would then find no entry and leak its Lua callback ref. Not SIGTERM-ing a child after management has torn down (children are fire-and-forget, §5) outweighs reclaiming the corner ([#467](https://github.com/hajiboy95/KiwiDesk/issues/467) / [#37](https://github.com/hajiboy95/KiwiDesk/issues/37)). | `cancelWatchdogs()` cancels the timeout watchdog but leaves the `running`/`inFlight` entry, since only the child's own eventual termination can safely release it (`ExecLauncher`). | Reload the config (a fresh VM and launcher) if a hook command stays silently dedup-blocked after an AX-permission cycle. |
 
 ### Blocked by macOS (SIP)
@@ -1236,13 +1237,41 @@ the first Save. Per-space rows number the digits
 by display position but bind each to its space **by name**
 (`⌃⌥3` → the third space's name at seed time; a later rename
 rewrites the binding to follow it, so it survives). The first run
-pads the discovered list to a **nine-space starter set** so all of
-`⌃⌥1`–`⌃⌥9` seed even though a fresh macOS reports only the active
-Space (#270) — a multi-monitor first run usually has several. The
-seeded Lua and labels mirror
+pads the discovered list to the **per-display beginner ladder**
+(see below) so the digit shortcuts seed even though a fresh macOS
+reports only the active Space (#270). Digits scale to the seeded
+count: `⌃⌥1`–`⌃⌥5` on one display, and up to `⌃⌥1`–`⌃⌥9` plus
+`⌃⌥0` for the tenth space on two (`0` is the top-row key after
+`9`; there is no eleventh, so spaces past the tenth ship unbound —
+see *Accepted limitations*). The seeded Lua and labels mirror
 `KeybindingCatalog` byte-for-byte (guarded by
 `DefaultSeedCatalogParityTests`) so the rows stay presets, not
-Custom (#4). (#91)
+Custom (#4). (#91/#466)
+
+**A fresh install seeds a five-per-display beginner ladder, not
+nine flat spaces (#466).** The old first run padded to nine
+numbered `bsp` spaces purely so `⌃⌥1`–`⌃⌥9` had somewhere to go
+(#270). But a shortcut never needs a pre-created space — `focus_space`
+already `ensureSpace`s on first press — so the nine existed only to
+back the digits, and every new user stared at nine identical `bsp`
+desktops. The ladder replaces them: **five spaces per connected
+display**, one per layout mode — track (new window → own track),
+stack (single master, 80/20), bsp, grid (3×2), floating — repeating
+whole on each monitor (1–5 main, 6–10 second, 11–15 third). It is a
+guided tour of what KiwiDesk does, sized to the hardware. Because the
+per-space modes, monitor pins, and tuning are **profile-scoped** and
+`gui.json` carries only globals, the ladder is materialized as a real,
+adopted **Starter** profile at first run (`seedFirstRunStarterProfile`,
+after the event loop reconciles displays) — the same durable store any
+saved profile uses, so a reload re-applies it and the user owns and
+edits it like any other. The identical ladder is also offered as the
+**Starter** preset for each screen count (`StandardProfiles`), sharing
+one pure generator (`StarterLadder`) with the seed so the two never
+drift; it is deliberately **not** the silent `isStandard` fallback —
+landing in a demo of empty modes on a monitor change would be a poor
+default, so the workflow Standards keep that job. First-run-only, and
+gated on the same "no authored binding disarms the seed" guard, so it
+never touches a configured setup. (#466, supersedes the #270 nine-pad)
 
 **Orphaned space shortcuts are surfaced, never pruned.** A
 binding that targets a space by name outlives the space's

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1120,14 +1120,19 @@ mode (see [Per-Profile Shortcut Overrides](#per-profile-shortcut-overrides)).
 
 ### Built-in Standards & Presets
 
-KiwiDesk ships seven built-in **profiles** — Standards for 1, 2, or
-3 screens that resolve silently when no saved profile matches, and
+KiwiDesk ships ten built-in **profiles** — a beginner **Starter**
+ladder plus workflow layouts for 1, 2, or 3 screens. One workflow
+layout per screen count is the *Standard* that resolves silently
+when no saved profile matches; the rest (Starter included) are
 Presets you can apply to spin up a starting point. (These are whole
 profiles — not to be confused with the six layout *modes* like bsp
 or stack.)
 
 **1 Screen:**
 
+- **Starter** — One space per layout mode: track, stack, bsp, grid,
+  and floating. The fresh-install tour; a good way back to a
+  known-good starting point.
 - **Developer** *(Standard)* — IDE in stack (space 2), docs in scrolling
   (space 3), preview fullscreen (space 4). Best for software dev.
 - **Minimalist** — Spacious gaps (20 pt), scrolling reading (space 1),
@@ -1138,6 +1143,8 @@ or stack.)
 
 **2 Screens:**
 
+- **Starter** — The five-mode ladder repeated on each display
+  (spaces 1–5 on the main, 6–10 on the second).
 - **Dual Developer** *(Standard)* — Main screen: IDE/docs/preview.
   Secondary: mail/chat/media. Tight gaps (8 pt).
 - **Coder & Monitor** — Main screen: editor/terminals. Secondary:
@@ -1145,6 +1152,8 @@ or stack.)
 
 **3 Screens:**
 
+- **Starter** — The five-mode ladder on all three displays
+  (spaces 1–5 / 6–10 / 11–15).
 - **Command Center** *(Standard)* — Left: communication (stack).
   Center: workspace (IDE/docs/preview). Right: logs/monitoring.
 - **Visual Creative & Developer** — Left: design canvas. Center:
@@ -1281,6 +1290,27 @@ combos to actions. Every shortcut lives in a **mode** — normally the
 **default** mode (active at startup), plus optional modal modes
 (vim-style); only the active mode's bindings fire at a time.
 
+### Your first run
+
+A fresh install doesn't drop you onto an empty desktop. It seeds a
+**beginner ladder** — five spaces per connected display, each set to
+a different layout mode so you meet the whole range at once:
+
+| Space | Mode | Shows off |
+| --- | --- | --- |
+| 1 | track | a new window opens its own new track |
+| 2 | stack | a single master with an 80/20 split |
+| 3 | bsp | the default binary layout |
+| 4 | grid | a 3×2 grid |
+| 5 | floating | windows left untiled |
+
+With a second display the block repeats — spaces 6–10 on the second
+monitor, 11–15 on a third, and so on. The ladder is saved as an
+ordinary, editable profile named **Starter**, so nothing here is
+locked in: change any space's mode, delete spaces, or apply a
+different [preset](#presets) whenever you like. (The same ladder is
+always available as the **Starter** preset if you want it back.)
+
 ### Default Shortcuts
 
 A fresh install starts with a usable set in the default mode, so
@@ -1289,10 +1319,10 @@ you can drive KiwiDesk before configuring anything:
 | Action | Shortcut |
 | --- | --- |
 | Focus window left / down / up / right | `⌃⌥←` `⌃⌥↓` `⌃⌥↑` `⌃⌥→` |
-| Go to space 1–9 | `⌃⌥1` … `⌃⌥9` |
+| Go to space | `⌃⌥1` … `⌃⌥9`, then `⌃⌥0` for the tenth |
 | Swap with window left / down / up / right | `⌃⌥⇧←` `⌃⌥⇧↓` `⌃⌥⇧↑` `⌃⌥⇧→` |
-| Move to space 1–9 | `⌃⌥⇧1` … `⌃⌥⇧9` |
-| Move to space 1–9 and follow | `⌃⌥⌘1` … `⌃⌥⌘9` |
+| Move to space | `⌃⌥⇧1` … `⌃⌥⇧9`, `⌃⌥⇧0` |
+| Move to space and follow | `⌃⌥⌘1` … `⌃⌥⌘9`, `⌃⌥⌘0` |
 | Grow / Shrink width | `⌃⌥⌘→` / `⌃⌥⌘←` |
 | Grow / Shrink height | `⌃⌥⌘↑` / `⌃⌥⌘↓` |
 | Toggle floating | `⌃⌥F` |
@@ -1309,10 +1339,11 @@ Directions use the arrow keys, which are identical on every layout.
 Each space digit is bound to a space *by name*: `⌃⌥3` goes to
 whichever space was third when the set was seeded. Renaming that
 space in Settings rewrites the shortcut to follow it, so the binding
-survives a rename. All nine digits `⌃⌥1`…`⌃⌥9` are seeded on a fresh
-install — even before you have created that many spaces — so the
-shortcuts work out of the box (a common multi-monitor first run
-already has several).
+survives a rename. The digit shortcuts scale to the seeded ladder —
+`⌃⌥1`…`⌃⌥5` on one display, up to `⌃⌥1`…`⌃⌥9` plus `⌃⌥0` (the tenth
+space) on two. The number row stops at ten keys, so **spaces past
+the tenth ship without a default digit shortcut** — reach them from
+the Space Bar or bind them yourself in the Keybindings editor.
 
 The set is seeded only while **no** shortcut is bound anywhere —
 into `gui.json` at first launch on a fresh install, or into the


### PR DESCRIPTION
Fixes #466. **Do not merge yet — first-run behavior needs on-device QA.**

## What

Supersedes the flat nine-space first-run pad (#270) with a guided **beginner ladder**: five spaces per connected display, each in a different layout mode so a newcomer meets the whole range at once.

| Space (per display block) | Mode | Shows off |
|---|---|---|
| 1 | track | new window → its own new track |
| 2 | stack | single master, 80/20 split |
| 3 | bsp | the default binary layout |
| 4 | grid | 3×2 |
| 5 | floating | untiled |

The block repeats per monitor (1–5 main, 6–10 second, 11–15 third; 5×N for more).

## How

- **`StarterLadder`** — one pure generator for the ladder's spaces, sparse modes, positional screens, tuning, and its `StandardLayout` shape. Shared by both callers so they can't drift (the hand-mirror trap at the logic level).
- **Durable Starter profile** — profile-scoped modes/pins/tuning can't live in `gui.json` (globals only), so first run materializes the ladder as a real, adopted **Starter** profile via the canonical `applyStandard` path (`seedFirstRunStarterProfile`). A reload re-applies it; the user owns and edits it like any profile. Gated on a truly fresh install: no `gui.json`, no Lua-owned settings, **and** no existing profile.
- **Starter preset** — the same ladder ships as an applyable **Starter** preset for 1/2/3 screens, listed first, deliberately **not** the silent `isStandard` fallback (a demo of empty modes shouldn't land silently on a monitor change).
- **Scaled digit shortcuts** — `DefaultKeybindings` caps per-space rows at ten, mapping the tenth to `⌃⌥0`; spaces past ten ship unbound (Space Bar / editor), an accepted limitation.
- **One display source** — `firstRunDisplays()` (live state, else `NSScreen`) drives both the gui.json space count and the profile, so they can't size to different display counts.

## Docs

user-guide (first-run ladder + Starter preset + scaled shortcuts), design-decisions (rationale + accepted-limitation row for spaces past the tenth).

## Review

Two-agent review (code-reviewer + architect-reviewer, parallel round 1). The code-reviewer caught a **critical** bug: the seed read `state.workspaces.allDisplays`, which is empty at seed time (displays are published in `eventLoop.start()`, after `loadConfig`) — so it sized to one display and saved an empty monitor set the first `handleMonitorChange` would drop. Fixed by reading `NSScreen` and populating state, then routing through `applyStandard` (the architect's main recommendation, which also picked up the `clearSessionRatios`/`reapplyStructuredOverrides` the hand-rolled version missed). Sequential re-review (code-reviewer then architect) confirmed the fix and seam: **merge-ready, no blocking findings.**

## Verify

Debug ✓, release ✓, lint ✓. Full suite green except the documented `SpaceBarDropCoordinator` dwell and lone `ExecTests` load-flakes (#344) — both pass isolated, unrelated to this diff.

## On-device QA checklist

- [ ] Fresh install, 1 display → 5 spaces, modes track/stack/bsp/grid/floating, `⌃⌥1`–`⌃⌥5`.
- [ ] Fresh install, 2 displays → 10 spaces, 6–10 pinned to the 2nd monitor, `⌃⌥0` = space 10.
- [ ] Starter profile is adopted and survives a config reload / relaunch (not dropped for a workflow Standard).
- [ ] Existing setup (config + profile) is untouched.
- [ ] Starter appears first in Presets for each screen count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)