### PR TITLE
chore(appearance): retire the Kiwi Dark preset

### DIFF
--- a/Sources/KiwiDeskCore/Resources/Palettes/bundled.json
+++ b/Sources/KiwiDeskCore/Resources/Palettes/bundled.json
@@ -1,33 +1,5 @@
 [
   {
-    "name": "Kiwi Dark",
-    "colors": {
-      "app_bar.item_color": "#EAF3EE",
-      "app_bar.fill_color": "#14201C99",
-      "app_bar.active_item_color": "#8DB354",
-      "app_bar.highlight_color": "#8DB354",
-      "app_bar.hover_fill_color": "#AACB5D80",
-      "app_bar.hover_item_color": "#EAF3EE",
-      "app_bar.group_badge_color": "#B00020",
-      "app_bar.group_badge_text_color": "#FFFFFF",
-      "space_bar.item_color": "#EAF3EE66",
-      "space_bar.active_item_color": "#8DB354",
-      "space_bar.focused_item_color": "#E8A33D",
-      "space_bar.hover_fill_color": "#AACB5D80",
-      "space_bar.hover_item_color": "#EAF3EE",
-      "space_bar.fill_color": "#14201C99",
-      "space_bar.highlight_color": "#8DB354",
-      "space_bar.group_badge_color": "#B00020",
-      "space_bar.group_badge_text_color": "#FFFFFF",
-      "border.focused_color": "#567A1F",
-      "border.unfocused_color": "#3A3A3C99",
-      "drag.ghost.border_color": "#567A1F",
-      "drag.ghost.fill_color": "#567A1F40",
-      "drag.drop_zone.border_color": "#C2790A",
-      "drag.drop_zone.fill_color": "#C2790A40"
-    }
-  },
-  {
     "name": "Kiwi Gold",
     "colors": {
       "app_bar.item_color": "#EAF3EE",

--- a/Tests/KiwiDeskCoreTests/ColorPaletteTests.swift
+++ b/Tests/KiwiDeskCoreTests/ColorPaletteTests.swift
@@ -117,15 +117,15 @@ struct ColorPaletteTests {
         #expect(settings.appBarStyle.fillColor == before)
     }
 
-    @Test("The bundled catalog is 9 palettes, default first, unique")
+    @Test("The bundled catalog is 8 palettes, default first, unique")
     func bundledCatalog() {
         let all = PaletteCatalog.bundled()
-        #expect(all.count == 9)
+        #expect(all.count == 8)
         #expect(all.first?.name == PaletteCatalog.defaultName)
         let names = all.map(\.name)
-        #expect(Set(names).count == 9)
-        // The eight authored palettes decoded from the resource.
-        #expect(PaletteCatalog.authored().count == 8)
+        #expect(Set(names).count == 8)
+        // The seven authored palettes decoded from the resource.
+        #expect(PaletteCatalog.authored().count == 7)
     }
 
     @Test("Every bundled palette's colors are valid hexes")

--- a/Tests/KiwiDeskCoreTests/PaletteStoreTests.swift
+++ b/Tests/KiwiDeskCoreTests/PaletteStoreTests.swift
@@ -23,7 +23,7 @@ struct PaletteStoreTests {
     @Test("Built-ins are the catalog; no user palettes at first")
     func initialState() {
         let (store, _) = makeStore()
-        #expect(store.builtins().count == 9)
+        #expect(store.builtins().count == 8)
         #expect(store.userPalettes().isEmpty)
     }
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1525,11 +1525,14 @@ identity. Chrome the app fully controls takes the brand kiwi
 green directly: bar `active`/`highlight` = `#8DB354`, hover =
 `#AACB5D80`, item text = cool ink `#EAF3EE`, fill = cool-dark
 `#14201C66`. The forest green `#4E9F3D` and cream `#F2EBD9` are
-retired everywhere. Two branded siblings lead the shelf after
-the default: **Kiwi Dark** (dark-base green identity, distinct
-from neutral True Dark) and **Kiwi Gold** (warm gold-fruit
-variant, green as its secondary) — both in `bundled.json`.
-The authored siblings are **hand-maintained**: unlike the derived
+retired everywhere. One branded sibling leads the shelf after
+the default: **Kiwi Gold** (warm gold-fruit variant, green as its
+secondary) in `bundled.json`. Bundled dark presets cover three
+non-overlapping axes — brand-soft (the default), neutral-hard
+(True Dark), warm (Kiwi Gold); a near-dupe fourth doesn't earn a
+slot, and opacity/contrast variants belong in Lua/profile tuning,
+not a second preset. The authored siblings are **hand-maintained**:
+unlike the derived
 "Kiwi (Default)" (which reads live from the struct defaults via
 `PaletteCatalog.defaultPalette`), they do not auto-track a
 brand-token change — shifting a brand hex means editing


### PR DESCRIPTION
After the green-forward convergence (#439) the default is itself a green-on-dark theme, so **Kiwi Dark** had collapsed to a near-dupe of it — identical but for bar-fill opacity (`#14201C99` vs `#14201C66`) and the unfocused-border grey.

The bundled dark presets already cover three non-overlapping axes — **default** (brand-soft), **True Dark** (neutral-hard), **Kiwi Gold** (warm). A fourth near-dupe doesn't earn a picker slot; an opacity/contrast dark variant is a Lua/profile tweak, not a preset ("GUI curates, Lua is open").

## Changes
- Remove the `Kiwi Dark` block from `bundled.json` (7 authored palettes, 8 total incl. the derived default)
- Update catalog-count assertions (`ColorPaletteTests` 9→8, `PaletteStoreTests` builtins 9→8)
- Trim the `design-decisions.md` note to the durable curation principle

## Test plan
- `swift build && swift test` (1831 pass) && `scripts/lint.sh` (clean) && `swift build -c release` (pass)

Pre-release, single-user: a profile that had Kiwi Dark selected falls back to the default on load — no migration (AGENTS.md §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)