### PR TITLE
fix: kill the full-suite test-runner hang at its two roots (#489)

### DIFF
--- a/Sources/KiwiDeskCore/IPC/SocketClient.swift
+++ b/Sources/KiwiDeskCore/IPC/SocketClient.swift
@@ -53,7 +53,14 @@ public final class SocketClient {
             }
         }
         guard result == 0 else {
-            Darwin.close(fd)
+            // Do NOT close here: every stored property is
+            // initialized by now, so a throwing class init still
+            // runs deinit, whose close would then be the SECOND
+            // close of this fd. Under concurrent fd churn the
+            // number gets recycled — and a guarded reissue turns
+            // the double close into an EXC_GUARD process kill
+            // (#489: the test-runner crash). deinit owns the one
+            // and only close.
             throw SocketError.connectFailed(
                 String(cString: strerror(errno))
             )

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -128,6 +128,15 @@ public final class ExecLauncher {
             process.standardError = pipes.err
             capture = OutputCapture(pipes.out, pipes.err)
         } else {
+            // Fire-and-forget: nobody reads the output, so give
+            // the child the null device instead of letting it
+            // inherit ours. An inherited pipe outlives us in a
+            // long-lived child (a wedged `sketchybar --trigger`),
+            // and whoever reads our stdout then waits for an EOF
+            // that never comes — the #489 test-runner hang, where
+            // the child held the swiftpm runner's pipe hostage.
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
             capture = nil
         }
 


### PR DESCRIPTION
## Summary
- `SocketClient`: a failed `connect()` closed the fd **and** threw from a fully-initialized class init — which still runs `deinit`, closing the same fd a second time. Under the swiftpm runner's concurrent fd churn the number gets recycled and guarded, turning the double close into an `EXC_GUARD` kill of the whole test process (crash reports: `swiftpm-testing-helper-2026-07-24-175843.ips` plus two retired ones from 2026-07-23, all the same signature).
- `ExecLauncher`: fire-and-forget children (no `onExit`) inherited our stdout/stderr. A wedged `sketchybar --trigger x` (spawned by `FirstRunSeedTests`' init.lua fixture — no daemon listening, the CLI blocks forever) held the runner's stdout pipe open past the crash, so `swift-test` waited for EOF forever: the crash presented as the familiar silent tail hang. Fire-and-forget output is never read; children now get the null device. The capture path is unchanged.

Together these explain why the hang was sporadic, why it survived `--skip ExecTests`, and why it looked like a hang rather than a failure.

## Verification
- Full suite `swift test --skip ExecTests`: **1833 tests / 311 suites passed** in 174s — the first complete run of the day; the two prior runs died mid-flight with the EXC_GUARD crash + pipe-hostage hang this PR removes.
- `swift test --filter ExecTests`: 14/14 passed.
- `scripts/lint.sh`: OK. `swift build -c release`: OK.

Fixes #489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)