### PR TITLE
fix(commands): re-anchor any window moved to a floating-mode space (#498)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+FloatReanchor.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+FloatReanchor.swift
@@ -13,9 +13,11 @@ import CoreGraphics
 /// apply path to drift. (Stickies are the one exception — see
 /// below: they never park, so they apply directly.)
 extension KiwiCore {
-    /// Re-anchors floating `id` onto `target`'s display when
-    /// that differs from the display its frame sits on. No-op
-    /// for tiled windows (the layout owns their frames),
+    /// Re-anchors `id` onto `target`'s display when that differs
+    /// from the display its frame sits on — every float-flagged
+    /// window, plus any window bound for a floating-MODE space
+    /// (#498, `FloatReanchor.eligible`). No-op for tiled windows
+    /// bound for tiling spaces (the layout owns their frames),
     /// same-display moves (#412 stash behavior unchanged),
     /// global stickies (visible everywhere, so a membership move
     /// never needs to teleport one), and a window mid-drag (the
@@ -26,7 +28,10 @@ extension KiwiCore {
     /// resolves the bars.
     func reanchorFloat(_ id: WindowID, to target: SpaceID) {
         guard let window = state.windows[id],
-            window.isFloating,
+            FloatReanchor.eligible(
+                isFloating: window.isFloating,
+                targetMode: state.workspaces[target]?.mode
+            ),
             window.stickyScope != .global,
             tiler.dragExemptWindow != id
         else { return }
@@ -70,7 +75,11 @@ extension KiwiCore {
         // would silently wipe the seed (`forgetStash`). No
         // park/restore cycle to ride: apply directly, dropping
         // any stale capture so a restore can't fight the frame.
-        if window.isSticky {
+        // A non-flagged window bound for a floating-MODE space
+        // (#498) also applies directly: the stash machinery only
+        // captures frames for float-FLAGGED windows, so a seeded
+        // capture would never be delivered for it.
+        if window.isSticky || !window.isFloating {
             tiler.forgetStash(id)
             tiler.applyFrame(
                 id,

--- a/Sources/KiwiDeskCore/Tiling/FloatReanchor.swift
+++ b/Sources/KiwiDeskCore/Tiling/FloatReanchor.swift
@@ -22,6 +22,20 @@ public enum FloatReanchor {
     /// untouched; an axis larger than the target pins to its
     /// min edge — `FloatNudge.confine`). A degenerate source
     /// span maps to the target's center.
+    /// Whether a window moved to `targetMode` needs the
+    /// re-anchor at all (#498): every float-flagged window, and
+    /// ANY window bound for a floating-MODE space — there the
+    /// layout assigns no frames, so "the retile delivers" never
+    /// happens and membership alone would leave it physically on
+    /// the old display. Tiled windows bound for tiling spaces
+    /// skip: the layout owns their frames.
+    public static func eligible(
+        isFloating: Bool,
+        targetMode: LayoutMode?
+    ) -> Bool {
+        isFloating || targetMode == .floating
+    }
+
     public static func target(
         frame: CGRect,
         from source: CGRect,

--- a/Tests/KiwiDeskCoreTests/FloatReanchorTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatReanchorTests.swift
@@ -179,4 +179,37 @@ struct FloatReanchorSeedTests {
         )
         #expect(engine.stashOriginal(WindowID(1)) == seeded)
     }
+
+    @Test("Eligibility: floats always, anyone into floating mode")
+    func eligibility() {
+        // Float-flagged windows re-anchor whatever the target.
+        #expect(
+            FloatReanchor.eligible(
+                isFloating: true,
+                targetMode: .bsp
+            )
+        )
+        // A tiled window bound for a floating-MODE space (#498)
+        // re-anchors too: that layout assigns no frames, so no
+        // retile would ever deliver it to the new display.
+        #expect(
+            FloatReanchor.eligible(
+                isFloating: false,
+                targetMode: .floating
+            )
+        )
+        // Tiled window into a tiling space: the layout owns it.
+        #expect(
+            !FloatReanchor.eligible(
+                isFloating: false,
+                targetMode: .track
+            )
+        )
+        #expect(
+            !FloatReanchor.eligible(
+                isFloating: false,
+                targetMode: nil
+            )
+        )
+    }
 }

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -173,7 +173,10 @@ If the target space is shown on **another monitor**, a floating
 window is re-anchored onto that display — it keeps its
 *proportional* position (a bottom-right float stays bottom-right
 on a differently-sized screen), clamped inside the target's
-usable area. (Tiled windows arrive through the layout anyway.)
+usable area. Tiled windows arrive through the layout — except
+into a **floating-mode space**, whose layout assigns no frames:
+any window moved there is re-anchored the same proportional
+way, so it physically arrives on that monitor too.
 
 A quick drag-and-drop of a window onto a Space item in the Space
 Bar performs this same move (see the user guide), re-anchoring a


### PR DESCRIPTION
## Summary
A tiled window moved to a floating-mode space shown on another monitor stayed physically on the old display (and with `_and_follow`, took focus there): the #444 re-anchor guards on `isFloating`, and "the retile delivers" never fires for a layout that assigns no frames — the move fell through both placement paths.

The re-anchor gate is now the pure `FloatReanchor.eligible(isFloating:targetMode:)`: float-flagged windows as before, **plus any window bound for a floating-mode space**. The non-flagged case applies its translated frame directly (the display-sticky precedent) — the stash machinery only captures frames for float-flagged windows, so a seeded capture would never deliver. Covers both call paths (`moveWindow`, `reanchorFloats` on display change). AeroSpace does the equivalent proportional position-only re-anchor in its floating layout pass, which corroborates the shape.

Docs: `move_to_space` re-anchor paragraph extended.

## Verification
- `FloatReanchorTests` extended with the eligibility pin; suite green.
- Debug + release builds, lint OK. Cross-display translation itself needs real screens — device eye-confirm (move a tiled window from monitor 1 to the floating space on monitor 2) is the merge gate.

Fixes #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)