### PR TITLE
fix(tiling): capture floating-mode members on park (#500)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -102,13 +102,9 @@ public final class KiwiCore {
     /// a user action, not our raise's echo.
     static let selfRaiseSiblingWindow: TimeInterval = 1.0
 
-    /// The last left-button press, in AX coordinates (#496): the
-    /// click discriminator for the cross-display sibling
-    /// distrust. A focus report backed by a fresh click inside
-    /// the reported window is a user action; one without is an
-    /// activation re-report. Stamped by the `MouseTracker` hook
-    /// in `KiwiCore+Lifecycle`; compared against
-    /// `selfRaiseSiblingWindow` so the two recencies agree.
+    /// Last left press, AX coords (#496): the click
+    /// discriminator for the cross-display sibling distrust —
+    /// see `recentClickInside`. Stamped in `KiwiCore+Lifecycle`.
     var lastLeftClick: (at: Date, point: CGPoint)?
 
     /// Windows we raised purely for z-order, stamped with the raise

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine+Stash.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine+Stash.swift
@@ -151,7 +151,14 @@ extension TilingEngine {
                     in: bounds,
                     corner: corner,
                     force: force,
-                    animated: animated
+                    animated: animated,
+                    // A floating-MODE space's members ride the
+                    // float capture/restore cycle whatever their
+                    // own flag (#500): its layout places nothing
+                    // on return, so without a capture nothing
+                    // would ever bring them back from the corner.
+                    capturesOriginal: window.isFloating
+                        || space.mode == .floating
                 )
             }
         }
@@ -167,12 +174,19 @@ extension TilingEngine {
     /// nil: a later forced re-stash (whose state frame is
     /// already the AX echo of the corner) must not overwrite
     /// the original.
+    /// `capturesOriginal` overrides the default `isFloating`
+    /// capture gate (#500): `stashInactive` passes the
+    /// EFFECTIVE-float verdict — flag OR floating-mode space —
+    /// since a floating layout places nothing on return and the
+    /// restore pass is such a window's only way back. Nil keeps
+    /// the flag-only default for direct callers.
     func stash(
         _ window: ManagedWindow,
         in bounds: CGRect,
         corner: HideCorner,
         force: Bool,
-        animated: Bool = false
+        animated: Bool = false,
+        capturesOriginal: Bool? = nil
     ) {
         let target = Self.stashFrame(
             window.frame,
@@ -182,7 +196,7 @@ extension TilingEngine {
         if !force, Self.close(window.frame, to: target) {
             return
         }
-        if window.isFloating,
+        if capturesOriginal ?? window.isFloating,
             stashedFrames[window.id] == nil
         {
             stashedFrames[window.id] = window.frame

--- a/Tests/KiwiDeskCoreTests/FloatingModeParkTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatingModeParkTests.swift
@@ -1,0 +1,57 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// #500 end to end: parking a floating-mode space captures its
+/// members' frames — flag or no flag — so activating the space
+/// restores them instead of leaving them in the stash corner.
+@Suite("Floating-mode space park (#500)", .serialized)
+@MainActor
+struct FloatingModeParkTests {
+    @Test("Parking a floating-mode space captures every member")
+    func parkCapturesMembers() {
+        let core = KiwiCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-floatpark-\(UUID().uuidString)"
+                )
+        )
+        core.execute(
+            "set_mode",
+            args: [.string("2"), .string("floating")]
+        )
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(
+                    id: WindowID(1),
+                    pid: 1,
+                    appName: "A"
+                )
+            )
+        )
+        let frame = CGRect(
+            x: 300,
+            y: 200,
+            width: 800,
+            height: 600
+        )
+        core.state.apply(.windowMoved(WindowID(1), frame))
+        // The move parks space 2's member on the retile; the
+        // NON-flagged window must capture its original like a
+        // float would — no layout will ever place it back.
+        core.moveWindow(
+            WindowID(1),
+            to: SpaceID(2),
+            follow: false
+        )
+        #expect(
+            core.tiler.stashOriginal(WindowID(1)) == frame
+        )
+        #expect(
+            core.state.windows[WindowID(1)]?.isFloating == false
+        )
+    }
+}

--- a/Tests/KiwiDeskCoreTests/MoveFocusLatchTests.swift
+++ b/Tests/KiwiDeskCoreTests/MoveFocusLatchTests.swift
@@ -66,6 +66,32 @@ struct MoveFocusLatchTests {
         #expect(!latch.isLatched(WindowID(1), at: later))
     }
 
+    /// #493 edge case 2: the floating-mode re-anchor (#498) is
+    /// pure geometry before the follow branch — a no-follow move
+    /// into a floating-mode space relocates the frame but must
+    /// compose with the latch exactly like any other no-follow
+    /// move: stay on the origin space, schedule no follow.
+    @Test("No-follow move to a floating-mode space stays put")
+    func noFollowFloatingModeMoveStaysPut() {
+        let core = makeCore()
+        core.execute(
+            "set_mode",
+            args: [.string("2"), .string("floating")]
+        )
+        addWindow(core, 10, pid: 5)
+        addWindow(core, 20, pid: 5)
+        core.moveWindow(
+            WindowID(20),
+            to: SpaceID(2),
+            follow: false
+        )
+        #expect(core.moveLatch.isLatched(WindowID(20)))
+        #expect(
+            core.state.workspaces.activeSpace == SpaceID(1)
+        )
+        #expect(core.deferred.task(for: .focusFollow) == nil)
+    }
+
     @Test("No-follow move latches; follow move does not")
     func noFollowMoveStampsLatch() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/StashRestoreTests.swift
+++ b/Tests/KiwiDeskCoreTests/StashRestoreTests.swift
@@ -86,6 +86,25 @@ struct StashCaptureTests {
         #expect(engine.stashedFrames.isEmpty)
     }
 
+    /// #500: `stashInactive` passes the EFFECTIVE-float verdict
+    /// — a floating-MODE space's member captures whatever its
+    /// own flag, since no layout will place it on return.
+    @Test("The effective-float override captures a tiled window")
+    func effectiveFloatOverrideCaptures() {
+        let engine = TilingEngine()
+        let window = makeWindow(1, floating: false)
+        engine.stash(
+            window,
+            in: bounds,
+            corner: .bottomRight,
+            force: true,
+            capturesOriginal: true
+        )
+        #expect(
+            engine.stashedFrames[WindowID(1)] == window.frame
+        )
+    }
+
     /// The sticky exemption moved out of `stash` into the
     /// `stickyExemptFromStash` predicate applied by `stashInactive`
     /// (#445), so `stash` itself now parks whatever it is handed —


### PR DESCRIPTION
## Summary
Switching away from a floating-mode space and back left its windows parked in the stash corner: the park machinery captured a restore frame only for float-flagged windows — non-flagged members are "the layout's to place" on return, but a floating layout places nothing, so nothing ever brought them back. Third surface of the effective-float blind spot (#493/#498 fixed the cross-display move; this is the park/restore cycle).

`stashInactive` now passes the effective-float verdict (flag OR floating-mode space) down to `stash`'s capture gate; the restore pass keys purely on the capture dict and needed no change. The `isFloating` flag stays orthogonal per #493's recorded decision.

Also pins #493's edge case 2: a no-follow move into a floating-mode space composes with the `MoveIntentLatch` (origin space kept, no follow scheduled). Trims `KiwiCore.swift` back under the 350-line ceiling.

## Verification
- New pins: engine-level capture-override test, end-to-end park-captures-member test, latch-composition test. Full suite 1862/319 + ExecTests 14/14, lint OK, release build OK.
- Device-QA'd by the owner: floating-space members now return to their positions on space switch, same- and cross-monitor.

Fixes #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)