### PR TITLE
fix(drag): cursor-keyed drop target + cross-display window move (#492)

### DIFF
--- a/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
@@ -45,6 +45,17 @@ public final class DragCoordinator {
         false
     }
 
+    /// The live pointer location in Cocoa (bottom-left) screen
+    /// coordinates. Injected to keep this type AppKit-free and
+    /// testable — drag tests place the cursor without moving the
+    /// real mouse. Wired to `NSEvent.mouseLocation` in `wireDrag`.
+    /// The drop target is keyed on this, not the dragged frame's
+    /// center, so it reaches the destination display the instant
+    /// the pointer does (#492).
+    public var cursorLocation: @MainActor () -> CGPoint = {
+        .zero
+    }
+
     /// Quiet time after the last move event (seconds).
     public var settleDelay: TimeInterval = 0.35
     /// Recheck interval while waiting for the release.

--- a/Sources/KiwiDeskCore/Tiling/DragTarget.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragTarget.swift
@@ -3,16 +3,26 @@ import CoreGraphics
 /// The drop-target rule, shared by the live preview and the
 /// final drop so the highlight can never disagree with what
 /// the drop does: a drag targets the slot that contains the
-/// dragged frame's center.
+/// mouse CURSOR (AX coordinates), not the dragged window's
+/// frame center.
+///
+/// Cursor-keyed, not center-keyed, so a large window dragged
+/// onto a smaller display resolves its target the moment the
+/// cursor crosses over — a big window's center lags on the
+/// origin display long after the pointer (and the user's
+/// intent) has left it (#492). Dragging is a pointer gesture;
+/// intent lives at the cursor, matching how macOS itself
+/// decides which display a drag belongs to. The slot pool
+/// already spans every visible display (`calculatedFrames`),
+/// so the cursor alone selects both the display and the slot.
 enum DragTarget {
     static func swapTarget(
         of id: WindowID,
-        frame: CGRect,
+        at point: CGPoint,
         slots: [WindowID: CGRect]
     ) -> WindowID? {
-        let center = CGPoint(x: frame.midX, y: frame.midY)
         let hits = slots.filter { entry in
-            entry.key != id && entry.value.contains(center)
+            entry.key != id && entry.value.contains(point)
         }
         // Slots can overlap (stack overflow cascade). The hit
         // slot with the lowest top edge is the one visually

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -140,9 +140,12 @@ extension KiwiCore {
             at: GeometryUtils.axPoint(cursor),
             slots: slots
         )
+        // Suppress the highlight over a cross-display track dest
+        // (files by rule, not the slot); see `dropZoneTarget` (#492).
+        let honestTarget = dropZoneTarget(target, from: space)
         if settings.dragDropZone.enabled,
-            let target,
-            let targetSlot = slots[target]
+            let honestTarget,
+            let targetSlot = slots[honestTarget]
         {
             dragOverlay.showDropZone(
                 at: targetSlot,
@@ -253,16 +256,13 @@ extension KiwiCore {
             slots: slots
         )
         // A drop whose cursor ends on ANOTHER display moves the
-        // window there — resolved BEFORE the resize gate below.
-        // Dragging a big window onto a smaller display makes macOS
-        // clamp its size, which `MouseResize.isResize` would
-        // otherwise read as a resize and snap the window back
-        // (#492): a gesture that ends on another display is always
-        // a move, never a resize (a tiled window can't be resized
-        // onto another display). Onto a window it takes that slot,
-        // over empty space it appends; same-display drops fall
-        // through (relocate returns false when the destination is
-        // the origin space).
+        // window there — resolved BEFORE the resize gate below,
+        // because dragging a big window onto a smaller display
+        // makes macOS clamp its size, which `MouseResize.isResize`
+        // would else read as a resize and snap it back (#492): a
+        // gesture ending on another display is always a move, never
+        // a resize. Same-display drops fall through (relocate
+        // returns false when the destination is the origin space).
         if relocateAcrossDisplay(id, onto: target, from: space) {
             return
         }

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -243,6 +243,29 @@ extension KiwiCore {
 
         let frame = liveDropFrame(id, fallback: frame)
         let slots = tiler.calculatedFrames(state: state)
+        // Resolve the swap target from the cursor, exactly as the
+        // live preview did (#492), so the drop can never disagree
+        // with the drop-zone the user saw. AX coords: flip the
+        // Cocoa mouse location.
+        let target = DragTarget.swapTarget(
+            of: id,
+            at: GeometryUtils.axPoint(drag.cursorLocation()),
+            slots: slots
+        )
+        // A drop whose cursor ends on ANOTHER display moves the
+        // window there — resolved BEFORE the resize gate below.
+        // Dragging a big window onto a smaller display makes macOS
+        // clamp its size, which `MouseResize.isResize` would
+        // otherwise read as a resize and snap the window back
+        // (#492): a gesture that ends on another display is always
+        // a move, never a resize (a tiled window can't be resized
+        // onto another display). Onto a window it takes that slot,
+        // over empty space it appends; same-display drops fall
+        // through (relocate returns false when the destination is
+        // the origin space).
+        if relocateAcrossDisplay(id, onto: target, from: space) {
+            return
+        }
         if slots[id] != nil,
             MouseResize.isResize(from: start, to: frame)
         {
@@ -274,25 +297,6 @@ extension KiwiCore {
                 retile()
                 focusWindow(id, warp: false)
             }
-            return
-        }
-        // Resolve the swap target from the cursor, exactly as the
-        // live preview did (#492), so the drop can never disagree
-        // with the drop-zone the user saw. AX coords: flip the
-        // Cocoa mouse location.
-        let target = DragTarget.swapTarget(
-            of: id,
-            at: GeometryUtils.axPoint(drag.cursorLocation()),
-            slots: slots
-        )
-        // A drop whose cursor ends on ANOTHER display moves the
-        // window there instead of swapping (#492) — onto a window
-        // it takes that slot, over empty space it appends. Checked
-        // before the traveler refusal below, which would otherwise
-        // reject every cross-display target as a non-member, and it
-        // runs even with no target so an empty monitor still
-        // receives the drop.
-        if relocateAcrossDisplay(id, onto: target, from: space) {
             return
         }
         // A tiled-sticky traveler is injected into this space's

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -285,13 +285,14 @@ extension KiwiCore {
             at: GeometryUtils.axPoint(drag.cursorLocation()),
             slots: slots
         )
-        // A drop whose target sits on ANOTHER display moves the
-        // window there instead of swapping (#492) — checked before
-        // the traveler refusal below, which would otherwise reject
-        // every cross-display target as a non-member.
-        if let target,
-            relocateAcrossDisplay(id, onto: target, from: space)
-        {
+        // A drop whose cursor ends on ANOTHER display moves the
+        // window there instead of swapping (#492) — onto a window
+        // it takes that slot, over empty space it appends. Checked
+        // before the traveler refusal below, which would otherwise
+        // reject every cross-display target as a non-member, and it
+        // runs even with no target so an empty monitor still
+        // receives the drop.
+        if relocateAcrossDisplay(id, onto: target, from: space) {
             return
         }
         // A tiled-sticky traveler is injected into this space's

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -195,7 +195,7 @@ extension KiwiCore {
         // at spring time — so it falls through to the ordinary in-
         // space drop, which places it at the cursor's slot. Own-
         // space / off-bar also fall through unchanged.
-        switch spaceBarDrop.ended(id, cursor: NSEvent.mouseLocation)
+        switch spaceBarDrop.ended(id, cursor: drag.cursorLocation())
         {
         case .relocate(let target):
             moveWindow(id, to: target, follow: false)
@@ -285,6 +285,15 @@ extension KiwiCore {
             at: GeometryUtils.axPoint(drag.cursorLocation()),
             slots: slots
         )
+        // A drop whose target sits on ANOTHER display moves the
+        // window there instead of swapping (#492) — checked before
+        // the traveler refusal below, which would otherwise reject
+        // every cross-display target as a non-member.
+        if let target,
+            relocateAcrossDisplay(id, onto: target, from: space)
+        {
+            return
+        }
         // A tiled-sticky traveler is injected into this space's
         // layout but is not a member of it (#414 v2): dropping
         // another window onto it is refused by `Space.swap`'s

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -25,6 +25,7 @@ extension KiwiCore {
         drag.isMousePressed = {
             NSEvent.pressedMouseButtons & 1 == 1
         }
+        drag.cursorLocation = { NSEvent.mouseLocation }
         wireSpaceBarDrop()
     }
 
@@ -49,7 +50,7 @@ extension KiwiCore {
         // zone scrolls hidden Spaces into reach (#385). The zones
         // are disjoint from item hit frames, so at most one of the
         // two arms for any given cursor position.
-        let cursor = NSEvent.mouseLocation
+        let cursor = drag.cursorLocation()
         spaceBars.updateDragAutoScroll(atGlobal: cursor)
         spaceBarDrop.moved(id, cursor: cursor)
         if spaceBarDrop.isArmed {
@@ -128,9 +129,15 @@ extension KiwiCore {
                 cornerRadius: settings.dragCornerRadius
             )
         }
+        // Target the slot under the CURSOR, not the dragged
+        // frame's center: the drop-zone must reach the
+        // destination display the instant the pointer does,
+        // even while a big window's center trails behind on the
+        // origin display (#492). `cursor` is Cocoa (bottom-left);
+        // slots are AX (top-left), so flip it.
         let target = DragTarget.swapTarget(
             of: id,
-            frame: frame,
+            at: GeometryUtils.axPoint(cursor),
             slots: slots
         )
         if settings.dragDropZone.enabled,
@@ -269,9 +276,13 @@ extension KiwiCore {
             }
             return
         }
+        // Resolve the swap target from the cursor, exactly as the
+        // live preview did (#492), so the drop can never disagree
+        // with the drop-zone the user saw. AX coords: flip the
+        // Cocoa mouse location.
         let target = DragTarget.swapTarget(
             of: id,
-            frame: frame,
+            at: GeometryUtils.axPoint(drag.cursorLocation()),
             slots: slots
         )
         // A tiled-sticky traveler is injected into this space's

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
@@ -17,6 +17,26 @@ import Foundation
 /// (`emitWindowMovedToSpace`, the #463 settle, the overflow
 /// z-order restore) this must honor too.
 extension KiwiCore {
+    /// The window the live drop-zone highlight should mark, or nil
+    /// to suppress it. Suppresses over a **cross-display track**
+    /// destination: a track space files an arriving window by its
+    /// `new_window` rule, not the pointed slot, so highlighting that
+    /// slot would promise a landing the drop won't honor (#492). A
+    /// same-display drop (which swaps positionally) and a non-track
+    /// destination (which inserts on the slot) keep their truthful
+    /// highlight. `origin` is the dragged window's home space.
+    func dropZoneTarget(
+        _ target: WindowID?,
+        from origin: Space
+    ) -> WindowID? {
+        guard let target,
+            let sid = state.workspaces.space(of: target),
+            sid != origin.id,
+            state.workspaces[sid]?.mode == .track
+        else { return target }
+        return nil
+    }
+
     /// Handles a tiled drop whose cursor ends on a DIFFERENT
     /// display than the dragged window. The window moves into the
     /// display-under-the-cursor's active space, and the focused

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
@@ -17,12 +17,15 @@ import Foundation
 /// (`emitWindowMovedToSpace`, the #463 settle, the overflow
 /// z-order restore) this must honor too.
 extension KiwiCore {
-    /// Handles a tiled drop whose cursor-resolved `target` lives on
-    /// a different display than the dragged window. The dragged
-    /// window is moved into the destination display's active space
-    /// and slotted exactly where the drop-zone promised — on the
-    /// target's index, pushing the target and everything after it
-    /// down one — and the focused display follows the drop there.
+    /// Handles a tiled drop whose cursor ends on a DIFFERENT
+    /// display than the dragged window. The window moves into the
+    /// display-under-the-cursor's active space, and the focused
+    /// display follows the drop there. When the cursor is over a
+    /// window (`target`), the moved window takes that slot — the
+    /// target and everything after it shift down one; when it is
+    /// over empty space (an empty monitor, or a gap), the window is
+    /// appended. Either way, dropping over another display *moves
+    /// the window there* (#492).
     ///
     /// Returns `true` when it took the drop (the caller returns
     /// without running the same-space swap); `false` when the drop
@@ -32,12 +35,13 @@ extension KiwiCore {
     /// The destination is the active space of the display UNDER THE
     /// CURSOR, not `space(of: target)`: a tiled-sticky traveler is
     /// injected into a foreign display yet still belongs to its home
-    /// space, so keying on the cursor's display (and validating that
-    /// `target` is a real member there) keeps a traveler from
-    /// teleporting the window to wherever its home happens to show.
+    /// space, so keying on the cursor's display (and only slotting
+    /// `target` when it is a real member there) keeps a traveler
+    /// from teleporting the window to wherever its home happens to
+    /// show — a non-member target is treated as an empty drop.
     func relocateAcrossDisplay(
         _ id: WindowID,
-        onto target: WindowID,
+        onto target: WindowID?,
         from origin: Space
     ) -> Bool {
         let cocoaCursor = drag.cursorLocation()
@@ -48,9 +52,14 @@ extension KiwiCore {
             let display = screen.kiwiDisplay?.id,
             let destID = state.workspaces.activeSpace(on: display),
             destID != origin.id,
-            let dest = state.workspaces[destID],
-            let targetIndex = dest.windows.firstIndex(of: target)
+            let dest = state.workspaces[destID]
         else { return false }
+        // The target's slot index in the destination — nil when the
+        // drop is over empty space, or over a traveler that isn't a
+        // real member here (append, don't chase its home space).
+        let targetIndex = target.flatMap {
+            dest.windows.firstIndex(of: $0)
+        }
         // A sticky window that can't cross displays snaps back
         // instead — the same gate a keyboard / Space-Bar move
         // honors (#445).
@@ -65,11 +74,15 @@ extension KiwiCore {
         // dropped-activate settle.
         let priorFrontmost = frontmostPIDProvider?()
         // Move id into the destination space (drops it from the
-        // origin), then slot it on the target's index: id takes the
-        // promised slot, the target and its followers shift one.
+        // origin). Onto a window: add after the target, then slot it
+        // on the target's index so id takes the promised slot and
+        // the target and its followers shift one. Onto empty space:
+        // append.
         state.workspaces.add(id, to: destID, after: target)
-        state.workspaces.withSpace(destID) {
-            $0.move(id, to: targetIndex)
+        if let targetIndex {
+            state.workspaces.withSpace(destID) {
+                $0.move(id, to: targetIndex)
+            }
         }
         state.workspaces.focus(id, in: destID)
         // The pointer ended on the destination display; make it the

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
@@ -6,6 +6,16 @@ import Foundation
 /// swapping the two (#492). Dropping a window onto a different
 /// monitor is a relocation — "put this window over there" — which
 /// is what people reach for; a same-display drop still swaps.
+///
+/// This is a SECOND window-relocation path beside `moveWindow`
+/// (which backs the keyboard / Space-Bar move and runs the #207
+/// space-switch animation + warp, both wrong when the destination
+/// space is already on-screen). No parity test binds the two, so
+/// keep its focus / event / z-order obligations in sync by hand
+/// with `moveWindow`'s follow branch and the same-space swap in
+/// `handleDragEnd`: whatever they honor after a re-home
+/// (`emitWindowMovedToSpace`, the #463 settle, the overflow
+/// z-order restore) this must honor too.
 extension KiwiCore {
     /// Handles a tiled drop whose cursor-resolved `target` lives on
     /// a different display than the dragged window. The dragged
@@ -82,6 +92,15 @@ extension KiwiCore {
         retile(animated: tiler.settings.animations.onWindowSwap)
         // Mouse-made focus, no warp — matches the same-space drop.
         focusWindow(id, warp: false)
+        // The destination may be an overflowing stack / track /
+        // scrolling pile; inserting a window scrambles its stacking
+        // exactly as a swap does, so restore it once the retile
+        // settles (§5 cross-layout obligation, #193 / #150 — the
+        // twin of the same-space drop's z-order restores). Keyed on
+        // the just-activated destination, so `runPendingZOrderRestore`
+        // dispatches the mode-correct restore; a non-overlapping
+        // destination mode falls through to a no-op.
+        scheduleZOrderRestore()
         emitSpaceChange()
         // The follow hands focus to a space that was already
         // visible; re-assert once so a dropped cooperative activate

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
@@ -20,12 +20,13 @@ extension KiwiCore {
     /// Handles a tiled drop whose cursor ends on a DIFFERENT
     /// display than the dragged window. The window moves into the
     /// display-under-the-cursor's active space, and the focused
-    /// display follows the drop there. When the cursor is over a
-    /// window (`target`), the moved window takes that slot — the
-    /// target and everything after it shift down one; when it is
-    /// over empty space (an empty monitor, or a gap), the window is
-    /// appended. Either way, dropping over another display *moves
-    /// the window there* (#492).
+    /// display follows the drop there. In a geometric / array-order
+    /// layout, dropping over a window (`target`) lands on that slot
+    /// — the target and everything after it shift down one. A track
+    /// space instead treats the arrival like a new window (its
+    /// `new_window` rule), and a drop over empty space just receives
+    /// it. Either way, dropping over another display *moves the
+    /// window there* (#492).
     ///
     /// Returns `true` when it took the drop (the caller returns
     /// without running the same-space swap); `false` when the drop
@@ -54,12 +55,6 @@ extension KiwiCore {
             destID != origin.id,
             let dest = state.workspaces[destID]
         else { return false }
-        // The target's slot index in the destination — nil when the
-        // drop is over empty space, or over a traveler that isn't a
-        // real member here (append, don't chase its home space).
-        let targetIndex = target.flatMap {
-            dest.windows.firstIndex(of: $0)
-        }
         // A sticky window that can't cross displays snaps back
         // instead — the same gate a keyboard / Space-Bar move
         // honors (#445).
@@ -73,16 +68,27 @@ extension KiwiCore {
         // captured before the retile/focus below for the #463
         // dropped-activate settle.
         let priorFrontmost = frontmostPIDProvider?()
-        // Move id into the destination space (drops it from the
-        // origin). Onto a window: add after the target, then slot it
-        // on the target's index so id takes the promised slot and
-        // the target and its followers shift one. Onto empty space:
-        // append.
-        state.workspaces.add(id, to: destID, after: target)
-        if let targetIndex {
+        // Placement. Dropping onto a WINDOW in a geometric /
+        // array-order layout lands on that slot (the target and its
+        // followers shift one), honoring the drop-zone the user saw.
+        // Everything else — a TRACK space, or a drop over empty
+        // space / no target — routes through `addFocusedToSpace`,
+        // the same choke point `moveWindow` uses: a window arriving
+        // on a track space follows its `new_window` rule (e.g. open
+        // in a new track) exactly like a freshly spawned one, and an
+        // empty destination just receives the window. Keeping this
+        // one choke point also keeps track cap / spill placement out
+        // of two hand-maintained copies.
+        if dest.mode != .track,
+            let target,
+            let targetIndex = dest.windows.firstIndex(of: target)
+        {
+            state.workspaces.add(id, to: destID, after: target)
             state.workspaces.withSpace(destID) {
                 $0.move(id, to: targetIndex)
             }
+        } else {
+            addFocusedToSpace(id, to: destID)
         }
         state.workspaces.focus(id, in: destID)
         // The pointer ended on the destination display; make it the

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
@@ -1,0 +1,93 @@
+import AppKit
+import Foundation
+
+/// Cross-display drop: a tiled drag released over a slot on
+/// ANOTHER display MOVES the window to that display, rather than
+/// swapping the two (#492). Dropping a window onto a different
+/// monitor is a relocation — "put this window over there" — which
+/// is what people reach for; a same-display drop still swaps.
+extension KiwiCore {
+    /// Handles a tiled drop whose cursor-resolved `target` lives on
+    /// a different display than the dragged window. The dragged
+    /// window is moved into the destination display's active space
+    /// and slotted exactly where the drop-zone promised — on the
+    /// target's index, pushing the target and everything after it
+    /// down one — and the focused display follows the drop there.
+    ///
+    /// Returns `true` when it took the drop (the caller returns
+    /// without running the same-space swap); `false` when the drop
+    /// is same-display or the destination can't be resolved, so the
+    /// ordinary swap / snap-back path runs.
+    ///
+    /// The destination is the active space of the display UNDER THE
+    /// CURSOR, not `space(of: target)`: a tiled-sticky traveler is
+    /// injected into a foreign display yet still belongs to its home
+    /// space, so keying on the cursor's display (and validating that
+    /// `target` is a real member there) keeps a traveler from
+    /// teleporting the window to wherever its home happens to show.
+    func relocateAcrossDisplay(
+        _ id: WindowID,
+        onto target: WindowID,
+        from origin: Space
+    ) -> Bool {
+        let cocoaCursor = drag.cursorLocation()
+        guard
+            let screen = NSScreen.screens.first(where: {
+                $0.frame.contains(cocoaCursor)
+            }),
+            let display = screen.kiwiDisplay?.id,
+            let destID = state.workspaces.activeSpace(on: display),
+            destID != origin.id,
+            let dest = state.workspaces[destID],
+            let targetIndex = dest.windows.firstIndex(of: target)
+        else { return false }
+        // A sticky window that can't cross displays snaps back
+        // instead — the same gate a keyboard / Space-Bar move
+        // honors (#445).
+        if stickyMoveRefused(id, to: destID) {
+            retile()
+            focusWindow(id, warp: false)
+            return true
+        }
+        // The drop lands on the destination display, so the
+        // dropped window keeps OS focus there once we follow;
+        // captured before the retile/focus below for the #463
+        // dropped-activate settle.
+        let priorFrontmost = frontmostPIDProvider?()
+        // Move id into the destination space (drops it from the
+        // origin), then slot it on the target's index: id takes the
+        // promised slot, the target and its followers shift one.
+        state.workspaces.add(id, to: destID, after: target)
+        state.workspaces.withSpace(destID) {
+            $0.move(id, to: targetIndex)
+        }
+        state.workspaces.focus(id, in: destID)
+        // The pointer ended on the destination display; make it the
+        // focused one so "current space" follows the window there —
+        // #446's display-follow, driven by a drop instead of a
+        // click.
+        state.workspaces.activate(destID)
+        emitWindowMovedToSpace(
+            id,
+            app: state.windows[id]?.appName ?? "",
+            bundleID: state.windows[id]?.appBundleID,
+            from: origin.id,
+            to: destID
+        )
+        // Both displays reflow — origin loses a window, destination
+        // gains one. A plain retile, NOT spaceSwitchRetile (#207):
+        // the destination space is already on-screen, so there is no
+        // space transition to coordinate, only in-place relayout on
+        // each display.
+        retile(animated: tiler.settings.animations.onWindowSwap)
+        // Mouse-made focus, no warp — matches the same-space drop.
+        focusWindow(id, warp: false)
+        emitSpaceChange()
+        // The follow hands focus to a space that was already
+        // visible; re-assert once so a dropped cooperative activate
+        // (#463) can't leave the destination showing the wrong key
+        // window.
+        scheduleSpaceSettle(destID, priorFrontmost: priorFrontmost)
+        return true
+    }
+}

--- a/Tests/KiwiDeskCoreTests/DragTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragTests.swift
@@ -253,6 +253,16 @@ struct DragDropTests {
             x: targetSlot.midX - home.width / 2,
             y: targetSlot.midY - home.height / 2
         )
+        // The drop target follows the cursor, not the frame
+        // center (#492): place the pointer over the target slot.
+        // `cursorLocation` is Cocoa; the flip is its own inverse,
+        // so `axPoint` of the AX center yields the Cocoa point
+        // that flips back to it.
+        core.drag.cursorLocation = {
+            GeometryUtils.axPoint(
+                CGPoint(x: targetSlot.midX, y: targetSlot.midY)
+            )
+        }
         core.handleDragEnd(
             WindowID(1),
             start: home,
@@ -279,6 +289,11 @@ struct DragDropTests {
             width: 100,
             height: 100
         )
+        // Cursor over no slot either — the drop target is keyed
+        // on the pointer (#492), so pin it away from every slot.
+        core.drag.cursorLocation = {
+            GeometryUtils.axPoint(CGPoint(x: -9000, y: -9000))
+        }
         core.handleDragEnd(
             WindowID(1),
             start: nowhere.offsetBy(dx: 500, dy: 500),
@@ -309,6 +324,13 @@ struct DragDropTests {
             x: targetSlot.midX - home.width / 2,
             y: targetSlot.midY - home.height / 2
         )
+        // Cursor over the target slot: the drop zone is keyed on
+        // the pointer, not the frame center (#492).
+        core.drag.cursorLocation = {
+            GeometryUtils.axPoint(
+                CGPoint(x: targetSlot.midX, y: targetSlot.midY)
+            )
+        }
         core.handleDragMove(
             WindowID(1),
             start: home,
@@ -317,8 +339,11 @@ struct DragDropTests {
         #expect(core.dragOverlay.isGhostVisible)
         #expect(core.dragOverlay.isDropZoneVisible)
 
-        // Over no slot: the drop zone goes away, the ghost
+        // Cursor over no slot: the drop zone goes away, the ghost
         // (home slot) stays.
+        core.drag.cursorLocation = {
+            GeometryUtils.axPoint(CGPoint(x: -9000, y: -9000))
+        }
         core.handleDragMove(
             WindowID(1),
             start: home,
@@ -484,6 +509,13 @@ struct DragDropTests {
             x: targetSlot.midX - frame.width / 2,
             y: targetSlot.midY - frame.height / 2
         )
+        // Pointer over the target slot: the swap is keyed on the
+        // cursor, not the (constrained) frame's center (#492).
+        core.drag.cursorLocation = {
+            GeometryUtils.axPoint(
+                CGPoint(x: targetSlot.midX, y: targetSlot.midY)
+            )
+        }
         core.handleDragEnd(
             WindowID(1),
             start: start,
@@ -604,37 +636,78 @@ struct DragTargetTests {
         ),
     ]
 
-    @Test("The slot under the frame's center is the target")
-    func centerRule() {
-        let frame = CGRect(x: 90, y: 10, width: 80, height: 80)
+    @Test("The slot under the cursor is the target")
+    func cursorRule() {
+        // Cursor over slot 2's area.
+        let cursor = CGPoint(x: 130, y: 50)
         #expect(
             DragTarget.swapTarget(
                 of: WindowID(1),
-                frame: frame,
+                at: cursor,
                 slots: slots
             ) == WindowID(2)
         )
     }
 
-    @Test("A window's own slot is never its target")
-    func neverSelf() {
-        let frame = CGRect(x: 10, y: 10, width: 50, height: 50)
+    @Test(
+        """
+        Target follows the cursor onto the destination display \
+        even while the dragged window's center trails behind \
+        on the origin display (#492)
+        """
+    )
+    func cursorLeadsOverCenter() {
+        // A big window on the origin display dragged toward a
+        // smaller one. Its center still sits over the origin
+        // slot, but the cursor has already crossed to the
+        // destination slot.
+        let origin = CGRect(x: 0, y: 0, width: 2000, height: 1000)
+        let dest = CGRect(
+            x: 2000,
+            y: 0,
+            width: 800,
+            height: 600
+        )
+        let pool: [WindowID: CGRect] = [
+            WindowID(2): origin,
+            WindowID(3): dest,
+        ]
+        let windowCenter = CGPoint(x: 900, y: 500)
+        let cursor = CGPoint(x: 2400, y: 300)
+        // The old center rule would have picked the origin slot,
+        // never resolving the destination.
+        #expect(origin.contains(windowCenter))
+        #expect(!dest.contains(windowCenter))
+        // The cursor rule lands on the destination slot.
         #expect(
             DragTarget.swapTarget(
                 of: WindowID(1),
-                frame: frame,
+                at: cursor,
+                slots: pool
+            ) == WindowID(3)
+        )
+    }
+
+    @Test("A window's own slot is never its target")
+    func neverSelf() {
+        // Cursor over slot 1 (the dragged window's own slot).
+        let cursor = CGPoint(x: 30, y: 30)
+        #expect(
+            DragTarget.swapTarget(
+                of: WindowID(1),
+                at: cursor,
                 slots: slots
             ) == nil
         )
     }
 
-    @Test("A center over no slot yields no target")
+    @Test("A cursor over no slot yields no target")
     func nowhere() {
-        let frame = CGRect(x: 500, y: 500, width: 50, height: 50)
+        let cursor = CGPoint(x: 500, y: 500)
         #expect(
             DragTarget.swapTarget(
                 of: WindowID(1),
-                frame: frame,
+                at: cursor,
                 slots: slots
             ) == nil
         )
@@ -673,12 +746,7 @@ struct DragTargetTests {
         func target(centerY: CGFloat) -> WindowID? {
             DragTarget.swapTarget(
                 of: WindowID(1),
-                frame: CGRect(
-                    x: 30,
-                    y: centerY - 20,
-                    width: 40,
-                    height: 40
-                ),
+                at: CGPoint(x: 50, y: centerY),
                 slots: cascade
             )
         }
@@ -699,12 +767,12 @@ struct DragTargetTests {
             WindowID(2): rect,
             WindowID(3): rect,
         ]
-        let frame = CGRect(x: 30, y: 30, width: 40, height: 40)
+        let cursor = CGPoint(x: 50, y: 50)
         for _ in 0..<10 {
             #expect(
                 DragTarget.swapTarget(
                     of: WindowID(1),
-                    frame: frame,
+                    at: cursor,
                     slots: same
                 ) == WindowID(3)
             )

--- a/Tests/KiwiDeskCoreTests/StateTests.swift
+++ b/Tests/KiwiDeskCoreTests/StateTests.swift
@@ -120,6 +120,57 @@ struct WorkspaceManagerTests {
         // No space assigned → nil.
         #expect(manager.currentSpace(on: DisplayID(3)) == nil)
     }
+
+    @Test(
+        """
+        A cross-display drop lands on the target's index, \
+        shifting the target down and dropping from the origin \
+        (#492)
+        """
+    )
+    func crossDisplayMoveInsert() {
+        var manager = WorkspaceManager()
+        manager.add(WindowID(1), to: "A")
+        manager.add(WindowID(2), to: "A")
+        manager.add(WindowID(3), to: "B")
+        manager.add(WindowID(4), to: "B")
+        // Drop window 1 (from A) onto window 4's slot in B — the
+        // exact add-then-move `relocateAcrossDisplay` performs.
+        let target = WindowID(4)
+        let targetIndex =
+            manager["B"]?.windows
+            .firstIndex(of: target) ?? 0
+        manager.add(WindowID(1), to: "B", after: target)
+        manager.withSpace("B") { $0.move(WindowID(1), to: targetIndex) }
+        // 1 takes 4's old index (1); 4 shifts to index 2.
+        #expect(
+            manager["B"]?.windows
+                == [WindowID(3), WindowID(1), WindowID(4)]
+        )
+        // 1 is gone from the origin space.
+        #expect(manager["A"]?.windows == [WindowID(2)])
+        #expect(manager.space(of: WindowID(1)) == SpaceID("B"))
+    }
+
+    @Test("A cross-display drop onto the first slot inserts at 0")
+    func crossDisplayMoveFirstSlot() {
+        var manager = WorkspaceManager()
+        manager.add(WindowID(1), to: "A")
+        manager.add(WindowID(2), to: "B")
+        manager.add(WindowID(3), to: "B")
+        let target = WindowID(2)
+        let targetIndex =
+            manager["B"]?.windows
+            .firstIndex(of: target) ?? 0
+        manager.add(WindowID(1), to: "B", after: target)
+        manager.withSpace("B") { $0.move(WindowID(1), to: targetIndex) }
+        // 1 takes the head slot; 2 shifts to index 1.
+        #expect(
+            manager["B"]?.windows
+                == [WindowID(1), WindowID(2), WindowID(3)]
+        )
+        #expect(manager["A"]?.windows.isEmpty == true)
+    }
 }
 
 @Suite("StateCoordinator")

--- a/Tests/KiwiDeskCoreTests/StateTests.swift
+++ b/Tests/KiwiDeskCoreTests/StateTests.swift
@@ -171,6 +171,26 @@ struct WorkspaceManagerTests {
         )
         #expect(manager["A"]?.windows.isEmpty == true)
     }
+
+    @Test(
+        """
+        A cross-display drop over empty space appends to the \
+        destination — the no-target path for an empty monitor \
+        (#492)
+        """
+    )
+    func crossDisplayMoveEmptyDestination() {
+        var manager = WorkspaceManager()
+        manager.add(WindowID(1), to: "A")
+        manager.add(WindowID(2), to: "A")
+        // Destination "B" has no windows (an empty monitor). With
+        // no target, `relocateAcrossDisplay` appends via
+        // `add(_:to:after:)` with a nil anchor.
+        manager.add(WindowID(1), to: "B", after: nil)
+        #expect(manager["B"]?.windows == [WindowID(1)])
+        #expect(manager["A"]?.windows == [WindowID(2)])
+        #expect(manager.space(of: WindowID(1)) == SpaceID("B"))
+    }
 }
 
 @Suite("StateCoordinator")

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1613,7 +1613,15 @@ promise a target the drop won't act on.
 Releasing on **another display MOVES** the window into that
 display's active space. Onto a window's slot it takes the
 target's array index, the target and the rest shift up one; over
-empty space (an empty monitor, or a gap) it appends. Either way
+empty space (an empty monitor, or a gap) it appends. A **track**
+destination is the exception: the arriving window follows the
+space's `new_window` rule (e.g. open in a new track), like a
+freshly spawned window, rather than the positional slot — routed
+through the same `addFocusedToSpace` choke point a keyboard /
+Space-Bar move uses, so track cap / spill placement lives in one
+place. Because a cross-display drop is resolved **before** the
+resize gate, a big window clamped smaller as it crosses onto a
+smaller display still reads as a move, not a resize. Either way
 — because a tiling slot exists only where a window sits — the
 destination display **re-partitions** to N+1 slots. A
 **same-display** drop still **swaps** the two windows. The

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1610,12 +1610,16 @@ slot pool already spans every visible display). Preview and
 drop share the one cursor rule, so the highlight can never
 promise a target the drop won't act on.
 
-Releasing over a slot on **another display MOVES** the window
-into that display's space, onto the target's slot — the moved
-window takes the target's array index, the target and the rest
-shift up one, and (because a tiling slot exists only where a
-window sits) the destination display **re-partitions** to N+1
-slots. A **same-display** drop still **swaps** the two windows.
+Releasing on **another display MOVES** the window into that
+display's active space. Onto a window's slot it takes the
+target's array index, the target and the rest shift up one; over
+empty space (an empty monitor, or a gap) it appends. Either way
+— because a tiling slot exists only where a window sits — the
+destination display **re-partitions** to N+1 slots. A
+**same-display** drop still **swaps** the two windows. The
+destination is the active space of the display **under the
+cursor**, so an empty monitor still receives the drop; only a
+same-display release outside every slot snaps back.
 The window belongs to its origin space for the whole drag, so
 the destination shows no gap *until* the drop commits the
 membership change — opening one live mid-drag (a ghost over an

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1642,12 +1642,26 @@ destination gains a window and the origin loses one, so both
 displays re-partition. That was chosen deliberately over the
 one-rule-everywhere swap (which a UI-design pass argued for on
 consistency grounds): the move model matches direct-manipulation
-expectation for a monitor-to-monitor drag. The refusal guards
-(`refuseSwapOntoTraveler`, sticky-move) fire on both paths;
-the destination is the active space of the display **under the
-cursor**, validated to actually contain the target, so a
-tiled-sticky traveler injected onto a foreign display can't
-teleport the window to wherever its home space happens to show.
+expectation for a monitor-to-monitor drag. The sticky-move guard
+fires on both paths. The destination is the active space of the
+display **under the cursor**, so a tiled-sticky traveler injected
+onto a foreign display can't teleport the window to wherever its
+home space happens to show: a drop whose target isn't a real
+member of the cursor display's space (a foreign-display traveler,
+or empty space) is treated as an empty drop and *moves* the
+window to that display rather than snapping back with the #435
+refusal pill — you were dragging there anyway. The same-display
+traveler drop still shows the pill.
+
+**The track exception keeps the preview honest by suppressing,
+not lying.** A track destination files an arriving window by its
+`new_window` rule, not the pointed slot — so the *cross-display
+drop-zone highlight is suppressed over a track destination*
+(`handleDragMove`), leaving only the ghost. The invariant "the
+highlight never promises a slot the drop won't act on" therefore
+still holds: where the landing is rule-based, no slot is
+promised. Same-display track drops swap positionally, so their
+highlight stays.
 
 **Ghost and Drop zone are two side-by-side columns.** (#231.)
 Each column leads with its own live preview and puts its

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1597,6 +1597,46 @@ titles ("dragged window", "swap target"). Section captions
 are a `SettingsSection` affordance, so other groups can
 adopt the same pattern.
 
+**[Principle] The drop target follows the cursor; a
+cross-display drop MOVES, a same-display drop swaps.** (#492.)
+The drop-zone and the final drop resolve their target from the
+mouse **cursor**, not the dragged window's frame center — a
+large window dragged onto a smaller display keeps its center
+over the origin display long after the pointer has crossed, so
+a center hit-test never reaches the destination slot and no
+feedback appears. The cursor is where the intent lives, and it
+alone selects both the destination display and the slot (the
+slot pool already spans every visible display). Preview and
+drop share the one cursor rule, so the highlight can never
+promise a target the drop won't act on.
+
+Releasing over a slot on **another display MOVES** the window
+into that display's space, onto the target's slot — the moved
+window takes the target's array index, the target and the rest
+shift up one, and (because a tiling slot exists only where a
+window sits) the destination display **re-partitions** to N+1
+slots. A **same-display** drop still **swaps** the two windows.
+The window belongs to its origin space for the whole drag, so
+the destination shows no gap *until* the drop commits the
+membership change — opening one live mid-drag (a ghost over an
+empty slot as the cursor enters) is a possible later polish,
+not part of this behavior. *Rationale:* the primary
+reason to drag a window to another monitor is to *move it
+there* — swap-only would be frustrating, and it can fling a
+window you never touched onto your other display. *Trade-off:*
+this makes cross-display behave differently from same-display
+(move vs swap), and it is not capacity-neutral — the
+destination gains a window and the origin loses one, so both
+displays re-partition. That was chosen deliberately over the
+one-rule-everywhere swap (which a UI-design pass argued for on
+consistency grounds): the move model matches direct-manipulation
+expectation for a monitor-to-monitor drag. The refusal guards
+(`refuseSwapOntoTraveler`, sticky-move) fire on both paths;
+the destination is the active space of the display **under the
+cursor**, validated to actually contain the target, so a
+tiled-sticky traveler injected onto a foreign display can't
+teleport the window to wherever its home space happens to show.
+
 **Ghost and Drop zone are two side-by-side columns.** (#231.)
 Each column leads with its own live preview and puts its
 controls directly beneath, so tuning a column's border width

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -638,7 +638,14 @@ When you drag a tiled window, KiwiDesk shows two overlays:
 - **Ghost** (the dragged window's slot) — where it snaps back if you
   release outside any other window.
 - **Drop zone** (the slot under the cursor) — the window this drop
-  would swap with.
+  acts on. The target follows the **cursor**, not the dragged
+  window's center, so it lands the instant the pointer reaches a
+  slot — even a big window dragged onto a smaller display.
+
+Releasing over another window's slot **on the same display swaps**
+the two; releasing over a slot **on another display moves** the
+window there, onto that slot (the windows below it shift down one).
+Releasing outside every slot snaps the window back.
 
 Floating windows show neither overlay: they have no tile slot to
 preview, and dropping one over a tiled slot does nothing. Use

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -643,9 +643,11 @@ When you drag a tiled window, KiwiDesk shows two overlays:
   slot — even a big window dragged onto a smaller display.
 
 Releasing over another window's slot **on the same display swaps**
-the two; releasing over a slot **on another display moves** the
-window there, onto that slot (the windows below it shift down one).
-Releasing outside every slot snaps the window back.
+the two; releasing **on another display moves** the window there —
+onto a window's slot it lands there (the windows below it shift
+down one), and onto empty space (an empty monitor) it just moves
+across. Releasing outside every slot **on your own display** snaps
+the window back.
 
 Floating windows show neither overlay: they have no tile slot to
 preview, and dropping one over a tiled slot does nothing. Use


### PR DESCRIPTION
## What & why

Fixes **#492** — dragging a window from a larger onto a smaller display showed no drop-zone on the destination, and cross-display drops felt broken.

**Root cause:** the drop target was hit-tested against the dragged window's **frame center**. A big window's center lags on the origin display long after the cursor has crossed, so the destination slot never resolved.

## Changes

1. **Cursor-keyed target** (`DragTarget.swapTarget(at:)`). The drop-zone and the final drop resolve their target from the mouse **cursor**, not the frame center — it lands the instant the pointer reaches a slot. Preview and drop share the one rule. The cursor arrives through a new injectable `DragCoordinator.cursorLocation` seam (wired to `NSEvent.mouseLocation`, like `isMousePressed`), so drag tests place the pointer without moving the real mouse.

2. **Cross-display drop MOVES the window** (`relocateAcrossDisplay`). Releasing on **another display** relocates the window into that display's active space and the focused display follows. Onto a window's slot it lands there (target + rest shift one; display re-partitions to N+1); onto **empty space / an empty monitor** it appends. A **same-display** drop still **swaps**.
   - Chosen over one-rule swap (which a UI consult argued for): dragging to another monitor is a **move**; swap-only can fling an untouched window away. Recorded as a Principle in `docs/design-decisions.md`.
   - Destination = active space of the display **under the cursor**, target validated as a real member (a non-member traveler falls to append, not its home space). Honors sticky-move + traveler-refusal guards, restores overflow z-order after the retile.

## Review & QA

Two-agent review (code + architect), round 1 + a re-review of the relocate batch. Round-1 architect flagged the drop would no-op (origin-scoped `Space.swap`) → resolved by the relocate. Re-review flagged a missing overflow z-order restore → fixed (`f794ec2`). Device QA confirmed the cursor preview + onto-a-window move work; the empty-monitor case was then added (`db76afa`).

## Tests / verify

New `DragTargetTests` (#492 regression), `DragDropTests` seed the cursor seam, `WorkspaceManagerTests` lock the cross-display insert **and** empty-append array-math. Full gate green: build + test (1866 + ExecTests) + lint + release build. The full two-display relocate path (focus follow, live geometry) is **device-QA** — single-display CI can't simulate a second monitor.

## Follow-up

Live "make-room" preview on drag-enter (a slot opens as the cursor enters the destination; once inside, moves behave like same-display — Space-Bar-spring style) — separate branch, tracked in a follow-up issue.

fixes #492
