### PR TITLE
feat(tiling): proportional float size scaling across displays (default on)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+FloatReanchor.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+FloatReanchor.swift
@@ -55,7 +55,8 @@ extension KiwiCore {
         let translated = FloatReanchor.target(
             frame: base,
             from: source,
-            to: dest
+            to: dest,
+            scaleSize: tiler.settings.floatScaleOnDisplayChange
         )
         // Clear of the strips painted for the target space TODAY
         // — the same clamp every float gets (#242). A parked

--- a/Sources/KiwiDeskCore/Commands/APIReference+Suggestion.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference+Suggestion.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Did-you-mean suggestion for an unknown command, split from
+/// `APIReference.swift` for the 350-line file ceiling.
+extension APIReference {
+    /// A close known command for a typo, if any. Suggests only
+    /// dispatchable names — the unknown-command path is reached
+    /// from the CLI/IPC socket too, where a Lua-only name would
+    /// be a dead-end hint.
+    public static func suggestion(
+        for unknown: String
+    ) -> String? {
+        var best: (name: String, distance: Int)?
+        for name in dispatchable {
+            let distance = editDistance(unknown, name)
+            let limit = max(2, unknown.count / 3)
+            guard distance <= limit else { continue }
+            if best == nil || distance < best!.distance {
+                best = (name, distance)
+            }
+        }
+        return best?.name
+    }
+
+    /// Levenshtein distance (small inputs only).
+    static func editDistance(
+        _ a: String,
+        _ b: String
+    ) -> Int {
+        let left = Array(a)
+        let right = Array(b)
+        if left.isEmpty { return right.count }
+        if right.isEmpty { return left.count }
+        var previous = Array(0...right.count)
+        var current = [Int](
+            repeating: 0,
+            count: right.count + 1
+        )
+        for i in 1...left.count {
+            current[0] = i
+            for j in 1...right.count {
+                let cost = left[i - 1] == right[j - 1] ? 0 : 1
+                current[j] = Swift.min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + cost
+                )
+            }
+            swap(&previous, &current)
+        }
+        return previous[right.count]
+    }
+}

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -43,6 +43,10 @@ public enum APIReference {
                 "set_swap_skips_cascade"
             ),
             ("set_float_nudge", "set_float_nudge"),
+            (
+                "set_float_scale_on_display_change",
+                "set_float_scale_on_display_change"
+            ),
             ("set_resize_step", "set_resize_step"),
             (
                 "set_resize_feedback",
@@ -296,53 +300,5 @@ public enum APIReference {
     /// the dispatcher (`exec`, `bind`, …).
     public static var allCommands: [String] {
         Set(dispatchable).union(luaOnly).sorted()
-    }
-
-    /// A close known command for a typo, if any. Suggests only
-    /// dispatchable names — the unknown-command path is reached
-    /// from the CLI/IPC socket too, where a Lua-only name would
-    /// be a dead-end hint.
-    public static func suggestion(
-        for unknown: String
-    ) -> String? {
-        var best: (name: String, distance: Int)?
-        for name in dispatchable {
-            let distance = editDistance(unknown, name)
-            let limit = max(2, unknown.count / 3)
-            guard distance <= limit else { continue }
-            if best == nil || distance < best!.distance {
-                best = (name, distance)
-            }
-        }
-        return best?.name
-    }
-
-    /// Levenshtein distance (small inputs only).
-    static func editDistance(
-        _ a: String,
-        _ b: String
-    ) -> Int {
-        let left = Array(a)
-        let right = Array(b)
-        if left.isEmpty { return right.count }
-        if right.isEmpty { return left.count }
-        var previous = Array(0...right.count)
-        var current = [Int](
-            repeating: 0,
-            count: right.count + 1
-        )
-        for i in 1...left.count {
-            current[0] = i
-            for j in 1...right.count {
-                let cost = left[i - 1] == right[j - 1] ? 0 : 1
-                current[j] = Swift.min(
-                    previous[j] + 1,
-                    current[j - 1] + 1,
-                    previous[j - 1] + cost
-                )
-            }
-            swap(&previous, &current)
-        }
-        return previous[right.count]
     }
 }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
@@ -77,6 +77,8 @@ extension KiwiCore {
             return setSwapSkipsCascade(args)
         case "set_float_nudge":
             return setFloatNudge(args)
+        case "set_float_scale_on_display_change":
+            return setFloatScaleOnDisplayChange(args)
         case "set_resize_step":
             return setResizeStep(args)
         case "set_resize_feedback":

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
@@ -96,6 +96,20 @@ extension KiwiCore {
         return .ok()
     }
 
+    func setFloatScaleOnDisplayChange(
+        _ args: [JSONValue]
+    ) -> CommandResponse {
+        guard let on = args.first?.boolValue else {
+            return .fail("expected boolean")
+        }
+        tiler.settings.floatScaleOnDisplayChange = on
+        // No retile (like `set_float_nudge`): the flag is read
+        // only by `FloatReanchor.target` at a display-crossing
+        // re-anchor, never by layout math, so flipping it moves
+        // nothing here.
+        return .ok()
+    }
+
     func setResizeStep(
         _ args: [JSONValue]
     ) -> CommandResponse {

--- a/Sources/KiwiDeskCore/Tiling/FloatReanchor.swift
+++ b/Sources/KiwiDeskCore/Tiling/FloatReanchor.swift
@@ -36,10 +36,21 @@ public enum FloatReanchor {
         isFloating || targetMode == .floating
     }
 
+    /// When `scaleSize` is on (#502, the default — see
+    /// `TilingSettings.floatScaleOnDisplayChange`), the window's
+    /// size is scaled by the per-axis ratio of the target to the
+    /// source visible frame *before* it is re-centered — so a float
+    /// keeps the same relative footprint across differently sized
+    /// displays (a too-wide window shrinks to fit instead of
+    /// overflowing the smaller screen's edge, which macOS lets it
+    /// do on width while it half-clamps height). Off keeps the
+    /// exact size (the pre-#502 behavior). A degenerate source span
+    /// leaves that axis's size untouched — no ratio to apply.
     public static func target(
         frame: CGRect,
         from source: CGRect,
-        to target: CGRect
+        to target: CGRect,
+        scaleSize: Bool = false
     ) -> CGRect {
         let relX =
             source.width > 0
@@ -49,13 +60,19 @@ public enum FloatReanchor {
             source.height > 0
             ? (frame.midY - source.minY) / source.height
             : 0.5
+        let width =
+            scaleSize && source.width > 0
+            ? frame.width * target.width / source.width
+            : frame.width
+        let height =
+            scaleSize && source.height > 0
+            ? frame.height * target.height / source.height
+            : frame.height
         let moved = CGRect(
-            x: target.minX + relX * target.width
-                - frame.width / 2,
-            y: target.minY + relY * target.height
-                - frame.height / 2,
-            width: frame.width,
-            height: frame.height
+            x: target.minX + relX * target.width - width / 2,
+            y: target.minY + relY * target.height - height / 2,
+            width: width,
+            height: height
         )
         return FloatNudge.confine(moved, to: target)
     }

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
@@ -26,6 +26,8 @@ extension TilingSettings: Codable {
         case minWindowSize = "min_window_size"
         case swapSkipsCascade = "swap_skips_cascade"
         case floatNudge = "float_nudge"
+        case floatScaleOnDisplayChange =
+            "float_scale_on_display_change"
         case placementOverride =
             "new_window_placement_override"
         case mouse
@@ -92,6 +94,11 @@ extension TilingSettings: Codable {
             try container.decodeIfPresent(
                 Bool.self,
                 forKey: .floatNudge
+            ) ?? true
+        floatScaleOnDisplayChange =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: .floatScaleOnDisplayChange
             ) ?? true
         placementOverride =
             try container.decodeIfPresent(

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Encoding.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Encoding.swift
@@ -23,6 +23,10 @@ extension TilingSettings {
             forKey: .floatNudge
         )
         try container.encode(
+            floatScaleOnDisplayChange,
+            forKey: .floatScaleOnDisplayChange
+        )
+        try container.encode(
             placementOverride,
             forKey: .placementOverride
         )

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
@@ -42,6 +42,25 @@ public struct TilingSettings: Sendable, Equatable {
     /// spaces), same tier as `swapSkipsCascade`; a niche polish
     /// toggle, Lua-only, no GUI. See `FloatNudge`.
     public var floatNudge = true
+    /// When true (default ON, #502), a floating window re-anchored
+    /// across displays also scales its SIZE by the per-axis ratio
+    /// of the target to the source display, keeping the same
+    /// relative footprint — an oversized float shrinks to fit the
+    /// smaller screen instead of overflowing its edge (the OS lets
+    /// width overflow while it half-clamps height, so keeping the
+    /// size lands the window partly off-screen, which reads as
+    /// broken to most users). Supersedes the #444/#493 "keep the
+    /// size" default. Set false to keep the exact pixel size across
+    /// displays (a deliberate multi-monitor choice — screen
+    /// recording, pixel-matched capture — that accepts the OS
+    /// overflow, and avoids the per-axis aspect distortion on
+    /// mismatched-aspect displays). Read only by
+    /// `FloatReanchor.target` at a display-crossing re-anchor,
+    /// never by layout math — so flipping it moves nothing, exactly
+    /// like `floatNudge`, its flat sibling. Lua-only knob
+    /// (`set_float_scale_on_display_change`); no GUI (the OFF state
+    /// is the narrow, technical ask — GUI-curates/Lua-open §2.7).
+    public var floatScaleOnDisplayChange = true
     public var bsp = BspParams()
     public var stack = StackParams()
     public var scrolling = ScrollingParams()

--- a/Tests/KiwiDeskCoreTests/FloatReanchorTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatReanchorTests.swift
@@ -109,6 +109,86 @@ struct FloatReanchorTests {
         )
         #expect(moved == frame)
     }
+
+    @Test("scaleSize off leaves the size untouched (default)")
+    func scaleOffKeepsSize() {
+        let frame = CGRect(
+            x: 60,
+            y: 100,
+            width: 1800,
+            height: 800
+        )
+        let moved = FloatReanchor.target(
+            frame: frame,
+            from: mainBounds,
+            to: sideBounds
+        )
+        #expect(moved.size == frame.size)
+    }
+
+    @Test("scaleSize shrinks an oversized float to fit (#502)")
+    func scaleShrinksToFit() {
+        // 1800 pt wide fits main (1920) but overflows the smaller
+        // side display (1440) at full size — the confine would
+        // pin it to a corner still overflowing. Scaled by the
+        // per-axis ratio it fits outright.
+        let frame = CGRect(
+            x: 60,
+            y: 100,
+            width: 1800,
+            height: 800
+        )
+        let moved = FloatReanchor.target(
+            frame: frame,
+            from: mainBounds,
+            to: sideBounds,
+            scaleSize: true
+        )
+        // Width ratio 1440/1920 = 0.75 → 1350 (exact).
+        #expect(moved.width == 1350)
+        #expect(moved.height < frame.height)
+        #expect(sideBounds.contains(moved))
+    }
+
+    @Test("scaleSize preserves the relative footprint (#502)")
+    func scaleKeepsRelativeFootprint() {
+        let frame = CGRect(
+            x: 480,
+            y: 305,
+            width: 960,
+            height: 400
+        )
+        let moved = FloatReanchor.target(
+            frame: frame,
+            from: mainBounds,
+            to: sideBounds,
+            scaleSize: true
+        )
+        // Same fraction of each display axis before and after.
+        let beforeW = frame.width / mainBounds.width
+        let afterW = moved.width / sideBounds.width
+        let beforeH = frame.height / mainBounds.height
+        let afterH = moved.height / sideBounds.height
+        #expect(abs(afterW - beforeW) < 0.0001)
+        #expect(abs(afterH - beforeH) < 0.0001)
+    }
+
+    @Test("scaleSize with a degenerate source keeps that axis")
+    func scaleDegenerateSourceKeepsAxis() {
+        // A zero-width source has no ratio to apply: the width is
+        // left untouched even when scaling is requested.
+        let degenerate = CGRect(x: 0, y: 25, width: 0, height: 1055)
+        let frame = CGRect(x: 0, y: 25, width: 400, height: 300)
+        let moved = FloatReanchor.target(
+            frame: frame,
+            from: degenerate,
+            to: sideBounds,
+            scaleSize: true
+        )
+        #expect(moved.width == frame.width)
+        // Height still scales by its own (valid) ratio.
+        #expect(moved.height != frame.height)
+    }
 }
 
 /// The seeded-capture bookkeeping the re-anchor delivery rides

--- a/Tests/KiwiDeskCoreTests/FloatScaleCommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/FloatScaleCommandTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+@MainActor
+private func makeCore() -> KiwiCore {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+            "kiwidesk-float-scale-\(UUID().uuidString)"
+        )
+    return KiwiCore(configDirectory: directory)
+}
+
+/// `set_float_scale_on_display_change` (#502): the proportional
+/// size scaling knob (ON by default). Pins its dispatch —
+/// storage, bool validation, and the on default. The scaling math
+/// itself lives in `FloatReanchorTests`. Flat verb beside
+/// `float_nudge`, dispatched with no retile (the flag is read only
+/// at a future re-anchor).
+@Suite("set_float_scale_on_display_change (#502)", .serialized)
+@MainActor
+struct FloatScaleCommandTests {
+    @Test("The command toggles and validates")
+    func toggle() {
+        let core = makeCore()
+        // On by default (#502 superseded the keep-the-size default).
+        #expect(core.tiler.settings.floatScaleOnDisplayChange)
+        #expect(
+            core.execute(
+                "set_float_scale_on_display_change",
+                args: [.bool(false)]
+            ).isSuccess
+        )
+        #expect(!core.tiler.settings.floatScaleOnDisplayChange)
+        // A non-bool arg is rejected and leaves the flag intact.
+        #expect(
+            !core.execute(
+                "set_float_scale_on_display_change",
+                args: [.string("yes")]
+            ).isSuccess
+        )
+        #expect(!core.tiler.settings.floatScaleOnDisplayChange)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
+++ b/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
@@ -28,7 +28,8 @@ struct SettingsCodingTests {
         #expect(
             Set(root.keys) == [
                 "animations", "app_bar", "border", "drag",
-                "float_nudge", "gap",
+                "float_nudge", "float_scale_on_display_change",
+                "gap",
                 "layout", "min_window_size", "mouse",
                 "mouse_resize", "new_window_placement_override", "quit",
                 "floating", "resize", "space", "space_bar",
@@ -94,6 +95,14 @@ struct SettingsCodingTests {
         // default: a tiled→floating toggle shoves the window
         // toward center so the state change is visible.
         #expect(root["float_nudge"] as? Bool == true)
+        // `set_float_scale_on_display_change` → top-level
+        // `float_scale_on_display_change` (#502), ON by default:
+        // a cross-display float scales to fit unless opted out
+        // (supersedes the #444/#493 keep-the-size default).
+        #expect(
+            root["float_scale_on_display_change"] as? Bool
+                == true
+        )
         // `set_space_icon` → `space.icon[space_id]` (#68).
         let space = try object(root["space"])
         let icons = try object(space["icon"])
@@ -237,6 +246,7 @@ struct SettingsCodingTests {
         settings.minWindowSize = 200
         settings.swapSkipsCascade = false
         settings.floatNudge = false
+        settings.floatScaleOnDisplayChange = false
         settings.resizeStep = 75
         settings.resizeFeedback = false
         settings.dragGhost.enabled = false

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1663,6 +1663,33 @@ still holds: where the landing is rule-based, no slot is
 promised. Same-display track drops swap positionally, so their
 highlight stays.
 
+**[Principle] A float crossing displays scales to fit by
+default; keeping the exact size is the opt-out.** (#502,
+supersedes #444/#493.) *Rationale:* #444/#493 originally kept a
+float's exact size on a cross-display re-anchor — "size is the
+user's choice" — and explicitly rejected shrink/center as the
+default. QA reversed the judgment: because macOS half-clamps a
+too-tall window's height but lets its width overflow the screen
+edge, a float that keeps its size on a move to a *smaller*
+display arrives partly off-screen, which reads as broken to most
+users. So `float_scale_on_display_change` now defaults **on** —
+the window is scaled by the per-axis ratio of the two displays
+(same relative footprint) as well as re-anchored, wherever a
+float crosses displays and for floating-mode members too (#498/
+#500), still confined clear of the bars. *Trade-off:* the scale
+is per-axis, so on displays of different aspect ratio it slightly
+distorts the window's aspect, and it resizes floats that already
+fit — accepted as the lesser surprise versus a window hanging off
+the edge. *Map:* the escape hatch stays **Lua-only, no GUI**
+(`set_float_scale_on_display_change(false)`) — the OFF state
+("keep my float's exact pixels, accept the overflow") is a
+narrow, technical ask (screen recording, pixel-matched capture),
+the same GUI-curates/Lua-open call as `float_nudge` and the bar
+`dim_factor` knobs; a GUI toggle would need a paragraph of caveats
+in its caption, which is contextual-help/Lua-reference work, not a
+Settings control. A future contributor must not re-derive "size is
+the user's choice" from the old #444/#493 record and revert this.
+
 **Ghost and Drop zone are two side-by-side columns.** (#231.)
 Each column leads with its own live preview and puts its
 controls directly beneath, so tuning a column's border width

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -488,6 +488,40 @@ Settings toggle.
 KiwiDesk.set_float_nudge(true)
 ```
 
+### set_float_scale_on_display_change
+
+**Expects:** `true` or `false` (default `true`).
+
+**Does:** whether a floating window re-anchored across displays
+also scales its **size** to keep the same relative footprint. By
+default (`true`) a float that crosses to a differently sized
+display is scaled by the per-axis ratio of the two displays — a
+window that filled half of a 4K screen fills half of a 1080p one
+— as well as re-anchored to the same relative spot (bottom-right
+stays bottom-right). This keeps an oversized float from arriving
+half off-screen: when the target display is smaller, macOS clamps
+a too-tall window's height but lets its width overflow the edge,
+so keeping the exact size lands the window partly off the screen.
+Applies wherever a float crosses displays (move-to-space, moving
+a space to another display, a display-change sweep) and to
+windows that are floating only because their space is in floating
+mode, not just explicitly floated ones. The result is still
+confined fully on screen and clear of any App/Space Bar. Set
+`false` to keep the exact pixel size across displays instead — a
+deliberate multi-monitor choice (screen recording, pixel-matched
+capture windows) that accepts the overflow and avoids the slight
+aspect-ratio change the per-axis scale introduces between
+displays of different aspect ratios (e.g. 16:9 → 16:10). Global
+(per profile, all spaces); a power-user knob, so it lives in
+config only, with no Settings toggle.
+
+**Example:**
+
+```lua
+-- keep a float's exact pixel size across displays
+KiwiDesk.set_float_scale_on_display_change(false)
+```
+
 ### set_resize_feedback
 
 **Expects:** `true` or `false` (default `true`).


### PR DESCRIPTION
## Summary

Floating windows now scale their **size** proportionally when re-anchored across displays of different sizes, so a float keeps the same relative footprint and an oversized one shrinks to fit the smaller screen instead of overflowing its edge (#502).

- **Default ON.** `set_float_scale_on_display_change(bool)` → JSON `float_scale_on_display_change`, default `true`.
- **Why on:** on a smaller target display macOS clamps a too-tall window's height but lets its width overflow the screen edge, so keeping the exact size lands the window partly off-screen — reads as broken to most users. Scaling by the per-axis display ratio fits it.
- **Supersedes #444/#493** (which kept exact size by default). Recorded as a decision-reversal entry in `docs/design-decisions.md` so it isn't re-derived and reverted.
- **Opt-out:** `set_float_scale_on_display_change(false)` keeps exact pixel size — a narrow, technical choice (screen recording, pixel-matched capture) that accepts the overflow and avoids the per-axis aspect distortion on mismatched-aspect displays.
- **Coverage:** rides the single `FloatReanchor.target` seam every re-anchor funnels through, so it applies to **both** true-floats and floating-mode members (#498/#500), across move-to-space, space-to-display, and the display-change sweep.

## Design notes

- **Stays Lua-only, no GUI** — `ui-designer` consult: the OFF state is the narrow technical ask (the ON state is just "make it fit"), the same GUI-curates/Lua-open call as `float_nudge` and the bar `dim_factor` knobs; a GUI toggle would need a paragraph of caveats in its caption, which is contextual-help/reference work.
- Scaling is pure geometry in `FloatReanchor.target` (`scaleSize` flag), next to the existing position math; `FloatNudge.confine` still clamps. Per-axis, mirroring the per-axis position re-anchor.
- **Flat verb, dispatched like `set_float_nudge`** (explicit switch, **no retile** — read only by `FloatReanchor.target` at a future re-anchor). An earlier `float.*` namespace form was dropped (architect review): it sat one edit from the existing `floating.*` namespace and would have forced a needless retile.
- Split `APIReference` did-you-mean helpers into `APIReference+Suggestion.swift` to stay under the 350-line ceiling.

## Testing

- `FloatReanchorTests`: scale-off (size untouched), shrink-to-fit, relative-footprint invariance, degenerate-source guard.
- `FloatScaleCommandTests`: dispatch, bool validation, **on** default.
- `SettingsCodingTests`: JSON shape + full round-trip.
- Verify gate green: `swift build`, `swift build -c release`, full suite (1871) + `ExecTests` (14), `scripts/lint.sh`.
- Reviewed by `code-reviewer` (clean) + `architect-reviewer` (findings addressed, re-verified clean); `ui-designer` consulted on GUI placement.

Not device-QA'd yet — pure geometry + config plumbing, but the on-device cross-display behavior (now default-on) is worth an eye-confirm before merge.

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)