### PR TITLE
feat(tiling): live cross-display make-room drag

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
@@ -169,7 +169,17 @@ extension KiwiCore {
             // corner forever — #412's "floating vanishes"
             // failure mode, reintroduced on this one path.
             tiler.rekeyStash(oldID: old, newID: new)
+            // A live display crossing's bookkeeping (#504) must
+            // follow the id swap, or a rekey after a crossing
+            // strands the (new) window on the destination space
+            // with no record to revert from. Transfer FIRST —
+            // cancelDrag(old) then finds nothing under the old
+            // id — and revert under the new one: the gesture is
+            // aborted, so the window goes home like any other
+            // abnormal end.
+            dragCrossing.rekey(old: old, new: new)
             cancelDrag(old)
+            revertLiveCrossing(new)
         default:
             break
         }

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -18,6 +18,8 @@ public final class KiwiCore {
     public let spaceBars = SpaceBarManager()
     /// Space Bar drag-drop gesture state (#372).
     let spaceBarDrop = SpaceBarDropCoordinator()
+    /// Live cross-display make-room gesture state (#504).
+    let dragCrossing = DragCrossingCoordinator()
     /// Glyph-vs-image icon decisions for bar items (#294),
     /// shared by the App Bar, the Space Bar (#293) and the
     /// shortcuts panel.

--- a/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/KiwiCore+SpaceBarDrop.swift
@@ -47,6 +47,11 @@ extension KiwiCore {
     /// leak onto a reused WindowID (#372, review).
     func cancelDrag(_ id: WindowID) {
         drag.cancel(id)
+        // A live display crossing (#504) already moved the
+        // window's membership; put it back where the gesture
+        // started (and always drop the crossing bookkeeping, so
+        // a reused WindowID can't inherit a stale gesture).
+        revertLiveCrossing(id)
         if tiler.dragExemptWindow == id {
             tiler.dragExemptWindow = nil
         }

--- a/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
@@ -55,6 +55,10 @@ public final class DragCrossingCoordinator {
         var stickyRefused = false
     }
     private var gestures: [WindowID: Gesture] = [:]
+    /// A single slot, not per-window: only one window is ever
+    /// user-dragged at a time, so `schedule` may displace another
+    /// window's dwell without harm. `gestures` stays per-window
+    /// because ids must not inherit stale bookkeeping.
     private var pending:
         (window: WindowID, display: DisplayID, task: Task<Void, Never>)?
 
@@ -128,6 +132,10 @@ public final class DragCrossingCoordinator {
         gestures[id]?.crossed == true
     }
 
+    /// Defense in depth only: sticky windows never arm the dwell
+    /// (`updateDragCrossing` filters them), so this fires solely
+    /// when a window BECAME sticky mid-dwell. Per-gesture, not
+    /// per-display — revisit if the sticky exclusion is relaxed.
     func markStickyRefused(_ id: WindowID) {
         var gesture = gestures[id] ?? Gesture()
         gesture.stickyRefused = true
@@ -136,6 +144,18 @@ public final class DragCrossingCoordinator {
 
     func stickyRefused(_ id: WindowID) -> Bool {
         gestures[id]?.stickyRefused == true
+    }
+
+    /// Retargets a gesture's bookkeeping onto a native-tab
+    /// rekeyed id (#308) — the id swapped in place mid-drag, and
+    /// the revert must find the origin under the NEW id. Any
+    /// pending dwell dies with the old id: the gesture is being
+    /// aborted, not continued.
+    func rekey(old: WindowID, new: WindowID) {
+        cancelPending(for: old)
+        guard let gesture = gestures.removeValue(forKey: old)
+        else { return }
+        gestures[new] = gesture
     }
 
     /// Ends the gesture at drop or cancel: disarms any dwell,

--- a/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
@@ -1,0 +1,170 @@
+import CoreGraphics
+import Foundation
+
+/// Debounce + per-gesture bookkeeping for the live cross-display
+/// "make-room" drag (#504).
+///
+/// While a tiled window is dragged, the cursor crossing onto a
+/// display OTHER than the one its space lives on arms a dwell
+/// timer; only when the cursor has stayed on that display for
+/// `dwell` does `onCross` fire, and KiwiCore eager-moves the
+/// window's membership there (the Space-Bar-spring model, #372,
+/// keyed on displays). The dwell is the flip-flop guard: a cursor
+/// skimming the display seam — or an overflow-inducing crossing
+/// bouncing straight back — never re-tiles both displays per
+/// mouse event; AX frame-sets are the slow path (AGENTS.md §5).
+///
+/// AppKit-free by injection (`displayAt`), like DragCoordinator:
+/// tests place the cursor and describe displays without screens.
+@MainActor
+public final class DragCrossingCoordinator {
+    /// How long the cursor must stay on a foreign display before
+    /// the membership moves. Long enough to ride out a seam skim,
+    /// short enough to read as immediate.
+    public var dwell: TimeInterval = 0.15
+
+    /// Resolves the display under a Cocoa (bottom-left) screen
+    /// point. Wired to an NSScreen lookup in `wireDragCrossing`;
+    /// injected so drag tests can fake a display topology.
+    public var displayAt: @MainActor (CGPoint) -> DisplayID? = {
+        _ in nil
+    }
+
+    /// Fired once per debounced crossing with the display the
+    /// cursor settled on. KiwiCore re-checks eligibility there —
+    /// state may have shifted during the dwell.
+    var onCross: @MainActor (WindowID, DisplayID) -> Void = {
+        _,
+        _ in
+    }
+
+    /// What one drag gesture accumulated. Cleared by
+    /// `endGesture` / `revertLiveCrossing` at drop or cancel.
+    private struct Gesture {
+        /// The window's home before the FIRST crossing — the
+        /// abnormal-cancel restore point. Later crossings keep
+        /// the original record.
+        var originSpace: SpaceID?
+        var originIndex = 0
+        /// Whether any crossing actually moved membership this
+        /// gesture. Read by the drop path to skip the resize
+        /// interpretation (#492's clamp gotcha, live edition).
+        var crossed = false
+        /// A sticky refusal already flashed its pill this
+        /// gesture; later dwell fires stay silent.
+        var stickyRefused = false
+    }
+    private var gestures: [WindowID: Gesture] = [:]
+    private var pending:
+        (window: WindowID, display: DisplayID, task: Task<Void, Never>)?
+
+    public init() {}
+
+    /// Feed every live drag move. Schedules a dwell when the
+    /// cursor sits on a display other than `homeDisplay`
+    /// (the dragged window's current space's display), keeps an
+    /// already-armed dwell for the SAME display running, and
+    /// disarms when the cursor returns home or resolves nowhere.
+    func moved(
+        _ id: WindowID,
+        cursor: CGPoint,
+        homeDisplay: DisplayID?
+    ) {
+        guard
+            let cursorDisplay = displayAt(cursor),
+            let homeDisplay,
+            cursorDisplay != homeDisplay
+        else {
+            cancelPending(for: id)
+            return
+        }
+        if let pending, pending.window == id,
+            pending.display == cursorDisplay
+        {
+            return
+        }
+        schedule(id, display: cursorDisplay)
+    }
+
+    /// Disarms a pending dwell for `id` (cursor back home, a
+    /// Space Bar target armed, or the gesture stopped looking
+    /// like a move).
+    func cancelPending(for id: WindowID) {
+        guard let pending, pending.window == id else { return }
+        pending.task.cancel()
+        self.pending = nil
+    }
+
+    /// Records the home to restore on an abnormal cancel. Only
+    /// the FIRST crossing of a gesture writes it.
+    func recordOriginIfNeeded(
+        _ id: WindowID,
+        space: SpaceID,
+        index: Int
+    ) {
+        var gesture = gestures[id] ?? Gesture()
+        guard gesture.originSpace == nil else { return }
+        gesture.originSpace = space
+        gesture.originIndex = index
+        gestures[id] = gesture
+    }
+
+    /// The pre-crossing home, for the abnormal-cancel revert.
+    func origin(for id: WindowID) -> (space: SpaceID, index: Int)? {
+        guard let space = gestures[id]?.originSpace else {
+            return nil
+        }
+        return (space, gestures[id]?.originIndex ?? 0)
+    }
+
+    func markCrossed(_ id: WindowID) {
+        var gesture = gestures[id] ?? Gesture()
+        gesture.crossed = true
+        gestures[id] = gesture
+    }
+
+    /// Whether membership already moved displays this gesture.
+    func hasCrossed(_ id: WindowID) -> Bool {
+        gestures[id]?.crossed == true
+    }
+
+    func markStickyRefused(_ id: WindowID) {
+        var gesture = gestures[id] ?? Gesture()
+        gesture.stickyRefused = true
+        gestures[id] = gesture
+    }
+
+    func stickyRefused(_ id: WindowID) -> Bool {
+        gestures[id]?.stickyRefused == true
+    }
+
+    /// Ends the gesture at drop or cancel: disarms any dwell,
+    /// forgets the bookkeeping, and reports whether the gesture
+    /// ever crossed (the drop path's resize-gate bypass).
+    @discardableResult
+    func endGesture(_ id: WindowID) -> Bool {
+        cancelPending(for: id)
+        let crossed = gestures[id]?.crossed == true
+        gestures[id] = nil
+        return crossed
+    }
+
+    private func schedule(_ id: WindowID, display: DisplayID) {
+        pending?.task.cancel()
+        let task = Task { [weak self] in
+            let ns = UInt64((self?.dwell ?? 0) * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: ns)
+            guard !Task.isCancelled else { return }
+            self?.fire(id, display: display)
+        }
+        pending = (id, display, task)
+    }
+
+    private func fire(_ id: WindowID, display: DisplayID) {
+        guard let pending, pending.window == id,
+            pending.display == display
+        else { return }
+        self.pending = nil
+        onCross(id, display)
+    }
+}

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -27,134 +27,7 @@ extension KiwiCore {
         }
         drag.cursorLocation = { NSEvent.mouseLocation }
         wireSpaceBarDrop()
-    }
-
-    /// Live feedback while a tiled window is dragged: a ghost
-    /// outline over the window's own slot and a highlight
-    /// over the slot a drop would swap with (settings toggle
-    /// each visual individually).
-    func handleDragMove(
-        _ id: WindowID,
-        start: CGRect,
-        frame: CGRect
-    ) {
-        // Pin the dragged window against `stashInactive` for the
-        // gesture's life, so a Space Bar spring can't stash it
-        // mid-drag (#372). Cleared at drop.
-        tiler.dragExemptWindow = id
-        // Feed the Space Bar drop machine the live cursor. While a
-        // bar target is armed (hover + pending spring), suppress
-        // the in-space ghost/drop-zone — the drag is heading off
-        // this space, not swapping within it. The autoscroll runs
-        // in parallel off the same cursor: a dwell over an arrow
-        // zone scrolls hidden Spaces into reach (#385). The zones
-        // are disjoint from item hit frames, so at most one of the
-        // two arms for any given cursor position.
-        let cursor = drag.cursorLocation()
-        spaceBars.updateDragAutoScroll(atGlobal: cursor)
-        spaceBarDrop.moved(id, cursor: cursor)
-        if spaceBarDrop.isArmed {
-            dragOverlay.hideAll()
-            return
-        }
-        let settings = tiler.settings
-        guard
-            settings.dragGhost.enabled
-                || settings.dragDropZone.enabled,
-            let space = activeSpace,
-            space.mode != .floating,
-            space.windows.contains(id),
-            state.windows[id]?.isFloating == false
-        else {
-            dragOverlay.hideAll()
-            return
-        }
-        let slots = tiler.calculatedFrames(state: state)
-        guard let slot = slots[id] else {
-            dragOverlay.hideAll()
-            return
-        }
-        // Show the swap overlays only once the gesture is
-        // clearly a MOVE — the window has translated with its
-        // size held; anything else hides them.
-        //
-        // A resize is caught from its first real frame by facts
-        // a magnitude test alone misses (it reads the sub-
-        // threshold start of a pull, and a dip back near the
-        // start size, as a move — flashing the ghost, #237):
-        //  - the press began in the slot's edge band, where
-        //    resize drags start (same signal isResizeGesture
-        //    uses), AND the size has already changed — so an
-        //    edge-grabbed move (drag near the top to swap) keeps
-        //    its ghost while a resize hides with no flash;
-        //  - the 10 pt magnitude test as the press-less
-        //    fallback, measured against the START frame, never
-        //    the slot: a window that can't shrink to its slot
-        //    (min sizes, character grids) differs forever, which
-        //    would call every plain move a resize.
-        // The gesture's FIRST frame has no delta (start ==
-        // frame) so it reads as neither; showing nothing there
-        // avoids a one-frame ghost before the size delta lands.
-        //
-        // This gate is intentionally stricter than the resize-
-        // vs-swap decision in handleDragEnd (plain isResize):
-        // the preview is advisory and biases toward hiding to
-        // kill the flash, so it may suppress a small edge resize
-        // the drop still treats as a swap — harmless, since a
-        // real move holds its size and never enters that band.
-        // Effectiveness rides on the live mouse monitor; with no
-        // recorded press (headless, tests) it falls back to the
-        // 10 pt magnitude test — the pre-fix behavior.
-        let pressNearEdge =
-            mouse.press.map {
-                MouseResize.nearEdge($0.location, of: slot)
-            } ?? false
-        let sizeChanged =
-            abs(frame.width - start.width) > 0.5
-            || abs(frame.height - start.height) > 0.5
-        let movedOrigin =
-            abs(frame.minX - start.minX) > 0.5
-            || abs(frame.minY - start.minY) > 0.5
-        let looksResize =
-            (pressNearEdge && sizeChanged)
-            || MouseResize.isResize(from: start, to: frame)
-        if looksResize || !movedOrigin {
-            dragOverlay.hideAll()
-            return
-        }
-        if settings.dragGhost.enabled {
-            dragOverlay.showGhost(
-                at: slot,
-                style: settings.dragGhost,
-                cornerRadius: settings.dragCornerRadius
-            )
-        }
-        // Target the slot under the CURSOR, not the dragged
-        // frame's center: the drop-zone must reach the
-        // destination display the instant the pointer does,
-        // even while a big window's center trails behind on the
-        // origin display (#492). `cursor` is Cocoa (bottom-left);
-        // slots are AX (top-left), so flip it.
-        let target = DragTarget.swapTarget(
-            of: id,
-            at: GeometryUtils.axPoint(cursor),
-            slots: slots
-        )
-        // Suppress the highlight over a cross-display track dest
-        // (files by rule, not the slot); see `dropZoneTarget` (#492).
-        let honestTarget = dropZoneTarget(target, from: space)
-        if settings.dragDropZone.enabled,
-            let honestTarget,
-            let targetSlot = slots[honestTarget]
-        {
-            dragOverlay.showDropZone(
-                at: targetSlot,
-                style: settings.dragDropZone,
-                cornerRadius: settings.dragCornerRadius
-            )
-        } else {
-            dragOverlay.hideDropZone()
-        }
+        wireDragCrossing()
     }
 
     /// Drop over another window's layout slot: the two windows
@@ -188,6 +61,10 @@ extension KiwiCore {
         frame: CGRect
     ) {
         tiler.dragExemptWindow = nil
+        // Whether this gesture live-crossed displays (#504);
+        // ends the crossing bookkeeping either way. A crossed
+        // gesture is a MOVE for the resize gate below.
+        let crossedDisplays = dragCrossing.endGesture(id)
         dragOverlay.hideAll()
         spaceBars.endDragAutoScroll()
         defer { scheduleBorderDropReconcile() }
@@ -266,7 +143,14 @@ extension KiwiCore {
         if relocateAcrossDisplay(id, onto: target, from: space) {
             return
         }
+        // A gesture that live-crossed displays (#504) skips the
+        // resize interpretation: macOS clamps a big window's size
+        // as it lands on a smaller display, which `isResize`
+        // would read as a resize and mangle the destination's
+        // ratios — the live twin of the relocate-before-resize
+        // ordering above (#492).
         if slots[id] != nil,
+            !crossedDisplays,
             MouseResize.isResize(from: start, to: frame)
         {
             // Only edges shared with a neighbor trade space;

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -65,6 +65,11 @@ extension KiwiCore {
         // ends the crossing bookkeeping either way. A crossed
         // gesture is a MOVE for the resize gate below.
         let crossedDisplays = dragCrossing.endGesture(id)
+        // For the crossed drop's #463 settle below — captured
+        // before the retile/focus can change it, mirroring the
+        // drop-commit relocate.
+        let priorFrontmost =
+            crossedDisplays ? frontmostPIDProvider?() : nil
         dragOverlay.hideAll()
         spaceBars.endDragAutoScroll()
         defer { scheduleBorderDropReconcile() }
@@ -221,6 +226,16 @@ extension KiwiCore {
         // drop snaps the window back to a slot the pointer
         // may sit outside of.
         focusWindow(id, warp: false)
+        // A live-crossed gesture activated the destination at
+        // crossing time with NO settle (mid-drag, the spring
+        // model); its drop is where the #463 re-assert belongs —
+        // parity with the drop-commit relocate's obligation.
+        if crossedDisplays {
+            scheduleSpaceSettle(
+                space.id,
+                priorFrontmost: priorFrontmost
+            )
+        }
         if crossedZones {
             scheduleZOrderRestore()
         }

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragCrossing.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragCrossing.swift
@@ -1,0 +1,152 @@
+import AppKit
+import Foundation
+
+/// Live cross-display "make-room" (#504): dragging a tiled window
+/// onto another display moves its MEMBERSHIP there mid-drag, after
+/// a short dwell — the destination's windows slide apart to open a
+/// real slot under the cursor while the dragged window stays
+/// pinned under the pointer (`dragExemptWindow`, never re-framed
+/// mid-drag). From then on the drag is an ordinary SAME-display
+/// gesture in the destination space — the Space-Bar-spring model
+/// (#372) keyed on displays — so the drop swaps / snaps exactly
+/// like a local drag, and `relocateAcrossDisplay` (#492) remains
+/// only the fast-flick path whose dwell never fired.
+extension KiwiCore {
+    /// Wires the crossing coordinator (once, from `wireDrag`).
+    func wireDragCrossing() {
+        dragCrossing.displayAt = { point in
+            NSScreen.screens
+                .first { $0.frame.contains(point) }?
+                .kiwiDisplay?.id
+        }
+        dragCrossing.onCross = { [weak self] id, display in
+            self?.performLiveCrossing(id, onto: display)
+        }
+    }
+
+    /// Feeds the crossing debounce from the live drag. Sticky
+    /// windows are excluded: their cross-display drop keeps the
+    /// full #445 gate + pill semantics of the drop-commit path,
+    /// and live-moving a sticky would fight the sticky render
+    /// pipeline mid-gesture.
+    func updateDragCrossing(_ id: WindowID, cursor: CGPoint) {
+        guard state.windows[id]?.isSticky != true else {
+            dragCrossing.cancelPending(for: id)
+            return
+        }
+        let home = state.workspaces.space(of: id)
+            .flatMap { state.workspaces.display(of: $0) }
+        dragCrossing.moved(id, cursor: cursor, homeDisplay: home)
+    }
+
+    /// The debounced crossing: eager-moves the dragged window into
+    /// the active space of the display the cursor settled on.
+    /// Mirrors `relocateAcrossDisplay`'s placement (shared
+    /// `insertDropped` choke point) but, like the Space-Bar spring,
+    /// asserts NO AX focus and schedules NO settle — the pointer is
+    /// inside the OS drag loop; the drop path owns focus.
+    private func performLiveCrossing(
+        _ id: WindowID,
+        onto display: DisplayID
+    ) {
+        guard
+            // Released during the dwell: the drop-commit
+            // relocate owns the gesture now.
+            drag.isMousePressed(),
+            let originID = state.workspaces.space(of: id),
+            let origin = state.workspaces[originID],
+            origin.windows.contains(id),
+            origin.mode != .floating,
+            state.windows[id]?.isFloating == false,
+            let destID = state.workspaces.activeSpace(on: display),
+            destID != originID,
+            let dest = state.workspaces[destID],
+            // A floating-mode destination has no layout to make
+            // room in; the drop-commit relocate handles it.
+            dest.mode != .floating
+        else { return }
+        // The #445 sticky gate, once per gesture: the refusal
+        // pill should not re-flash on every dwell while the
+        // cursor stays on the refused display.
+        guard !dragCrossing.stickyRefused(id) else { return }
+        if stickyMoveRefused(id, to: destID) {
+            dragCrossing.markStickyRefused(id)
+            return
+        }
+        dragCrossing.recordOriginIfNeeded(
+            id,
+            space: originID,
+            index: origin.windows.firstIndex(of: id) ?? 0
+        )
+        // Re-pin against stashInactive across the membership
+        // move, exactly like the spring (#372).
+        tiler.dragExemptWindow = id
+        // Cursor slot resolved BEFORE membership changes, from
+        // the same cursor rule as preview and drop (#492).
+        let slots = tiler.calculatedFrames(state: state)
+        let target = DragTarget.swapTarget(
+            of: id,
+            at: GeometryUtils.axPoint(drag.cursorLocation()),
+            slots: slots
+        )
+        insertDropped(id, onto: target, into: destID)
+        state.workspaces.focus(id, in: destID)
+        // Focused display follows the drag there (#446), so the
+        // preview machinery reads the destination as "this
+        // space" from now on.
+        state.workspaces.activate(destID)
+        emitWindowMovedToSpace(
+            id,
+            app: state.windows[id]?.appName ?? "",
+            bundleID: state.windows[id]?.appBundleID,
+            from: originID,
+            to: destID
+        )
+        dragCrossing.markCrossed(id)
+        // Both displays reflow; the slide IS the feature, so
+        // animate with the swap animation. The dragged window is
+        // exempt and never re-framed. Forced, like the spring: a
+        // membership mutation must apply exactly, not be
+        // swallowed by the ±2 pt echo tolerance.
+        retile(
+            animated: tiler.settings.animations.onWindowSwap,
+            force: true
+        )
+        // Inserting into an overflowing stack / track / scrolling
+        // pile scrambles its stacking — the same §5 obligation
+        // the drop-commit relocate honors.
+        scheduleZOrderRestore()
+        emitSpaceChange()
+    }
+
+    /// Abnormal drag end (window closed / rekeyed mid-drag) after
+    /// a live crossing: puts the membership back where the gesture
+    /// started, at its old index. A drop back on the origin
+    /// display needs none of this — crossing back is symmetric —
+    /// and a window that died mid-drag left state already.
+    func revertLiveCrossing(_ id: WindowID) {
+        defer { dragCrossing.endGesture(id) }
+        guard
+            let origin = dragCrossing.origin(for: id),
+            state.windows[id] != nil,
+            let current = state.workspaces.space(of: id),
+            current != origin.space,
+            state.workspaces[origin.space] != nil
+        else { return }
+        state.workspaces.add(id, to: origin.space)
+        state.workspaces.withSpace(origin.space) {
+            let last = $0.windows.count - 1
+            $0.move(id, to: min(origin.index, max(last, 0)))
+        }
+        state.workspaces.activate(origin.space)
+        emitWindowMovedToSpace(
+            id,
+            app: state.windows[id]?.appName ?? "",
+            bundleID: state.windows[id]?.appBundleID,
+            from: current,
+            to: origin.space
+        )
+        retile(animated: false, force: true)
+        emitSpaceChange()
+    }
+}

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragCrossing.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragCrossing.swift
@@ -53,6 +53,15 @@ extension KiwiCore {
             // Released during the dwell: the drop-commit
             // relocate owns the gesture now.
             drag.isMousePressed(),
+            // The dwell disarms only on AX move events, and
+            // Electron/WebKit apps deliver those 100–300 ms
+            // late — longer than the dwell (§5). Re-validate
+            // the LIVE cursor at fire time: still on the display
+            // the dwell armed for, and not aiming at a Space Bar
+            // item (a competing membership mover).
+            !spaceBarDrop.isArmed,
+            dragCrossing.displayAt(drag.cursorLocation())
+                == display,
             let originID = state.workspaces.space(of: id),
             let origin = state.workspaces[originID],
             origin.windows.contains(id),
@@ -138,6 +147,11 @@ extension KiwiCore {
             let last = $0.windows.count - 1
             $0.move(id, to: min(origin.index, max(last, 0)))
         }
+        // `add` re-homing cleared `lastFocused` (it was this
+        // window, stamped at the crossing); re-stamp it in the
+        // restored home so bar accents / focus-yield paths don't
+        // read a startup-like nil (review).
+        state.workspaces.focus(id, in: origin.space)
         state.workspaces.activate(origin.space)
         emitWindowMovedToSpace(
             id,
@@ -147,6 +161,10 @@ extension KiwiCore {
             to: origin.space
         )
         retile(animated: false, force: true)
+        // The revert re-inserts into a possibly-overflowing
+        // stack / track / pile — the same §5 obligation the
+        // crossing itself honors (review).
+        scheduleZOrderRestore()
         emitSpaceChange()
     }
 }

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragCrossing.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragCrossing.swift
@@ -58,8 +58,14 @@ extension KiwiCore {
             // late — longer than the dwell (§5). Re-validate
             // the LIVE cursor at fire time: still on the display
             // the dwell armed for, and not aiming at a Space Bar
-            // item (a competing membership mover).
+            // item (a competing membership mover) — checked both
+            // via the armed state AND a live bar hit-test, since
+            // the same event lag can leave the bar not yet armed
+            // while the pointer already hovers an item.
             !spaceBarDrop.isArmed,
+            spaceBars.spaceItem(
+                atGlobal: drag.cursorLocation()
+            ) == nil,
             dragCrossing.displayAt(drag.cursorLocation())
                 == display,
             let originID = state.workspaces.space(of: id),

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
@@ -130,6 +130,15 @@ extension KiwiCore {
         if (looksResize || !movedOrigin) && !crossed {
             if movedOrigin && !grew {
                 updateDragCrossing(id, cursor: cursor)
+            } else if grew {
+                // A grown frame is a real enlarge pull: also
+                // DISARM any dwell the gesture's sub-threshold
+                // prefix armed (its first frames can read as a
+                // size-held move with the cursor already across
+                // the seam) — an edge resize must never dwell
+                // into a membership move. A clamp never grows,
+                // so this cannot cost the clamp its crossing.
+                dragCrossing.cancelPending(for: id)
             }
             dragOverlay.hideAll()
             return

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
@@ -105,26 +105,32 @@ extension KiwiCore {
         // the magnitude test would read as a resize — hiding the
         // ghost the crossing just made room for (the live twin
         // of the #492 drop-ordering gotcha).
+        // The dwell feed never disarms in this branch (nothing
+        // needs it: a genuine resize can't arm, see below) and
+        // admits, besides size-held moves, exactly one
+        // size-changed shape: SHRUNK while the origin
+        // translates. That is the macOS clamp's signature — a
+        // big window dragged toward a smaller display is
+        // clamped SMALLER mid-translation, possibly before the
+        // cursor ever crosses the seam (a trailing-side grab),
+        // and the latched size delta must not cost the gesture
+        // its crossing (review rounds 1–3). A genuine edge pull
+        // is excluded either way: an enlarge-pull GROWS, and a
+        // shrink-pull walks the cursor into the window's own
+        // body — the home display — so it feeds a dwell that
+        // never arms. If the gate still misreads a gesture the
+        // loss is graceful: the drop-commit relocate (#492)
+        // moves the window at release, and the fire-time
+        // guards (button, display, bar) bound every stale
+        // fire. Visuals below stay strictly move-gated (#237).
+        let grew =
+            frame.width > start.width + 0.5
+            || frame.height > start.height + 0.5
         let crossed = dragCrossing.hasCrossed(id)
         if (looksResize || !movedOrigin) && !crossed {
-            // NO dwell feed and NO disarm here — both matter.
-            // A resize changes its size from the first real
-            // frame, so a resize gesture never sees the
-            // size-held feed below and can never ARM the dwell:
-            // a seam-adjacent edge pull cannot live-cross
-            // mid-resize (review round 2), with nothing to
-            // cancel. The macOS size clamp near a smaller
-            // display also lands in this branch — but only
-            // after the size-held approach frames already armed
-            // the dwell, and an armed dwell survives un-fed
-            // frames (only returning home, or the fire-time
-            // cursor re-check, disarms it), so the clamp cannot
-            // kill the crossing it heralds (review round 1: a
-            // disarm here did exactly that). Visuals stay
-            // hidden either way (#237); if this gate misreads a
-            // move, the loss is graceful — the drop-commit
-            // relocate (#492) still moves the window at
-            // release.
+            if movedOrigin && !grew {
+                updateDragCrossing(id, cursor: cursor)
+            }
             dragOverlay.hideAll()
             return
         }

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
@@ -107,29 +107,28 @@ extension KiwiCore {
         // of the #492 drop-ordering gotcha).
         let crossed = dragCrossing.hasCrossed(id)
         if (looksResize || !movedOrigin) && !crossed {
-            // Only a CONFIDENT resize (press in the edge band,
-            // size changing) disarms the dwell: an edge pull
-            // near the display seam must never dwell into a
-            // membership move. The magnitude-only fallback keeps
-            // feeding it — macOS live-clamps a big window's size
-            // as it approaches a smaller display, which reads as
-            // a resize and would otherwise permanently kill the
-            // dwell in the feature's headline case (review). The
-            // coordinator only ever arms while the cursor is on
-            // a FOREIGN display, so a same-display resize feeds
-            // it nothing. Visuals stay hidden either way (#237),
-            // and if the stricter gate still misreads a move the
-            // loss is graceful: the drop-commit relocate (#492)
-            // moves the window at release.
-            if pressNearEdge && sizeChanged {
-                dragCrossing.cancelPending(for: id)
-            } else if movedOrigin {
-                updateDragCrossing(id, cursor: cursor)
-            }
+            // NO dwell feed and NO disarm here — both matter.
+            // A resize changes its size from the first real
+            // frame, so a resize gesture never sees the
+            // size-held feed below and can never ARM the dwell:
+            // a seam-adjacent edge pull cannot live-cross
+            // mid-resize (review round 2), with nothing to
+            // cancel. The macOS size clamp near a smaller
+            // display also lands in this branch — but only
+            // after the size-held approach frames already armed
+            // the dwell, and an armed dwell survives un-fed
+            // frames (only returning home, or the fire-time
+            // cursor re-check, disarms it), so the clamp cannot
+            // kill the crossing it heralds (review round 1: a
+            // disarm here did exactly that). Visuals stay
+            // hidden either way (#237); if this gate misreads a
+            // move, the loss is graceful — the drop-commit
+            // relocate (#492) still moves the window at
+            // release.
             dragOverlay.hideAll()
             return
         }
-        // A clear move: arm / keep the cross-display dwell.
+        // A size-held move: arm / keep the cross-display dwell.
         updateDragCrossing(id, cursor: cursor)
         let settings = tiler.settings
         guard

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
@@ -107,10 +107,24 @@ extension KiwiCore {
         // of the #492 drop-ordering gotcha).
         let crossed = dragCrossing.hasCrossed(id)
         if (looksResize || !movedOrigin) && !crossed {
-            if looksResize {
-                // An edge pull near the display seam must never
-                // dwell into a membership move.
+            // Only a CONFIDENT resize (press in the edge band,
+            // size changing) disarms the dwell: an edge pull
+            // near the display seam must never dwell into a
+            // membership move. The magnitude-only fallback keeps
+            // feeding it — macOS live-clamps a big window's size
+            // as it approaches a smaller display, which reads as
+            // a resize and would otherwise permanently kill the
+            // dwell in the feature's headline case (review). The
+            // coordinator only ever arms while the cursor is on
+            // a FOREIGN display, so a same-display resize feeds
+            // it nothing. Visuals stay hidden either way (#237),
+            // and if the stricter gate still misreads a move the
+            // loss is graceful: the drop-commit relocate (#492)
+            // moves the window at release.
+            if pressNearEdge && sizeChanged {
                 dragCrossing.cancelPending(for: id)
+            } else if movedOrigin {
+                updateDragCrossing(id, cursor: cursor)
             }
             dragOverlay.hideAll()
             return

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragMove.swift
@@ -1,0 +1,162 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// The live half of the drag pipeline (split from
+/// `KiwiCore+Drag.swift` for the file ceiling; the drop
+/// resolution stays there).
+extension KiwiCore {
+    /// Live feedback while a tiled window is dragged: a ghost
+    /// outline over the window's own slot, a highlight over the
+    /// slot a drop would swap with (settings toggle each visual
+    /// individually), and the cross-display make-room debounce
+    /// (#504) that moves the window's membership once the cursor
+    /// dwells on another display.
+    func handleDragMove(
+        _ id: WindowID,
+        start: CGRect,
+        frame: CGRect
+    ) {
+        // Pin the dragged window against `stashInactive` for the
+        // gesture's life, so a Space Bar spring can't stash it
+        // mid-drag (#372). Cleared at drop.
+        tiler.dragExemptWindow = id
+        // Feed the Space Bar drop machine the live cursor. While a
+        // bar target is armed (hover + pending spring), suppress
+        // the in-space ghost/drop-zone — the drag is heading off
+        // this space, not swapping within it. The autoscroll runs
+        // in parallel off the same cursor: a dwell over an arrow
+        // zone scrolls hidden Spaces into reach (#385). The zones
+        // are disjoint from item hit frames, so at most one of the
+        // two arms for any given cursor position.
+        let cursor = drag.cursorLocation()
+        spaceBars.updateDragAutoScroll(atGlobal: cursor)
+        spaceBarDrop.moved(id, cursor: cursor)
+        if spaceBarDrop.isArmed {
+            // A bar spring and a display crossing are competing
+            // membership moves; the armed bar wins the dwell.
+            dragCrossing.cancelPending(for: id)
+            dragOverlay.hideAll()
+            return
+        }
+        guard
+            let space = activeSpace,
+            space.mode != .floating,
+            space.windows.contains(id),
+            state.windows[id]?.isFloating == false
+        else {
+            dragCrossing.cancelPending(for: id)
+            dragOverlay.hideAll()
+            return
+        }
+        let slots = tiler.calculatedFrames(state: state)
+        guard let slot = slots[id] else {
+            dragCrossing.cancelPending(for: id)
+            dragOverlay.hideAll()
+            return
+        }
+        // Show the swap overlays only once the gesture is
+        // clearly a MOVE — the window has translated with its
+        // size held; anything else hides them.
+        //
+        // A resize is caught from its first real frame by facts
+        // a magnitude test alone misses (it reads the sub-
+        // threshold start of a pull, and a dip back near the
+        // start size, as a move — flashing the ghost, #237):
+        //  - the press began in the slot's edge band, where
+        //    resize drags start (same signal isResizeGesture
+        //    uses), AND the size has already changed — so an
+        //    edge-grabbed move (drag near the top to swap) keeps
+        //    its ghost while a resize hides with no flash;
+        //  - the 10 pt magnitude test as the press-less
+        //    fallback, measured against the START frame, never
+        //    the slot: a window that can't shrink to its slot
+        //    (min sizes, character grids) differs forever, which
+        //    would call every plain move a resize.
+        // The gesture's FIRST frame has no delta (start ==
+        // frame) so it reads as neither; showing nothing there
+        // avoids a one-frame ghost before the size delta lands.
+        //
+        // This gate is intentionally stricter than the resize-
+        // vs-swap decision in handleDragEnd (plain isResize):
+        // the preview is advisory and biases toward hiding to
+        // kill the flash, so it may suppress a small edge resize
+        // the drop still treats as a swap — harmless, since a
+        // real move holds its size and never enters that band.
+        // Effectiveness rides on the live mouse monitor; with no
+        // recorded press (headless, tests) it falls back to the
+        // 10 pt magnitude test — the pre-fix behavior.
+        let pressNearEdge =
+            mouse.press.map {
+                MouseResize.nearEdge($0.location, of: slot)
+            } ?? false
+        let sizeChanged =
+            abs(frame.width - start.width) > 0.5
+            || abs(frame.height - start.height) > 0.5
+        let movedOrigin =
+            abs(frame.minX - start.minX) > 0.5
+            || abs(frame.minY - start.minY) > 0.5
+        let looksResize =
+            (pressNearEdge && sizeChanged)
+            || MouseResize.isResize(from: start, to: frame)
+        // A gesture that already crossed displays (#504) is a
+        // move for the rest of its life: macOS clamps a big
+        // window's size as it lands on a smaller display, which
+        // the magnitude test would read as a resize — hiding the
+        // ghost the crossing just made room for (the live twin
+        // of the #492 drop-ordering gotcha).
+        let crossed = dragCrossing.hasCrossed(id)
+        if (looksResize || !movedOrigin) && !crossed {
+            if looksResize {
+                // An edge pull near the display seam must never
+                // dwell into a membership move.
+                dragCrossing.cancelPending(for: id)
+            }
+            dragOverlay.hideAll()
+            return
+        }
+        // A clear move: arm / keep the cross-display dwell.
+        updateDragCrossing(id, cursor: cursor)
+        let settings = tiler.settings
+        guard
+            settings.dragGhost.enabled
+                || settings.dragDropZone.enabled
+        else {
+            dragOverlay.hideAll()
+            return
+        }
+        if settings.dragGhost.enabled {
+            dragOverlay.showGhost(
+                at: slot,
+                style: settings.dragGhost,
+                cornerRadius: settings.dragCornerRadius
+            )
+        }
+        // Target the slot under the CURSOR, not the dragged
+        // frame's center: the drop-zone must reach the
+        // destination display the instant the pointer does,
+        // even while a big window's center trails behind on the
+        // origin display (#492). `cursor` is Cocoa (bottom-left);
+        // slots are AX (top-left), so flip it.
+        let target = DragTarget.swapTarget(
+            of: id,
+            at: GeometryUtils.axPoint(cursor),
+            slots: slots
+        )
+        // Suppress the highlight over a cross-display track dest
+        // (files by rule, not the slot); see `dropZoneTarget` (#492).
+        let honestTarget = dropZoneTarget(target, from: space)
+        if settings.dragDropZone.enabled,
+            let honestTarget,
+            let targetSlot = slots[honestTarget]
+        {
+            dragOverlay.showDropZone(
+                at: targetSlot,
+                style: settings.dragDropZone,
+                cornerRadius: settings.dragCornerRadius
+            )
+        } else {
+            dragOverlay.hideDropZone()
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
@@ -7,15 +7,27 @@ import Foundation
 /// monitor is a relocation — "put this window over there" — which
 /// is what people reach for; a same-display drop still swaps.
 ///
-/// This is a SECOND window-relocation path beside `moveWindow`
-/// (which backs the keyboard / Space-Bar move and runs the #207
-/// space-switch animation + warp, both wrong when the destination
-/// space is already on-screen). No parity test binds the two, so
-/// keep its focus / event / z-order obligations in sync by hand
-/// with `moveWindow`'s follow branch and the same-space swap in
-/// `handleDragEnd`: whatever they honor after a re-home
-/// (`emitWindowMovedToSpace`, the #463 settle, the overflow
-/// z-order restore) this must honor too.
+/// FOUR window-relocation paths now exist, with DELIBERATELY
+/// different post-rehome obligations. No parity test can bind
+/// behavior — this table is the registry; keep it honest by hand
+/// when touching any of the four:
+///
+///   path                  AX focus   #463    z-order   retile
+///                                    settle  restore   force
+///   moveWindow(follow:)   yes+warp   yes     —         —
+///   Space-Bar spring      none       none    none      yes
+///   live crossing (#504)  none       none    yes       yes
+///   drop-commit (below)   no-warp    yes     yes       no
+///
+/// The spring and the crossing run MID-DRAG: the pointer is
+/// inside the OS drag loop, so they assert no AX focus and
+/// schedule no settle (a warp would rip the pointer out of the
+/// drag); the crossed gesture's DROP schedules the #463 settle
+/// instead (`handleDragEnd`). All four emit
+/// `windowMovedToSpace` + `spaceChange`. Placement can never
+/// diverge: relocate and crossing share `insertDropped`; spring
+/// and moveWindow share `addFocusedToSpace` (which insertDropped
+/// also routes through for track / empty destinations).
 extension KiwiCore {
     /// The window the live drop-zone highlight should mark, or nil
     /// to suppress it. Suppresses over a **cross-display track**

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
@@ -67,13 +67,13 @@ extension KiwiCore {
     ) -> Bool {
         let cocoaCursor = drag.cursorLocation()
         guard
-            let screen = NSScreen.screens.first(where: {
-                $0.frame.contains(cocoaCursor)
-            }),
-            let display = screen.kiwiDisplay?.id,
+            // Same display resolution the live crossing uses
+            // (#504) — injected, so drag tests can fake a
+            // topology; wired to NSScreen in wireDragCrossing.
+            let display = dragCrossing.displayAt(cocoaCursor),
             let destID = state.workspaces.activeSpace(on: display),
             destID != origin.id,
-            let dest = state.workspaces[destID]
+            state.workspaces[destID] != nil
         else { return false }
         // A sticky window that can't cross displays snaps back
         // instead — the same gate a keyboard / Space-Bar move
@@ -99,17 +99,7 @@ extension KiwiCore {
         // empty destination just receives the window. Keeping this
         // one choke point also keeps track cap / spill placement out
         // of two hand-maintained copies.
-        if dest.mode != .track,
-            let target,
-            let targetIndex = dest.windows.firstIndex(of: target)
-        {
-            state.workspaces.add(id, to: destID, after: target)
-            state.workspaces.withSpace(destID) {
-                $0.move(id, to: targetIndex)
-            }
-        } else {
-            addFocusedToSpace(id, to: destID)
-        }
+        insertDropped(id, onto: target, into: destID)
         state.workspaces.focus(id, in: destID)
         // The pointer ended on the destination display; make it the
         // focused one so "current space" follows the window there —
@@ -147,5 +137,33 @@ extension KiwiCore {
         // window.
         scheduleSpaceSettle(destID, priorFrontmost: priorFrontmost)
         return true
+    }
+
+    /// Files a dragged window into `destID` — the ONE placement
+    /// choke point shared by the drop-commit relocate (#492) and
+    /// the live crossing (#504), so the two paths can never land
+    /// a window differently. Onto a member window in a geometric /
+    /// array-order layout: the target's index (target and
+    /// followers shift one). A track destination, or no / foreign
+    /// target: `addFocusedToSpace`, the same seam a keyboard /
+    /// Space-Bar move uses, so the `new_window` rule and track
+    /// cap / spill live in one place.
+    func insertDropped(
+        _ id: WindowID,
+        onto target: WindowID?,
+        into destID: SpaceID
+    ) {
+        guard let dest = state.workspaces[destID] else { return }
+        if dest.mode != .track,
+            let target,
+            let targetIndex = dest.windows.firstIndex(of: target)
+        {
+            state.workspaces.add(id, to: destID, after: target)
+            state.workspaces.withSpace(destID) {
+                $0.move(id, to: targetIndex)
+            }
+        } else {
+            addFocusedToSpace(id, to: destID)
+        }
     }
 }

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
@@ -14,10 +14,13 @@ import Foundation
 ///
 ///   path                  AX focus   #463    z-order   retile
 ///                                    settle  restore   force
-///   moveWindow(follow:)   yes+warp   yes     —         —
+///   moveWindow(follow:)   yes+warp   yes     —         yes*
 ///   Space-Bar spring      none       none    none      yes
 ///   live crossing (#504)  none       none    yes       yes
 ///   drop-commit (below)   no-warp    yes     yes       no
+///
+///   *follow runs `spaceSwitchRetile` (forced); the no-follow
+///    branch retiles un-forced.
 ///
 /// The spring and the crossing run MID-DRAG: the pointer is
 /// inside the OS drag loop, so they assert no AX focus and

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+DragRelocate.swift
@@ -14,20 +14,23 @@ import Foundation
 ///
 ///   path                  AX focus   #463    z-order   retile
 ///                                    settle  restore   force
-///   moveWindow(follow:)   yes+warp   yes     —         yes*
+///   moveWindow(follow:)   yes+warp   yes*    —         yes*
 ///   Space-Bar spring      none       none    none      yes
 ///   live crossing (#504)  none       none    yes       yes
 ///   drop-commit (below)   no-warp    yes     yes       no
 ///
-///   *follow runs `spaceSwitchRetile` (forced); the no-follow
-///    branch retiles un-forced.
+///   *follow only: `spaceSwitchRetile` (forced) + the #463
+///    settle. The no-follow branch retiles un-forced, runs the
+///    conditional #482 `moveLatch` / `scheduleMoveSettle` pair
+///    instead, and emits no `spaceChange`.
 ///
 /// The spring and the crossing run MID-DRAG: the pointer is
 /// inside the OS drag loop, so they assert no AX focus and
 /// schedule no settle (a warp would rip the pointer out of the
 /// drag); the crossed gesture's DROP schedules the #463 settle
 /// instead (`handleDragEnd`). All four emit
-/// `windowMovedToSpace` + `spaceChange`. Placement can never
+/// `windowMovedToSpace`; all but the no-follow move emit
+/// `spaceChange`. Placement can never
 /// diverge: relocate and crossing share `insertDropped`; spring
 /// and moveWindow share `addFocusedToSpace` (which insertDropped
 /// also routes through for track / empty destinations).

--- a/Tests/KiwiDeskCoreTests/DragCrossingCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragCrossingCoordinatorTests.swift
@@ -1,0 +1,150 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Generous hang-guard for waits on the dwell Task's `onCross`
+/// (#344): swift-testing runs suites concurrently, so the main
+/// actor can be starved for seconds under full-suite load. The
+/// polls exit the instant the condition holds, so a passing run
+/// never slows — the deadline only bounds a genuine hang.
+private let crossingHangGuard: Duration = .seconds(30)
+
+@Suite("DragCrossingCoordinator", .serialized)
+@MainActor
+struct DragCrossingCoordinatorTests {
+    /// Left half of the plane is display 1, right half display 2.
+    private func makeCoordinator() -> DragCrossingCoordinator {
+        let crossing = DragCrossingCoordinator()
+        crossing.dwell = 0.05
+        crossing.displayAt = { point in
+            point.x < 1000 ? DisplayID(1) : DisplayID(2)
+        }
+        return crossing
+    }
+
+    @Test("A dwell on a foreign display fires one crossing")
+    func dwellFires() async throws {
+        let crossing = makeCoordinator()
+        var fired: [DisplayID] = []
+        crossing.onCross = { _, display in
+            fired.append(display)
+        }
+        let id = WindowID(1)
+        let onForeign = CGPoint(x: 1500, y: 100)
+        crossing.moved(
+            id,
+            cursor: onForeign,
+            homeDisplay: DisplayID(1)
+        )
+        let deadline = ContinuousClock.now + crossingHangGuard
+        while fired.isEmpty, ContinuousClock.now < deadline {
+            // Same-display moves must keep the armed dwell
+            // running, not restart it.
+            crossing.moved(
+                id,
+                cursor: onForeign,
+                homeDisplay: DisplayID(1)
+            )
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        // Grace window so a wrong second fire would show up.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(fired == [DisplayID(2)])
+    }
+
+    @Test("Returning home before the dwell disarms it")
+    func returnHomeDisarms() async throws {
+        let crossing = makeCoordinator()
+        var fired = 0
+        crossing.onCross = { _, _ in fired += 1 }
+        let id = WindowID(1)
+        crossing.moved(
+            id,
+            cursor: CGPoint(x: 1500, y: 100),
+            homeDisplay: DisplayID(1)
+        )
+        // Back on the home display before the dwell elapses:
+        // the seam-skim case the debounce exists for.
+        crossing.moved(
+            id,
+            cursor: CGPoint(x: 100, y: 100),
+            homeDisplay: DisplayID(1)
+        )
+        try await Task.sleep(nanoseconds: 150_000_000)
+        #expect(fired == 0)
+    }
+
+    @Test("A cursor over no display disarms the dwell")
+    func nowhereDisarms() async throws {
+        let crossing = makeCoordinator()
+        var fired = 0
+        crossing.onCross = { _, _ in fired += 1 }
+        let id = WindowID(1)
+        // Arm toward a display that then stops resolving
+        // (topology change mid-drag).
+        crossing.displayAt = { _ in DisplayID(2) }
+        crossing.moved(
+            id,
+            cursor: CGPoint(x: 1500, y: 100),
+            homeDisplay: DisplayID(1)
+        )
+        crossing.displayAt = { _ in nil }
+        crossing.moved(
+            id,
+            cursor: CGPoint(x: 1500, y: 100),
+            homeDisplay: DisplayID(1)
+        )
+        try await Task.sleep(nanoseconds: 150_000_000)
+        #expect(fired == 0)
+    }
+
+    @Test("endGesture disarms the pending dwell and reports")
+    func endGestureDisarms() async throws {
+        let crossing = makeCoordinator()
+        var fired = 0
+        crossing.onCross = { _, _ in fired += 1 }
+        let id = WindowID(1)
+        crossing.moved(
+            id,
+            cursor: CGPoint(x: 1500, y: 100),
+            homeDisplay: DisplayID(1)
+        )
+        // Nothing crossed yet — the drop landed before the
+        // dwell elapsed (the fast flick #492 still owns).
+        #expect(crossing.endGesture(id) == false)
+        try await Task.sleep(nanoseconds: 150_000_000)
+        #expect(fired == 0)
+    }
+
+    @Test("Gesture bookkeeping: origin once, crossed, cleared")
+    func gestureBookkeeping() {
+        let crossing = makeCoordinator()
+        let id = WindowID(1)
+        crossing.recordOriginIfNeeded(id, space: "A", index: 2)
+        // A second crossing keeps the FIRST home — that is the
+        // abnormal-cancel restore point.
+        crossing.recordOriginIfNeeded(id, space: "B", index: 0)
+        #expect(crossing.origin(for: id)?.space == SpaceID("A"))
+        #expect(crossing.origin(for: id)?.index == 2)
+        #expect(crossing.hasCrossed(id) == false)
+        crossing.markCrossed(id)
+        #expect(crossing.hasCrossed(id))
+        #expect(crossing.endGesture(id) == true)
+        // Ended: a reused WindowID starts clean.
+        #expect(crossing.origin(for: id) == nil)
+        #expect(crossing.hasCrossed(id) == false)
+    }
+
+    @Test("A sticky refusal is remembered for the gesture")
+    func stickyRefusalOnce() {
+        let crossing = makeCoordinator()
+        let id = WindowID(1)
+        #expect(crossing.stickyRefused(id) == false)
+        crossing.markStickyRefused(id)
+        #expect(crossing.stickyRefused(id))
+        crossing.endGesture(id)
+        #expect(crossing.stickyRefused(id) == false)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/DragCrossingCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragCrossingCoordinatorTests.swift
@@ -137,6 +137,31 @@ struct DragCrossingCoordinatorTests {
         #expect(crossing.hasCrossed(id) == false)
     }
 
+    @Test("rekey moves the gesture record; the dwell dies")
+    func rekeyTransfersGesture() async throws {
+        let crossing = makeCoordinator()
+        var fired = 0
+        crossing.onCross = { _, _ in fired += 1 }
+        let old = WindowID(1)
+        let new = WindowID(9)
+        crossing.recordOriginIfNeeded(old, space: "A", index: 1)
+        crossing.markCrossed(old)
+        crossing.moved(
+            old,
+            cursor: CGPoint(x: 1500, y: 100),
+            homeDisplay: DisplayID(1)
+        )
+        crossing.rekey(old: old, new: new)
+        // The bookkeeping follows the id swap (#308)…
+        #expect(crossing.origin(for: new)?.space == SpaceID("A"))
+        #expect(crossing.origin(for: new)?.index == 1)
+        #expect(crossing.hasCrossed(new))
+        #expect(crossing.origin(for: old) == nil)
+        // …but the armed dwell dies with the aborted gesture.
+        try await Task.sleep(nanoseconds: 150_000_000)
+        #expect(fired == 0)
+    }
+
     @Test("A sticky refusal is remembered for the gesture")
     func stickyRefusalOnce() {
         let crossing = makeCoordinator()

--- a/Tests/KiwiDeskCoreTests/DragCrossingTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragCrossingTests.swift
@@ -155,6 +155,64 @@ struct DragCrossingTests {
         )
     }
 
+    @Test("A stale dwell fire is dropped when the cursor left")
+    func staleFireRevalidatesCursor() {
+        let core = makeTwoDisplayCore()
+        // AX move events can lag the pointer by more than the
+        // dwell (Electron): by fire time the cursor is back on
+        // the home display — the fire must not commit.
+        core.drag.cursorLocation = { CGPoint(x: 100, y: 100) }
+        let id = WindowID(1)
+        core.dragCrossing.onCross(id, DisplayID(2))
+        #expect(
+            core.state.workspaces.space(of: id) == SpaceID(1)
+        )
+        #expect(core.dragCrossing.hasCrossed(id) == false)
+    }
+
+    @Test("An armed Space Bar target blocks the dwell fire")
+    func armedBarBlocksFire() throws {
+        let core = makeTwoDisplayCore()
+        let id = WindowID(1)
+        // Arm a bar target through the coordinator's own API: a
+        // hit over a foreign space's item arms synchronously.
+        core.spaceBarDrop.hitTest = { _ in SpaceID("9") }
+        core.spaceBarDrop.currentSpace = { _ in SpaceID(1) }
+        core.spaceBarDrop.moved(id, cursor: .zero)
+        try #require(core.spaceBarDrop.isArmed)
+        // The bar spring is a competing membership mover; an
+        // armed target wins over a racing dwell fire.
+        core.dragCrossing.onCross(id, DisplayID(2))
+        #expect(
+            core.state.workspaces.space(of: id) == SpaceID(1)
+        )
+        #expect(core.dragCrossing.hasCrossed(id) == false)
+    }
+
+    @Test("A native-tab rekey reverts under the new id")
+    func rekeyTransfersRevert() {
+        let core = makeTwoDisplayCore()
+        let old = WindowID(1)
+        let new = WindowID(9)
+        core.dragCrossing.onCross(old, DisplayID(2))
+        #expect(
+            core.state.workspaces.space(of: old) == SpaceID("2")
+        )
+        // The state fold swaps the id in place (#308), then the
+        // event handler transfers the crossing bookkeeping,
+        // cancels the old gesture, and reverts under the new id
+        // — the exact wiring in KiwiCore+Events.
+        core.state.apply(.windowRekeyed(old, new))
+        core.dragCrossing.rekey(old: old, new: new)
+        core.cancelDrag(old)
+        core.revertLiveCrossing(new)
+        #expect(
+            core.state.workspaces.space(of: new) == SpaceID(1)
+        )
+        #expect(core.dragCrossing.origin(for: new) == nil)
+        #expect(core.dragCrossing.origin(for: old) == nil)
+    }
+
     @Test("A marked sticky refusal blocks later crossings")
     func stickyRefusalBlocks() {
         let core = makeTwoDisplayCore()

--- a/Tests/KiwiDeskCoreTests/DragCrossingTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragCrossingTests.swift
@@ -1,0 +1,202 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The live cross-display make-room move (#504) at the KiwiCore
+/// level: membership eager-moves on a crossing, reverts on an
+/// abnormal cancel, and the drop path ends the gesture. Displays
+/// are faked through the injected `displayAt`, so no real second
+/// monitor (or any screen) is needed — the crossing acts on
+/// state, not geometry.
+@Suite("Drag display crossing", .serialized)
+@MainActor
+struct DragCrossingTests {
+    private func makeCore() -> KiwiCore {
+        KiwiCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-crossing-\(UUID().uuidString)"
+                )
+        )
+    }
+
+    private func addWindow(
+        _ core: KiwiCore,
+        _ raw: UInt32
+    ) {
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(
+                    id: WindowID(raw),
+                    pid: 1,
+                    appName: "App\(raw)"
+                )
+            )
+        )
+    }
+
+    /// Two displays: the default space "1" (with windows 1, 2)
+    /// on display 1, an empty space "2" on display 2. The drag
+    /// machinery believes the mouse is pressed.
+    private func makeTwoDisplayCore() -> KiwiCore {
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        core.state.workspaces.assign(
+            SpaceID(1),
+            to: DisplayID(1)
+        )
+        core.state.workspaces.assign("2", to: DisplayID(2))
+        core.drag.isMousePressed = { true }
+        core.drag.cursorLocation = { CGPoint(x: 1500, y: 100) }
+        // Fake topology replaces the NSScreen lookup for BOTH
+        // the crossing and the drop-commit relocate: left half
+        // is display 1, right half display 2 — otherwise a real
+        // screen whose id collides with the fixture's would let
+        // `relocateAcrossDisplay` act during the drop tests.
+        core.dragCrossing.displayAt = { point in
+            point.x < 1000 ? DisplayID(1) : DisplayID(2)
+        }
+        return core
+    }
+
+    @Test("A crossing eager-moves membership and follows focus")
+    func crossingMovesMembership() {
+        let core = makeTwoDisplayCore()
+        let id = WindowID(1)
+        // The wired onCross is the debounced dwell's landing
+        // point — fire it directly, as the coordinator would.
+        core.dragCrossing.onCross(id, DisplayID(2))
+        #expect(
+            core.state.workspaces.space(of: id) == SpaceID("2")
+        )
+        #expect(
+            core.state.workspaces[SpaceID(1)]?.windows
+                == [WindowID(2)]
+        )
+        // The focused display followed the drag (#446); the
+        // moved window is the destination's focus.
+        #expect(core.activeSpace?.id == SpaceID("2"))
+        #expect(core.activeSpace?.focused == id)
+        // The gesture knows it crossed — the drop path's
+        // resize-gate bypass reads exactly this.
+        #expect(core.dragCrossing.hasCrossed(id))
+        #expect(
+            core.dragCrossing.origin(for: id)?.space
+                == SpaceID(1)
+        )
+        #expect(core.dragCrossing.origin(for: id)?.index == 0)
+        // The window stays pinned under the cursor: exempt from
+        // re-framing for the rest of the gesture.
+        #expect(core.tiler.dragExemptWindow == id)
+    }
+
+    @Test("A release during the dwell leaves membership alone")
+    func releasedDwellIsIgnored() {
+        let core = makeTwoDisplayCore()
+        core.drag.isMousePressed = { false }
+        let id = WindowID(1)
+        // The dwell fired after the release: the drop-commit
+        // relocate (#492) owns the gesture now.
+        core.dragCrossing.onCross(id, DisplayID(2))
+        #expect(
+            core.state.workspaces.space(of: id) == SpaceID(1)
+        )
+        #expect(core.dragCrossing.hasCrossed(id) == false)
+    }
+
+    @Test("An abnormal cancel restores the origin space + index")
+    func cancelReverts() {
+        let core = makeTwoDisplayCore()
+        let id = WindowID(2)
+        core.dragCrossing.onCross(id, DisplayID(2))
+        #expect(
+            core.state.workspaces.space(of: id) == SpaceID("2")
+        )
+        // Window closed / rekeyed mid-drag: the gesture never
+        // reaches handleDragEnd.
+        core.cancelDrag(id)
+        #expect(
+            core.state.workspaces.space(of: id) == SpaceID(1)
+        )
+        #expect(
+            core.state.workspaces[SpaceID(1)]?.windows
+                == [WindowID(1), WindowID(2)]
+        )
+        // Bookkeeping is gone — a reused id starts clean.
+        #expect(core.dragCrossing.origin(for: id) == nil)
+        #expect(core.dragCrossing.hasCrossed(id) == false)
+    }
+
+    @Test("The drop ends the gesture and reports the crossing")
+    func dropEndsGesture() {
+        let core = makeTwoDisplayCore()
+        let id = WindowID(1)
+        core.dragCrossing.onCross(id, DisplayID(2))
+        #expect(core.dragCrossing.hasCrossed(id))
+        // The real drop runs handleDragEnd, which must both
+        // read the crossing (resize bypass) and clear it.
+        core.handleDragEnd(
+            id,
+            start: CGRect(x: 0, y: 0, width: 500, height: 500),
+            frame: CGRect(x: 1400, y: 50, width: 400, height: 400)
+        )
+        #expect(core.dragCrossing.hasCrossed(id) == false)
+        #expect(core.dragCrossing.origin(for: id) == nil)
+        // Size changed mid-gesture (the smaller-display clamp),
+        // yet the window stays MOVED — never re-interpreted as
+        // a resize snapping it home (#492's gotcha, live).
+        #expect(
+            core.state.workspaces.space(of: id) == SpaceID("2")
+        )
+    }
+
+    @Test("A marked sticky refusal blocks later crossings")
+    func stickyRefusalBlocks() {
+        let core = makeTwoDisplayCore()
+        let id = WindowID(1)
+        core.dragCrossing.markStickyRefused(id)
+        core.dragCrossing.onCross(id, DisplayID(2))
+        #expect(
+            core.state.workspaces.space(of: id) == SpaceID(1)
+        )
+    }
+
+    @Test("insertDropped lands on the target's index")
+    func insertDroppedOnTarget() {
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        addWindow(core, 3)
+        core.state.workspaces.assign("B", to: DisplayID(2))
+        core.state.workspaces.add(WindowID(2), to: "B")
+        core.state.workspaces.add(WindowID(3), to: "B")
+        // The shared placement choke point (#492 / #504): onto a
+        // member window → its index, target shifts down.
+        core.insertDropped(
+            WindowID(1),
+            onto: WindowID(3),
+            into: "B"
+        )
+        #expect(
+            core.state.workspaces[SpaceID("B")]?.windows
+                == [WindowID(2), WindowID(1), WindowID(3)]
+        )
+    }
+
+    @Test("insertDropped with no target appends")
+    func insertDroppedAppends() {
+        let core = makeCore()
+        addWindow(core, 1)
+        core.state.workspaces.assign("B", to: DisplayID(2))
+        core.insertDropped(WindowID(1), onto: nil, into: "B")
+        #expect(
+            core.state.workspaces[SpaceID("B")]?.windows
+                == [WindowID(1)]
+        )
+    }
+}

--- a/Tests/KiwiDeskCoreTests/DragCrossingTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragCrossingTests.swift
@@ -198,14 +198,12 @@ struct DragCrossingTests {
         #expect(
             core.state.workspaces.space(of: old) == SpaceID("2")
         )
-        // The state fold swaps the id in place (#308), then the
-        // event handler transfers the crossing bookkeeping,
-        // cancels the old gesture, and reverts under the new id
-        // — the exact wiring in KiwiCore+Events.
-        core.state.apply(.windowRekeyed(old, new))
-        core.dragCrossing.rekey(old: old, new: new)
-        core.cancelDrag(old)
-        core.revertLiveCrossing(new)
+        // Drive the REAL event handler: the state fold swaps
+        // the id in place (#308), then the handler transfers
+        // the crossing bookkeeping, cancels the old gesture,
+        // and reverts under the new id — this pins the wiring
+        // ORDER in KiwiCore+Events, not just the pieces.
+        core.handle(.windowRekeyed(old, new))
         #expect(
             core.state.workspaces.space(of: new) == SpaceID(1)
         )

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -294,8 +294,10 @@ must also refresh their state on `native_space_change`.
 
 `window_moved_to_space` fires when a window is explicitly
 moved to another virtual space (`move_to_space`,
-with or without follow); bulk reassignments (profile load,
-session restore) stay silent:
+with or without follow, or a drag onto another display — the
+live crossing emits as the membership moves, so a drag pulled
+back before release emits once per crossing); bulk
+reassignments (profile load, session restore) stay silent:
 
 ```json
 {"event": "window_moved_to_space",

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1628,11 +1628,32 @@ destination display **re-partitions** to N+1 slots. A
 destination is the active space of the display **under the
 cursor**, so an empty monitor still receives the drop; only a
 same-display release outside every slot snaps back.
-The window belongs to its origin space for the whole drag, so
-the destination shows no gap *until* the drop commits the
-membership change — opening one live mid-drag (a ghost over an
-empty slot as the cursor enters) is a possible later polish,
-not part of this behavior. *Rationale:* the primary
+The move happens **live** (#504): once the cursor has dwelt on
+the destination display for a beat (a debounce, so skimming the
+seam — or an overflow-inducing crossing that would bounce right
+back — never re-tiles both displays per mouse event), the
+window's *membership* eager-moves there and both displays
+re-partition, opening a real slot under the cursor while the
+dragged window stays pinned under the pointer (`dragExemptWindow`
+— its frame is never set mid-drag). This is the Space-Bar-spring
+model (#372) keyed on displays, and it buys the unification: from
+the crossing on, the drag *is* a same-display drag in the
+destination space — swap on a window, snap into the opened gap,
+one "you're inside this space now" rule. Dragging back before
+release crosses back symmetrically; an abnormal end (window
+closed or rekeyed mid-drag) restores the origin space and index.
+A gesture that crossed is a **move for the rest of its life**:
+the drop skips the resize interpretation outright — the live twin
+of the relocate-before-resize-gate ordering — because macOS
+clamps a big window's size on a smaller display, which the
+magnitude test would misread as a resize. The drop-commit
+relocate path remains for the fast flick whose dwell never fired,
+sharing one placement choke point (`insertDropped`) with the
+crossing so the two can never land a window differently. Sticky
+windows are the deliberate exception: they never live-cross —
+their cross-display drop keeps the full #445 gate + pill
+semantics of the drop-commit path, resolved once at release.
+*Rationale:* the primary
 reason to drag a window to another monitor is to *move it
 there* — swap-only would be frustrating, and it can fling a
 window you never touched onto your other display. *Trade-off:*

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -643,9 +643,17 @@ When you drag a tiled window, KiwiDesk shows two overlays:
   slot — even a big window dragged onto a smaller display.
 
 Releasing over another window's slot **on the same display swaps**
-the two; releasing **on another display moves** the window there —
+the two; dragging **onto another display moves** the window there.
+The move happens **live**: once the cursor has settled on the
+other display for a beat, the destination's windows slide apart to
+open a real slot under the cursor — the dragged window itself
+stays pinned under the pointer — and from that moment the drag
+behaves exactly like a local one there (release over a window to
+swap, release outside every slot to snap into the opened gap).
+Pulling the cursor back before releasing moves the window home the
+same way. A fast flick across still commits the move at release —
 onto a window's slot it lands there (the windows below it shift
-down one), and onto empty space (an empty monitor) it just moves
+down one), onto empty space (an empty monitor) it just moves
 across. Releasing outside every slot **on your own display** snaps
 the window back.
 


### PR DESCRIPTION
## Description

Live "make-room" preview for cross-display drags (follow-up to #492's drop-commit model). Once the cursor dwells ~150 ms on another display while dragging a tiled window, the window's membership eager-moves into that display's active space: the destination's windows slide apart to open a real slot under the cursor while the dragged window stays pinned under the pointer (`dragExemptWindow` — never re-framed mid-drag). From the crossing on, the drag is an ordinary same-display gesture in the destination space (the Space-Bar-spring model, #372, keyed on displays), unifying cross- and same-display drags under one rule. The #492 drop-commit relocate remains as the fast-flick path; both share the `insertDropped` placement choke point.

Guards shaped by three review rounds:
- **Dwell debounce** — one retile per crossing, never per mouse event (AX slow path, overflow flip-flop at the seam).
- **Fire-time re-validation** — live cursor display, mouse button, Space Bar armed state and live bar hit-test re-checked when the dwell fires (AX move events can lag past the dwell on Electron/WebKit apps).
- **Dwell feed classification** — arms on size-held moves plus the macOS clamp's shrink-while-translating signature; enlarge pulls disarm, so an edge resize can never dwell into a membership move, while a big window clamped en route to a smaller display keeps its crossing.
- **Crossed gestures are moves for life** — the drop skips the resize interpretation (the smaller-display size clamp would read as a resize; #492's ordering, live edition), and schedules the #463 settle the flick path already had.
- **Clean revert** — crossing back is symmetric; native-tab rekey mid-drag transfers the bookkeeping and reverts under the new id; sticky windows never live-cross (full #445 gate + pill at release).

The four window-relocation paths (moveWindow / spring / crossing / relocate) now have a hand-kept obligations table in `KiwiCore+DragRelocate.swift`. `handleDragMove` split into `KiwiCore+DragMove.swift` for the file ceiling.

## Related Issue(s)

Closes #504

## Checklist

- [x] I understand what this change does and have run it in the app to confirm it works as intended
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested (17 crossing tests: coordinator debounce/rekey + KiwiCore membership/revert/fire-guards)
- [x] User-facing changes are documented in `docs/` (user-guide, design-decisions principle amendment, cli events note)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes (1888 + 14 ExecTests)
- [x] Release build passes: `swift build -c release`
- [x] PR is focused

## How I verified

Owner device-QA'd the live make-room on two displays (drag across, gap opens live, drop swaps/snaps like a local drag, pull-back crosses home) — QA build was the feature commit; the four follow-up commits harden edges surfaced by review (clamp/resize classification, stale-fire guards, rekey revert, settle parity) without changing the QA'd happy path. Full verify gate re-ran green on the final HEAD.

## Notes for Reviewer

Two-agent review ran per AGENTS §3: code-reviewer (4 rounds, final verdict clean) and architect-reviewer (2 rounds, "architecture holds"; its two pre-PR minors are in the last commit). On-record accepted nits: headless press-less classification corner (falls back to drop-commit), app-self-reposition-while-button-held coincidence (pre-existing class), traveler-refusal drop exit skips the settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)