### PR TITLE
fix(profiles): keep the Starter ladder scaled across display changes (#485)

### DIFF
--- a/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
+++ b/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
@@ -59,15 +59,7 @@ public enum DefaultKeybindings {
             )
         }
         for (digit, space) in numbered(spaces) {
-            rows.append(
-                KeyBinding(
-                    combo: "control+option+\(digit)",
-                    lua: "KiwiDesk.focus_space"
-                        + "(\(SpaceLuaArg.quote(space.raw)))",
-                    kind: .navigation,
-                    label: "Go to Space \(space.raw)"
-                )
-            )
+            rows.append(focusSpaceRow(digit: digit, space: space))
         }
         // Tier 2 — ⌃⌥⇧: swap a window, move it to a space.
         for (dir, phrase) in directions {
@@ -81,28 +73,12 @@ public enum DefaultKeybindings {
             )
         }
         for (digit, space) in numbered(spaces) {
-            rows.append(
-                KeyBinding(
-                    combo: "control+option+shift+\(digit)",
-                    lua: "KiwiDesk.move_to_space"
-                        + "(\(SpaceLuaArg.quote(space.raw)))",
-                    kind: .navigation,
-                    label: "Move to Space \(space.raw)"
-                )
-            )
+            rows.append(moveSpaceRow(digit: digit, space: space))
         }
         // Tier 3 — ⌃⌥⌘: resize, move-to-space-and-follow.
         rows.append(contentsOf: resizeRows(step: resizeStep))
         for (digit, space) in numbered(spaces) {
-            rows.append(
-                KeyBinding(
-                    combo: "control+option+command+\(digit)",
-                    lua: "KiwiDesk.move_to_space_and_follow"
-                        + "(\(SpaceLuaArg.quote(space.raw)))",
-                    kind: .navigation,
-                    label: "Move to Space \(space.raw) & follow"
-                )
-            )
+            rows.append(followSpaceRow(digit: digit, space: space))
         }
         // Toggles — mnemonic letters. Display sticky is the more
         // frequent scope, so it takes the lighter ⌃⌥ chord; the
@@ -164,6 +140,87 @@ public enum DefaultKeybindings {
                 label: "Shrink height"
             ),
         ]
+    }
+
+    // MARK: - Per-space rows (one per tier, shared with top-up)
+
+    /// Tier 1 — ⌃⌥ + digit: focus (go to) a space.
+    private static func focusSpaceRow(
+        digit: String,
+        space: SpaceID
+    ) -> KeyBinding {
+        KeyBinding(
+            combo: "control+option+\(digit)",
+            lua: "KiwiDesk.focus_space"
+                + "(\(SpaceLuaArg.quote(space.raw)))",
+            kind: .navigation,
+            label: "Go to Space \(space.raw)"
+        )
+    }
+
+    /// Tier 2 — ⌃⌥⇧ + digit: move the window to a space.
+    private static func moveSpaceRow(
+        digit: String,
+        space: SpaceID
+    ) -> KeyBinding {
+        KeyBinding(
+            combo: "control+option+shift+\(digit)",
+            lua: "KiwiDesk.move_to_space"
+                + "(\(SpaceLuaArg.quote(space.raw)))",
+            kind: .navigation,
+            label: "Move to Space \(space.raw)"
+        )
+    }
+
+    /// Tier 3 — ⌃⌥⌘ + digit: move the window and follow it.
+    private static func followSpaceRow(
+        digit: String,
+        space: SpaceID
+    ) -> KeyBinding {
+        KeyBinding(
+            combo: "control+option+command+\(digit)",
+            lua: "KiwiDesk.move_to_space_and_follow"
+                + "(\(SpaceLuaArg.quote(space.raw)))",
+            kind: .navigation,
+            label: "Move to Space \(space.raw) & follow"
+        )
+    }
+
+    /// The per-space digit rows MISSING from `existing` for the
+    /// live `spaces` — the additive top-up when a display change
+    /// grows the space count past the digits seeded on first run
+    /// (#485). Strictly additive: a digit whose combo is already
+    /// bound (a seeded default OR a user's custom chord) is left
+    /// untouched, so the top-up can never overwrite a binding. The
+    /// same position → digit mapping and ten-cap as `bindings`
+    /// (`numbered`), so a space past the tenth still ships unbound.
+    /// Combo identity is by parsed `KeyCombo`, so an equivalent
+    /// hand-authored alias (`ctrl+alt+6`) counts as taken.
+    public static func digitTopUp(
+        existing: [KeyBinding],
+        spaces: [SpaceID]
+    ) -> [KeyBinding] {
+        let taken = Set(
+            existing.compactMap {
+                KeyCombo.parse($0.combo)
+            }
+        )
+        let isFree: (KeyBinding) -> Bool = { row in
+            guard let combo = KeyCombo.parse(row.combo) else {
+                return false
+            }
+            return !taken.contains(combo)
+        }
+        var rows: [KeyBinding] = []
+        for (digit, space) in numbered(spaces) {
+            let candidates = [
+                focusSpaceRow(digit: digit, space: space),
+                moveSpaceRow(digit: digit, space: space),
+                followSpaceRow(digit: digit, space: space),
+            ]
+            rows.append(contentsOf: candidates.filter(isFree))
+        }
+        return rows
     }
 
     /// The first ten spaces paired with the digit key each

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+MonitorChange.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+MonitorChange.swift
@@ -68,10 +68,14 @@ extension KiwiCore {
             }
             profiles.markDirty()
         case .none:
+            // On the beginner ladder baseline, recompose the
+            // ladder at the live display count instead of a
+            // workflow Standard, so the five-per-display shape
+            // survives the change (#485). Any other baseline gets
+            // the count's built-in Standard, unchanged (#53).
             guard
-                let composed = ProfileComposition.compose(
-                    displays: displays,
-                    mainID: PositionalDisplays.liveMainID
+                let composed = composeMonitorChangeFallback(
+                    displays: displays
                 )
             else { return }
             // A hand-written or hybrid Lua config keeps
@@ -99,6 +103,20 @@ extension KiwiCore {
             }
             apply(composed: composed, forceRetile: false)
             profiles.adoptStandard(named: composed.sourceName)
+            // The ladder's five-per-display plan is not the count's
+            // Standard that `apply` lets `resolveSpaceDisplays`
+            // recompose, so pin its blocks from the composed
+            // assignment and re-resolve — otherwise the blocks would
+            // scatter into the workflow Standard's positions (#485).
+            if composed.sourceName == StarterLadder.name {
+                adoptComposedPlacement(composed)
+                resolveSpaceDisplays()
+                retile()
+            }
+            // Bind ⌃⌥N for spaces the change added past the
+            // first-run seed — additive, never overwriting a
+            // custom chord (#485).
+            topUpDigitShortcuts()
             onLog(
                 "monitor change: no matching profile, "
                     + "composed standard '\(composed.sourceName)'"

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+MonitorChange.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+MonitorChange.swift
@@ -101,18 +101,11 @@ extension KiwiCore {
                 )
                 return
             }
+            // `apply(composed:)` adopts the composed placement, so
+            // the ladder's five-per-display blocks land correctly
+            // (not scattered into the workflow Standard's slots).
             apply(composed: composed, forceRetile: false)
             profiles.adoptStandard(named: composed.sourceName)
-            // The ladder's five-per-display plan is not the count's
-            // Standard that `apply` lets `resolveSpaceDisplays`
-            // recompose, so pin its blocks from the composed
-            // assignment and re-resolve — otherwise the blocks would
-            // scatter into the workflow Standard's positions (#485).
-            if composed.sourceName == StarterLadder.name {
-                adoptComposedPlacement(composed)
-                resolveSpaceDisplays()
-                retile()
-            }
             // Bind ⌃⌥N for spaces the change added past the
             // first-run seed — additive, never overwriting a
             // custom chord (#485).

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileEdit.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileEdit.swift
@@ -54,6 +54,11 @@ extension KiwiCore {
             )
         )
         copy.isDefault = false
+        // A save-as-new copy is the user's own profile, never the
+        // beginner-ladder baseline — the sibling of `isDefault`
+        // here, and both identity flags the copy must neutralize
+        // (#485, AGENTS.md §5 mirror rule).
+        copy.isStarterLadder = false
         try profiles.write(copy)
         return copy.name
     }

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
@@ -231,26 +231,19 @@ extension KiwiCore {
         // If the save below fails, state honestly reflects a
         // transient Standard instead of a stale profile.
         profiles.adoptStandard(named: composed.sourceName)
-        let ordered = PositionalDisplays.ordered(
-            displays,
-            mainID: mainID
-        )
-        var pins: [SpaceID: String] = [:]
-        var mains: Set<SpaceID> = []
-        for space in composed.spaces {
-            let assigned = composed.assignment[space]
-            if assigned == ordered.first?.id || assigned == nil {
-                mains.insert(space)
-            } else if let display = ordered.first(where: {
-                $0.id == assigned
-            }) {
-                pins[space] = display.fingerprint
-            }
-        }
-        spacePins = pins
-        mainSpaces = mains
+        adoptComposedPlacement(composed)
         let name = profiles.freeName(base: layout.name)
-        try profiles.save(buildProfile(name: name))
+        var profile = buildProfile(name: name)
+        // Tag the beginner ladder so a later unmatched monitor
+        // change recomposes it (not a workflow Standard) at the
+        // new display count (#485). Every other preset saves a
+        // normal, unflagged profile.
+        profile.isStarterLadder = layout.name == StarterLadder.name
+        try profiles.save(profile)
+        // A preset can define more spaces than the first-run seed
+        // authored digit shortcuts for; bind the newcomers
+        // additively so ⌃⌥N covers them too (#485).
+        topUpDigitShortcuts()
         return name
     }
 

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileResolution.swift
@@ -180,8 +180,12 @@ extension KiwiCore {
                 composed.spaceModes[space] ?? .bsp
             )
         }
-        spacePins = [:]
-        mainSpaces = []
+        // Honor the composed layout's own positional plan (#485):
+        // for a workflow Standard this equals what
+        // `resolveSpaceDisplays` re-derives below, but the ladder's
+        // five-per-display plan is NOT the count's Standard, so its
+        // blocks would otherwise scatter into the Standard's slots.
+        adoptComposedPlacement(composed)
         fallbackSpace = nil
         // A transient Standard has no keybinding or app-rule
         // override — revert to the base gui.json config
@@ -227,19 +231,16 @@ extension KiwiCore {
                 live: displays.count
             )
         }
+        // `apply(composed:)` adopts the composed placement, so the
+        // pins/mains `buildProfile` captures below are already set.
         apply(composed: composed, forceRetile: true)
         // If the save below fails, state honestly reflects a
-        // transient Standard instead of a stale profile.
+        // transient Standard instead of a stale profile. Adopting
+        // the standard first also lets `buildProfile` tag the
+        // beginner ladder from `currentStandard` (#485).
         profiles.adoptStandard(named: composed.sourceName)
-        adoptComposedPlacement(composed)
         let name = profiles.freeName(base: layout.name)
-        var profile = buildProfile(name: name)
-        // Tag the beginner ladder so a later unmatched monitor
-        // change recomposes it (not a workflow Standard) at the
-        // new display count (#485). Every other preset saves a
-        // normal, unflagged profile.
-        profile.isStarterLadder = layout.name == StarterLadder.name
-        try profiles.save(profile)
+        try profiles.save(buildProfile(name: name))
         // A preset can define more spaces than the first-run seed
         // authored digit shortcuts for; bind the newcomers
         // additively so ⌃⌥N covers them too (#485).
@@ -307,11 +308,14 @@ extension KiwiCore {
             // whose deltas may sit inside the tolerance.
             apply(profile: profile, forceRetile: true)
         } else if profiles.currentStandard != nil,
-            let composed = ProfileComposition.compose(
-                displays: state.workspaces.allDisplays,
-                mainID: PositionalDisplays.liveMainID
+            let composed = composeMonitorChangeFallback(
+                displays: state.workspaces.allDisplays
             )
         {
+            // Recompose through the same baseline-aware fallback as
+            // a monitor change, so a reload while on the transient
+            // ladder Standard re-applies the LADDER, not the count's
+            // workflow Standard (#485). `apply` adopts its placement.
             apply(composed: composed, forceRetile: true)
         }
     }

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
@@ -101,6 +101,39 @@ extension KiwiCore {
 
     // MARK: - Building / persisting
 
+    /// Writes a composed layout's positional `assignment` into the
+    /// live `spacePins` + `mainSpaces` — the composed-placement
+    /// primitive behind `apply(composed:)`. A space assigned to the
+    /// main display (or unassigned) takes the Main role; the rest
+    /// pin to their display's fingerprint. For a workflow Standard
+    /// this equals what `resolveSpaceDisplays` re-derives from the
+    /// count's Standard, so it's a no-op in effect; for the beginner
+    /// ladder, whose five-per-display plan is NOT the count's
+    /// Standard, it's load-bearing — without it the blocks scatter
+    /// into the Standard's slots (#485).
+    func adoptComposedPlacement(
+        _ composed: ProfileComposition.Composed
+    ) {
+        let ordered = PositionalDisplays.ordered(
+            state.workspaces.allDisplays,
+            mainID: PositionalDisplays.liveMainID
+        )
+        var pins: [SpaceID: String] = [:]
+        var mains: Set<SpaceID> = []
+        for space in composed.spaces {
+            let assigned = composed.assignment[space]
+            if assigned == ordered.first?.id || assigned == nil {
+                mains.insert(space)
+            } else if let display = ordered.first(where: {
+                $0.id == assigned
+            }) {
+                pins[space] = display.fingerprint
+            }
+        }
+        spacePins = pins
+        mainSpaces = mains
+    }
+
     /// The connected monitors as a stored set, carrying the
     /// live space pins (pins to disconnected monitors drop).
     func liveMonitorSet() -> MonitorSet {

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+Profiles.swift
@@ -126,6 +126,15 @@ extension KiwiCore {
             name: name,
             monitorSets: [liveMonitorSet()],
             mainSpaces: mainSpaces.sorted { $0.raw < $1.raw },
+            // Carry the beginner-ladder identity when the live
+            // layout IS the ladder (#485): the transient ladder
+            // Standard sets `currentStandard`, so a first save of
+            // it stays a baseline that re-scales on later display
+            // changes. `applyStandard` adopts the standard before
+            // this, so the preset path is covered here too; a
+            // save-as-new copy (which reads, not builds) is not.
+            isStarterLadder: profiles.currentStandard
+                == StarterLadder.name,
             spaces: liveSpaces,
             fallbackSpace: fallbackSpace.flatMap {
                 liveSpaces.contains($0) ? $0 : nil

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+StarterRescale.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+StarterRescale.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// Keeping the beginner ladder scaled to the hardware (#485).
+///
+/// A fresh install seeds the `Starter` ladder sized to its
+/// displays (#466), but the seeded profile only covers that one
+/// display count — so a later monitor change matched no stored
+/// set, fell to the composed *workflow* Standard, and dropped the
+/// beginner onto fewer spaces (e.g. Dual Developer's 8, not the
+/// ladder's 10) with no digit shortcut past the seeded count.
+///
+/// These helpers close both halves while the user stays on the
+/// ladder baseline: the unmatched-monitor fallback recomposes the
+/// *ladder* at the live display count, and the ⌃⌥N digit
+/// shortcuts top up additively for the spaces that appear.
+extension KiwiCore {
+    /// Whether the layout currently on screen is the beginner
+    /// `Starter` ladder — either the adopted seed profile (flagged
+    /// via `Profile.isStarterLadder`, so the identity survives a
+    /// renamed file or an edited mode) or a transient ladder
+    /// Standard already recomposed by an earlier display change
+    /// (`currentStandard`, sticky across further changes). Only
+    /// then does an unmatched monitor change recompose the ladder
+    /// rather than a workflow Standard. A saved-as-new copy is the
+    /// user's own profile (unflagged) and resolves normally.
+    var isOnStarterBaseline: Bool {
+        if profiles.currentStandard == StarterLadder.name {
+            return true
+        }
+        guard let name = profiles.currentName,
+            let profile = try? profiles.read(name: name)
+        else { return false }
+        return profile.isStarterLadder
+    }
+
+    /// The fallback layout for a monitor change no stored set
+    /// covers (#53): the beginner ladder scaled to the live
+    /// display count while on the Starter baseline (#485),
+    /// otherwise the count's built-in workflow Standard. Nil only
+    /// when no display is connected.
+    func composeMonitorChangeFallback(
+        displays: [Display]
+    ) -> ProfileComposition.Composed? {
+        let mainID = PositionalDisplays.liveMainID
+        guard isOnStarterBaseline else {
+            return ProfileComposition.compose(
+                displays: displays,
+                mainID: mainID
+            )
+        }
+        return ProfileComposition.compose(
+            layout: StarterLadder.standardLayout(
+                displayCount: displays.count
+            ),
+            displays: displays,
+            mainID: mainID
+        )
+    }
+
+    /// Translates a composed layout's positional `assignment`
+    /// into the live `spacePins` + `mainSpaces`, so the composed
+    /// blocks land on their planned displays. `apply(composed:)`
+    /// itself discards the assignment and lets
+    /// `resolveSpaceDisplays` recompose the *count's* Standard —
+    /// which places a workflow Standard correctly (it IS that
+    /// Standard) but would scatter the ladder's five-per-display
+    /// blocks (#485). Shared by `applyStandard` (which then saves
+    /// the pins into a profile) and the transient ladder fallback
+    /// (which re-resolves in place). A space assigned to the main
+    /// display — or unassigned — takes the Main role; the rest pin
+    /// to their display's fingerprint.
+    func adoptComposedPlacement(
+        _ composed: ProfileComposition.Composed
+    ) {
+        let ordered = PositionalDisplays.ordered(
+            state.workspaces.allDisplays,
+            mainID: PositionalDisplays.liveMainID
+        )
+        var pins: [SpaceID: String] = [:]
+        var mains: Set<SpaceID> = []
+        for space in composed.spaces {
+            let assigned = composed.assignment[space]
+            if assigned == ordered.first?.id || assigned == nil {
+                mains.insert(space)
+            } else if let display = ordered.first(where: {
+                $0.id == assigned
+            }) {
+                pins[space] = display.fingerprint
+            }
+        }
+        spacePins = pins
+        mainSpaces = mains
+    }
+
+    /// Adds ⌃⌥N digit shortcuts for spaces that appeared after the
+    /// first-run seed authored them — the display-change twin of
+    /// `seedDefaultShortcuts` (#485). Strictly additive and
+    /// GUI-managed only: a Lua user owns their bindings, and a
+    /// digit already bound (a seeded default OR a custom chord) is
+    /// never rewritten (see `DefaultKeybindings.digitTopUp`), so it
+    /// respects the ten-cap accepted limitation and can't clobber a
+    /// user shortcut. Writes the sidecar directly and re-registers
+    /// the base bindings in place — NOT `saveGuiConfig`, which
+    /// would reload the whole config mid-change (mirrors
+    /// `syncGuiSpacesToLive`). A no-op when nothing grew, so it is
+    /// safe to call after any GUI-managed apply.
+    func topUpDigitShortcuts() {
+        guard isGuiManaged, var config = guiConfigStore.load(),
+            let index = config.modes.firstIndex(
+                where: { $0.isDefault }
+            )
+        else { return }
+        let spaces = SpaceID.deduplicated(
+            state.workspaces.allSpaces.map(\.id)
+        )
+        let added = DefaultKeybindings.digitTopUp(
+            existing: config.modes[index].bindings,
+            spaces: spaces
+        )
+        guard !added.isEmpty else { return }
+        config.modes[index].bindings.append(
+            contentsOf: added
+        )
+        try? guiConfigStore.save(config)
+        // Re-register the base bindings from the just-written
+        // sidecar without a full reload, resolving through any
+        // active profile override just as `applyStructuredConfig`
+        // does (a transient Standard baseline has none).
+        guard let lua = keys.lua else { return }
+        applyStructuredKeybindings(
+            modes: config.modes,
+            profile: activeProfileOverrides()?.modes,
+            lua: lua
+        )
+    }
+}

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+StarterRescale.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+StarterRescale.swift
@@ -57,41 +57,6 @@ extension KiwiCore {
         )
     }
 
-    /// Translates a composed layout's positional `assignment`
-    /// into the live `spacePins` + `mainSpaces`, so the composed
-    /// blocks land on their planned displays. `apply(composed:)`
-    /// itself discards the assignment and lets
-    /// `resolveSpaceDisplays` recompose the *count's* Standard —
-    /// which places a workflow Standard correctly (it IS that
-    /// Standard) but would scatter the ladder's five-per-display
-    /// blocks (#485). Shared by `applyStandard` (which then saves
-    /// the pins into a profile) and the transient ladder fallback
-    /// (which re-resolves in place). A space assigned to the main
-    /// display — or unassigned — takes the Main role; the rest pin
-    /// to their display's fingerprint.
-    func adoptComposedPlacement(
-        _ composed: ProfileComposition.Composed
-    ) {
-        let ordered = PositionalDisplays.ordered(
-            state.workspaces.allDisplays,
-            mainID: PositionalDisplays.liveMainID
-        )
-        var pins: [SpaceID: String] = [:]
-        var mains: Set<SpaceID> = []
-        for space in composed.spaces {
-            let assigned = composed.assignment[space]
-            if assigned == ordered.first?.id || assigned == nil {
-                mains.insert(space)
-            } else if let display = ordered.first(where: {
-                $0.id == assigned
-            }) {
-                pins[space] = display.fingerprint
-            }
-        }
-        spacePins = pins
-        mainSpaces = mains
-    }
-
     /// Adds ⌃⌥N digit shortcuts for spaces that appeared after the
     /// first-run seed authored them — the display-change twin of
     /// `seedDefaultShortcuts` (#485). Strictly additive and

--- a/Sources/KiwiDeskCore/Profiles/Profile.swift
+++ b/Sources/KiwiDeskCore/Profiles/Profile.swift
@@ -70,6 +70,15 @@ public struct Profile: Codable, Sendable, Equatable {
     /// Marks this profile as its screen count's default (the
     /// dirty-load fallback when no set matches exactly).
     public var isDefault: Bool
+    /// Marks this profile as the beginner `Starter` ladder seed
+    /// (#466/#485). While it is the active baseline, a monitor
+    /// change that no stored set covers recomposes the *ladder*
+    /// at the live display count instead of a workflow Standard,
+    /// so the five-per-display shape survives every reconnect.
+    /// Survives edits (a tweaked mode keeps the identity) but not
+    /// a "save as new" — an explicitly named copy is the user's
+    /// own profile. Legacy/other profiles decode to `false`.
+    public var isStarterLadder: Bool
     /// Persisted display order of the profile's spaces (#75).
     /// This is the authoritative order for the Spaces list and
     /// for the reconcile rehome fallback on profile switch.
@@ -151,6 +160,7 @@ public struct Profile: Codable, Sendable, Equatable {
         case monitorSets = "monitor_sets"
         case mainSpaces = "main_spaces"
         case isDefault = "default"
+        case isStarterLadder = "starter_ladder"
         case spaces
         case fallbackSpace = "fallback_space"
         case spaceModes = "space_modes"
@@ -167,6 +177,7 @@ public struct Profile: Codable, Sendable, Equatable {
         monitorSets: [MonitorSet],
         mainSpaces: [SpaceID] = [],
         isDefault: Bool = false,
+        isStarterLadder: Bool = false,
         spaces: [SpaceID] = [],
         fallbackSpace: SpaceID? = nil,
         spaceModes: [SpaceID: LayoutMode],
@@ -181,6 +192,7 @@ public struct Profile: Codable, Sendable, Equatable {
         self.monitorSets = Self.sanitized(monitorSets)
         self.mainSpaces = mainSpaces.sorted { $0.raw < $1.raw }
         self.isDefault = isDefault
+        self.isStarterLadder = isStarterLadder
         self.spaces = SpaceID.deduplicated(spaces)
         self.fallbackSpace = fallbackSpace
         self.spaceModes = spaceModes
@@ -223,6 +235,13 @@ public struct Profile: Codable, Sendable, Equatable {
             try container.decodeIfPresent(
                 Bool.self,
                 forKey: .isDefault
+            ) ?? false
+        // Lenient: absent on every profile authored before #485
+        // (and on user-authored copies), decoding to `false`.
+        isStarterLadder =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: .isStarterLadder
             ) ?? false
         // Lenient: missing key on legacy profiles → empty,
         // which `orderedSpaces` converts to the derived order.

--- a/Sources/KiwiDeskCore/Profiles/StarterLadder.swift
+++ b/Sources/KiwiDeskCore/Profiles/StarterLadder.swift
@@ -19,6 +19,11 @@ import Foundation
 /// hand-mirrored (`.claude/rules/parity-tests.md`, at the logic
 /// level).
 public enum StarterLadder {
+    /// The canonical name of the ladder, shared by its
+    /// `StandardLayout` face and the monitor-change baseline
+    /// predicate (#485) — one string, never a magic literal.
+    public static let name = "Starter"
+
     /// Spaces each display's block contributes.
     public static let spacesPerDisplay = 5
 
@@ -99,7 +104,7 @@ public enum StarterLadder {
         summary: String = ""
     ) -> StandardLayout {
         StandardLayout(
-            name: "Starter",
+            name: name,
             summary: summary,
             screenCount: max(1, displayCount),
             spaceCount: spaceCount(displayCount: displayCount),

--- a/Tests/KiwiDeskCoreTests/DefaultKeybindingsTests.swift
+++ b/Tests/KiwiDeskCoreTests/DefaultKeybindingsTests.swift
@@ -141,4 +141,112 @@ struct DefaultKeybindingsTests {
         // The directional / resize / float set still seeds.
         #expect(!rows.isEmpty)
     }
+
+    // MARK: - Additive digit top-up (#485)
+
+    @Test("top-up binds only the digits grown past the seed")
+    func topUpAddsOnlyNewDigits() {
+        // Seeded for five spaces; the display change grew to ten.
+        let existing = DefaultKeybindings.bindings(
+            spaces: spaces(5),
+            resizeStep: 50
+        )
+        let added = DefaultKeybindings.digitTopUp(
+            existing: existing,
+            spaces: spaces(10)
+        )
+        let combos = Set(added.map(\.combo))
+        // ⌃⌥6-9 and ⌃⌥0 (tenth), across all three tiers — nothing
+        // for the already-bound ⌃⌥1-5.
+        #expect(!combos.contains("control+option+5"))
+        #expect(combos.contains("control+option+6"))
+        #expect(combos.contains("control+option+0"))
+        #expect(combos.contains("control+option+shift+6"))
+        #expect(combos.contains("control+option+command+0"))
+        // Five new digits × three tiers.
+        #expect(added.count == 15)
+        #expect(
+            added.contains {
+                $0.combo == "control+option+0"
+                    && $0.lua == "KiwiDesk.focus_space(\"10\")"
+            }
+        )
+    }
+
+    @Test("top-up never overwrites a user's custom chord")
+    func topUpSkipsCustomChords() {
+        // The user rebound ⌃⌥6 to something of their own.
+        var existing = DefaultKeybindings.bindings(
+            spaces: spaces(5),
+            resizeStep: 50
+        )
+        existing.append(
+            KeyBinding(
+                combo: "control+option+6",
+                lua: "KiwiDesk.toggle_floating()",
+                kind: .custom,
+                label: "Mine"
+            )
+        )
+        let added = DefaultKeybindings.digitTopUp(
+            existing: existing,
+            spaces: spaces(10)
+        )
+        // Tier 1 for space 6 is taken, so it is not re-added; the
+        // shift/command tiers for space 6 are still free.
+        #expect(
+            !added.contains { $0.combo == "control+option+6" }
+        )
+        #expect(
+            added.contains {
+                $0.combo == "control+option+shift+6"
+            }
+        )
+    }
+
+    @Test("top-up counts an equivalent alias as already bound")
+    func topUpHonorsAliasedCombos() {
+        // A hand-written config authored ⌃⌥7 as `ctrl+alt+7`.
+        let existing = [
+            KeyBinding(
+                combo: "ctrl+alt+7",
+                lua: "whatever()"
+            )
+        ]
+        let added = DefaultKeybindings.digitTopUp(
+            existing: existing,
+            spaces: spaces(7)
+        )
+        // The alias parses to the same physical shortcut, so the
+        // focus tier for space 7 is treated as taken.
+        #expect(
+            !added.contains { $0.combo == "control+option+7" }
+        )
+    }
+
+    @Test("top-up respects the ten-space cap")
+    func topUpCapsAtTen() {
+        let added = DefaultKeybindings.digitTopUp(
+            existing: [],
+            spaces: spaces(12)
+        )
+        // Ten spaces × three tiers; nothing for spaces 11-12.
+        #expect(added.count == 30)
+        #expect(
+            !added.contains { $0.lua.contains("(\"11\")") }
+        )
+    }
+
+    @Test("top-up is a no-op when every digit is already bound")
+    func topUpIdempotent() {
+        let existing = DefaultKeybindings.bindings(
+            spaces: spaces(5),
+            resizeStep: 50
+        )
+        let added = DefaultKeybindings.digitTopUp(
+            existing: existing,
+            spaces: spaces(5)
+        )
+        #expect(added.isEmpty)
+    }
 }

--- a/Tests/KiwiDeskCoreTests/ProfileCopyTests.swift
+++ b/Tests/KiwiDeskCoreTests/ProfileCopyTests.swift
@@ -107,6 +107,32 @@ struct ProfileCopyTests {
         #expect(!copy.isDefault)
     }
 
+    @Test("Copy of the Starter ladder is not the baseline (#485)")
+    func copyClearsStarterLadderFlag() throws {
+        let core = try makeGuiCore()
+        var starter = sourceProfile()
+        starter.name = "Starter"
+        starter.isStarterLadder = true
+        try core.profiles.save(starter)
+        let edited = try core.loadGuiConfig(editing: "Starter")
+
+        try core.copyProfile(
+            named: "Starter",
+            to: "My Setup",
+            with: edited
+        )
+
+        // The copy is the user's own profile — the ladder
+        // baseline flag must not ride along, or an unmatched
+        // monitor change would recompose the ladder over it.
+        let copy = try core.profiles.read(name: "My Setup")
+        #expect(!copy.isStarterLadder)
+        // The source keeps the flag.
+        #expect(
+            try core.profiles.read(name: "Starter").isStarterLadder
+        )
+    }
+
     @Test("Pending edits land in the copy, not the source")
     func pendingEditsLandInCopy() throws {
         let core = try makeGuiCore()

--- a/Tests/KiwiDeskCoreTests/ProfileTests.swift
+++ b/Tests/KiwiDeskCoreTests/ProfileTests.swift
@@ -244,6 +244,43 @@ struct ProfileModelTests {
         #expect(json.contains("\"spaces\":["))
     }
 
+    @Test("starter_ladder flag round-trips (#485)")
+    func starterLadderRoundTrips() throws {
+        var profile = makeProfile(name: "s", monitors: ["A:1x1"])
+        profile.isStarterLadder = true
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(profile)
+        #expect(
+            String(decoding: data, as: UTF8.self)
+                .contains("\"starter_ladder\":true")
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Profile.self, from: data)
+        #expect(decoded.isStarterLadder)
+    }
+
+    @Test("starter_ladder defaults false when absent (#485)")
+    func starterLadderDecodeDefault() throws {
+        // Legacy profiles predate the key — they decode to false,
+        // never the ladder baseline.
+        let json = """
+            {"name":"old",
+             "monitor_sets":[{"monitors":["A:1x1"]}],
+             "space_modes":{},
+             "settings":{},
+             "saved_at":"2026-06-01T00:00:00Z"}
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let profile = try decoder.decode(
+            Profile.self,
+            from: Data(json.utf8)
+        )
+        #expect(!profile.isStarterLadder)
+    }
+
     @Test("Profile.orderedSpaces uses stored order")
     func orderedSpacesUsesStoredOrder() {
         let profile = Profile(

--- a/Tests/KiwiDeskCoreTests/StarterRescaleTests.swift
+++ b/Tests/KiwiDeskCoreTests/StarterRescaleTests.swift
@@ -159,6 +159,39 @@ struct StarterRescaleTests {
         #expect(!core.isOnStarterBaseline)
     }
 
+    @Test("saving a recomposed ladder Standard stays the baseline")
+    func savingTransientLadderKeepsFlag() throws {
+        let core = try onStarterBaseline()
+        connect(core, [display(2, "B", x: 100)])
+        core.handleMonitorChange()
+        // A transient ladder Standard is on screen (10 spaces).
+        #expect(core.profiles.currentStandard == "Starter")
+        // The user saves it under a new name.
+        core.execute("save_profile", args: [.string("Both")])
+        // buildProfile tags it from currentStandard, so the saved
+        // profile is still the ladder baseline — a later change
+        // won't drop them to a workflow Standard.
+        #expect(try core.profiles.read(name: "Both").isStarterLadder)
+        #expect(core.isOnStarterBaseline)
+    }
+
+    @Test("a reload on the transient ladder re-applies the ladder")
+    func reloadKeepsLadder() throws {
+        let core = try onStarterBaseline()
+        connect(core, [display(2, "B", x: 100)])
+        core.handleMonitorChange()
+        #expect(core.state.workspaces.allSpaces.count == 10)
+        // The profile re-apply a config reload performs must keep
+        // the ladder, not recompose the workflow Standard (#485,
+        // the second recompose site).
+        core.reapplyActiveProfileState()
+        #expect(core.profiles.currentStandard == "Starter")
+        #expect(core.state.workspaces.allSpaces.count == 10)
+        let blockTwo = displaysOf(core, 6...10)
+        #expect(blockTwo.count == 1)
+        #expect(displaysOf(core, 1...5) != blockTwo)
+    }
+
     // MARK: - Additive shortcut top-up
 
     @Test("display change tops up ⌃⌥N for the new spaces")

--- a/Tests/KiwiDeskCoreTests/StarterRescaleTests.swift
+++ b/Tests/KiwiDeskCoreTests/StarterRescaleTests.swift
@@ -1,0 +1,229 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The beginner ladder surviving display changes (#485): an
+/// unmatched monitor change recomposes the *ladder* (not a
+/// workflow Standard) while the user is on the Starter baseline,
+/// and the ⌃⌥N digit shortcuts top up additively for the spaces
+/// the change adds.
+@Suite("Starter ladder rescale (#485)", .serialized)
+@MainActor
+struct StarterRescaleTests {
+    private func makeCore() -> KiwiCore {
+        KiwiCore(
+            configDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-rescale-\(UUID().uuidString)"
+                )
+        )
+    }
+
+    /// GUI-managed: a `gui.json` sidecar exists, so a composed
+    /// layout may own tiling on an unmatched change (#53).
+    private func makeGuiManagedCore() -> KiwiCore {
+        let core = makeCore()
+        try? core.guiConfigStore.save(GuiConfig())
+        return core
+    }
+
+    private func display(
+        _ id: UInt32,
+        _ name: String,
+        x: CGFloat = 0
+    ) -> Display {
+        Display(
+            id: DisplayID(id),
+            name: name,
+            frame: CGRect(x: x, y: 0, width: 100, height: 100)
+        )
+    }
+
+    private func connect(_ core: KiwiCore, _ displays: [Display]) {
+        for display in displays {
+            core.state.workspaces.upsertDisplay(display)
+        }
+    }
+
+    /// A GUI-managed core seeded onto the one-display Starter
+    /// ladder as its adopted, flagged baseline.
+    private func onStarterBaseline() throws -> KiwiCore {
+        let core = makeGuiManagedCore()
+        connect(core, [display(1, "A")])
+        try core.applyStandard(
+            StarterLadder.standardLayout(displayCount: 1)
+        )
+        return core
+    }
+
+    // MARK: - Baseline predicate
+
+    @Test("the seeded ladder profile is the starter baseline")
+    func seededProfileIsBaseline() throws {
+        let core = try onStarterBaseline()
+        #expect(core.profiles.currentName == "Starter")
+        #expect(
+            try core.profiles.read(name: "Starter").isStarterLadder
+        )
+        #expect(core.isOnStarterBaseline)
+    }
+
+    @Test("a workflow preset is not the starter baseline")
+    func workflowPresetNotBaseline() throws {
+        let core = makeGuiManagedCore()
+        connect(core, [display(1, "A")])
+        try core.applyStandard(StandardProfiles.developer)
+        #expect(
+            try core.profiles.read(name: "Developer")
+                .isStarterLadder == false
+        )
+        #expect(!core.isOnStarterBaseline)
+    }
+
+    // MARK: - Fallback recomposition
+
+    @Test("display change recomposes the ladder, not a Standard")
+    func displayChangeKeepsLadder() throws {
+        let core = try onStarterBaseline()
+        // A second display appears; no stored set covers it.
+        connect(core, [display(2, "B", x: 100)])
+        core.handleMonitorChange()
+
+        // Ten spaces on the ladder — not the eight-space Dual
+        // Developer workflow Standard.
+        #expect(core.profiles.currentStandard == "Starter")
+        #expect(core.state.workspaces.allSpaces.count == 10)
+        #expect(core.state.workspaces[SpaceID(6)]?.mode == .track)
+        #expect(core.state.workspaces[SpaceID(9)]?.mode == .grid)
+        // The bsp rung stays bsp, not remapped by a Standard.
+        #expect(core.state.workspaces[SpaceID(3)]?.mode == .bsp)
+        // Five per display, not the Dual Developer 4/4/2 scatter:
+        // each five-space block lands whole on one screen, and the
+        // two blocks are on different screens. (Asserted by block
+        // cohesion, not fixed ids — the test's live "main" depends
+        // on CGMainDisplayID.)
+        let blockOne = displaysOf(core, 1...5)
+        let blockTwo = displaysOf(core, 6...10)
+        #expect(blockOne.count == 1)
+        #expect(blockTwo.count == 1)
+        #expect(blockOne != blockTwo)
+    }
+
+    /// The set of displays the spaces in `range` resolved onto.
+    private func displaysOf(
+        _ core: KiwiCore,
+        _ range: ClosedRange<Int>
+    ) -> Set<DisplayID?> {
+        Set(
+            range.map {
+                core.state.workspaces.display(of: SpaceID($0))
+            }
+        )
+    }
+
+    @Test("the ladder baseline is sticky across further changes")
+    func ladderStickyAcrossCounts() throws {
+        let core = try onStarterBaseline()
+        connect(core, [display(2, "B", x: 100)])
+        core.handleMonitorChange()
+        // Now on a transient ladder Standard; a THIRD display must
+        // still recompose the ladder (15 spaces), not a Standard.
+        connect(core, [display(3, "C", x: 200)])
+        core.handleMonitorChange()
+        #expect(core.profiles.currentStandard == "Starter")
+        #expect(core.state.workspaces.allSpaces.count == 15)
+        #expect(core.state.workspaces[SpaceID(11)]?.mode == .track)
+        // Three whole five-space blocks, one per display.
+        let blocks = [
+            displaysOf(core, 1...5),
+            displaysOf(core, 6...10),
+            displaysOf(core, 11...15),
+        ]
+        #expect(blocks.allSatisfy { $0.count == 1 })
+        #expect(Set(blocks.flatMap { $0 }).count == 3)
+    }
+
+    @Test("a non-ladder baseline still falls to a Standard")
+    func nonLadderFallsToStandard() throws {
+        let core = makeGuiManagedCore()
+        connect(core, [display(1, "A")])
+        core.state.workspaces.ensureSpace(SpaceID(1))
+        core.execute("save_profile", args: [.string("desk")])
+        // A second display appears; "desk" covers only one screen
+        // and isn't the ladder, so the workflow Standard resolves.
+        connect(core, [display(2, "B", x: 100)])
+        core.handleMonitorChange()
+        #expect(core.profiles.currentStandard == "Dual Developer")
+        #expect(!core.isOnStarterBaseline)
+    }
+
+    // MARK: - Additive shortcut top-up
+
+    @Test("display change tops up ⌃⌥N for the new spaces")
+    func displayChangeTopsUpShortcuts() throws {
+        let core = try onStarterBaseline()
+        // The one-display seed bound ⌃⌥1-5 only.
+        let seeded = Set(
+            (core.persistedGuiConfig()?.modes
+                .first { $0.isDefault }?.bindings ?? [])
+                .map(\.combo)
+        )
+        #expect(seeded.contains("control+option+5"))
+        #expect(!seeded.contains("control+option+6"))
+        #expect(!seeded.contains("control+option+0"))
+
+        connect(core, [display(2, "B", x: 100)])
+        core.handleMonitorChange()
+
+        let grown = Set(
+            (core.persistedGuiConfig()?.modes
+                .first { $0.isDefault }?.bindings ?? [])
+                .map(\.combo)
+        )
+        // ⌃⌥6-9 and ⌃⌥0 (tenth space) now bound, all three tiers.
+        #expect(grown.contains("control+option+6"))
+        #expect(grown.contains("control+option+0"))
+        #expect(grown.contains("control+option+shift+9"))
+        #expect(grown.contains("control+option+command+0"))
+        // The original ⌃⌥1-5 are untouched (still present once).
+        let goToSix =
+            (core.persistedGuiConfig()?.modes
+            .first { $0.isDefault }?.bindings ?? [])
+            .filter { $0.combo == "control+option+0" }
+        #expect(goToSix.count == 1)
+        #expect(
+            goToSix.first?.lua == "KiwiDesk.focus_space(\"10\")"
+        )
+    }
+
+    @Test("top-up leaves a user's custom digit chord intact")
+    func topUpPreservesCustomChord() throws {
+        let core = try onStarterBaseline()
+        // The user rebinds ⌃⌥6 in the sidecar before the change.
+        var config = core.persistedGuiConfig() ?? GuiConfig()
+        let index = config.modes.firstIndex { $0.isDefault }!
+        config.modes[index].bindings.append(
+            KeyBinding(
+                combo: "control+option+6",
+                lua: "KiwiDesk.toggle_floating()",
+                kind: .custom,
+                label: "Mine"
+            )
+        )
+        try core.guiConfigStore.save(config)
+
+        connect(core, [display(2, "B", x: 100)])
+        core.handleMonitorChange()
+
+        let sixes =
+            (core.persistedGuiConfig()?.modes
+            .first { $0.isDefault }?.bindings ?? [])
+            .filter { $0.combo == "control+option+6" }
+        // Still exactly one ⌃⌥6 — the user's, not overwritten by
+        // the default focus_space row.
+        #expect(sixes.count == 1)
+        #expect(sixes.first?.lua == "KiwiDesk.toggle_floating()")
+    }
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1289,6 +1289,31 @@ default, so the workflow Standards keep that job. First-run-only, and
 gated on the same "no authored binding disarms the seed" guard, so it
 never touches a configured setup. (#466, supersedes the #270 nine-pad)
 
+**The ladder IS the unmatched-change fallback — but only while it's
+the active baseline (#485).** [Rationale] #466 keeps the ladder out
+of the silent `isStandard` fallback so nobody *else* lands in a demo
+of empty modes. But the beginner who started on the ladder hit the
+mirror-image bug: the seeded **Starter** profile only covers its
+first-run display count, so plugging a second monitor matched no
+stored set, fell to `.none`, and composed a *workflow* Standard —
+handing the newcomer fewer spaces (Dual Developer's 8, not the
+ladder's 10) and no `⌃⌥N` past the seeded count. The fix scopes the
+override tightly: `handleMonitorChange`'s `.none` branch recomposes
+the **ladder** at the live display count *only when the user is on the
+Starter baseline* (`isOnStarterBaseline` — the adopted seed profile,
+flagged `Profile.isStarterLadder` so the identity survives a rename or
+an edited mode, or a transient ladder Standard from an earlier change,
+sticky via `currentStandard`). Every other baseline still gets the
+workflow Standard, so #466's "no silent demo layout" promise holds for
+everyone who didn't choose the ladder. The flag rides re-saves and
+edits but **not** a save-as-new — an explicitly named copy is the
+user's own profile and resolves normally. The digit-shortcut half is
+the additive twin: `topUpDigitShortcuts` binds only the `⌃⌥N` a growth
+left unbound (GUI-managed, never overwriting a custom chord, capped at
+ten), so the shortcuts follow the spaces. Do not "simplify" the `.none`
+branch back to a bare `StandardProfiles.standard` — that reintroduces
+#485. (#485)
+
 **Orphaned space shortcuts are surfaced, never pruned.** A
 binding that targets a space by name outlives the space's
 presence in the current profile: it stays Carbon-registered

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1307,11 +1307,22 @@ sticky via `currentStandard`). Every other baseline still gets the
 workflow Standard, so #466's "no silent demo layout" promise holds for
 everyone who didn't choose the ladder. The flag rides re-saves and
 edits but **not** a save-as-new — an explicitly named copy is the
-user's own profile and resolves normally. The digit-shortcut half is
-the additive twin: `topUpDigitShortcuts` binds only the `⌃⌥N` a growth
+user's own profile and resolves normally (`copyProfile` clears it
+beside `isDefault`, the two identity flags a copy must neutralize). A
+transient ladder Standard carries the flag onto the first profile the
+user *saves* of it, via `buildProfile` reading `currentStandard`, so a
+save doesn't drop them off the ladder either. Both recompose sites are
+covered: `handleMonitorChange`'s `.none` branch and
+`reapplyActiveProfileState` (a config reload) both route through
+`composeMonitorChangeFallback`, and `apply(composed:)` now adopts its
+own `composed.assignment` (`adoptComposedPlacement`) rather than
+discarding it — equivalent for a workflow Standard, correct for the
+ladder's five-per-display blocks. The digit-shortcut half is the
+additive twin: `topUpDigitShortcuts` binds only the `⌃⌥N` a growth
 left unbound (GUI-managed, never overwriting a custom chord, capped at
-ten), so the shortcuts follow the spaces. Do not "simplify" the `.none`
-branch back to a bare `StandardProfiles.standard` — that reintroduces
+ten), so the shortcuts follow the spaces. Do not "simplify" either
+recompose site back to a bare `StandardProfiles.standard`, nor make
+`apply(composed:)` discard its assignment again — each reintroduces
 #485. (#485)
 
 **Orphaned space shortcuts are surfaced, never pruned.** A

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1391,8 +1391,12 @@ a different layout mode so you meet the whole range at once:
 | 5 | floating | windows left untiled |
 
 With a second display the block repeats — spaces 6–10 on the second
-monitor, 11–15 on a third, and so on. The ladder is saved as an
-ordinary, editable profile named **Starter**, so nothing here is
+monitor, 11–15 on a third, and so on. The ladder keeps this shape as
+you plug and unplug displays: while you're still on the Starter
+layout, connecting or removing a monitor re-scales it to five spaces
+per screen, and the `⌃⌥N` space shortcuts extend to cover the new
+spaces (up to ten — the number row's limit). The ladder is saved as
+an ordinary, editable profile named **Starter**, so nothing here is
 locked in: change any space's mode, delete spaces, or apply a
 different [preset](#presets) whenever you like. (The same ladder is
 always available as the **Starter** preset if you want it back.)


### PR DESCRIPTION
Fixes #485.

## Problem

The first-run seed sized the beginner **Starter ladder** (5 spaces/display) and its `⌃⌥N` digit shortcuts to the connected displays, but nothing re-scaled them on a *later* display change. The seeded Starter profile covers only its first-run screen count, so plugging a second monitor:

1. matched no stored set → fell to the composed **workflow Standard** (Dual Developer's 8 spaces, not the ladder's 10), and
2. left `⌃⌥6`–`⌃⌥0` unbound (shortcuts were authored once, gated on first run).

## Fix

**Ladder as the beginner's fallback.** A new `Profile.isStarterLadder` flag (JSON `starter_ladder`) tags the seeded ladder as the baseline identity — surviving edits/renames, but not a save-as-new. While it's the active baseline (`isOnStarterBaseline`, also honoring a transient ladder Standard via `currentStandard`, sticky across counts), both recompose sites — `handleMonitorChange`'s `.none` branch **and** `reapplyActiveProfileState` (config reload) — route through `composeMonitorChangeFallback`, recomposing the ladder at the live display count instead of a workflow Standard. `apply(composed:)` now adopts its own `composed.assignment` (`adoptComposedPlacement`) so the five-per-display blocks land correctly rather than scattering into the Standard's slots.

**Additive shortcut top-up.** `DefaultKeybindings.digitTopUp` / `topUpDigitShortcuts` binds `⌃⌥N` for newly-added spaces — GUI-managed only (a Lua user owns bindings), never overwriting a bound digit (default or custom, alias-aware via parsed `KeyCombo`), capped at ten (the accepted limitation). Runs on the monitor-change ladder path and after `applyStandard`, so applying any preset with more spaces than the seed binds their digits too.

The `.none` override of #466's "the ladder is deliberately not the silent fallback" rule is scoped to the Starter baseline and documented in `docs/design-decisions.md`; every other baseline still gets the workflow Standard.

## Tests

New `StarterRescaleTests` (fallback recomposition, 5-per-display block cohesion, sticky-across-counts, reload, additive top-up, custom-chord preservation, transient-save flag), `DefaultKeybindingsTests.digitTopUp` cases, `ProfileTests` flag round-trip, `ProfileCopyTests` copy-clears-flag.

## Review

`code-reviewer` + `architect-reviewer`, parallel round 1 + sequential re-review after the fix batch. All findings closed (copyProfile flag leak, transient-save flag drop, `apply(composed:)` discarding its assignment, second recompose site, helper file placement + stale comment).

## Verify

`swift build`, `swift test --skip ExecTests` (1905) + `--filter ExecTests` (14), `scripts/lint.sh`, and `swift build -c release` — all green.

## Device QA — pending before merge

Unplug/replug a second display on the Starter baseline; eye-confirm the ladder (10 spaces, 5/display) and `⌃⌥6`–`⌃⌥0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)