### PR TITLE
feat(borders): optional glow bloom on the focused ring (#358)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Appearance/FocusBorderEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/Appearance/FocusBorderEditor.swift
@@ -87,6 +87,17 @@ struct FocusBorderEditor: View {
                 (L("border.corner.square", "Square"), .square),
             ]
         )
+        // A render trait of the ring like Width and Corners — a soft
+        // bloom in the focused ring's hue (#358). Sits with the other
+        // styling traits, no caption (the live preview above shows
+        // it on toggle); a11y gets the descriptive gloss.
+        Toggle(L("border.glow", "Glow"), isOn: style.glow)
+            .accessibilityLabel(
+                L(
+                    "border.glow.a11y",
+                    "Soft glow around the focus border"
+                )
+            )
         Divider()
         FitGapsAction(model: model)
     }
@@ -108,10 +119,16 @@ private struct FocusBorderPreview: View {
             RoundedRectangle(cornerRadius: 6)
                 .fill(Color.secondary.opacity(0.12))
             HStack(spacing: 16) {
-                window(color: style.focusedColor, ringed: true)
+                window(
+                    color: style.focusedColor,
+                    ringed: true,
+                    // Glow is focused-ring-only (#358).
+                    glow: style.glow
+                )
                 window(
                     color: style.unfocusedColor,
-                    ringed: style.unfocusedEnabled
+                    ringed: style.unfocusedEnabled,
+                    glow: false
                 )
             }
             .padding(14)
@@ -123,7 +140,8 @@ private struct FocusBorderPreview: View {
 
     private func window(
         color: String,
-        ringed: Bool
+        ringed: Bool,
+        glow: Bool
     ) -> some View {
         // Remap the 1–20 pt width onto the preview's smaller span
         // so a thick border reads without swamping the mock.
@@ -132,6 +150,11 @@ private struct FocusBorderPreview: View {
             from: 1...20,
             to: 1...7
         )
+        // Remap the nominal 10 pt glow blur (BorderGeometry.glowBlur)
+        // the same way — the literal 10 pt would swamp this 96 pt
+        // mock and read as a smear, not a halo (#358). A proportional
+        // approximation, like width and corners here.
+        let glowRadius = scale(10, from: 1...20, to: 1...7)
         let radius: CGFloat =
             style.cornerStyle == .square ? 0 : 12
         return RoundedRectangle(cornerRadius: radius)
@@ -145,6 +168,11 @@ private struct FocusBorderPreview: View {
                         .stroke(
                             Color(kiwiHex: color),
                             lineWidth: width
+                        )
+                        .shadow(
+                            color: glow
+                                ? Color(kiwiHex: color) : .clear,
+                            radius: glow ? glowRadius : 0
                         )
                 }
             }

--- a/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
@@ -94,7 +94,8 @@ extension KiwiCore {
                     ?? spec.frame,
                 colorHex: spec.colorHex,
                 width: spec.width,
-                cornerStyle: spec.cornerStyle
+                cornerStyle: spec.cornerStyle,
+                glow: spec.glow
             )
         }
     }
@@ -155,7 +156,10 @@ extension KiwiCore {
                     frame: focusedFrame,
                     colorHex: style.focusedColor,
                     width: width,
-                    cornerStyle: style.cornerStyle
+                    cornerStyle: style.cornerStyle,
+                    // Focused ring only — a bloom on every unfocused
+                    // ring undercuts the one it should make pop.
+                    glow: style.glow
                 )
             )
         }

--- a/Sources/KiwiDeskCore/Bar/NSColor+KiwiHex.swift
+++ b/Sources/KiwiDeskCore/Bar/NSColor+KiwiHex.swift
@@ -40,8 +40,9 @@ extension NSColor {
     /// black-at-low-alpha and reads gray. Rebuilding the color in
     /// sRGB with alpha forced to 1 (JankyBorders' own
     /// `CGColorCreateGenericRGB(r, g, b, 1.0)`) keeps the bloom the
-    /// ring's hue. Used for both the shadow and the solid halo band
-    /// so the two never disagree.
+    /// ring's hue. Used for the shadow color only — the ring body
+    /// keeps its faithful hex (alpha included), so a translucent
+    /// `focused_color` still reads translucent.
     static func kiwiGlow(hex: String) -> CGColor {
         let base = NSColor(kiwiHex: hex)
         let srgb = base.usingColorSpace(.sRGB) ?? base

--- a/Sources/KiwiDeskCore/Bar/NSColor+KiwiHex.swift
+++ b/Sources/KiwiDeskCore/Bar/NSColor+KiwiHex.swift
@@ -32,6 +32,27 @@ extension NSColor {
         return luminance > 0.6 ? .black : .white
     }
 
+    /// An opaque sRGB `CGColor` for the focus-border glow bloom
+    /// (#358). The glow is a `CGContextSetShadowWithColor` shadow,
+    /// and on a SkyLight window-backed context a calibrated/catalog
+    /// `CGColor` (what `NSColor(kiwiHex:).cgColor` yields) is not
+    /// honored for the shadow path — it drops to the default
+    /// black-at-low-alpha and reads gray. Rebuilding the color in
+    /// sRGB with alpha forced to 1 (JankyBorders' own
+    /// `CGColorCreateGenericRGB(r, g, b, 1.0)`) keeps the bloom the
+    /// ring's hue. Used for both the shadow and the solid halo band
+    /// so the two never disagree.
+    static func kiwiGlow(hex: String) -> CGColor {
+        let base = NSColor(kiwiHex: hex)
+        let srgb = base.usingColorSpace(.sRGB) ?? base
+        return CGColor(
+            srgbRed: srgb.redComponent,
+            green: srgb.greenComponent,
+            blue: srgb.blueComponent,
+            alpha: 1
+        )
+    }
+
     /// Colors come as user-set hex strings; a string that no
     /// longer parses falls back to the system accent color.
     convenience init(kiwiHex hex: String) {

--- a/Sources/KiwiDeskCore/Borders/AppKitBorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/AppKitBorderOverlay.swift
@@ -1,0 +1,169 @@
+import AppKit
+
+/// One window's focus-border ring (#278): a borderless,
+/// non-activating, shadowless panel that ignores mouse events and
+/// draws a single stroked rounded rect. The manager
+/// (`BorderManager`) creates one per bordered window and feeds it
+/// geometry; the overlay knows nothing about layouts or focus.
+///
+/// Non-interactive by design (`ignoresMouseEvents`) — unlike the
+/// app bar, a border is never clicked. Sits at the normal window
+/// level and is stacked directly behind its target window with
+/// `order(.below, relativeTo:)` (see `order(relativeTo:)`). The stroke's
+/// inner overlap sits under the target while its outward reach stays
+/// visible; child panels and other windows above the target therefore
+/// cover the ring naturally. The mandatory AppKit fallback for the
+/// SkyLight fast path — `BorderOverlay` swaps to one on any private
+/// surface failure — so it is module-internal, not file-private.
+@MainActor
+final class AppKitBorderOverlay: BorderOverlayBackend {
+    private var panel: NSPanel?
+    private let shape = CAShapeLayer()
+
+    /// The AppKit panel stacks below its target (it cannot express a
+    /// SkyLight sub-level, so `above` here would paint over child
+    /// popovers — the #320 regression). Below keeps that occlusion
+    /// correct at the cost of the rounded corner seam, which only
+    /// the SkyLight `above` path fixes.
+    let orderMode: BorderGeometry.Order = .below
+
+    /// Positions the ring around `geometry.overlayFrame` (AX
+    /// coords) and strokes it in `colorHex`. Used both for a
+    /// steady-state sync and per animation tick — implicit Core
+    /// Animation is disabled so the ring snaps to each commanded
+    /// frame instead of easing a step behind the window. Stacking
+    /// is left to `order(relativeTo:)`, called only on sync (not per
+    /// tick) so the ring isn't re-ordered every frame.
+    func update(
+        geometry: BorderGeometry,
+        colorHex: String,
+        screen: NSScreen?
+    ) -> Bool {
+        let panel = self.panel ?? makePanel()
+        self.panel = panel
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        panel.setFrame(
+            GeometryUtils.flip(
+                geometry.overlayFrame,
+                primaryHeight: GeometryUtils.primaryHeight
+            ),
+            display: false
+        )
+        let bounds = CGRect(
+            origin: .zero,
+            size: geometry.overlayFrame.size
+        )
+        shape.frame = bounds
+        // Stroke is centered on its path, so inset the path by half
+        // the line width to keep the whole stroke inside the overlay
+        // bounds — plus `glowMargin` (0 without glow) so the ring
+        // stays put in the grown frame and the margin is bloom room
+        // (#358).
+        let inset = geometry.glowMargin + geometry.lineWidth / 2
+        let rect = bounds.insetBy(dx: inset, dy: inset)
+        shape.path = CGPath(
+            roundedRect: rect,
+            cornerWidth: geometry.cornerRadius,
+            cornerHeight: geometry.cornerRadius,
+            transform: nil
+        )
+        shape.lineWidth = geometry.lineWidth
+        shape.strokeColor = NSColor(kiwiHex: colorHex).cgColor
+        shape.fillColor = NSColor.clear.cgColor
+        shape.contentsScale = screen?.backingScaleFactor ?? 2
+        applyGlow(geometry: geometry, rect: rect, colorHex: colorHex)
+        CATransaction.commit()
+        if !panel.isVisible {
+            panel.orderFrontRegardless()
+        }
+        return true
+    }
+
+    /// The glow bloom on the fallback ring (#358). The shadow is
+    /// cast from a **filled** outer rounded-rect `shadowPath`, not
+    /// the thin stroke, so the bloom is a solid halo instead of a
+    /// banded contour smear. Below-order occludes the inward half of
+    /// the bloom behind the window, so only the outward bloom shows
+    /// — matching the SkyLight path. `masksToBounds` stays false so
+    /// the halo can spill past the shape into the grown frame.
+    private func applyGlow(
+        geometry: BorderGeometry,
+        rect: CGRect,
+        colorHex: String
+    ) {
+        guard geometry.glowMargin > 0 else {
+            shape.shadowOpacity = 0
+            shape.shadowColor = nil
+            shape.shadowPath = nil
+            return
+        }
+        let half = geometry.lineWidth / 2
+        let radius = geometry.cornerRadius
+        let outerRadius = radius <= 0 ? 0 : radius + half
+        shape.shadowColor = NSColor.kiwiGlow(hex: colorHex)
+        shape.shadowRadius = geometry.glowMargin
+        shape.shadowOpacity = 1
+        shape.shadowOffset = .zero
+        shape.shadowPath = CGPath(
+            roundedRect: rect.insetBy(dx: -half, dy: -half),
+            cornerWidth: outerRadius,
+            cornerHeight: outerRadius,
+            transform: nil
+        )
+    }
+
+    /// Stacks the ring directly behind its target window in the
+    /// global window order (`windowNumber` is the target's
+    /// `CGWindowID`). Anything layered over the target — an
+    /// ignored panel, a higher-level utility window — therefore
+    /// stays in front of the ring. Called on sync, not per tick.
+    /// A no-op until the panel exists (first `update` creates it).
+    func order(relativeTo windowNumber: CGWindowID) -> Bool {
+        panel?.order(.below, relativeTo: Int(windowNumber))
+        return true
+    }
+
+    func hide() -> Bool {
+        panel?.orderOut(nil)
+        return true
+    }
+
+    private func makePanel() -> NSPanel {
+        // A frame-constraining panel would clamp a top-row ring's
+        // upward dead-end bump to zero (#436) — see BorderOverlayPanel.
+        let panel = BorderOverlayPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = true
+        // Normal window level (not floating): the ring is stacked
+        // relative to its target by `order(relativeTo:)`, so it must
+        // share the target's band to sit *below* windows layered
+        // over it — a floating level would force it above them.
+        panel.level = .normal
+        panel.isReleasedWhenClosed = false
+        panel.animationBehavior = .none
+        // A fullscreen window gets no border (auxiliary only); not
+        // cycled by the app switcher. `.transient` hides this AppKit
+        // fallback ring in Exposé/Mission Control at the compositor
+        // level so it vanishes with the swipe — the SkyLight fast
+        // path self-vanishes via its space pin, and this hint gives
+        // the fallback ring the same instant behavior.
+        panel.collectionBehavior = [
+            .transient,
+            .fullScreenAuxiliary,
+            .ignoresCycle,
+        ]
+        let view = NSView()
+        view.wantsLayer = true
+        view.layer?.addSublayer(shape)
+        panel.contentView = view
+        return panel
+    }
+}

--- a/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
@@ -29,8 +29,20 @@ struct BorderGeometry: Equatable {
     /// plus the overlap hidden behind the target.
     let lineWidth: CGFloat
     /// Corner radius (pt) of the stroke's centerline path, drawn
-    /// in the overlay's own bounds inset by `lineWidth / 2`.
+    /// in the overlay's own bounds inset by `lineWidth / 2` plus
+    /// `glowMargin`.
     let cornerRadius: CGFloat
+    /// Extra outward room (pt) the overlay frame carries **beyond**
+    /// the visible reach so a glow bloom isn't clipped by the
+    /// window bounds (#358). `0` when glow is off — then the frame
+    /// and draw math are identical to a plain ring. When on, the
+    /// frame grows by this on every side and the stroke path is
+    /// inset back by it, so the ring stays put and the margin is
+    /// pure bloom space. Deliberately kept OUT of `outwardReach`:
+    /// the soft bloom is allowed to bleed into the layout gap, so
+    /// `border.fit_gaps` stays sized to the crisp stroke (#358
+    /// ui-designer decision).
+    let glowMargin: CGFloat
 
     /// **`below`-order only.** The one cushion beyond what corner
     /// geometry strictly requires, shared by both styles: rounded's arc
@@ -78,17 +90,25 @@ struct BorderGeometry: Equatable {
     /// unchanged); only the inner edge moves.
     static let aboveVisibleLapCap: CGFloat = 1
 
+    /// The glow bloom's blur radius (pt), and the amount the overlay
+    /// frame grows on every side when glow is on so the halo isn't
+    /// clipped (#358). Matches JankyBorders' fixed 10 pt
+    /// `COLOR_STYLE_GLOW` shadow.
+    static let glowBlur: CGFloat = 10
+
     /// Builds the ring geometry for `windowFrame` (AX coords).
     /// `width` is clamped defensively; `systemRadius` is the
     /// shared window corner radius (rounded style) or ignored
-    /// (square style → 0).
+    /// (square style → 0). `glow` grows the overlay frame by
+    /// `glowBlur` on every side so the bloom has room (#358).
     static func compute(
         windowFrame: CGRect,
         width: CGFloat,
         cornerStyle: BorderStyle.CornerStyle,
         order: Order = .below,
         systemRadius: CGFloat = GeometryUtils
-            .systemWindowCornerRadius
+            .systemWindowCornerRadius,
+        glow: Bool = false
     ) -> BorderGeometry {
         let visible = Self.clamp(width)
         let overlap = overlap(
@@ -103,13 +123,15 @@ struct BorderGeometry: Equatable {
         let radius =
             cornerStyle == .square
             ? 0 : max(0, systemRadius + visible - stroke / 2)
+        let margin = glow ? glowBlur : 0
         return BorderGeometry(
             overlayFrame: windowFrame.insetBy(
-                dx: -visible,
-                dy: -visible
+                dx: -(visible + margin),
+                dy: -(visible + margin)
             ),
             lineWidth: stroke,
-            cornerRadius: radius
+            cornerRadius: radius,
+            glowMargin: margin
         )
     }
 

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -19,19 +19,25 @@ public final class BorderManager {
         public let colorHex: String
         public let width: CGFloat
         public let cornerStyle: BorderStyle.CornerStyle
+        /// Whether this ring wears the glow bloom (#358). Set only on
+        /// the focused ring — `borderSpecs` never glows an unfocused
+        /// ring, so this is `false` for every non-focused spec.
+        public let glow: Bool
 
         public init(
             window: WindowID,
             frame: CGRect,
             colorHex: String,
             width: CGFloat,
-            cornerStyle: BorderStyle.CornerStyle
+            cornerStyle: BorderStyle.CornerStyle,
+            glow: Bool = false
         ) {
             self.window = window
             self.frame = frame
             self.colorHex = colorHex
             self.width = width
             self.cornerStyle = cornerStyle
+            self.glow = glow
         }
     }
 
@@ -152,7 +158,8 @@ public final class BorderManager {
                 cornerStyle: spec.cornerStyle,
                 cornerRadius: cornerRadius(for: spec.window),
                 colorHex: spec.colorHex,
-                screen: screen(for: spec.frame)
+                screen: screen(for: spec.frame),
+                glow: spec.glow
             )
             // Re-assert stacking each sync (focus change, retile,
             // z-order restore) — the target may have moved in the
@@ -190,6 +197,7 @@ public final class BorderManager {
             cornerRadius: cornerRadius(for: id),
             colorHex: spec.colorHex,
             screen: screen(for: windowFrame),
+            glow: spec.glow,
             restoreVisibility: restoreVisibility
         )
     }

--- a/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
@@ -35,6 +35,10 @@ final class BorderOverlay {
     private var lastWidth: CGFloat = 0
     private var lastCornerStyle: BorderStyle.CornerStyle = .rounded
     private var lastColorHex = ""
+    /// Whether the last render asked for the glow bloom (#358). Kept
+    /// alongside the other raw inputs so a fallback swap or a
+    /// dead-end bump rebuilds geometry with the same glow state.
+    private var lastGlow = false
     private weak var lastScreen: NSScreen?
     private var targetWindow: CGWindowID
     /// The target's real corner radius, resolved by `BorderManager`
@@ -104,6 +108,7 @@ final class BorderOverlay {
         cornerRadius: CGFloat,
         colorHex: String,
         screen: NSScreen?,
+        glow: Bool = false,
         restoreVisibility: Bool = false
     ) {
         lastFrame = frame
@@ -112,6 +117,7 @@ final class BorderOverlay {
         lastCornerRadius = cornerRadius
         lastColorHex = colorHex
         lastScreen = screen
+        lastGlow = glow
         let shouldRestore = restoreVisibility && isHidden
         guard
             backend.update(
@@ -168,7 +174,8 @@ final class BorderOverlay {
             width: lastWidth,
             cornerStyle: lastCornerStyle,
             order: backend.orderMode,
-            systemRadius: lastCornerRadius
+            systemRadius: lastCornerRadius,
+            glow: lastGlow
         )
     }
 
@@ -208,137 +215,5 @@ final class BorderOverlay {
                 _ = appKit.order(relativeTo: targetWindow)
             }
         }
-    }
-}
-
-/// One window's focus-border ring (#278): a borderless,
-/// non-activating, shadowless panel that ignores mouse events and
-/// draws a single stroked rounded rect. The manager
-/// (`BorderManager`) creates one per bordered window and feeds it
-/// geometry; the overlay knows nothing about layouts or focus.
-///
-/// Non-interactive by design (`ignoresMouseEvents`) — unlike the
-/// app bar, a border is never clicked. Sits at the normal window
-/// level and is stacked directly behind its target window with
-/// `order(.below, relativeTo:)` (see `order(relativeTo:)`). The stroke's
-/// inner overlap sits under the target while its outward reach stays
-/// visible; child panels and other windows above the target therefore
-/// cover the ring naturally.
-@MainActor
-private final class AppKitBorderOverlay: BorderOverlayBackend {
-    private var panel: NSPanel?
-    private let shape = CAShapeLayer()
-
-    /// The AppKit panel stacks below its target (it cannot express a
-    /// SkyLight sub-level, so `above` here would paint over child
-    /// popovers — the #320 regression). Below keeps that occlusion
-    /// correct at the cost of the rounded corner seam, which only
-    /// the SkyLight `above` path fixes.
-    let orderMode: BorderGeometry.Order = .below
-
-    /// Positions the ring around `geometry.overlayFrame` (AX
-    /// coords) and strokes it in `colorHex`. Used both for a
-    /// steady-state sync and per animation tick — implicit Core
-    /// Animation is disabled so the ring snaps to each commanded
-    /// frame instead of easing a step behind the window. Stacking
-    /// is left to `order(relativeTo:)`, called only on sync (not per
-    /// tick) so the ring isn't re-ordered every frame.
-    func update(
-        geometry: BorderGeometry,
-        colorHex: String,
-        screen: NSScreen?
-    ) -> Bool {
-        let panel = self.panel ?? makePanel()
-        self.panel = panel
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        panel.setFrame(
-            GeometryUtils.flip(
-                geometry.overlayFrame,
-                primaryHeight: GeometryUtils.primaryHeight
-            ),
-            display: false
-        )
-        let bounds = CGRect(
-            origin: .zero,
-            size: geometry.overlayFrame.size
-        )
-        shape.frame = bounds
-        // Stroke is centered on its path, so inset the path by
-        // half the line width to keep the whole stroke inside the
-        // overlay bounds.
-        let rect = bounds.insetBy(
-            dx: geometry.lineWidth / 2,
-            dy: geometry.lineWidth / 2
-        )
-        shape.path = CGPath(
-            roundedRect: rect,
-            cornerWidth: geometry.cornerRadius,
-            cornerHeight: geometry.cornerRadius,
-            transform: nil
-        )
-        shape.lineWidth = geometry.lineWidth
-        shape.strokeColor = NSColor(kiwiHex: colorHex).cgColor
-        shape.fillColor = NSColor.clear.cgColor
-        shape.contentsScale = screen?.backingScaleFactor ?? 2
-        CATransaction.commit()
-        if !panel.isVisible {
-            panel.orderFrontRegardless()
-        }
-        return true
-    }
-
-    /// Stacks the ring directly behind its target window in the
-    /// global window order (`windowNumber` is the target's
-    /// `CGWindowID`). Anything layered over the target — an
-    /// ignored panel, a higher-level utility window — therefore
-    /// stays in front of the ring. Called on sync, not per tick.
-    /// A no-op until the panel exists (first `update` creates it).
-    func order(relativeTo windowNumber: CGWindowID) -> Bool {
-        panel?.order(.below, relativeTo: Int(windowNumber))
-        return true
-    }
-
-    func hide() -> Bool {
-        panel?.orderOut(nil)
-        return true
-    }
-
-    private func makePanel() -> NSPanel {
-        // A frame-constraining panel would clamp a top-row ring's
-        // upward dead-end bump to zero (#436) — see BorderOverlayPanel.
-        let panel = BorderOverlayPanel(
-            contentRect: .zero,
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
-        )
-        panel.isOpaque = false
-        panel.backgroundColor = .clear
-        panel.hasShadow = false
-        panel.ignoresMouseEvents = true
-        // Normal window level (not floating): the ring is stacked
-        // relative to its target by `order(relativeTo:)`, so it must
-        // share the target's band to sit *below* windows layered
-        // over it — a floating level would force it above them.
-        panel.level = .normal
-        panel.isReleasedWhenClosed = false
-        panel.animationBehavior = .none
-        // A fullscreen window gets no border (auxiliary only); not
-        // cycled by the app switcher. `.transient` hides this AppKit
-        // fallback ring in Exposé/Mission Control at the compositor
-        // level so it vanishes with the swipe — the SkyLight fast
-        // path self-vanishes via its space pin, and this hint gives
-        // the fallback ring the same instant behavior.
-        panel.collectionBehavior = [
-            .transient,
-            .fullScreenAuxiliary,
-            .ignoresCycle,
-        ]
-        let view = NSView()
-        view.wantsLayer = true
-        view.layer?.addSublayer(shape)
-        panel.contentView = view
-        return panel
     }
 }

--- a/Sources/KiwiDeskCore/Borders/BorderStyle.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderStyle.swift
@@ -67,6 +67,16 @@ public struct BorderStyle: Sendable, Equatable {
     /// the focused ring for attention.
     public var unfocusedColor = "#8E8E93CC"
     public var cornerStyle: CornerStyle = .rounded
+    /// A soft colored bloom around the focused ring (#358) — the
+    /// JankyBorders `COLOR_STYLE_GLOW` look, a zero-offset blurred
+    /// halo in the ring's own hue. A render trait like width and
+    /// corners, not a visibility toggle: it reuses `focusedColor`,
+    /// introduces no color choice, and applies to the **focused
+    /// ring only** (a bloom on every unfocused ring would undercut
+    /// the focused one it is meant to make pop). Default OFF —
+    /// native-first, matching JankyBorders' own default; the flat
+    /// ring already reads clearly, glow is additive flourish.
+    public var glow = false
     /// Ring stacked behind windows (default) or in front. A niche
     /// Lua-only preference with no GUI control (#367).
     public var drawOrder: DrawOrder = .behind
@@ -126,6 +136,7 @@ extension BorderStyle: Codable {
         case unfocusedEnabled = "unfocused_enabled"
         case unfocusedColor = "unfocused_color"
         case cornerStyle = "corner_style"
+        case glow
         case drawOrder = "draw_order"
     }
 
@@ -166,6 +177,11 @@ extension BorderStyle: Codable {
                 CornerStyle.self,
                 forKey: .cornerStyle
             ) ?? defaults.cornerStyle
+        glow =
+            try container.decodeIfPresent(
+                Bool.self,
+                forKey: .glow
+            ) ?? defaults.glow
         drawOrder =
             try container.decodeIfPresent(
                 DrawOrder.self,

--- a/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay+Surface.swift
+++ b/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay+Surface.swift
@@ -115,22 +115,29 @@ extension SkyLightBorderOverlay {
             origin: .zero,
             size: geometry.overlayFrame.size
         )
-        let pathRect = bounds.insetBy(
-            dx: geometry.lineWidth / 2,
-            dy: geometry.lineWidth / 2
-        )
+        // The stroke sits `glowMargin` in from the grown frame so
+        // the ring stays put and the extra margin is bloom room
+        // (#358); `glowMargin` is 0 for a plain ring, so this is the
+        // original inset then.
+        let inset = geometry.glowMargin + geometry.lineWidth / 2
+        let pathRect = bounds.insetBy(dx: inset, dy: inset)
         context.clear(bounds)
-        context.setLineWidth(geometry.lineWidth)
-        context.setStrokeColor(NSColor(kiwiHex: colorHex).cgColor)
-        context.addPath(
-            CGPath(
-                roundedRect: pathRect,
-                cornerWidth: geometry.cornerRadius,
-                cornerHeight: geometry.cornerRadius,
-                transform: nil
+        if geometry.glowMargin > 0 {
+            paintGlow(
+                context,
+                bounds: bounds,
+                pathRect: pathRect,
+                geometry: geometry,
+                colorHex: colorHex
             )
-        )
-        context.strokePath()
+        } else {
+            paintRing(
+                context,
+                pathRect: pathRect,
+                geometry: geometry,
+                colorHex: colorHex
+            )
+        }
         context.flush()
         guard
             SkyLight.flushWindowContent?(
@@ -145,6 +152,76 @@ extension SkyLightBorderOverlay {
             connection,
             window
         ) == .success
+    }
+
+    /// A plain crisp ring: stroke the centerline path at the full
+    /// line width. The no-glow path, and identical to the pre-#358
+    /// draw.
+    private func paintRing(
+        _ context: CGContext,
+        pathRect: CGRect,
+        geometry: BorderGeometry,
+        colorHex: String
+    ) {
+        context.setLineWidth(geometry.lineWidth)
+        context.setStrokeColor(NSColor(kiwiHex: colorHex).cgColor)
+        context.addPath(
+            CGPath(
+                roundedRect: pathRect,
+                cornerWidth: geometry.cornerRadius,
+                cornerHeight: geometry.cornerRadius,
+                transform: nil
+            )
+        )
+        context.strokePath()
+    }
+
+    /// The glow ring (#358): a **filled** ring band that casts a
+    /// soft outward bloom. Shadowing a thin stroke banded into
+    /// visible contour lines (the shelved first attempt); casting
+    /// the shadow from a solid band — the JankyBorders technique —
+    /// blooms cleanly. Clipped to everything but the window interior
+    /// so the bloom spills outward into the grown margin but never
+    /// paints over window content. The band itself is the ring, so
+    /// no separate stroke is drawn.
+    private func paintGlow(
+        _ context: CGContext,
+        bounds: CGRect,
+        pathRect: CGRect,
+        geometry: BorderGeometry,
+        colorHex: String
+    ) {
+        let half = geometry.lineWidth / 2
+        let radius = geometry.cornerRadius
+        // Square rings (radius 0) keep sharp corners on both edges.
+        let outerRadius = radius <= 0 ? 0 : radius + half
+        let innerRadius = radius <= 0 ? 0 : max(0, radius - half)
+        let outer = CGPath(
+            roundedRect: pathRect.insetBy(dx: -half, dy: -half),
+            cornerWidth: outerRadius,
+            cornerHeight: outerRadius,
+            transform: nil
+        )
+        let inner = CGPath(
+            roundedRect: pathRect.insetBy(dx: half, dy: half),
+            cornerWidth: innerRadius,
+            cornerHeight: innerRadius,
+            transform: nil
+        )
+        let color = NSColor.kiwiGlow(hex: colorHex)
+        context.saveGState()
+        context.addRect(bounds)
+        context.addPath(inner)
+        context.clip(using: .evenOdd)
+        context.setShadow(
+            offset: .zero,
+            blur: geometry.glowMargin,
+            color: color
+        )
+        context.setFillColor(color)
+        context.addPath(outer)
+        context.fillPath()
+        context.restoreGState()
     }
 
     func makeRegion(_ rect: CGRect) -> CFTypeRef? {

--- a/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay+Surface.swift
+++ b/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay+Surface.swift
@@ -208,7 +208,12 @@ extension SkyLightBorderOverlay {
             cornerHeight: innerRadius,
             transform: nil
         )
-        let color = NSColor.kiwiGlow(hex: colorHex)
+        // The ring body keeps the faithful hex (alpha and all), so a
+        // translucent `focused_color` stays translucent — only the
+        // shadow forces opacity, matching JankyBorders and the other
+        // render paths.
+        let ringColor = NSColor(kiwiHex: colorHex).cgColor
+        let glowColor = NSColor.kiwiGlow(hex: colorHex)
         context.saveGState()
         context.addRect(bounds)
         context.addPath(inner)
@@ -216,9 +221,9 @@ extension SkyLightBorderOverlay {
         context.setShadow(
             offset: .zero,
             blur: geometry.glowMargin,
-            color: color
+            color: glowColor
         )
-        context.setFillColor(color)
+        context.setFillColor(ringColor)
         context.addPath(outer)
         context.fillPath()
         context.restoreGState()

--- a/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
@@ -90,6 +90,7 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
             sizeChanged
             || previous?.lineWidth != geometry.lineWidth
             || previous?.cornerRadius != geometry.cornerRadius
+            || previous?.glowMargin != geometry.glowMargin
             || self.colorHex != colorHex
 
         if sizeChanged && !reshape(to: geometry.overlayFrame) {

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -255,7 +255,8 @@ public enum APIReference {
         "border": [
             "set_enabled", "set_width", "set_focused_color",
             "set_unfocused_enabled", "set_unfocused_color",
-            "set_corner_style", "set_draw_order", "fit_gaps",
+            "set_corner_style", "set_glow", "set_draw_order",
+            "fit_gaps",
         ],
         "sticky": [
             "set_indicator", "set_color",

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+BorderCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+BorderCommands.swift
@@ -77,6 +77,10 @@ extension KiwiCore {
             return setColor(args) {
                 tiler.settings.borderStyle.unfocusedColor = $0
             }
+        case "glow":
+            return setBool(args) {
+                tiler.settings.borderStyle.glow = $0
+            }
         case "corner_style":
             guard let raw = args.first?.stringValue,
                 let style = BorderStyle.CornerStyle(rawValue: raw)

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -138,6 +138,8 @@
   "border.fit_gaps.updated_new": "Draft updated — Save as New Profile… to apply and persist.",
   "border.focused_color": "Color",
   "border.focused_color.a11y": "Focused window border color",
+  "border.glow": "Glow",
+  "border.glow.a11y": "Soft glow around the focus border",
   "border.title": "Focus border",
   "border.unfocused_color": "Color",
   "border.unfocused_color.a11y": "Unfocused window border color",

--- a/Tests/KiwiDeskCoreTests/BorderCommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderCommandTests.swift
@@ -37,6 +37,27 @@ struct BorderCommandTests {
         #expect(core.tiler.settings.borderStyle.unfocusedEnabled)
     }
 
+    @Test("set_glow toggles the bloom, rejects non-bool")
+    func glowToggle() {
+        let core = makeCore()
+        #expect(!core.tiler.settings.borderStyle.glow)
+        #expect(
+            core.execute(
+                "border.set_glow",
+                args: [.bool(true)]
+            ).isSuccess
+        )
+        #expect(core.tiler.settings.borderStyle.glow)
+        // A non-boolean argument is rejected, leaving the flag on.
+        #expect(
+            !core.execute(
+                "border.set_glow",
+                args: [.string("yes")]
+            ).isSuccess
+        )
+        #expect(core.tiler.settings.borderStyle.glow)
+    }
+
     @Test("set_width clamps out-of-range silently, rejects type")
     func widthClamp() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/BorderGeometryTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderGeometryTests.swift
@@ -220,6 +220,9 @@ struct BorderGeometryTests {
     /// style **and both order modes**. The overlap (hidden below,
     /// on-window above) must never leak into this public reach, or
     /// the fit-gaps math would drift when the ring flips order.
+    /// Glow is deliberately excluded here — its bloom bleeds into the
+    /// gap on purpose, so `glow: true` grows the frame *past* the
+    /// reach (covered by `glowGrowsFrame`), not a violation of this.
     @Test("outwardReach matches compute's outward offset")
     func outwardReachMatchesCompute() {
         let widths: [CGFloat] = [BorderStyle.minWidth, 2, 10, 20]

--- a/Tests/KiwiDeskCoreTests/BorderGeometryTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderGeometryTests.swift
@@ -29,6 +29,39 @@ struct BorderGeometryTests {
         )
     }
 
+    @Test("Glow grows the overlay frame, leaves reach alone")
+    func glowGrowsFrame() {
+        let plain = BorderGeometry.compute(
+            windowFrame: window,
+            width: 2,
+            cornerStyle: .rounded,
+            systemRadius: 16
+        )
+        let glowing = BorderGeometry.compute(
+            windowFrame: window,
+            width: 2,
+            cornerStyle: .rounded,
+            systemRadius: 16,
+            glow: true
+        )
+        // Frame grows by the blur on every side so the halo has
+        // room; the stroke geometry itself is unchanged (#358).
+        #expect(plain.glowMargin == 0)
+        #expect(glowing.glowMargin == BorderGeometry.glowBlur)
+        #expect(
+            glowing.overlayFrame
+                == window.insetBy(
+                    dx: -(2 + BorderGeometry.glowBlur),
+                    dy: -(2 + BorderGeometry.glowBlur)
+                )
+        )
+        #expect(glowing.lineWidth == plain.lineWidth)
+        #expect(glowing.cornerRadius == plain.cornerRadius)
+        // Outward reach (fit-gaps) must NOT count the bloom — it
+        // bleeds into the gap by design.
+        #expect(BorderGeometry.outwardReach(width: 2) == 2)
+    }
+
     @Test("Thick width also keeps a fixed hidden overlap")
     func thickWidth() {
         let g = BorderGeometry.compute(

--- a/Tests/KiwiDeskCoreTests/BorderSpecsTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderSpecsTests.swift
@@ -86,6 +86,24 @@ struct BorderSpecsTests {
         #expect(other?.colorHex == style.unfocusedColor)
     }
 
+    @Test("Glow rides the focused ring only, never unfocused")
+    func glowFocusedOnly() {
+        var style = BorderStyle()
+        style.glow = true
+        style.unfocusedEnabled = true
+        let result = specs(style, focused: w1, slots: disjoint)
+        let focused = result.first { $0.window == w1 }
+        let other = result.first { $0.window == w2 }
+        #expect(focused?.glow == true)
+        // A bloom on every unfocused ring would undercut the one it
+        // should make pop (#358) — so unfocused rings never glow.
+        #expect(other?.glow == false)
+        // And with glow off, the focused ring doesn't glow either.
+        style.glow = false
+        let plain = specs(style, focused: w1, slots: disjoint)
+        #expect(plain.first { $0.window == w1 }?.glow == false)
+    }
+
     @Test("Monocle stays focused-only despite unfocused toggle")
     func monocleFocusedOnly() {
         var style = BorderStyle()

--- a/Tests/KiwiDeskCoreTests/BorderStyleParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderStyleParityTests.swift
@@ -21,6 +21,7 @@ struct BorderStyleParityTests {
         style.unfocusedEnabled = true
         style.unfocusedColor = "#222222"
         style.cornerStyle = .square
+        style.glow = true
         style.drawOrder = .front
         return style
     }

--- a/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
+++ b/Tests/KiwiDeskCoreTests/SettingsCodingTests.swift
@@ -44,7 +44,7 @@ struct SettingsCodingTests {
             Set(border.keys) == [
                 "enabled", "width", "focused_color",
                 "unfocused_enabled", "unfocused_color",
-                "corner_style", "draw_order",
+                "corner_style", "glow", "draw_order",
             ]
         )
         #expect(border["enabled"] as? Bool == true)
@@ -52,6 +52,7 @@ struct SettingsCodingTests {
         #expect(border["focused_color"] as? String == "#567A1F")
         #expect(border["unfocused_enabled"] as? Bool == false)
         #expect(border["corner_style"] as? String == "rounded")
+        #expect(border["glow"] as? Bool == false)
         #expect(border["draw_order"] as? String == "behind")
         // Bar chrome defaults take the brand kiwi green (#439);
         // pinned here so an accidental struct-default change
@@ -258,6 +259,7 @@ struct SettingsCodingTests {
         settings.borderStyle.unfocusedEnabled = true
         settings.borderStyle.unfocusedColor = "#04050607"
         settings.borderStyle.cornerStyle = .square
+        settings.borderStyle.glow = true
         settings.stickyStyle.indicator = false
         settings.stickyStyle.color = "#4E9F3D"
         settings.floatingStyle.color = "#E8A33D"

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -308,6 +308,23 @@ Ghostty's quick terminal #21). The draw-time heuristic remains for
 the structural floats that stay managed: panel-subrole windows of
 regular apps and accessory apps' layer-0 windows.
 
+The optional **glow** (#358) — a soft blurred colored bloom around
+the ring, the JankyBorders `COLOR_STYLE_GLOW` look — is a global
+bool (`border.glow`, default OFF) with two deliberate scope choices.
+It rides the **focused ring only**, never the unfocused set: a bloom
+on every dim ring would undercut the one it exists to make pop, and
+`unfocused_color` is tuned to be present-without-competing, the
+opposite intent. And its outward extent is kept **out of
+`outwardReach`**, so `border.fit_gaps` still sizes gaps to the crisp
+stroke and the soft bloom is allowed to bleed into the gap — the
+overlay *frame* grows by the blur so the halo isn't clipped, but the
+gap math stays simple. (An earlier attempt that shadowed the thin
+stroke directly banded into contour lines and dropped to gray on the
+SkyLight context; the shipped version casts the shadow from a solid
+clipped ring-band in an sRGB alpha-1 color, matching JankyBorders.
+Default OFF is native-first — a fresh install reads as a crisp flat
+ring, glow is opt-in flourish.)
+
 A **native-fullscreen** (green-button) window is suppressed by the
 same draw-time mechanism: it stays a member of its home virtual
 space (macOS moves it to its own Space without a destroy), but it

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -2611,6 +2611,25 @@ squared frame on rounded ones.
 border.set_corner_style("rounded")
 ```
 
+### border.set_glow
+
+**Expects:** a boolean.
+
+**Does:** when `true`, wraps the **focused** ring in a soft colored
+bloom — a zero-offset blurred halo in the ring's own color, the
+JankyBorders "glow" look (default `false`). A render trait like
+width and corners: it reuses `focused_color`, adds no color choice,
+and never rings the unfocused windows (a bloom on every dim ring
+would undo the point of making the focused one stand out). The soft
+edge is allowed to bleed into the layout gap, so `fit_gaps` is
+unaffected.
+
+**Example:**
+
+```lua
+border.set_glow(true)
+```
+
 ### border.set_draw_order
 
 **Expects:** `"behind"` or `"front"`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -705,6 +705,10 @@ windows. Below it:
 - **Corners**: **Rounded** matches your windows' real corner
   radius; **Square** draws sharp corners — seamless on windows that
   are already square, an intentional squared frame on rounded ones.
+- **Glow**: wraps the focused ring in a soft colored bloom for a bit
+  more presence. Off by default; it only ever touches the focused
+  window, never the unfocused rings. The live preview shows the
+  effect as you toggle it.
 - **Fit layout gaps**: previews the exact global **Outer** and
   **Inner** values needed to keep rings apart, plus the requested
   **Extra spacing** (0–100 pt, default 0). Inner gaps account for


### PR DESCRIPTION
Adds an optional **glow** to the focus border: a soft blurred colored bloom around the focused ring — the JankyBorders `COLOR_STYLE_GLOW` look. Global bool `border.glow` (Lua `border.set_glow`, JSON `border.glow`), **default OFF**, **focused-ring-only**.

Closes #358.

## The corrected technique
A prior attempt was shelved because it shadowed the **thin stroke** directly, which banded into contour lines and dropped to gray on the SkyLight window context. This ships the corrected halo:

- **sRGB alpha-1 shadow color** (`NSColor.kiwiGlow`) — fixes the gray (a calibrated `CGColor` is not honored for the shadow path on a SkyLight-backed context).
- **Shadow cast from a solid clipped ring-band fill**, not a thin stroke (SkyLight `paintGlow`); the AppKit fallback casts from a filled `shadowPath`. Solid bloom, no banding — matches JankyBorders.
- The overlay frame grows by the blur radius so the halo isn't clipped, while `outwardReach` stays at the crisp stroke → `fit_gaps` is unaffected (the soft bloom bleeds into the gap by design).
- The ring **body** keeps the faithful hex (alpha included); only the shadow forces opacity.

## GUI
A "Glow" toggle after Corners with a scaled live-preview bloom (a11y label, no caption).

## Docs
`border.set_glow` (lua-reference), the Glow control (user-guide), and a durable-decision entry in design-decisions.md.

## Review
Two-agent review (code-reviewer + architect-reviewer, parallel): no blocking findings; the one real Low finding (opaque ring body) is fixed in this branch.

## ⚠️ On-device eye-confirm
This is a purely visual feature with a known prior on-device rejection. The bloom was **confirmed on real hardware** before merge — tests can't judge it.

## Verify gate
`swift build` + `swift test --skip ExecTests` (1908) + `swift test --filter ExecTests` (14) + `scripts/lint.sh` + `swift build -c release` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)