### PR TITLE
fix(gui): grey preset Apply while editing a stored profile

### DIFF
--- a/Sources/KiwiDesk/Settings/Sections/PresetsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/PresetsSection.swift
@@ -118,8 +118,12 @@ struct PresetsSection: View {
     @ViewBuilder private func applyButton(
         _ layout: StandardLayout
     ) -> some View {
+        // Two independent reasons Apply can be unavailable, so
+        // the help has to say WHICH one (#518).
+        let editing = model.editingStoredProfile
         let appliable =
             model.displays.count == layout.screenCount
+            && !editing
         // Apply materializes a profile and reloads, so it
         // drops staged edits like the profile actions (#515).
         let button = Button(L("presets.apply", "Apply")) {
@@ -137,15 +141,7 @@ struct PresetsSection: View {
         }
         .controlSize(.large)
         .disabled(!appliable)
-        .help(
-            appliable
-                ? ""
-                : L(
-                    "presets.needs_screens",
-                    "Needs %1$d connected screen(s).",
-                    layout.screenCount
-                )
-        )
+        .help(applyHelp(layout, editing: editing))
         if appliable, layout.isStandard,
             model.profileSummaries.isEmpty
         {
@@ -153,6 +149,32 @@ struct PresetsSection: View {
         } else {
             button.buttonStyle(.bordered)
         }
+    }
+
+    /// Greyed, never hidden (#171) — with the reason, because
+    /// "why is Apply dead" has two different answers and the
+    /// stored-profile one contradicts what the user just read
+    /// in the header.
+    private func applyHelp(
+        _ layout: StandardLayout,
+        editing: Bool
+    ) -> String {
+        if editing {
+            return L(
+                "presets.editing_stored",
+                "Applying a preset switches your live layout, "
+                    + "which editing a saved profile never does. "
+                    + "Switch to Live to apply one."
+            )
+        }
+        if model.displays.count != layout.screenCount {
+            return L(
+                "presets.needs_screens",
+                "Needs %1$d connected screen(s).",
+                layout.screenCount
+            )
+        }
+        return ""
     }
 }
 

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -510,6 +510,7 @@
   "presets.developer.summary": "IDE stack, scrolling docs, and a fullscreen preview space.",
   "presets.dual_developer.name": "Dual Developer",
   "presets.dual_developer.summary": "Code and docs on the main display; mail, chat, and media on the second.",
+  "presets.editing_stored": "Applying a preset switches your live layout, which editing a saved profile never does. Switch to Live to apply one.",
   "presets.focus_stack.name": "Focus Stack",
   "presets.focus_stack.summary": "Two stacked task spaces and a deep-work monocle space.",
   "presets.minimalist.name": "Minimalist",

--- a/Tests/KiwiDeskGuiTests/GreyOutParityTests.swift
+++ b/Tests/KiwiDeskGuiTests/GreyOutParityTests.swift
@@ -64,6 +64,12 @@ struct GreyOutParityTests {
             "active: g.resolvedGrid(for: space).autoSize"
         ),
         ("AppBarGroups+Colors.swift", "active: gapOnly"),
+        // Not a GreyOut site — a plain `.disabled` with its own
+        // reason-bearing help — but the same convention, and
+        // the same failure if it is dropped: Apply would switch
+        // the live layout while the header promises it won't
+        // (#518).
+        ("PresetsSection.swift", "model.editingStoredProfile"),
     ]
 
     @Test("every gated editor still greys off its own switch")

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1290,6 +1290,12 @@ your connected displays. The layout loads and is saved as an editable
 profile under the preset's name. The first profile saved for a screen
 count becomes that count's default.
 
+Apply switches your **live** layout, so it is greyed while you are
+editing a saved profile from the banner picker — that mode never
+touches what is on screen. Switch back to Live to apply one. It is
+also greyed when the preset's screen count doesn't match your
+connected displays; the tooltip says which of the two it is.
+
 Presets themselves cannot be deleted; they always stay available. If
 you delete all saved profiles for a screen count, that count silently
 reverts to its Standard on the next monitor change.


### PR DESCRIPTION
Closes #518. Found by the #406 UX audit (finding 5), re-traced against `main` before fixing.

## The defect

`PresetsSection` renders in **both** edit modes, and its Apply button carried no `editingStoredProfile` gate — only `.disabled(!appliable)` on the screen count. So Apply called `apply(composed:, forceRetile: true)` and adopted a new profile — **switching the running layout** — while `ProfileHeader` displayed, in the same window:

> Editing a saved profile — changes won't switch your layout

That promise is the whole contract of stored-profile editing mode (#18). A button that breaks it is worse than a dead control: the user has been told, on screen, that this cannot happen.

## The fix

Greyed, not hidden (#171) — **with the reason**. Apply now has two independent unavailability causes, and a single tooltip about screen counts would confidently explain the wrong one:

- editing a stored profile → *"Applying a preset switches your live layout, which editing a saved profile never does. Switch to Live to apply one."*
- screen-count mismatch → the existing "Needs %1$d connected screen(s)."

## Considered and deliberately not done

Redefining Apply in this mode to write the preset's layout **into the profile being edited** rather than the live one. That is arguably what a user in that mode actually wants — but it is a feature with its own unanswered semantics (which fields does a preset overwrite in a stored profile? does it replace the space set?), not a defect fix. Greying is correct either way, and the promise holds now regardless. Worth filing separately if you want it.

## Test

Pinned in `GreyOutParityTests` beside the other gates. It is not a `GreyOut` site — a plain `.disabled` with its own reason-bearing help — but it is the same convention and the same failure if it is dropped, so it belongs in the same guard rather than in a suite nobody reads next to it.

## Gate

`swift build` · `swift test --skip ExecTests` (1960 tests / 333 suites) · `swift test --filter ExecTests` (14) · `scripts/lint.sh` exit 0 · `swift build -c release` — green.

## Needs your eyes

One button changes from live to dimmed in one mode. Low risk, but it is rendered pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)