### PR TITLE
docs(comments): drop citations to unreachable design blueprints

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog.swift
@@ -3,8 +3,7 @@ import KiwiDeskCore
 
 /// The catalog backing the keybindings tab: navigation presets
 /// and installed applications. Known macOS shortcuts used for
-/// conflict detection live in Core's `SystemShortcuts`
-/// (05_GUI_Concept §2, Tab 5).
+/// conflict detection live in Core's `SystemShortcuts`.
 enum KeybindingCatalog {
     // dir is the Lua argument; phrase is the positional English
     // wording used in the canonical `label` ("above"/"below"

--- a/Sources/KiwiDesk/Settings/Components/Lua/LuaEditorTab.swift
+++ b/Sources/KiwiDesk/Settings/Components/Lua/LuaEditorTab.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 /// The integrated Lua editor. Shown when init.lua holds code
 /// the visual editor can't represent (foreign code touching
-/// managed vocabulary), or when the user opts to edit raw Lua
-/// (05_GUI_Concept §2). Edits here write the whole file verbatim.
+/// managed vocabulary), or when the user opts to edit raw Lua.
+/// Edits here write the whole file verbatim.
 struct LuaEditorTab: View {
     @ObservedObject var model: SettingsModel
     @State private var confirmingAdopt = false

--- a/Sources/KiwiDeskCore/AX/FloatDetection.swift
+++ b/Sources/KiwiDeskCore/AX/FloatDetection.swift
@@ -177,8 +177,7 @@ public enum FloatDetection {
 extension AXHelper {
     /// Detects macOS native tabs (Finder, Terminal, Safari).
     /// A tab group is a single `NSWindow` and is treated as
-    /// ONE tiling unit — tabs are never split apart (see
-    /// 03_Layout_Engine §6.1).
+    /// ONE tiling unit — tabs are never split apart.
     @MainActor
     public static func hasNativeTabs(
         _ element: AXUIElement

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift
@@ -2,7 +2,7 @@ import AppKit
 import Foundation
 
 /// Command execution: the single entry point shared by the
-/// Lua API, the CLI, and the IPC socket (see 04_API_Contract).
+/// Lua API, the CLI, and the IPC socket.
 extension KiwiCore {
     @discardableResult
     public func execute(

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift
@@ -2,7 +2,7 @@ import CoreGraphics
 import Foundation
 
 /// Gap and minimum-size setters. Both accept the values the
-/// GUI's Layouts & Gaps tab produces (see 05_GUI_Concept §3).
+/// GUI's Layouts & Gaps tab produces.
 extension KiwiCore {
     func setGaps(
         _ command: String,

--- a/Sources/KiwiDeskCore/Keys/KeybindingConflicts.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingConflicts.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Conflict detection for the keybindings tab. Comparisons run
 /// on the parsed `KeyCombo` (key code + modifiers), so they are
-/// independent of how a combo was spelled (05_GUI_Concept §2,
-/// Tab 5). Lives in Core (not the GUI target) since it is pure
-/// logic over `KeyBinding`/`KeyMode`, with no GUI dependency.
+/// independent of how a combo was spelled. Lives in Core (not
+/// the GUI target) since it is pure logic over
+/// `KeyBinding`/`KeyMode`, with no GUI dependency.
 public enum KeybindingConflicts {
     /// A tooltip describing the conflict on this row, or nil if
     /// the combo is empty, invalid-but-empty, or unique.

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
@@ -14,7 +14,7 @@ public protocol HotkeyRegistrar: AnyObject {
 
 extension CarbonHotkeyCenter: HotkeyRegistrar {}
 
-/// Modal keybindings (04_API_Contract §8): named modes hold
+/// Modal keybindings: named modes hold
 /// their own bindings; exactly one mode is active. The default
 /// mode holds `KiwiDesk.bind(...)` registrations.
 @MainActor

--- a/Sources/KiwiDeskCore/Layouts/LayoutSystem.swift
+++ b/Sources/KiwiDeskCore/Layouts/LayoutSystem.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// A layout algorithm: a pure function from a flat window array
 /// to per-window geometry. No trees, no containers — this is the
-/// core KiwiDesk idea (see 01_Manifest).
+/// core KiwiDesk idea.
 public protocol LayoutSystem: Sendable {
     /// Calculates frames for tiled windows inside the context's
     /// bounds. Windows not present in the result keep their

--- a/Sources/KiwiDeskCore/Layouts/Space+StackZones.swift
+++ b/Sources/KiwiDeskCore/Layouts/Space+StackZones.swift
@@ -1,4 +1,4 @@
-// MARK: - Stack zone array operations (see 03_Layout_Engine)
+// MARK: - Stack zone array operations
 
 extension Space {
     /// Moves a stack-zone window into the master zone by

--- a/Sources/KiwiDeskCore/Lua/KiwiCore+LuaAPI.swift
+++ b/Sources/KiwiDeskCore/Lua/KiwiCore+LuaAPI.swift
@@ -20,11 +20,11 @@ extension JSONValue {
     }
 }
 
-/// Registers the KiwiDesk Lua API (see 04_API_Contract).
+/// Registers the KiwiDesk Lua API.
 ///
 /// Main commands live on the global `KiwiDesk` table; layout
 /// sub-APIs live on `stack`, `bsp`, `scroll`, and `grid`
-/// tables, matching the contract examples verbatim.
+/// tables.
 extension KiwiCore {
     func registerLuaAPI(on lua: LuaInterpreter) {
         for entry in APIReference.commands {
@@ -64,8 +64,7 @@ extension KiwiCore {
         }
     }
 
-    /// `KiwiDesk.bind`, `define_mode`, and `switch_mode`
-    /// (04_API_Contract §8).
+    /// `KiwiDesk.bind`, `define_mode`, and `switch_mode`.
     private func registerKeybindingAPI(
         on lua: LuaInterpreter
     ) {

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+NativeSpaces.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+NativeSpaces.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Per-native-space profile binding (04_API_Contract §6):
-/// each Mission Control desktop can carry its own profile,
-/// swapped in when the user switches native Spaces.
+/// Per-native-space profile binding: each Mission Control
+/// desktop can carry its own profile, swapped in when the user
+/// switches native Spaces.
 extension KiwiCore {
     // MARK: - Commands
 

--- a/Sources/KiwiDeskCore/Service/ServiceManager.swift
+++ b/Sources/KiwiDeskCore/Service/ServiceManager.swift
@@ -3,7 +3,7 @@ import Foundation
 /// launchd service control (`KiwiDesk service start|stop|
 /// restart`). Writes a LaunchAgent referencing the installed
 /// binary and drives it via `launchctl bootstrap`/`bootout` —
-/// no Homebrew services dependency (see 04_API_Contract §10).
+/// no Homebrew services dependency.
 public enum ServiceManager {
     public static let label = "org.kiwidesk.KiwiDesk"
 


### PR DESCRIPTION
## Summary

Thirteen source comments cited numbered design blueprints by name and section — `01_Manifest`, `03_Layout_Engine`, `04_API_Contract`, `05_GUI_Concept`. Those documents live only under `plan/archive/`, and `plan/` is gitignored (`.gitignore:63`), so every one of those citations points at a document no contributor and no fresh agent can read. The comment names a section number that cannot be looked up.

AGENTS.md §3.5 requires code and docs not to describe different behavior; this is the adjacent failure — a comment pointing at nothing.

## Approach

Owner's call: **remove the reference**, don't repoint it. No replacement target was invented. Where dropping the citation left a dangling clause, the surrounding prose is reflowed so it stands on its own — notably `KiwiCore+LuaAPI`'s "matching the contract examples verbatim", which goes with the contract it referred to.

Comment-only. No behavior change.

## Sites

| File | Was |
|---|---|
| `Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog.swift` | `05_GUI_Concept §2, Tab 5` |
| `Sources/KiwiDesk/Settings/Components/Lua/LuaEditorTab.swift` | `05_GUI_Concept §2` |
| `Sources/KiwiDeskCore/AX/FloatDetection.swift` | `03_Layout_Engine §6.1` |
| `Sources/KiwiDeskCore/Lua/KiwiCore+LuaAPI.swift` | `04_API_Contract` (×2, incl. §8) |
| `Sources/KiwiDeskCore/Layouts/LayoutSystem.swift` | `01_Manifest` |
| `Sources/KiwiDeskCore/Layouts/Space+StackZones.swift` | `03_Layout_Engine` |
| `Sources/KiwiDeskCore/Keys/KeybindingConflicts.swift` | `05_GUI_Concept §2, Tab 5` |
| `Sources/KiwiDeskCore/Keys/KeybindingManager.swift` | `04_API_Contract §8` |
| `Sources/KiwiDeskCore/Commands/KiwiCore+Commands.swift` | `04_API_Contract` |
| `Sources/KiwiDeskCore/Commands/KiwiCore+GapCommands.swift` | `05_GUI_Concept §3` |
| `Sources/KiwiDeskCore/Profiles/KiwiCore+NativeSpaces.swift` | `04_API_Contract §6` |
| `Sources/KiwiDeskCore/Service/ServiceManager.swift` | `04_API_Contract §10` |

The repo-wide grep for these names now returns nothing across `Sources/`, `Tests/`, `docs/`, and `scripts/`.

## Verification

- `swift build` — complete
- `swift test --skip ExecTests` — 1982 tests in 338 suites passed
- `swift test --filter ExecTests` — exit 0
- `scripts/lint.sh` — exit 0 (`Lint OK`; remaining output is the pre-existing sweet-spot file-length warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)