### PR TITLE
fix(gui): grey-don't-hide follow-ups — stuck disclosures, stale global gates (#527)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarGroups.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarGroups.swift
@@ -93,9 +93,24 @@ struct GlobalAppBarGroup: View {
             L("app_bar.global_colors.title", "Global colors")
         ) {
             AppBarColorGrid { inlineColors }
+                .modifier(
+                    GreyOut(active: !anyBarShown, help: noBarHelp)
+                )
+            // The gate sits on the drawer's CONTENT, never on the
+            // `DisclosureGroup` — a disabled disclosure refuses to
+            // toggle in either direction (owner-confirmed, #527),
+            // so gating the whole section left this one stuck in
+            // whatever state it was in and hid the colors it
+            // holds. The label stays live; the swatches dim.
             DisclosureGroup(isExpanded: $advancedColorsExpanded) {
                 AppBarColorGrid { advancedColors }
                     .padding(.top, 8)
+                    .modifier(
+                        GreyOut(
+                            active: !anyBarShown,
+                            help: noBarHelp
+                        )
+                    )
             } label: {
                 Text(
                     L("bars.advanced_colors", "Advanced colors")
@@ -103,7 +118,6 @@ struct GlobalAppBarGroup: View {
                 .font(.subheadline)
             }
         }
-        .modifier(GreyOut(active: !anyBarShown, help: noBarHelp))
     }
 
     @ViewBuilder private var behavior: some View {

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarLayoutGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarLayoutGroup.swift
@@ -39,20 +39,35 @@ struct LayoutAppBarGroup: View {
                 L("app_bar.layout.overrides", "Overrides"),
                 isExpanded: $overridesExpanded
             ) {
+                // The gate goes on the CONTENT, never the
+                // `DisclosureGroup` — a disabled disclosure
+                // refuses to expand (owner-confirmed on device,
+                // #527), so gating the whole thing left the
+                // stored values exactly as concealed as removing
+                // the rows would have, which is the one outcome
+                // the comment above says greying avoids. The
+                // label stays live: the user can open the drawer,
+                // read what is kept, and see it is not editable
+                // yet.
                 overrides
-            }
-            .modifier(
-                GreyOut(
-                    active: !bar.enabled,
-                    help: L(
-                        "app_bar.layout.overrides.disabled",
-                        "Turn on Show app bar to edit this "
-                            + "layout's overrides. They are kept "
-                            + "either way."
+                    .modifier(
+                        GreyOut(
+                            active: !bar.enabled,
+                            help: overridesDisabledHelp
+                        )
                     )
-                )
-            )
+            }
         }
+    }
+
+    /// Why the rows are dimmed, on the rows themselves — the
+    /// disclosure label stays live so this is reachable.
+    private var overridesDisabledHelp: String {
+        L(
+            "app_bar.layout.overrides.disabled",
+            "Turn on Show app bar to edit this layout's "
+                + "overrides. They are kept either way."
+        )
     }
 
     /// Split out so `DisclosureGroup` builds it lazily.

--- a/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarColorsGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarColorsGroup.swift
@@ -11,18 +11,34 @@ import SwiftUI
 /// (tab switch) — the app-wide disclosure precedent.
 struct SpaceBarColorsGroup: View {
     @ObservedObject var model: SettingsModel
+    /// Whether the bar is off, and the explanation to show while
+    /// it is. Taken as parameters rather than letting the caller
+    /// wrap this whole view in a `GreyOut`: the gate has to reach
+    /// the disclosure's *content* and skip its label, because a
+    /// disabled `DisclosureGroup` refuses to toggle in either
+    /// direction (owner-confirmed, #527) — wrapping it from
+    /// outside strands the drawer and hides the colors it holds.
+    var gatedOff: Bool = false
+    var gateHelp: String = ""
     @State private var advancedColorsExpanded = false
 
     private var style: Binding<SpaceBarStyle> {
         $model.config.settings.spaceBarStyle
     }
 
+    private var gate: GreyOut {
+        GreyOut(active: gatedOff, help: gateHelp)
+    }
+
     var body: some View {
         copyAppearance
+            .modifier(gate)
         accentLadder
+            .modifier(gate)
         DisclosureGroup(isExpanded: $advancedColorsExpanded) {
             AppBarColorGrid { advancedColors }
                 .padding(.top, 8)
+                .modifier(gate)
         } label: {
             Text(
                 L("bars.advanced_colors", "Advanced colors")

--- a/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarGroups.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarGroups.swift
@@ -71,8 +71,14 @@ struct SpaceBarEditorGroup: View {
         SettingsSection(
             L("space_bar.colors.title", "Space Bar colors")
         ) {
-            SpaceBarColorsGroup(model: model)
-                .modifier(GreyOut(active: !enabled, help: offHelp))
+            // Gate passed IN, not wrapped around: the group has
+            // to keep its "Advanced colors" disclosure label
+            // live (#527).
+            SpaceBarColorsGroup(
+                model: model,
+                gatedOff: !enabled,
+                gateHelp: offHelp
+            )
         }
     }
 

--- a/Sources/KiwiDesk/Settings/Components/Common/AutoGatedGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/AutoGatedGroup.swift
@@ -26,6 +26,14 @@ struct AutoGatedGroup<Gated: View>: View {
     /// behaviour (the App Bar sizes), keeping the caption's job to
     /// "name a source the control can't" rather than gloss "why".
     var caption: String? = nil
+    /// Whether the gated controls are genuinely inert. Defaults
+    /// to `isOn` — the common case, where this toggle is the only
+    /// thing that can silence them. A surface whose value can be
+    /// re-enabled elsewhere passes a narrower predicate: the
+    /// global Grid editor's steppers stay live for any space that
+    /// overrides auto-size OFF, and greying a control something
+    /// still reads is the worse direction (#520, #527).
+    var gatedIsInert: Bool? = nil
     @ViewBuilder let gated: Gated
 
     var body: some View {
@@ -37,7 +45,7 @@ struct AutoGatedGroup<Gated: View>: View {
                     .foregroundStyle(.secondary)
             }
             gated
-                .modifier(GreyOut(active: isOn))
+                .modifier(GreyOut(active: gatedIsInert ?? isOn))
         }
     }
 }

--- a/Sources/KiwiDesk/Settings/Components/Layouts/GridEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/GridEditor.swift
@@ -11,6 +11,43 @@ struct GridEditor: View {
         $model.config.settings.grid
     }
 
+    /// Whether any space's override satisfies `predicate`.
+    ///
+    /// A control on this GLOBAL editor is inert only when nothing
+    /// still reads it — and a per-space override can keep it live
+    /// after the global condition would silence it. Asking the
+    /// global alone greys a control that is running, the worse of
+    /// the two failure directions (#520 wrote the rule one level
+    /// down: ask the value that is actually read, never the
+    /// global; #527 found this pair still asking the global).
+    ///
+    /// Deliberately ignores whether that space also overrides the
+    /// gated value itself. If it does, the control is inert for
+    /// it and we leave it enabled anyway — erring toward enabled
+    /// is the safe direction here.
+    private func anyOverride(
+        _ predicate: (GridOverride) -> Bool
+    ) -> Bool {
+        model.config.settings.grid.override.values
+            .contains(where: predicate)
+    }
+
+    /// Fill-empty applies to dynamic grids only, so a rigid
+    /// global silences it — unless a space overrides its type
+    /// back to dynamic, which makes the global value live again.
+    private var fillEmptyIsInert: Bool {
+        model.config.settings.grid.type == .rigid
+            && !anyOverride { $0.type == .dynamic }
+    }
+
+    /// Auto-size supplies the dimensions, so it silences the
+    /// Columns/Rows steppers — unless a space overrides auto-size
+    /// OFF, which makes the global dimensions live for it.
+    private var dimensionsAreInert: Bool {
+        model.config.settings.grid.autoSize
+            && !anyOverride { $0.autoSize == false }
+    }
+
     var body: some View {
         SettingsSection(
             L("layout.grid.name", "Grid"),
@@ -73,12 +110,12 @@ struct GridEditor: View {
                 ),
                 isOn: grid.fillEmptySpace
             )
-            // Fill-empty only applies to dynamic grids; greyed
-            // (not hidden) in rigid so its value stays visible
-            // (see design-decisions "grey inapplicable controls").
-            .disabled(
-                model.config.settings.grid.type == .rigid
-            )
+            // Greyed (not hidden) so its value stays visible (see
+            // design-decisions "grey inapplicable controls").
+            // `GreyOut`, not a bare `.disabled`, so it dims the
+            // same way as its per-space twin — the two used to
+            // read differently for the same state (#527).
+            .modifier(GreyOut(active: fillEmptyIsInert))
             Divider()
             // Auto-size + its dimensions read as a distinct block
             // from the grid-fill behaviour above, mirroring the
@@ -103,7 +140,8 @@ struct GridEditor: View {
                 "Fits as many columns and rows as the "
                     + "screen allows, using the minimum "
                     + "window size above."
-            )
+            ),
+            gatedIsInert: dimensionsAreInert
         ) {
             StepperRow(
                 label: L("scroll_grid.columns", "Columns"),

--- a/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
@@ -63,10 +63,7 @@ struct BarsSection: View {
                 .spaceBarSharesEdgeWithAppBar
                 ? model.config.settings.spaceBarStyle.edge
                 : nil,
-            layoutBars: [
-                model.config.settings.monocle.appBar,
-                model.config.settings.scrolling.appBar,
-            ]
+            layoutBars: model.config.settings.appBarHosts
         )
         LayoutAppBarGroup(
             title: L("layout.monocle.name", "Monocle"),

--- a/Sources/KiwiDeskCore/App/KiwiCore+AppBar.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+AppBar.swift
@@ -148,13 +148,11 @@ extension KiwiCore {
     }
 
     /// The bar-hosting layout for a space mode, or nil for modes
-    /// that don't show a bar.
+    /// that don't show a bar. Delegates to the one list on
+    /// `TilingSettings` (#527) — do not re-enumerate the modes
+    /// here.
     func barHost(for mode: LayoutMode) -> AppBarHosting? {
-        switch mode {
-        case .monocle: return tiler.settings.monocle
-        case .scrolling: return tiler.settings.scrolling
-        default: return nil
-        }
+        tiler.settings.appBarHost(for: mode)
     }
 
     /// Drag-and-drop reorder from the bar: moves the item at

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Resolution.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Resolution.swift
@@ -174,10 +174,41 @@ extension TilingSettings {
     /// can't drift. Honors per-layout edge overrides.
     public var spaceBarSharesEdgeWithAppBar: Bool {
         guard spaceBarStyle.enabled else { return false }
-        return [monocle.appBar, scrolling.appBar].contains {
+        return appBarHosts.contains {
             $0.enabled
                 && $0.resolved(with: appBarStyle).edge
                     == spaceBarStyle.edge
+        }
+    }
+
+    /// The bar-hosting layout for a mode, or nil for modes that
+    /// show no bar. **The one place that decides which layouts
+    /// host an App Bar** — everything that asks "does this mode
+    /// show a bar?" or "any bar shown?" derives from here, so a
+    /// third hosting layout is one edit.
+    ///
+    /// The list had been hand-copied to three sites; a fourth
+    /// hosting layout added later would have left the Settings
+    /// copy claiming no bar is shown while one rendered, greying
+    /// a live editor (#527). `KiwiCore.barHost(for mode:)`
+    /// delegates here; its per-*space* twin necessarily keeps its
+    /// own switch, because it resolves per-space params — two
+    /// mirrors, which §2.4 allows, rather than three.
+    public func appBarHost(
+        for mode: LayoutMode
+    ) -> AppBarHosting? {
+        switch mode {
+        case .monocle: return monocle
+        case .scrolling: return scrolling
+        default: return nil
+        }
+    }
+
+    /// Every bar-hosting layout's per-layout bar, derived from
+    /// `appBarHost(for:)` rather than re-listed.
+    public var appBarHosts: [LayoutAppBar] {
+        LayoutMode.allCases.compactMap {
+            appBarHost(for: $0)?.appBar
         }
     }
 

--- a/docs/ui-patterns.md
+++ b/docs/ui-patterns.md
@@ -714,6 +714,20 @@ written down:
   the block above it lands at `0.25` and reads as broken rather
   than disabled. Write the inner predicate as
   `blockIsOn && ownRule`.
+- **Never gate a `DisclosureGroup` — gate its content.** A
+  disabled disclosure refuses to toggle in **either** direction
+  (owner-confirmed on device, #527): shut, it will not open, so
+  the values inside are as hidden as if the rows had been
+  removed — the one outcome greying exists to prevent; open, it
+  will not close, so the user is stranded in a wall of dimmed
+  controls. Put the `GreyOut` on the drawer's content and leave
+  the label live. That also means a block gate must not wrap a
+  section that *contains* a disclosure: push it down to the
+  siblings, or pass the gate into the child view
+  (`SpaceBarColorsGroup(gatedOff:gateHelp:)`) so it can place it
+  correctly. Expansion state is deliberately preserved across
+  the toggle — with the label live, closing is one click, and
+  auto-collapsing would lose a drawer the user opened on purpose.
 
 And one exemption worth stating: a control whose *only* consumer
 is off may still have a second one. The App Bar's "App symbol


### PR DESCRIPTION
Three of the four #527 follow-ups. Item 1 (the unclickable `?`
inside a greyed block) is deliberately left — see below.

## A greyed disclosure could not be opened

Owner found this on device, and it is the one that mattered:
with an App Bar off, its **Overrides** drawer will not open —
and if it was already open, it will not close either. A disabled
`DisclosureGroup` refuses to toggle in **both** directions.

That makes `AppBarLayoutGroup`'s own justification false. It
argued the drawer must be greyed rather than hidden because
removing the rows "actively concealed that the stored values are
PRESERVED" — but a drawer that will not open conceals them just
as thoroughly. The user gained one dimmed row for nothing, or a
wall of dimmed controls they could not dismiss.

The gate now sits on each drawer's **content**, leaving the
label live: open it, read what is kept, see it is not editable
yet. Three sites had the shape — the per-layout Overrides
drawer, and both "Advanced colors" disclosures, which were
stranded by a block gate wrapping the whole `SettingsSection`
around them. `SpaceBarColorsGroup` now takes `gatedOff` /
`gateHelp` rather than being wrapped from outside, because only
the child can place the gate around its own disclosure content.

Expansion state is preserved across the toggle rather than
auto-collapsing (owner's call): with the label live, closing is
one click, and auto-collapse would discard a drawer opened on
purpose.

## Two gates still asked the global

`GridEditor` greyed "Fill empty space" whenever the *global*
grid type was rigid, and Columns/Rows whenever *global*
auto-size was on — but a per-space override flips either, and
those spaces go on reading the global value. Dimmed while live
is the worse direction, and exactly what `ui-patterns.md`
already forbids ("ask the value that is actually read, never the
global").

`AutoGatedGroup` gains an optional `gatedIsInert` for this. Fill
empty space also moves from a bare `.disabled` to `GreyOut`, so
it dims the same way as its per-space twin — the two rendered
the same state differently.

## The bar-hosting list stops being a third copy

`BarsSection` hardcoded `[monocle.appBar, scrolling.appBar]`
alongside `spaceBarSharesEdgeWithAppBar` and `barHost(for:)`. A
third hosting layout added later and forgotten there would make
`anyBarShown` false while a bar renders — greying the whole
global editor *while it is live*, precisely the failure #520
exists to prevent.

`TilingSettings.appBarHost(for:)` is now the single decision
point; `appBarHosts` derives from it, `KiwiCore.barHost(for
mode:)` delegates, and the GUI reads the derived list. The
per-*space* twin keeps its own switch because it resolves
per-space params — two mirrors, which §2.4 allows, rather than
three.

## Item 1 is not here, on purpose

The unclickable `?` inside a `GreyOut` block cannot be patched:
a child cannot escape an ancestor's `.disabled` in SwiftUI. The
real fix is either a redesign where `GreyOut` publishes a flag
and each primitive disables only its own control — 29 gate sites
plus every row type, with a nasty failure mode where a missed
site becomes **dimmed but still clickable** — or moving the
explanation to the gate, which is block-level and lands as a
hover tooltip, the thing #94 rejected as insufficient. Worth
noting meanwhile: **10 of the 29 gates pass no `help:` at all**,
so those blocks currently explain nothing by any route. It wants
a `ui-designer` verdict, not a quick patch.

## Verification

`swift build`, `swift test --skip ExecTests` (1982),
`swift test --filter ExecTests` (14), `scripts/lint.sh` (exit
0), `npm run build` in `site/` — all green.

The disclosure fix is code-reasoned, not re-observed on device:
rebuild and toggle a bar off, then click its dimmed **Overrides**
triangle — it should open onto dimmed rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)