### PR TITLE
fix(gui): label the glow toggle as a noun phrase

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Appearance/FocusBorderEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/Appearance/FocusBorderEditor.swift
@@ -106,9 +106,14 @@ struct FocusBorderEditor: View {
         // A render trait of the ring like Width and Corners — a soft
         // bloom in the focused ring's hue (#358). Sits with the other
         // styling traits, no caption (the live preview above shows
-        // it on toggle); a11y gets the descriptive gloss.
+        // it on toggle); a11y gets the descriptive gloss. A noun
+        // phrase like its true siblings (Width, Corners), NOT the
+        // "Show X" family — that family gates an element other
+        // controls configure, while this toggles a trait; and the
+        // verb form was ambiguous in German ("Leuchten anzeigen"
+        // reads as "show lamps"). ui-designer verdict 2026-07-26.
         Toggle(
-            L("border.glow", "Show glow"),
+            L("border.glow", "Glow effect"),
             isOn: style.glow
         )
         .accessibilityLabel(

--- a/Sources/KiwiDeskCore/Resources/Locales/de.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/de.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "Entwurf aktualisiert — Abstände bleiben gespeichert, sobald Bedienungshilfen aktiv sind und du das Profil sicherst.",
   "border.focused_color": "Farbe",
   "border.focused_color.a11y": "Rahmenfarbe des fokussierten Fensters",
-  "border.glow": "Leuchten anzeigen",
   "border.glow.a11y": "Sanftes Leuchten um den Fokus-Rahmen",
   "border.title": "Fokus-Rahmen",
   "border.unfocused_color": "Farbe",

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -142,7 +142,7 @@
   "border.fit_gaps.updated_paused": "Draft updated — gaps persist once Accessibility is on and you save the profile.",
   "border.focused_color": "Color",
   "border.focused_color.a11y": "Focused window border color",
-  "border.glow": "Show glow",
+  "border.glow": "Glow effect",
   "border.glow.a11y": "Soft glow around the focus border",
   "border.title": "Focus border",
   "border.unfocused_color": "Color",

--- a/Sources/KiwiDeskCore/Resources/Locales/es.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/es.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "Borrador actualizado: los espacios se conservarán cuando Accesibilidad esté activada y guardes el perfil.",
   "border.focused_color": "Color",
   "border.focused_color.a11y": "Color del borde de ventana enfocada",
-  "border.glow": "Resplandor",
   "border.glow.a11y": "Resplandor suave alrededor del borde de foco",
   "border.title": "Bordes de ventana",
   "border.unfocused_color": "Color",

--- a/Sources/KiwiDeskCore/Resources/Locales/fr.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/fr.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "Brouillon mis à jour — les espacements seront conservés une fois l'Accessibilité activée et le profil enregistré.",
   "border.focused_color": "Couleur",
   "border.focused_color.a11y": "Couleur de bordure de la fenêtre ciblée",
-  "border.glow": "Effet de lueur",
   "border.glow.a11y": "Halo diffus autour de la bordure de focus",
   "border.title": "Bordures de fenêtre",
   "border.unfocused_color": "Couleur",

--- a/Sources/KiwiDeskCore/Resources/Locales/it.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/it.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "Bozza aggiornata: le spaziature verranno conservate quando l'Accessibilità sarà attiva e avrai salvato il profilo.",
   "border.focused_color": "Colore",
   "border.focused_color.a11y": "Colore del bordo della finestra attiva",
-  "border.glow": "Effetto bagliore",
   "border.glow.a11y": "Alone tenue attorno al bordo di fuoco",
   "border.title": "Bordi della finestra",
   "border.unfocused_color": "Colore",

--- a/Sources/KiwiDeskCore/Resources/Locales/ja.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/ja.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "下書きを更新しました。アクセシビリティをオンにしてプロファイルを保存すると、間隔が保持されます。",
   "border.focused_color": "カラー",
   "border.focused_color.a11y": "フォーカスされたウインドウの境界線のカラー",
-  "border.glow": "グロー効果",
   "border.glow.a11y": "フォーカスの境界線を囲む柔らかな光",
   "border.title": "ウインドウボーダー",
   "border.unfocused_color": "カラー",

--- a/Sources/KiwiDeskCore/Resources/Locales/ko.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/ko.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "초안이 업데이트되었습니다. 손쉬운 사용을 켜고 프로파일을 저장하면 간격이 유지됩니다.",
   "border.focused_color": "색상",
   "border.focused_color.a11y": "포커스된 윈도우의 테두리 색상",
-  "border.glow": "글로우 효과",
   "border.glow.a11y": "포커스 테두리를 감싸는 부드러운 광채",
   "border.title": "윈도우 테두리",
   "border.unfocused_color": "색상",

--- a/Sources/KiwiDeskCore/Resources/Locales/pt-BR.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/pt-BR.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "Rascunho atualizado — os espaçamentos serão mantidos quando a Acessibilidade estiver ativada e você salvar o perfil.",
   "border.focused_color": "Cor",
   "border.focused_color.a11y": "Cor da borda da janela em foco",
-  "border.glow": "Efeito de brilho",
   "border.glow.a11y": "Brilho suave ao redor da borda de foco",
   "border.title": "Bordas de janela",
   "border.unfocused_color": "Cor",

--- a/Sources/KiwiDeskCore/Resources/Locales/ru.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/ru.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "Черновик обновлён — отступы сохранятся, когда включишь «Универсальный доступ» и сохранишь профиль.",
   "border.focused_color": "Цвет",
   "border.focused_color.a11y": "Цвет рамки окна в фокусе",
-  "border.glow": "Показывать свечение",
   "border.glow.a11y": "Мягкое свечение вокруг рамки фокуса",
   "border.title": "Рамка фокуса",
   "border.unfocused_color": "Цвет",

--- a/Sources/KiwiDeskCore/Resources/Locales/zh-Hans.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/zh-Hans.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "草稿已更新。打开“辅助功能”并存储描述文件后，间距即会保留。",
   "border.focused_color": "颜色",
   "border.focused_color.a11y": "焦点窗口的边框颜色",
-  "border.glow": "发光效果",
   "border.glow.a11y": "焦点边框周围的柔和光晕",
   "border.title": "窗口边框",
   "border.unfocused_color": "颜色",

--- a/Sources/KiwiDeskCore/Resources/Locales/zh-Hant.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/zh-Hant.json
@@ -142,7 +142,6 @@
   "border.fit_gaps.updated_paused": "草稿已更新，間距會在「輔助使用」開啟且你儲存描述檔後保留。",
   "border.focused_color": "顏色",
   "border.focused_color.a11y": "焦點視窗邊框顏色",
-  "border.glow": "顯示光暈",
   "border.glow.a11y": "焦點邊框周圍的柔和光暈",
   "border.title": "焦點邊框",
   "border.unfocused_color": "顏色",


### PR DESCRIPTION
Owner-requested, ui-designer-endorsed: **"Show glow" → "Glow effect"**.

The "Show X" family gates an element other controls configure; glow is a render trait whose true siblings are the bare nouns Width and Corners. German "Leuchten anzeigen" could misread as "show lamps"; "Leuchteffekt"-style compounds are unambiguous. Meaning shift → `scripts/drop-key border.glow`, so all locales fall back to the new English and the key reappears on each to-translate list. Wire name `border.glow` unchanged.

Verified: build, localization guard suites, lint — green locally (CI still down repo-wide; local gate per AGENTS §3.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)