### PR TITLE
fix(gui): centre the onboarding window instead of hiding it under the menu bar

### DIFF
--- a/Sources/KiwiDesk/AppDelegate+Onboarding.swift
+++ b/Sources/KiwiDesk/AppDelegate+Onboarding.swift
@@ -59,14 +59,23 @@ extension AppDelegate {
             "onboarding.window.title",
             "KiwiDesk Setup"
         )
-        window.contentView = NSHostingView(
+        let host = NSHostingView(
             rootView: LocaleScopedRoot {
                 OnboardingView(model: onboardingModel)
             }
             .environmentObject(LocalizationManager.shared)
         )
+        window.contentView = host
         window.isReleasedWhenClosed = false
         window.delegate = self
+        // Size BEFORE centering. `center()` on a still-zero-sized
+        // window puts its bottom-left corner at the screen centre;
+        // the SwiftUI frame then grows the window upward from
+        // there, so the wizard opened tucked under the menu bar
+        // instead of centred. Read the size from the view rather
+        // than repeating `OnboardingView`'s own frame here — two
+        // copies would drift the moment a step needs more room.
+        window.setContentSize(host.fittingSize)
         window.center()
         // Stays `.normal` until Accessibility is granted — see
         // `floatOnboardingAboveManagedWindows()`. Floating it now


### PR DESCRIPTION
## The bug

`AppDelegate+Onboarding.swift` created the wizard with
`contentRect: .zero` and called `window.center()` before anything had
sized it. Centering a zero-sized window puts its **bottom-left corner**
at the screen centre; SwiftUI's `.frame(width: 480, height: 360)` then
sized the content afterwards, and AppKit grew the frame *upward* from
that origin.

Reported by the owner as the setup window appearing "always on the top,
very close to my usual menu bar".

## Measured

Reproduced the exact construction sequence in isolation (both orderings,
windows never ordered on screen) against a 1728x1085 visible frame:

```
OLD  frame=480x392 topEdgeFromScreenTop=-88pt
NEW  frame=480x392 topEdgeFromScreenTop=174pt
```

The old ordering put the window's top edge **88pt above the visible
area** — partly behind the menu bar. The fix lands it fully on screen.
(392 rather than 360 is the title bar; `center()` biasing above true
centre is standard AppKit behaviour, not a residual bug.)

## The fix

Size the window from the hosting view's `fittingSize` before centering.
The size is read from the view rather than repeating `OnboardingView`'s
own `.frame` here, so the two cannot drift when a step needs more room.

## Verification

`swift build` clean, `scripts/lint.sh` exit 0. Not eye-confirmed on
device by me — the debug binary turned out to still hold its
Accessibility grant, so launching it managed windows rather than showing
onboarding. The owner can confirm via the menu-bar warning row, which
reopens the same wizard at the grant step through
`showAccessibilityHelp()`.

## Not included

A `ui-designer` consult on the wider first-run flow recommended keeping
onboarding and Settings as two separate windows (the same wizard is
reused for mid-session permission revoke, so merging would let that path
take over the whole Settings window and duplicate `PermissionPausedBanner`).
It also suggested a size bump to ~560x420 and a cross-fade hand-off —
both deliberately left out here, since it was reasoning about a
perceived seam without knowing about this positioning bug.