### PR TITLE
fix(localization): run the feature-name guard in merge-keys too

### DIFF
--- a/Tests/KiwiDeskCoreTests/LocalizationProductNameGuardTests.swift
+++ b/Tests/KiwiDeskCoreTests/LocalizationProductNameGuardTests.swift
@@ -80,6 +80,67 @@ struct LocalizationProductNameGuardTests {
         #expect(result.status == 0)
     }
 
+    /// **Presence, not parity** — the semantics every other pass
+    /// fixture here happens to leave unpinned, because each is 1:1
+    /// in mention count. The guard asks whether the name survives
+    /// at all, never how often: dropping a redundant repetition of
+    /// a proper noun is normal translation practice, and the defect
+    /// this was written for was locales *renaming* the feature,
+    /// never mentioning it fewer times.
+    ///
+    /// Unpinned, "tighten it to parity" is a one-line change that
+    /// breaks no test — and #561 was filed proposing exactly that,
+    /// as new work, by the author of the shipped guard. Prose in
+    /// `docs/translating.md` did not prevent that; this does.
+    @Test(
+        "fewer mentions than the English still passes",
+        arguments: [
+            (
+                "de",
+                "The App Bar lists windows. The App Bar is optional.",
+                "Die App Bar listet Fenster. Sie ist optional."
+            ),
+            (
+                "fr",
+                "Space Bar colors and Space Bar position",
+                "Couleurs et position de la Space Bar"
+            ),
+        ]
+    )
+    func fewerMentionsPasses(
+        locale: String,
+        english: String,
+        value: String
+    ) throws {
+        let result = try ProductNameFixture.check(
+            locale: locale,
+            english: english,
+            value: value
+        )
+        #expect(result.status == 0)
+    }
+
+    /// The complementary half: presence is per **name**, so a value
+    /// naming both bars must keep both. That is not branding, it is
+    /// meaning — the real `bars.same_edge` string contrasts them
+    /// ("Space Bar sits at the screen edge, App Bar sits next to
+    /// the windows"), and a translation keeping one turns a
+    /// contrast into a tautology. Softening the rule to "any one
+    /// name is enough" would let that through.
+    @Test("keeping only one of two names still fails")
+    func keepingOnlyOneNameFails() throws {
+        let result = try ProductNameFixture.check(
+            locale: "de",
+            english:
+                "Space Bar sits at the edge, App Bar sits inside.",
+            value:
+                "Die Space Bar sitzt am Rand, die App-Leiste "
+                + "sitzt innen."
+        )
+        #expect(result.status != 0)
+        #expect(result.stderr.contains("App Bar"))
+    }
+
     /// Capitalization is the locale's own business — a lower-cased
     /// "app bar" still names the thing, and flagging it would turn
     /// a style guide into a build failure.

--- a/Tests/KiwiDeskCoreTests/LocalizationProductNameGuardTests.swift
+++ b/Tests/KiwiDeskCoreTests/LocalizationProductNameGuardTests.swift
@@ -89,9 +89,13 @@ struct LocalizationProductNameGuardTests {
     /// never mentioning it fewer times.
     ///
     /// Unpinned, "tighten it to parity" is a one-line change that
-    /// breaks no test — and #561 was filed proposing exactly that,
-    /// as new work, by the author of the shipped guard. Prose in
-    /// `docs/translating.md` did not prevent that; this does.
+    /// breaks no test and reads like a strengthening, which is
+    /// what makes it likely. It is a regression: parity rejects a
+    /// translation naming the bar once where the English named it
+    /// twice — ordinary practice, not a dropped name — and pushes
+    /// the translator toward a literal, worse sentence to satisfy
+    /// the tool. `docs/translating.md` states the rule; this makes
+    /// breaking it fail.
     @Test(
         "fewer mentions than the English still passes",
         arguments: [

--- a/Tests/KiwiDeskCoreTests/MergeKeysContentGuardTests.swift
+++ b/Tests/KiwiDeskCoreTests/MergeKeysContentGuardTests.swift
@@ -83,6 +83,78 @@ struct MergeKeysContentGuardTests {
         #expect(run.stdout.contains("3 dropped"))
     }
 
+    /// The feature-name guard is scoped to **Latin-script**
+    /// locales, so it cannot ride the `ja` worksheet above — in
+    /// Japanese an untouched "App Bar" is a foreign body and
+    /// adapting it is a real editorial call. German is the locale
+    /// the guard was written for.
+    ///
+    /// This is the predicate `merge-keys` was missing: it gated the
+    /// other four, so a renamed feature name merged cleanly and
+    /// then failed `extract-keys --check` at commit time, with the
+    /// worksheet already unlinked.
+    @Test("a renamed feature name is skipped, one mention is kept")
+    func renamedFeatureNameIsSkipped() throws {
+        let fixture = try makeRepoShapedFixture(
+            prefix: "kiwi-merge-product",
+            locales: [
+                "en.json": """
+                {
+                  "b.renamed": "Show the App Bar",
+                  "b.compound": "Space Bar colors",
+                  "b.fewer": "The App Bar lists windows. \
+                The App Bar is optional."
+                }
+                """,
+                "de.json": "{\n  \"b.kept\": \"Vorhanden\"\n}",
+                "missing_de.json": """
+                {
+                  "b.renamed": {
+                    "source": "Show the App Bar",
+                    "translation": "Die App-Leiste anzeigen"
+                  },
+                  "b.compound": {
+                    "source": "Space Bar colors",
+                    "translation": "Space-Bar-Farben"
+                  },
+                  "b.fewer": {
+                    "source": "The App Bar lists windows. \
+                The App Bar is optional.",
+                    "translation": "Die App Bar listet Fenster."
+                  }
+                }
+                """,
+            ]
+        )
+        defer { fixture.cleanup() }
+        let run = try runRepoScript(
+            "merge-keys",
+            arguments: ["de"],
+            in: fixture,
+            repoRoot: repoRoot
+        )
+        #expect(run.status == 0)
+
+        let merged = try fixture.decodeLocale("de.json")
+        #expect(merged["b.renamed"] == nil)
+        #expect(merged["b.kept"] == "Vorhanden")
+        // German compounds a two-word proper noun onto the next
+        // noun with hyphens, so this IS keeping the name.
+        #expect(merged["b.compound"] == "Space-Bar-Farben")
+        // Presence, not parity: the English names the bar twice,
+        // one mention satisfies the guard. Pinned here as well as
+        // in `LocalizationProductNameGuardTests` because a merge
+        // that silently dropped this row would push a translator
+        // toward a literal, worse sentence.
+        #expect(merged["b.fewer"] == "Die App Bar listet Fenster.")
+
+        #expect(
+            run.stderr.contains("feature name(s) App Bar")
+        )
+        #expect(run.stderr.contains("App-Leiste"))
+        #expect(run.stdout.contains("1 dropped"))
+    }
+
     /// The skipped keys are absent from `ja.json` by construction,
     /// which is the precondition `write_missing`'s re-mint recovery
     /// needs — so a translator really can get them back.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -252,14 +252,17 @@ separators are flattened, so German's "Space-Bar-Farben" counts
 as keeping it; case is the locale's own. What it rejects is a
 translation with *zero* mentions.
 
-That distinction is the whole entry, because the guard's author
-misremembered it and filed
-[#561](https://github.com/KiwiCanopy/KiwiDesk/issues/561)
-proposing a per-key opt-out to buy back flexibility the guard
-already allows. Re-deriving it is easy and the conclusion is
-not, so it is written down and pinned by
-`LocalizationProductNameGuardTests` (a parity implementation
-fails two of its arguments).
+The distinction matters because tightening presence to parity
+reads like a strengthening and is a regression. Dropping a
+redundant repetition of a proper noun is ordinary translation
+practice, so a parity check rejects correct work and pushes the
+translator toward a literal, worse sentence to satisfy the tool.
+The defect this guard exists to catch is a locale *renaming* the
+feature; a locale naming it fewer times has not renamed
+anything. `LocalizationProductNameGuardTests` pins the
+distinction — a parity implementation fails two of its
+arguments — because a rule that is only written down invites the
+plausible-looking tightening.
 
 **No exemption file, and none is needed** — the escape hatches
 are ordered and all better than one:
@@ -286,15 +289,19 @@ sentence wrong rather than tighter. That is why presence is
 per-name.
 
 **Growth clause.** Obligation scales with authored English
-mentions, not list length, so adding a name is cheaper than it
-looks. The real hazard is that the check is case-insensitive and
-so cannot tell a *referential* mention from a *descriptive* one.
-Both current names are two-word coinages that only ever occur
-referentially; a future name built from ordinary words would
-fire on incidental prose, and that is when someone will re-argue
-the opt-out. So the existing rule in `PRODUCT_NAMES` — argue a
-name in, never add one to silence a hit — also bars a name that
-can occur descriptively.
+mentions, not with list length, so adding a name binds only the
+keys whose English already contains it — cheaper than it looks.
+The constraint that does not scale is that the check is
+case-insensitive and therefore cannot tell a *referential*
+mention from a *descriptive* one. Both current names are
+two-word coinages that only ever occur referentially, so the
+question never arises. A name built from ordinary words would
+fire on incidental prose that was never naming the feature,
+demanding a verbatim keep for a sentence that has nothing to
+keep — a guard failing on correct copy, which is the one failure
+that makes an exemption file look necessary. So the existing
+rule in `PRODUCT_NAMES` — argue a name in, never add one to
+silence a hit — also bars a name that can occur descriptively.
 
 ### Layout navigation & overflow models
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -234,6 +234,68 @@ it buys something back — Sparkle's update path is first
 exercised against a real previous release instead of being
 debugged on the release everyone downloads.
 
+### The feature-name guard checks presence, and needs no opt-out
+
+**[Principle]**
+
+`dropped_product_names` requires a Latin-script locale to carry
+each `PRODUCT_NAMES` entry the English carries — "App Bar",
+"Space Bar" — because the GUI ships those names untranslated, so
+prose renaming them points at something the interface does not
+call that. Search sharpened it: a destination name is now a
+breadcrumb segment, so an invented name appears on every hit
+inside that pane.
+
+**It is a presence check, not a parity check.** One mention
+satisfies it however often the English repeats the name;
+separators are flattened, so German's "Space-Bar-Farben" counts
+as keeping it; case is the locale's own. What it rejects is a
+translation with *zero* mentions.
+
+That distinction is the whole entry, because the guard's author
+misremembered it and filed
+[#561](https://github.com/KiwiCanopy/KiwiDesk/issues/561)
+proposing a per-key opt-out to buy back flexibility the guard
+already allows. Re-deriving it is easy and the conclusion is
+not, so it is written down and pinned by
+`LocalizationProductNameGuardTests` (a parity implementation
+fails two of its arguments).
+
+**No exemption file, and none is needed** — the escape hatches
+are ordered and all better than one:
+
+1. Reword around the name. All 125 name-bearing translations
+   across the five Latin locales did this, none contorted.
+2. If the name is redundant under its section header, delete it
+   from the **English**. That lifts the obligation in every
+   locale at once and improves the English — the GUI already
+   does this (`SpaceBarGroups`' caption omits the name its
+   header supplies), so the obligation is *authored*, not
+   imposed. An opt-out would invert this, letting locales
+   diverge from an English redundancy nobody fixed.
+3. `scripts/drop-key --locale <locale> <key>` retires one
+   locale's value to the English fallback. A loud escape, which
+   is the point.
+
+Trade-off: a translator who wants the name gone entirely must
+change the English or drop the key. Accepted — no English value
+repeats a single name, and the only multi-mention strings
+*contrast* the two bars ("Space Bar sits at the screen edge, App
+Bar sits next to the windows"), where dropping one makes the
+sentence wrong rather than tighter. That is why presence is
+per-name.
+
+**Growth clause.** Obligation scales with authored English
+mentions, not list length, so adding a name is cheaper than it
+looks. The real hazard is that the check is case-insensitive and
+so cannot tell a *referential* mention from a *descriptive* one.
+Both current names are two-word coinages that only ever occur
+referentially; a future name built from ordinary words would
+fire on incidental prose, and that is when someone will re-argue
+the opt-out. So the existing rule in `PRODUCT_NAMES` — argue a
+name in, never add one to silence a hit — also bars a name that
+can occur descriptively.
+
 ### Layout navigation & overflow models
 
 **[Map]**

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -510,7 +510,14 @@ of the locale set, and one of those is a heuristic:
   ("Die App-Leiste", "Barra delle app") describes something the
   interface does not call that. Keep the name verbatim and
   translate around it: "Mostra la App Bar", "Couleurs de la
-  Space Bar". Capitalization is yours ("App bar" is fine).
+  Space Bar". Capitalization is yours ("App bar" is fine), and so
+  is compounding — German's "Space-Bar-Farben" keeps the name,
+  because separators are flattened before the comparison.
+  **One mention is enough.** The check asks whether the name
+  survives, never how often: if the English names a bar twice and
+  your sentence reads better naming it once, that passes. Keep
+  each name the English carries, though — a string contrasting
+  the two bars needs both, or the contrast collapses.
   **Latin-script locales only** — the exact complement of the
   rule above, and for the mirror reason: in a Japanese or Russian
   sentence the English phrase is a foreign body, so adapting it

--- a/scripts/merge-keys
+++ b/scripts/merge-keys
@@ -77,6 +77,7 @@ import sys
 from pathlib import Path
 
 from localization_guards import (
+    dropped_product_names,
     english_residue,
     foreign_scripts,
     placeholder_drift,
@@ -143,6 +144,15 @@ def _content_defect(
     drift = placeholder_drift(value, english)
     if drift:
         return f"{drift} relative to the English"
+    dropped = dropped_product_names(locale, value, english)
+    if dropped:
+        return (
+            "translates the untranslated feature name(s) "
+            f"{', '.join(dropped)}"
+        )
+    # Ordered above the `residue` gate to match `check_content`:
+    # the feature-name guard is scoped by script, not by corpus,
+    # so site mode runs it too.
     if not residue:
         return None
     left = english_residue(locale, value, english)


### PR DESCRIPTION
Closes the loose ends the `dropped_product_names` guard (#558) left, and settles #561.

## 1. `merge-keys` was missing the guard — a real bug

`scripts/merge-keys` imported four of the five per-value predicates from `localization_guards`, but not `dropped_product_names`. Its own docstring states the contract it was breaking:

> a divergent copy here would admit exactly what the gate rejects, so a translator would merge cleanly and then be unable to commit.

That was live: a translation renaming "App Bar" to "App-Leiste" merged into the catalog, then failed `extract-keys --check` at commit time — with the worksheet already unlinked, so the transcript was the only copy of the text left. This is precisely the ergonomic pain #561 anticipated, arriving at the worst possible moment.

Ordered above the `residue` gate to match `check_content`: the feature-name guard is scoped by script, not by corpus, so site mode runs it too.

AGENTS.md §5 claims "`merge-keys` runs the per-value guards so contamination never lands" — that sentence is now true.

## 2. Presence-not-parity was unpinned

Every existing pass fixture in `LocalizationProductNameGuardTests` is 1:1 in mention count, so nothing failed if the check were tightened to parity. Two new arguments pin it; both fail under a parity implementation (verified by patching the guard and re-running).

Parity reads like a strengthening, which is what makes it a likely edit — and it is a regression: it rejects a translation naming the bar once where the English named it twice, which is ordinary practice rather than a dropped name. #561 proposed exactly that tightening as new work, so the prose alone clearly was not enough. That prose also read stricter than the code, omitting that fewer mentions are fine. Both are fixed.

## 3. The #561 decision, recorded

New `[Principle]` entry in `docs/design-decisions.md`: **no per-key opt-out.** The escape hatches, in order, are all better than one:

1. Reword around the name — all 125 name-bearing translations across the five Latin locales did this, none contorted
2. If the name is redundant under its section header, delete it from the **English** — lifts the obligation in every locale at once, and the GUI already does this (`SpaceBarGroups`' caption omits the name its header supplies)
3. `scripts/drop-key --locale <locale> <key>` — a loud per-key escape that already exists

Supporting evidence, measured against the corpus:

| | de | es | fr | it | pt-BR |
|---|---|---|---|---|---|
| name-bearing keys | 25/25 | 25/25 | 25/25 | 25/25 | 25/25 |
| guard failures | 0 | 0 | 0 | 0 | 0 |

And **no English value repeats a single product name** (0 of 815). The three with more than one mention name *two different* bars once each and are contrastive — dropping one makes the sentence wrong, not tighter. That is why presence is per-name, pinned by a new test.

## Verification

- `swift test` — 2092 tests in 359 suites, 0 failures (68.2s)
- `scripts/lint.sh` — exit 0
- Both new guards proven to **fail** without their fix, not just to pass with it

Refs #558.

Fixes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

