### PR TITLE
refactor(settings): collapse navigation state behind model.nav

### DIFF
--- a/Sources/KiwiDesk/Settings/CrossReferenceLink.swift
+++ b/Sources/KiwiDesk/Settings/CrossReferenceLink.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// Cross-tab navigation for the settings detail pane: the view
+/// owning the sidebar selection injects a navigator, and deep
+/// sections render quiet links ("Appearance ▸ App Bar") where
+/// their prose points at a control that lives on another tab —
+/// a pointer the user can follow instead of a dead end.
+
+private struct SettingsNavigateKey: EnvironmentKey {
+    static let defaultValue: @MainActor (SettingsDestination) -> Void = { _ in
+    }
+}
+
+extension EnvironmentValues {
+    /// Jumps the settings window to a sidebar destination.
+    var settingsNavigate: @MainActor (SettingsDestination) -> Void
+    {
+        get { self[SettingsNavigateKey.self] }
+        set { self[SettingsNavigateKey.self] = newValue }
+    }
+}
+
+/// The standard "lives elsewhere" row: a caption sentence
+/// ending in a tab link, so every pointer at another tab reads
+/// the same and the wording can't drift per section.
+struct CrossReferenceRow: View {
+    let prose: String
+    let linkTitle: String
+    let destination: SettingsDestination
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(prose)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            CrossReferenceLink(linkTitle, to: destination)
+        }
+    }
+}
+
+/// A quiet inline tab link in the make-default link's language
+/// (underlined caption, hover lift + pointing hand) so every
+/// "lives elsewhere" pointer reads and acts the same.
+struct CrossReferenceLink: View {
+    let title: String
+    let destination: SettingsDestination
+    @Environment(\.settingsNavigate) private var navigate
+
+    init(_ title: String, to destination: SettingsDestination) {
+        self.title = title
+        self.destination = destination
+    }
+
+    var body: some View {
+        Button {
+            navigate(destination)
+        } label: {
+            Text(title).underline()
+        }
+        .buttonStyle(.plain)
+        .font(.caption)
+        .linkHover()
+    }
+}

--- a/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
@@ -25,12 +25,12 @@ struct BarsSection: View {
                     // selection lives on the model (#277) so a
                     // search hit on a `space_bar.*` header can
                     // open the editor that renders it.
-                    BarEditorPicker(selection: $model.barEditor)
+                    BarEditorPicker(selection: $model.nav.barEditor)
                     Text(switchCaption)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-                switch model.barEditor {
+                switch model.nav.barEditor {
                 case .appBar: appBarEditor
                 case .spaceBar:
                     SpaceBarEditorGroup(model: model)

--- a/Sources/KiwiDesk/Settings/Sections/LayoutDefaultsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/LayoutDefaultsSection.swift
@@ -25,8 +25,8 @@ struct LayoutDefaultsSection: View {
     /// most-used-mode landing below survives.
     private var selected: Binding<LayoutMode> {
         Binding(
-            get: { model.layoutModeTab ?? initialMode },
-            set: { model.layoutModeTab = $0 }
+            get: { model.nav.layoutModeTab ?? initialMode },
+            set: { model.nav.layoutModeTab = $0 }
         )
     }
 
@@ -60,13 +60,14 @@ struct LayoutDefaultsSection: View {
         // re-deriving `initialMode`, so adding a space in another
         // tab could move this one under the user.
         //
-        // The latch is cleared by `SettingsModel.resetSurfaces()`
-        // — on window open and on an edit-target switch — so this
-        // still re-derives per visit in the cases that matter,
-        // which is what it did as view-local `@State`.
+        // The latch is cleared by
+        // `SettingsNavigation.resetSurfaces()` — on window open
+        // and on an edit-target switch — so this still re-derives
+        // per visit in the cases that matter, which is what it did
+        // as view-local `@State`.
         .onAppear {
-            if model.layoutModeTab == nil {
-                model.layoutModeTab = initialMode
+            if model.nav.layoutModeTab == nil {
+                model.nav.layoutModeTab = initialMode
             }
         }
     }

--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -36,44 +36,13 @@ final class SettingsModel: ObservableObject {
     /// against the as-loaded baselines, not a latched flag —
     /// manually undoing an edit clears the footer again.
     @Published var isDirty = false
-    /// A one-shot navigation request: a sidebar destination, the
-    /// local surface to switch to, and optionally a label to
-    /// scroll to and flash. Serves both the read-only shortcuts
-    /// panel's "Edit in Settings…" bridge (#326, destination
-    /// only) and a sidebar search hit (#277, full anchor).
-    ///
-    /// `SettingsView` applies the destination and surface; the
-    /// detail pane's scroll driver performs the reveal and clears
-    /// this. A request that arrives while the raw Lua editor is
-    /// showing therefore lingers rather than being dropped, and
-    /// resolves when the visual editor comes back — the detail
-    /// pane is where a scroll target can exist at all.
-    @Published var pendingReveal: SettingsAnchor?
-    /// The flash in progress. Published into the environment so
-    /// each anchored view can recognize itself; nil between
-    /// reveals. Written only through `startFlash` / `endFlash`,
-    /// which own the re-trigger token.
-    @Published private(set) var flash: SettingsFlash?
-    private var flashToken = 0
-    /// Phase 2 of a reveal: the anchor whose pane is now showing
-    /// and can be scrolled. Minted by `SettingsView.apply` once
-    /// the destination and surface are set, consumed by the
-    /// detail pane's scroll driver — see `pendingReveal` for why
-    /// the two phases are separate fields.
-    @Published var pendingScroll: String?
-    /// The Layout Defaults mode tab, and the Bars editor behind
-    /// the App Bar / Space Bar switch.
-    ///
-    /// On the model rather than in the owning views' `@State`
-    /// (#277): a search hit on a mode-gated or bar-gated control
-    /// has to select the surface that renders it before there is
-    /// anything to scroll to, and view-local state cannot be set
-    /// from outside. `layoutModeTab` starts nil so the section
-    /// can still land on the profile's most-used mode the first
-    /// time it appears; a user's later pick, and a reveal, both
-    /// write it.
-    @Published var layoutModeTab: LayoutMode?
-    @Published var barEditor: BarEditor = .spaceBar
+    /// The window's transient navigation state — the one-shot
+    /// reveal request, its two-phase scroll/flash, and the local
+    /// surface selections (Layout mode tab, Bars editor). Behind
+    /// one `@Published` so this file stays under the 350-line
+    /// ceiling as #277 part 2 grows the set; a value type, so
+    /// `$model.nav.barEditor` still projects a `Binding`.
+    @Published var nav = SettingsNavigation()
     /// Which sidebar row is selected.
     ///
     /// Held here rather than as `@State` in `SettingsView`
@@ -104,56 +73,6 @@ final class SettingsModel: ObservableObject {
     /// from model staleness (a space that appeared live while
     /// the dashboard sat open) — see `KiwiCore.mergeLiveSpaces`.
     var seedSpaces: [SpaceID] = []
-
-    /// Forgets both surface selections, so they re-derive their
-    /// defaults. For window open, which re-asserts `destination`
-    /// for the same reason.
-    ///
-    /// Needed because moving them off view-local `@State` (#277)
-    /// silently promoted two per-visit landings to
-    /// process-lifetime ones: Layout Defaults re-derived the
-    /// profile's most-used mode on every mount, and Bars always
-    /// opened on the Space Bar (both ui-designer calls).
-    func resetSurfaces() {
-        resetLayoutModeTab()
-        barEditor = .spaceBar
-    }
-
-    /// Just the mode tab — for an **edit-target switch**, where a
-    /// different profile means a different most-used mode.
-    ///
-    /// Separate from `resetSurfaces` because that reasoning covers
-    /// only this one: `barEditor`'s default is a fixed design call
-    /// with no profile dependence, so resetting it here would
-    /// throw a user comparing App Bar colors across profiles back
-    /// to the Space Bar editor mid-task.
-    func resetLayoutModeTab() {
-        layoutModeTab = nil
-    }
-
-    /// Starts a flash on `anchor`, bumping the token so that
-    /// revealing the same anchor twice still re-fires (#277).
-    func startFlash(_ anchor: String) -> Int {
-        flashToken += 1
-        flash = SettingsFlash(
-            anchor: anchor,
-            token: flashToken
-        )
-        return flashToken
-    }
-
-    /// Ends the flash, if `token` is still the current one.
-    ///
-    /// Must be called: `SearchRevealFlash` uses `.task(id:)`,
-    /// which runs on *appear* as well as on change, so a value
-    /// left standing re-washes the card every time the user
-    /// navigates back to it — no user action involved. The token
-    /// check makes a late finisher from a superseded flash unable
-    /// to cancel the current one.
-    func endFlash(token: Int) {
-        guard flash?.token == token else { return }
-        flash = nil
-    }
 
     func recomputeDirty() {
         isDirty =

--- a/Sources/KiwiDesk/Settings/SettingsNavigation.swift
+++ b/Sources/KiwiDesk/Settings/SettingsNavigation.swift
@@ -1,64 +1,101 @@
-import SwiftUI
+import KiwiDeskCore
 
-/// Cross-tab navigation for the settings detail pane: the view
-/// owning the sidebar selection injects a navigator, and deep
-/// sections render quiet links ("Appearance ▸ App Bar") where
-/// their prose points at a control that lives on another tab —
-/// a pointer the user can follow instead of a dead end.
+/// The Settings window's transient navigation state, collapsed
+/// behind one `@Published var nav` on `SettingsModel` (#277).
+///
+/// A value type on purpose: `$model.nav.barEditor` still projects
+/// a `Binding`, so call sites keep their shape while the model
+/// file stays under the 350-line ceiling as part 2 grows this set
+/// (drawer expansions, the Shortcuts mode strip). Everything here
+/// is a one-shot navigation request or a local surface selection —
+/// never edited config, which stays on the model.
+struct SettingsNavigation {
+    /// A one-shot navigation request: a sidebar destination, the
+    /// local surface to switch to, and optionally a label to
+    /// scroll to and flash. Serves both the read-only shortcuts
+    /// panel's "Edit in Settings…" bridge (#326, destination
+    /// only) and a sidebar search hit (#277, full anchor).
+    ///
+    /// `SettingsView` applies the destination and surface; the
+    /// detail pane's scroll driver performs the reveal and clears
+    /// this. A request that arrives while the raw Lua editor is
+    /// showing therefore lingers rather than being dropped, and
+    /// resolves when the visual editor comes back — the detail
+    /// pane is where a scroll target can exist at all.
+    var pendingReveal: SettingsAnchor?
+    /// The flash in progress. Read into the environment so each
+    /// anchored view can recognize itself; nil between reveals.
+    /// Written only through `startFlash` / `endFlash`, which own
+    /// the re-trigger token.
+    private(set) var flash: SettingsFlash?
+    private var flashToken = 0
+    /// Phase 2 of a reveal: the anchor whose pane is now showing
+    /// and can be scrolled. Minted by `SettingsView.apply` once
+    /// the destination and surface are set, consumed by the
+    /// detail pane's scroll driver — see `pendingReveal` for why
+    /// the two phases are separate fields.
+    var pendingScroll: String?
+    /// The Layout Defaults mode tab, and the Bars editor behind
+    /// the App Bar / Space Bar switch.
+    ///
+    /// On the model rather than in the owning views' `@State`
+    /// (#277): a search hit on a mode-gated or bar-gated control
+    /// has to select the surface that renders it before there is
+    /// anything to scroll to, and view-local state cannot be set
+    /// from outside. `layoutModeTab` starts nil so the section
+    /// can still land on the profile's most-used mode the first
+    /// time it appears; a user's later pick, and a reveal, both
+    /// write it.
+    var layoutModeTab: LayoutMode?
+    var barEditor: BarEditor = .spaceBar
 
-private struct SettingsNavigateKey: EnvironmentKey {
-    static let defaultValue: @MainActor (SettingsDestination) -> Void = { _ in
+    /// Forgets both surface selections, so they re-derive their
+    /// defaults. For window open, which re-asserts `destination`
+    /// for the same reason.
+    ///
+    /// Needed because moving them off view-local `@State` (#277)
+    /// silently promoted two per-visit landings to
+    /// process-lifetime ones: Layout Defaults re-derived the
+    /// profile's most-used mode on every mount, and Bars always
+    /// opened on the Space Bar (both ui-designer calls).
+    mutating func resetSurfaces() {
+        resetLayoutModeTab()
+        barEditor = .spaceBar
     }
-}
 
-extension EnvironmentValues {
-    /// Jumps the settings window to a sidebar destination.
-    var settingsNavigate: @MainActor (SettingsDestination) -> Void
-    {
-        get { self[SettingsNavigateKey.self] }
-        set { self[SettingsNavigateKey.self] = newValue }
-    }
-}
-
-/// The standard "lives elsewhere" row: a caption sentence
-/// ending in a tab link, so every pointer at another tab reads
-/// the same and the wording can't drift per section.
-struct CrossReferenceRow: View {
-    let prose: String
-    let linkTitle: String
-    let destination: SettingsDestination
-
-    var body: some View {
-        HStack(spacing: 4) {
-            Text(prose)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            CrossReferenceLink(linkTitle, to: destination)
-        }
-    }
-}
-
-/// A quiet inline tab link in the make-default link's language
-/// (underlined caption, hover lift + pointing hand) so every
-/// "lives elsewhere" pointer reads and acts the same.
-struct CrossReferenceLink: View {
-    let title: String
-    let destination: SettingsDestination
-    @Environment(\.settingsNavigate) private var navigate
-
-    init(_ title: String, to destination: SettingsDestination) {
-        self.title = title
-        self.destination = destination
+    /// Just the mode tab — for an **edit-target switch**, where a
+    /// different profile means a different most-used mode.
+    ///
+    /// Separate from `resetSurfaces` because that reasoning covers
+    /// only this one: `barEditor`'s default is a fixed design call
+    /// with no profile dependence, so resetting it here would
+    /// throw a user comparing App Bar colors across profiles back
+    /// to the Space Bar editor mid-task.
+    mutating func resetLayoutModeTab() {
+        layoutModeTab = nil
     }
 
-    var body: some View {
-        Button {
-            navigate(destination)
-        } label: {
-            Text(title).underline()
-        }
-        .buttonStyle(.plain)
-        .font(.caption)
-        .linkHover()
+    /// Starts a flash on `anchor`, bumping the token so that
+    /// revealing the same anchor twice still re-fires (#277).
+    mutating func startFlash(_ anchor: String) -> Int {
+        flashToken += 1
+        flash = SettingsFlash(
+            anchor: anchor,
+            token: flashToken
+        )
+        return flashToken
+    }
+
+    /// Ends the flash, if `token` is still the current one.
+    ///
+    /// Must be called: `SearchRevealFlash` uses `.task(id:)`,
+    /// which runs on *appear* as well as on change, so a value
+    /// left standing re-washes the card every time the user
+    /// navigates back to it — no user action involved. The token
+    /// check makes a late finisher from a superseded flash unable
+    /// to cancel the current one.
+    mutating func endFlash(token: Int) {
+        guard flash?.token == token else { return }
+        flash = nil
     }
 }

--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -64,15 +64,15 @@ struct SettingsView: View {
             // The mode tab ONLY — the Bars switch has no profile
             // dependence, and resetting it here would move a user
             // comparing App Bar colors across profiles.
-            model.resetLayoutModeTab()
+            model.nav.resetLayoutModeTab()
         }
         // A navigation request — the #326 "Edit in Settings…"
         // deep link, or a #277 search hit. Guarded by the same
         // reachability filter as every other nav path (#18).
-        .onChange(of: model.pendingReveal) { _, request in
+        .onChange(of: model.nav.pendingReveal) { _, request in
             apply(request)
         }
-        .onAppear { apply(model.pendingReveal) }
+        .onAppear { apply(model.nav.pendingReveal) }
     }
 
     /// Phase 1 of a reveal: destination and surface, the half
@@ -105,7 +105,7 @@ struct SettingsView: View {
     /// bridge in Lua mode, with every test still green.
     private func apply(_ request: SettingsAnchor?) {
         guard let request else { return }
-        model.pendingReveal = nil
+        model.nav.pendingReveal = nil
         guard
             let resolved = request.resolved(
                 editingStoredProfile: model.editingStoredProfile
@@ -116,9 +116,9 @@ struct SettingsView: View {
         case .main:
             break
         case .layoutMode(let mode):
-            model.layoutModeTab = mode
+            model.nav.layoutModeTab = mode
         case .bar(let editor):
-            model.barEditor = editor
+            model.nav.barEditor = editor
         }
         // Unconditional, including the nil case. Guarding it to
         // avoid a nil→nil publish would mean a destination-only
@@ -128,7 +128,7 @@ struct SettingsView: View {
         // That trades a guaranteed supersede for one saved
         // re-render, in the field whose whole design is one
         // writer and one clearer.
-        model.pendingScroll = resolved.scroll
+        model.nav.pendingScroll = resolved.scroll
     }
 
     /// The structured settings shell: a fixed-width source list
@@ -153,7 +153,7 @@ struct SettingsView: View {
                 editingStoredProfile: model.editingStoredProfile,
                 spotlightProfiles:
                     model.profileSummaries.isEmpty,
-                reveal: { model.pendingReveal = $0 }
+                reveal: { model.nav.pendingReveal = $0 }
             )
             chrome { detailPane }
                 .frame(maxWidth: .infinity)
@@ -240,14 +240,17 @@ struct SettingsView: View {
             // wrappers would buy nothing and drift.
             ScrollViewReader { proxy in
                 detail
-                    .environment(\.settingsFlash, model.flash)
-                    .onChange(of: model.pendingScroll) {
+                    .environment(\.settingsFlash, model.nav.flash)
+                    .onChange(of: model.nav.pendingScroll) {
                         _,
                         anchor in
                         reveal(anchor, proxy: proxy)
                     }
                     .onAppear {
-                        reveal(model.pendingScroll, proxy: proxy)
+                        reveal(
+                            model.nav.pendingScroll,
+                            proxy: proxy
+                        )
                     }
             }
         }
@@ -262,7 +265,7 @@ struct SettingsView: View {
         proxy: ScrollViewProxy
     ) {
         guard let anchor else { return }
-        model.pendingScroll = nil
+        model.nav.pendingScroll = nil
         revealTask?.cancel()
         // Captured, so a task that outlives its pane bails instead
         // of relying on the id being absent from the new one.
@@ -300,7 +303,7 @@ struct SettingsView: View {
             // nothing at all. Layout has certainly run by now; if
             // the first attempt landed, this is a no-op.
             proxy.scrollTo(anchor, anchor: .top)
-            let token = model.startFlash(anchor)
+            let token = model.nav.startFlash(anchor)
             // Under Reduce Motion the wash has no fade to live
             // through — clearing removes it instantly — so the
             // hold absorbs the fade's duration instead. Without
@@ -314,7 +317,7 @@ struct SettingsView: View {
             )
             // Clearing is what triggers the fade — the modifier
             // keeps no timer of its own.
-            model.endFlash(token: token)
+            model.nav.endFlash(token: token)
         }
     }
 

--- a/Sources/KiwiDesk/Settings/SettingsWindowController.swift
+++ b/Sources/KiwiDesk/Settings/SettingsWindowController.swift
@@ -47,7 +47,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     /// the read-only shortcuts panel's "Edit in Settings…" bridge
     /// (#326). The request is one-shot; `SettingsView` clears it.
     func show(navigatingTo destination: SettingsDestination) {
-        model.pendingReveal = SettingsAnchor(
+        model.nav.pendingReveal = SettingsAnchor(
             destination: destination
         )
         show()
@@ -80,7 +80,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         // The two surface selections live on the model too now
         // (#277), so they need the same re-assertion — otherwise
         // reopening Settings can land in the App Bar editor.
-        model.resetSurfaces()
+        model.nav.resetSurfaces()
         // Promote on every open, not just the first — closing
         // the window demotes to `.accessory`, so a reused
         // window must re-raise to get its Dock icon back.

--- a/Tests/KiwiDeskGuiTests/SidebarSearchAnchorSiteTests.swift
+++ b/Tests/KiwiDeskGuiTests/SidebarSearchAnchorSiteTests.swift
@@ -57,7 +57,7 @@ struct SidebarSearchAnchorSiteTests {
     /// bug for that side.
     private let alternatelyMounted: [String: Int] = [
         // The App Bar and Space Bar colour drawers. `BarsSection`
-        // renders exactly one editor per `switch model.barEditor`.
+        // renders one editor per `switch model.nav.barEditor`.
         "bars.advanced_colors": 2,
         // `MonitorsSection`'s cards section and its
         // "not connected" read-only twin are if/else branches.


### PR DESCRIPTION
## What

`SettingsModel.swift` sat at **348/350** lines, and `@Published`
cannot live in an extension — so the file hard-blocked any change
touching model state. #277 part 2 (the per-control search catalog)
needs ~10 more navigation fields (drawer expansions, the Shortcuts
mode strip). This is the mechanical prerequisite, on its own branch
(doing it inside part 2 means paying it twice).

Collapse the window's six transient navigation members plus their
four mutators out of `SettingsModel` into one value type,
`SettingsNavigation`, held behind a single `@Published var nav`.

Moved verbatim: `pendingReveal`, `pendingScroll`, `flash`
(`private(set)`), `flashToken` (`private`), `layoutModeTab`,
`barEditor`, and `resetSurfaces` / `resetLayoutModeTab` /
`startFlash` / `endFlash` (now `mutating`). ~22 call sites
retargeted `model.X` → `model.nav.X`. Model drops **348 → 267**.

The old `SettingsNavigation.swift` held only cross-reference-link
view machinery (no type of that name), so it is renamed to
`CrossReferenceLink.swift` to free the type name.

## Behaviour-preserving invariants (all held, both reviewers verified)

- **Call sites keep their shape:** `$model.nav.barEditor` still
  projects a `Binding`; `model.nav.startFlash(...)` still mutates
  and publishes (value-type write-back through `@Published` fires
  `objectWillChange`).
- **`flash` stays `private(set)`** — external writes still route
  only through `startFlash`/`endFlash`.
- **`.onChange(of: model.nav.pendingReveal)` / `.onAppear` stay on
  the outer `Group`, above the `editingLua` branch** — the sole
  reason a request arriving in raw-Lua mode resolves later (the
  #326 deep-link). Unchanged.
- **One writer / one clearer per field** preserved
  (`pendingReveal` → `SettingsView.apply`; `pendingScroll` → the
  detail pane driver).
- All `onChange` targets stay `Equatable`.

## Verify

`swift build`, `swift test` (2088 + 14 ExecTests), `scripts/lint.sh`
(exit 0), and `swift build -c release` — all green locally. CI
Actions is dead repo-wide on billing, so the `Release Build` job
could not report; ran it locally instead. Reviewed by `code-reviewer`
+ `architect-reviewer` (both clean, no findings).

Part of #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)