### PR TITLE
chore(release-prep): remove pre-release back-compat shims (#116)

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+GuiConfig.swift
@@ -227,7 +227,7 @@ extension KiwiCore {
     /// discriminator for the three tiling tiers (#36): only a
     /// GUI-managed config lets the composed Standard own
     /// tiling on an unmatched monitor change; hand-written or
-    /// hybrid configs (foreign Lua beside the managed block)
+    /// hybrid configs (foreign Lua in `init.lua`)
     /// keep their Lua-declared tiling and get placement-only
     /// resolution. Mirrors the editor, which demotes itself to
     /// the raw-Lua fallback on foreign code.
@@ -235,8 +235,8 @@ extension KiwiCore {
         guiConfigStore.exists && !configHasForeignCode
     }
 
-    /// Whether `init.lua` holds code outside the managed block
-    /// that touches the managed vocabulary — verbs the GUI
+    /// Whether `init.lua` holds code that touches the managed
+    /// vocabulary — verbs the GUI
     /// itself generates. When true the visual editor cannot
     /// safely co-own the file and falls back to raw Lua mode.
     /// Harmless custom Lua (e.g. `print`, sketchybar hooks)
@@ -253,7 +253,7 @@ extension KiwiCore {
     }
 
     /// Whether `init.lua` holds any non-blank, non-comment Lua
-    /// outside the managed block (including harmless code that
+    /// (including harmless code that
     /// does not touch managed vocabulary). Used to show the
     /// "you also have custom Lua" banner in the visual editor.
     /// Always `false` when `configHasForeignCode` is `true`

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -63,11 +63,6 @@ public enum APIReference {
             ("list_monitors", "list_monitors"),
             ("debug_log", "debug_log"),
             ("reload_config", "reload_config"),
-            (
-                "set_animation_duration",
-                "set_animation_duration"
-            ),
-            ("set_space_animation", "set_space_animation"),
             ("set_mouse_resize", "set_mouse_resize"),
             ("enable_wake_restore", "enable_wake_restore"),
             (
@@ -124,7 +119,7 @@ public enum APIReference {
             "set_ratio_h_override", "set_ratio_v_override",
         ],
         "scroll": [
-            "set_slot_size", "set_anchor", "set_speed",
+            "set_slot_size", "set_anchor",
             "set_orientation", "set_new_window_placement",
             "set_wrap_focus",
             "set_slot_size_override", "set_anchor_override",

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+ScrollCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+ScrollCommands.swift
@@ -29,20 +29,6 @@ extension KiwiCore {
                 )
             else { return Self.orientationError }
             tiler.settings.scrolling.orientation = orientation
-        case "scroll.set_speed":
-            // Deprecated alias for `animations.set_scroll_speed`
-            // (issue #51). Previously shared `durationMS` with
-            // `animations.set_duration`; now writes the separate
-            // `scrollDurationMS` knob.
-            guard let ms = args.first?.intValue else {
-                return .fail("expected milliseconds")
-            }
-            onLog(
-                "scroll.set_speed is deprecated — use "
-                    + "animations.set_scroll_speed(ms)"
-            )
-            // Engine syncs via TilingEngine.settings.didSet.
-            tiler.settings.animations.scrollSpeedMS = ms
         case "scroll.set_new_window_placement":
             guard let placement = parsePlacement(args) else {
                 return placementError

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SettingsCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SettingsCommands.swift
@@ -10,28 +10,6 @@ extension KiwiCore {
         _ args: [JSONValue]
     ) -> CommandResponse {
         switch command {
-        case "set_animation_duration":
-            // Deprecated alias for `animations.set_duration`.
-            guard let ms = args.first?.intValue else {
-                return .fail("expected milliseconds")
-            }
-            onLog(
-                "set_animation_duration is deprecated — use "
-                    + "animations.set_duration(ms)"
-            )
-            // Engine syncs via TilingEngine.settings.didSet.
-            tiler.settings.animations.durationMS = ms
-        case "set_space_animation":
-            // Deprecated alias for `animations.set_on_space_change`
-            // (issue #11). Still works so existing configs load.
-            guard let enabled = args.first?.boolValue else {
-                return .fail("expected boolean")
-            }
-            onLog(
-                "set_space_animation is deprecated — use "
-                    + "animations.set_on_space_change(bool)"
-            )
-            tiler.settings.animations.onSpaceChange = enabled
         case "set_mouse_resize":
             guard let raw = args.first?.stringValue,
                 let mode = MouseResizeMode(rawValue: raw)
@@ -128,7 +106,6 @@ extension KiwiCore {
         case "animations.set_scroll_speed":
             // The scroll-specific duration knob, split from
             // `animations.set_duration` (issue #51).
-            // `scroll.set_speed` is the deprecated alias.
             guard let ms = args.first?.intValue else {
                 return .fail("expected milliseconds")
             }

--- a/Sources/KiwiDeskCore/Config/ManagedConfig.swift
+++ b/Sources/KiwiDeskCore/Config/ManagedConfig.swift
@@ -1,26 +1,22 @@
 import Foundation
 
-/// Recognizes the legacy app-managed block in `init.lua` and
-/// classifies the code around it (#55: the app no longer
-/// GENERATES a block — `gui.json` and profiles are loaded
-/// directly, and `init.lua` is hooks-only). The split stays so
-/// a stale block from an earlier version keeps being treated
-/// as app-owned (inert, never "foreign") until the user
-/// deletes it by hand — re-saving is the migration.
+/// Classifies `init.lua` by whether its code touches the GUI's
+/// managed vocabulary (#55: the app loads `gui.json` and profiles
+/// directly and treats `init.lua` as hooks-only — it neither
+/// generates nor recognizes a managed block).
 ///
-/// The GUI only falls back to the raw Lua editor when code
-/// outside a (stale) block touches the managed vocabulary —
-/// verbs the GUI owns in `gui.json`. Harmless custom Lua
-/// (print calls, debug hooks, sketchybar integrations)
-/// coexists with the visual editor; it shows an informational
-/// banner instead of locking the user out.
+/// The GUI falls back to the raw Lua editor only when the code
+/// touches the managed vocabulary — verbs the GUI owns in
+/// `gui.json`. Harmless custom Lua (print calls, debug hooks,
+/// sketchybar integrations) coexists with the visual editor; it
+/// shows an informational banner instead of locking the user out.
+///
+/// Pre-release, the marker-block recognition that used to keep a
+/// stale pre-#55 block "app-owned" was removed (#116): such a block
+/// is now scanned like any other code — its `set_*` verbs read as
+/// Lua-owned config (so it is never seeded over), which is the safe
+/// direction. Re-saving is the migration.
 public enum ManagedConfig {
-    public static let beginMarker =
-        "-- >>> KiwiDesk managed block "
-        + "(edit in the app, not by hand) >>>"
-    public static let endMarker =
-        "-- <<< KiwiDesk managed block <<<"
-
     // MARK: - Managed vocabulary
 
     /// Tokens matched against non-comment lines outside the
@@ -57,45 +53,6 @@ public enum ManagedConfig {
         "KiwiDesk.define_mode(",
         "KiwiDesk.bind_profile_to_native_space(",
     ]
-
-    // MARK: - Split / merge
-
-    /// The three regions of a config file. `managed` excludes
-    /// the marker lines; it is nil when no block is present.
-    public struct Split: Equatable {
-        public var before: String
-        public var managed: String?
-        public var after: String
-    }
-
-    /// Divides `source` on the marker lines. A file without
-    /// markers is entirely `before` (managed nil, after empty).
-    public static func split(_ source: String) -> Split {
-        let lines = source.components(separatedBy: "\n")
-        guard
-            let begin = lines.firstIndex(where: {
-                $0.trimmed == beginMarker
-            }),
-            let end = lines[begin...].firstIndex(where: {
-                $0.trimmed == endMarker
-            })
-        else {
-            return Split(
-                before: source,
-                managed: nil,
-                after: ""
-            )
-        }
-        let before = lines[..<begin].joined(separator: "\n")
-        let managed = lines[(begin + 1)..<end]
-            .joined(separator: "\n")
-        let after = lines[(end + 1)...].joined(separator: "\n")
-        return Split(
-            before: before,
-            managed: managed,
-            after: after
-        )
-    }
 
     // `adopt` and its selective-comment machinery live in
     // `ManagedConfig+Adopt.swift` (file-size split, §2).
@@ -229,14 +186,8 @@ public enum ManagedConfig {
     public static func classify(
         _ source: String
     ) -> (foreign: Bool, custom: Bool) {
-        let sp = split(source)
-        let foreign =
-            touchesManagedVocabulary(sp.before)
-            || touchesManagedVocabulary(sp.after)
-        let custom =
-            foreign
-            || isCode(sp.before)
-            || isCode(sp.after)
+        let foreign = touchesManagedVocabulary(source)
+        let custom = foreign || isCode(source)
         return (foreign: foreign, custom: custom)
     }
 

--- a/Sources/KiwiDeskCore/Config/ManagedConfig.swift
+++ b/Sources/KiwiDeskCore/Config/ManagedConfig.swift
@@ -13,14 +13,14 @@ import Foundation
 ///
 /// Pre-release, the marker-block recognition that used to keep a
 /// stale pre-#55 block "app-owned" was removed (#116): such a block
-/// is now scanned like any other code — its `set_*` verbs read as
-/// Lua-owned config (so it is never seeded over), which is the safe
-/// direction. Re-saving is the migration.
+/// is now scanned like any other code, so a bind or rule inside it
+/// reads as foreign — the file becomes Lua-owned (raw editor, never
+/// seeded over), the safe direction. Re-saving is the migration.
 public enum ManagedConfig {
     // MARK: - Managed vocabulary
 
-    /// Tokens matched against non-comment lines outside the
-    /// (stale) managed block (see `touchesManagedVocabulary`).
+    /// Tokens matched against non-comment, non-blank lines of the
+    /// source (see `touchesManagedVocabulary`).
     /// A match forces the raw editor because the GUI cannot
     /// safely co-own that vocabulary — it owns app rules,
     /// float/ignore rules, keybindings, and profile bindings in
@@ -59,10 +59,9 @@ public enum ManagedConfig {
 
     // MARK: - Foreign-code detection
 
-    /// Whether code outside the managed block touches the GUI's
-    /// managed vocabulary — verbs the GUI itself writes into the
-    /// block (`app_rules`, `float_rules`, `ignore_rules`,
-    /// `KiwiDesk.bind(`,
+    /// Whether the code touches the GUI's managed vocabulary —
+    /// verbs the GUI itself owns in `gui.json` (`app_rules`,
+    /// `float_rules`, `ignore_rules`, `KiwiDesk.bind(`,
     /// etc.). When `true` the visual editor cannot safely co-own
     /// those constructs, so it yields to the raw Lua editor.
     ///
@@ -73,8 +72,8 @@ public enum ManagedConfig {
         classify(source).foreign
     }
 
-    /// Whether any non-blank, non-comment Lua exists outside the
-    /// managed block. This includes harmless code that does NOT
+    /// Whether any non-blank, non-comment Lua exists in the file.
+    /// This includes harmless code that does NOT
     /// touch the managed vocabulary. Used by the GUI to show an
     /// informational banner while keeping the visual editor
     /// active.
@@ -265,8 +264,8 @@ public enum ManagedConfig {
 }
 
 extension StringProtocol {
-    /// Trims spaces, tabs, and line terminators (`\r`) so marker
-    /// matching and the foreign-code scan survive CRLF files.
+    /// Trims spaces, tabs, and line terminators (`\r`) so the
+    /// foreign-code scan survives CRLF files.
     fileprivate var trimmed: String {
         trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Tests/KiwiDeskCoreTests/AnimationPersistenceTests.swift
+++ b/Tests/KiwiDeskCoreTests/AnimationPersistenceTests.swift
@@ -93,47 +93,6 @@ struct AnimationPersistenceTests {
         )
     }
 
-    @Test("scroll.set_speed is a deprecated alias")
-    func scrollSetSpeedAlias() {
-        let core = makeCore()
-        var logs: [String] = []
-        core.onLog = { logs.append($0) }
-        let response = core.execute(
-            "scroll.set_speed",
-            args: [.number(200)]
-        )
-        #expect(response.isSuccess)
-        #expect(
-            core.tiler.animation.scrollDurationMS == 200
-        )
-        #expect(
-            core.tiler.settings.animations.scrollSpeedMS == 200
-        )
-        // Must log a deprecation notice.
-        #expect(logs.contains { $0.contains("deprecated") })
-        #expect(
-            logs.contains {
-                $0.contains("animations.set_scroll_speed")
-            }
-        )
-    }
-
-    @Test("set_animation_duration persists in settings")
-    func oldAliasAlsoPersists() {
-        let core = makeCore()
-        var logs: [String] = []
-        core.onLog = { logs.append($0) }
-        core.execute(
-            "set_animation_duration",
-            args: [.number(300)]
-        )
-        #expect(core.tiler.animation.durationMS == 300)
-        #expect(
-            core.tiler.settings.animations.durationMS == 300
-        )
-        #expect(logs.contains { $0.contains("deprecated") })
-    }
-
     @Test("duration clamped to 50–1000 on engine AND settings")
     func durationClamping() {
         let core = makeCore()

--- a/Tests/KiwiDeskCoreTests/CommandBehaviorTests.swift
+++ b/Tests/KiwiDeskCoreTests/CommandBehaviorTests.swift
@@ -24,15 +24,14 @@ struct CommandBehaviorTests {
             args: [.number(2500)]
         )
         #expect(core.sleepWake.restoreDelayMS == 2500)
-        // Duration: namespaced command clamps; old top-level name
-        // still works as a deprecated alias.
+        // Duration: the namespaced command clamps to 50–1000.
         core.execute(
             "animations.set_duration",
             args: [.number(5000)]
         )
         #expect(core.tiler.animation.durationMS == 1000)
         core.execute(
-            "set_animation_duration",
+            "animations.set_duration",
             args: [.number(300)]
         )
         #expect(core.tiler.animation.durationMS == 300)
@@ -79,18 +78,6 @@ struct CommandBehaviorTests {
             args: [.bool(false)]
         )
         #expect(!core.tiler.settings.animations.onRelayout)
-        // The old command still works as a deprecated alias, both
-        // ways: set it true then back to false.
-        core.execute(
-            "set_space_animation",
-            args: [.bool(true)]
-        )
-        #expect(core.tiler.settings.animations.onSpaceChange)
-        core.execute(
-            "set_space_animation",
-            args: [.bool(false)]
-        )
-        #expect(!core.tiler.settings.animations.onSpaceChange)
         #expect(core.tiler.settings.mouseResize == .layout)
         core.execute(
             "set_mouse_resize",

--- a/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
+++ b/Tests/KiwiDeskCoreTests/ConfigWriteTests.swift
@@ -237,7 +237,6 @@ struct ConfigWriteTests {
         // managed block is generated (#55).
         #expect(file.contains("-- KiwiDesk.bind(\"cmd+h\""))
         #expect(file.contains("-- KiwiDesk.set_gap_global(7)"))
-        #expect(!file.contains(ManagedConfig.beginMarker))
         // The harmless hook stays LIVE so integrations keep
         // firing after adoption (#355) — its head line is not
         // commented.

--- a/Tests/KiwiDeskCoreTests/ManagedConfigAdoptTests.swift
+++ b/Tests/KiwiDeskCoreTests/ManagedConfigAdoptTests.swift
@@ -210,7 +210,6 @@ struct ManagedConfigAdoptTests {
     func header() {
         let adopted = adopt("print(\"x\")")
         #expect(adopted.contains("Adopted by KiwiDesk on 2026-07-18"))
-        #expect(!adopted.contains(ManagedConfig.beginMarker))
     }
 
     @Test("An empty config adopts to just the header")

--- a/Tests/KiwiDeskCoreTests/ManagedConfigTests.swift
+++ b/Tests/KiwiDeskCoreTests/ManagedConfigTests.swift
@@ -3,81 +3,13 @@ import Testing
 
 @testable import KiwiDeskCore
 
-/// Tests for `ManagedConfig`'s split logic and the
-/// token-scoped foreign-code detection introduced in #14.
-/// #55: the app no longer generates a block — split stays so
-/// a STALE block keeps classifying as app-owned, not foreign.
-/// Round-trip and KiwiCore tests live in `ConfigWriteTests`.
-@Suite("ManagedConfig split / detection")
+/// Tests for `ManagedConfig`'s token-scoped foreign-code detection
+/// (#14). #55: the app no longer generates a managed block, and
+/// #116 removed the marker-block recognition entirely — `classify`
+/// now scans the whole source. Round-trip and KiwiCore tests live
+/// in `ConfigWriteTests`.
+@Suite("ManagedConfig detection")
 struct ManagedConfigTests {
-    // MARK: - Split
-
-    @Test("managed block splits and preserves user code")
-    func managedSplit() {
-        let source = """
-            -- my own comment
-            KiwiDesk.debug_log("hi")
-
-            \(ManagedConfig.beginMarker)
-            KiwiDesk.set_gap_global(10)
-            \(ManagedConfig.endMarker)
-
-            KiwiDesk.debug_log("after")
-            """
-        let split = ManagedConfig.split(source)
-        #expect(split.managed?.contains("set_gap_global") == true)
-        #expect(split.before.contains("my own comment"))
-        #expect(split.after.contains("after"))
-        // debug_log is NOT managed vocabulary: the visual editor
-        // stays active; hasForeignCode must be false (#14).
-        #expect(!ManagedConfig.hasForeignCode(source))
-        // But there IS non-comment Lua outside the block.
-        #expect(ManagedConfig.hasCustomCode(source))
-    }
-
-    @Test("comment-only files are neither foreign nor custom")
-    func noForeignCode() {
-        let source = """
-            -- just a comment
-            \(ManagedConfig.beginMarker)
-            KiwiDesk.set_gap_global(10)
-            \(ManagedConfig.endMarker)
-            """
-        #expect(!ManagedConfig.hasForeignCode(source))
-        #expect(!ManagedConfig.hasCustomCode(source))
-    }
-
-    @Test("split tolerates CRLF line endings")
-    func crlfSplit() {
-        let source =
-            "-- header\r\n" + ManagedConfig.beginMarker
-            + "\r\nKiwiDesk.set_gap_global(10)\r\n"
-            + ManagedConfig.endMarker + "\r\n"
-        let split = ManagedConfig.split(source)
-        #expect(
-            split.managed?.contains("set_gap_global") == true
-        )
-        #expect(split.before.contains("-- header"))
-    }
-
-    @Test("adopt comments managed lines, keeps custom live")
-    func adoptSelective() {
-        // The managed `bind` is commented; the harmless `print`
-        // stays live (#355). Full adopt matrix lives in
-        // `ManagedConfigAdoptTests`.
-        let adopted = ManagedConfig.adopt(
-            original: "KiwiDesk.bind(\"alt+h\", fn)\n\nprint(\"hi\")",
-            date: "2026-07-07"
-        )
-        #expect(!adopted.contains(ManagedConfig.beginMarker))
-        #expect(
-            adopted.contains("-- KiwiDesk.bind(\"alt+h\", fn)")
-        )
-        #expect(adopted.contains("\nprint(\"hi\")"))
-        // Ownership invariant: nothing foreign remains.
-        #expect(!ManagedConfig.hasForeignCode(adopted))
-    }
-
     // MARK: - Token-scoped detection (#14)
 
     @Test("harmless custom Lua: not foreign, is custom")
@@ -87,96 +19,71 @@ struct ManagedConfigTests {
         let source = """
             KiwiDesk.debug_log("started")
             print("sketchybar hook")
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
             """
         #expect(!ManagedConfig.hasForeignCode(source))
         #expect(ManagedConfig.hasCustomCode(source))
     }
 
-    @Test("managed-vocabulary Lua outside block is foreign")
+    @Test("comment-only files are neither foreign nor custom")
+    func commentOnly() {
+        let source = "-- just a comment\n-- and another"
+        #expect(!ManagedConfig.hasForeignCode(source))
+        #expect(!ManagedConfig.hasCustomCode(source))
+    }
+
+    @Test("managed-vocabulary Lua is foreign")
     func managedVocabIsForeign() {
-        // A binding outside the block touches KiwiDesk.bind(,
-        // which the GUI writes inside the block → raw editor.
+        // A binding touches KiwiDesk.bind(, which the GUI owns in
+        // gui.json → raw editor.
         let source = """
             KiwiDesk.bind("alt+h", function()
                 KiwiDesk.focus("left")
             end)
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
             """
         #expect(ManagedConfig.hasForeignCode(source))
         #expect(ManagedConfig.hasCustomCode(source))
     }
 
-    @Test("app_rules outside the block is foreign")
+    @Test("app_rules is foreign")
     func appRulesIsForeign() {
-        let source = """
-            app_rules = { ["Finder"] = "1" }
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
-            """
+        let source = #"app_rules = { ["Finder"] = "1" }"#
         #expect(ManagedConfig.hasForeignCode(source))
     }
 
-    @Test("float_rules outside the block is foreign")
+    @Test("float_rules is foreign")
     func floatRulesIsForeign() {
-        let source = """
-            float_rules = { "Calculator" }
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
-            """
+        let source = #"float_rules = { "Calculator" }"#
         #expect(ManagedConfig.hasForeignCode(source))
     }
 
-    @Test("ignore_rules outside the block is foreign")
+    @Test("ignore_rules is foreign")
     func ignoreRulesIsForeign() {
-        let source = """
-            ignore_rules = { "io.tailscale.ipn.macos" }
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
-            """
+        let source = #"ignore_rules = { "io.tailscale.ipn.macos" }"#
         #expect(ManagedConfig.hasForeignCode(source))
     }
 
-    @Test("define_mode outside the block is foreign")
+    @Test("define_mode is foreign")
     func defineModeIsForeign() {
-        let source = """
-            KiwiDesk.define_mode("resize", {})
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
-            """
+        let source = #"KiwiDesk.define_mode("resize", {})"#
         #expect(ManagedConfig.hasForeignCode(source))
     }
 
-    @Test("bind_profile_to_native_space outside block is foreign")
+    @Test("bind_profile_to_native_space is foreign")
     func profileBindingIsForeign() {
-        let source = """
-            KiwiDesk.bind_profile_to_native_space(1, "Desk")
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
-            """
+        let source =
+            #"KiwiDesk.bind_profile_to_native_space(1, "Desk")"#
         #expect(ManagedConfig.hasForeignCode(source))
     }
 
-    @Test("tiling-only Lua beside the block is NOT foreign")
+    @Test("tiling-only Lua is NOT foreign")
     func tilingOnlyIsNotForeign() {
-        // set_gap_global, set_mode etc. are not in the managed
-        // block (tiling moved to profiles, #36) — they're
-        // harmless alongside the visual editor.
+        // set_gap_global, set_mode etc. are not foreign tokens
+        // (tiling moved to profiles, #36) — harmless alongside the
+        // visual editor, though a `set_*` verb still declares a
+        // managed setting (see `declaresManagedSettingsTests`).
         let source = """
             KiwiDesk.set_gap_global(30)
             KiwiDesk.set_mode(1, "stack")
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
             """
         #expect(!ManagedConfig.hasForeignCode(source))
         #expect(ManagedConfig.hasCustomCode(source))
@@ -189,9 +96,6 @@ struct ManagedConfigTests {
         let source = """
             -- app_rules = { ["Finder"] = "1" }
             -- KiwiDesk.bind("x", function() end)
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
             """
         #expect(!ManagedConfig.hasForeignCode(source))
         #expect(!ManagedConfig.hasCustomCode(source))
@@ -208,21 +112,13 @@ struct ManagedConfigTests {
             KiwiDesk.bind ("alt+h", function()
                 KiwiDesk.focus("left")
             end)
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
             """
         #expect(ManagedConfig.hasForeignCode(source))
     }
 
     @Test("KiwiDesk.define_mode with space before ( is foreign")
     func defineModeWithSpaceBeforeParenIsForeign() {
-        let source = """
-            KiwiDesk.define_mode ("resize", {})
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
-            """
+        let source = #"KiwiDesk.define_mode ("resize", {})"#
         #expect(ManagedConfig.hasForeignCode(source))
     }
 
@@ -233,12 +129,7 @@ struct ManagedConfigTests {
         // app_rules_count contains app_rules but is a
         // different identifier: the word-boundary + assignment
         // anchor prevents a false positive.
-        let source = """
-            local app_rules_count = 0
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
-            """
+        let source = "local app_rules_count = 0"
         #expect(!ManagedConfig.hasForeignCode(source))
         // It IS custom (a non-comment Lua line).
         #expect(ManagedConfig.hasCustomCode(source))
@@ -248,31 +139,19 @@ struct ManagedConfigTests {
     func appRulesInStringNotForeign() {
         // A string literal containing the token word must
         // not be detected as foreign (no assignment).
-        let source = """
-            print("app_rules")
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
-            """
+        let source = #"print("app_rules")"#
         #expect(!ManagedConfig.hasForeignCode(source))
     }
 
-    @Test("app_rules assignment outside block is foreign")
+    @Test("app_rules assignment is foreign")
     func appRulesAssignmentForeign() {
-        let source = """
-            app_rules = { ["Finder"] = "1" }
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
-            """
+        let source = #"app_rules = { ["Finder"] = "1" }"#
         #expect(ManagedConfig.hasForeignCode(source))
     }
 
     // MARK: - Block-comment behavior (Fix 5 — pinned)
 
-    @Test(
-        "block-comment interior lines are treated as code"
-    )
+    @Test("block-comment interior lines are treated as code")
     func blockCommentInteriorIsTreatedAsCode() {
         // --[[ … ]] block comments: interior lines that don't
         // start with -- are treated as code by the current
@@ -283,9 +162,6 @@ struct ManagedConfigTests {
             --[[ multi-line block comment
             this line has no leading dashes
             ]]
-
-            \(ManagedConfig.beginMarker)
-            \(ManagedConfig.endMarker)
             """
         // Over-conservative: interior is seen as code.
         #expect(ManagedConfig.hasCustomCode(source))

--- a/Tests/KiwiDeskCoreTests/StructuredConfigTests.swift
+++ b/Tests/KiwiDeskCoreTests/StructuredConfigTests.swift
@@ -170,20 +170,20 @@ struct StructuredConfigTests {
         #expect(core.state.appRules["xcode"] == nil)
     }
 
-    // MARK: - Stale managed block (O6)
+    // MARK: - Hand-written bind in init.lua (O6)
 
-    /// A stale pre-#55 managed block binding `combo` — earlier
-    /// versions generated this into init.lua. It still
+    /// A `KiwiDesk.bind` in init.lua binding `combo` — it still
     /// executes on load, but must stay inert in effect: the
     /// structured loader resets its refs and re-registers from
-    /// gui.json.
+    /// gui.json. (Formerly a pre-#55 managed block; the marker
+    /// recognition was removed in #116 — the bind is what the
+    /// loader-reset behavior turns on, not the surrounding
+    /// comments.)
     private func staleBlock(binding combo: String) -> String {
         """
-        \(ManagedConfig.beginMarker)
         KiwiDesk.bind("\(combo)", function()
             -- noop
         end)
-        \(ManagedConfig.endMarker)
         """
     }
 
@@ -224,16 +224,19 @@ struct StructuredConfigTests {
         #expect(bindings.count == 1)
     }
 
-    /// Leak canary for stale-block refs: `luaL_ref` reuses
-    /// released slots, so after `loadConfig()` a probe
-    /// second `makeFunction` probe must land on the same slot
-    /// number in a core whose init.lua holds a stale managed
-    /// block as in one whose init.lua is empty. Transactional
-    /// replacement prepares the structured ref first, then
-    /// releases the stale ref: the block core's first probe
-    /// reuses that slot, while both second probes match. If the
-    /// stale ref leaked, both block probes would shift up.
-    @Test("Stale-block refs are released (slot-reuse canary)")
+    /// Leak canary for an init.lua bind that duplicates a
+    /// gui.json binding: the structured loader must release the
+    /// init.lua ref so it does not accumulate. `luaL_ref` reuses
+    /// released slots, so after `loadConfig()` the **second**
+    /// probe must land on the same slot in a core whose init.lua
+    /// holds the extra bind as in one whose init.lua is empty —
+    /// that equality is the real no-leak invariant. The first
+    /// probe must not shift *up* (a leaked ref would push it
+    /// higher); whether it lands strictly lower depends on the
+    /// release/re-register ordering, which #116 changed when it
+    /// dropped managed-block recognition (a pre-#55 bind is now an
+    /// ordinary foreign bind), so this asserts `<=`, not `<`.
+    @Test("init.lua bind refs are released (slot-reuse canary)")
     func noLeakedRefsAfterLoad() throws {
         var config = GuiConfig()
         config.modes = [
@@ -280,7 +283,10 @@ struct StructuredConfigTests {
             try blockLua
             .makeFunction(body: "-- second probe").get()
 
-        #expect(blockProbe < bareProbe)
+        // No leak: the block core's ref is released, so its probe
+        // never shifts up (a leak would). The second probes must
+        // match exactly — that is the invariant.
+        #expect(blockProbe <= bareProbe)
         #expect(blockSecondProbe == bareSecondProbe)
     }
 }

--- a/Tests/KiwiDeskCoreTests/StructuredConfigTests.swift
+++ b/Tests/KiwiDeskCoreTests/StructuredConfigTests.swift
@@ -187,8 +187,13 @@ struct StructuredConfigTests {
         """
     }
 
-    /// Verifies exactly one ref per combo exists after
-    /// loadConfig — structured loader resets stale-block refs.
+    /// A `KiwiDesk.bind` in init.lua makes the config Lua-owned
+    /// (`isGuiManaged` false, #116: a bind is a foreign token), so
+    /// gui.json is not structure-loaded and the init.lua bind is
+    /// the sole registration — exactly one ref per combo, no
+    /// double. (The structured loader's own ref reset is guarded by
+    /// `structuredReloadReleasesRefs` below, which keeps the config
+    /// GUI-managed.)
     @Test("Only one ref per combo after loadConfig (no double)")
     func noDoubleRegistration() throws {
         let core = makeGuiCore()
@@ -207,7 +212,8 @@ struct StructuredConfigTests {
             )
         ]
         try core.saveGuiConfig(config)
-        // A stale block (pre-#55) also binds alt+h on load.
+        // A hand-written bind in init.lua binds alt+h on load,
+        // and (being foreign) makes the config Lua-owned.
         try writeInitLua(
             staleBlock(binding: "alt+h"),
             core: core
@@ -216,27 +222,26 @@ struct StructuredConfigTests {
 
         let combo = try #require(KeyCombo.parse("alt+h"))
         let bindings = core.keys.bindings(for: "default")
-        // Pins re-registration: the structured entry is the
-        // only one. The keyed dict cannot hold duplicates, so
-        // the ref-leak half of the guard lives in
-        // `noLeakedRefsAfterLoad` below.
+        // The init.lua bind is the only registration (gui.json is
+        // ignored while Lua-owned); the keyed dict cannot hold
+        // duplicates. The structured ref-reset guard lives in
+        // `structuredReloadReleasesRefs` below.
         #expect(bindings[combo] != nil)
         #expect(bindings.count == 1)
     }
 
-    /// Leak canary for an init.lua bind that duplicates a
-    /// gui.json binding: the structured loader must release the
-    /// init.lua ref so it does not accumulate. `luaL_ref` reuses
-    /// released slots, so after `loadConfig()` the **second**
-    /// probe must land on the same slot in a core whose init.lua
-    /// holds the extra bind as in one whose init.lua is empty —
-    /// that equality is the real no-leak invariant. The first
-    /// probe must not shift *up* (a leaked ref would push it
-    /// higher); whether it lands strictly lower depends on the
-    /// release/re-register ordering, which #116 changed when it
-    /// dropped managed-block recognition (a pre-#55 bind is now an
-    /// ordinary foreign bind), so this asserts `<=`, not `<`.
-    @Test("init.lua bind refs are released (slot-reuse canary)")
+    /// No-leak canary comparing a Lua-owned core (a `KiwiDesk.bind`
+    /// in init.lua, #116) against a GUI-managed core with the same
+    /// gui.json and an empty init.lua. Each registers one live
+    /// keybinding ref, so the registry must not diverge: `luaL_ref`
+    /// reuses released slots, so the **second** probe must land on
+    /// the same slot in both (the real no-leak invariant), and the
+    /// first must never shift *up* (a leaked ref would). `<=`, not
+    /// `<`: both cores now reach the same high-water mark, where a
+    /// pre-#116 managed block would have freed a slot the loader
+    /// reused first. (The structured loader's own reload reset is
+    /// guarded by `structuredReloadReleasesRefs`.)
+    @Test("init.lua bind refs do not leak (slot-reuse canary)")
     func noLeakedRefsAfterLoad() throws {
         var config = GuiConfig()
         config.modes = [
@@ -266,8 +271,7 @@ struct StructuredConfigTests {
             try bareLua
             .makeFunction(body: "-- second probe").get()
 
-        // Block core: a stale pre-#55 block also binds alt+h
-        // on load; its ref must be released by the reset.
+        // Block core: an init.lua bind registers alt+h (Lua-owned).
         let block = makeGuiCore()
         try block.saveGuiConfig(config)
         try writeInitLua(
@@ -288,5 +292,44 @@ struct StructuredConfigTests {
         // match exactly — that is the invariant.
         #expect(blockProbe <= bareProbe)
         #expect(blockSecondProbe == bareSecondProbe)
+    }
+
+    /// The structured loader's transactional reset: reloading a
+    /// GUI-managed config (empty init.lua, so it stays managed)
+    /// must release the prior load's binding refs before
+    /// re-registering, so the registry does not grow across
+    /// reloads. This is the live `applyStructuredConfig` path —
+    /// after #116 no init.lua bind can drive it (a bind is foreign
+    /// → Lua-owned), so a reload is what exercises the reset.
+    @Test("Reloading a GUI-managed config releases prior refs")
+    func structuredReloadReleasesRefs() throws {
+        var config = GuiConfig()
+        config.modes = [
+            KeyMode(
+                name: "default",
+                bindings: [
+                    KeyBinding(
+                        combo: "alt+h",
+                        lua: "-- noop",
+                        kind: .custom,
+                        label: ""
+                    )
+                ]
+            )
+        ]
+        let core = makeGuiCore()
+        try core.saveGuiConfig(config)
+        try writeInitLua("", core: core)  // hooks-only → GUI-managed
+        core.loadConfig()  // first structured load
+        let afterFirst =
+            try #require(core.lua)
+            .makeFunction(body: "-- probe").get()
+        core.loadConfig()  // reload: release prior, re-register
+        let afterReload =
+            try #require(core.lua)
+            .makeFunction(body: "-- probe").get()
+        // No accumulation: the reload released the prior ref, so
+        // the probe does not climb across reloads.
+        #expect(afterReload <= afterFirst)
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,9 +140,6 @@ item's only appearance in CLI output.
 | | `animations.set_on_window_resize` | true\|false (default true) |
 | | `animations.set_on_window_swap` | true\|false (default true) |
 | | `animations.set_on_relayout` | true\|false (default true) |
-| | `set_space_animation` | deprecated alias for `animations.set_on_space_change` |
-| | `set_animation_duration` | deprecated alias for `animations.set_duration` |
-| | `scroll.set_speed` | deprecated alias for `animations.set_scroll_speed` |
 | Sleep/Wake | `enable_wake_restore` | true\|false |
 | | `set_wake_restore_delay` | ms |
 | Drag | `drag.set_ghost_enabled` | true\|false |


### PR DESCRIPTION
Sweeps the codebase for the §5 "no backward-compat shims" baseline before the beta cut. Closes #116.

## Removed
**3 deprecated Lua/CLI verb aliases** (old name kept alongside new — the exact "still works so existing configs load" rationale §5 rejects):
- `set_animation_duration` → `animations.set_duration`
- `set_space_animation` → `animations.set_on_space_change`
- `scroll.set_speed` → `animations.set_scroll_speed`

Dropped from dispatch, `APIReference`, `docs/cli.md`, and the redundant alias tests (canonical verbs fully covered; `TypoGuard` dispatch↔registration parity stays green).

**Legacy managed-block recognition** in `ManagedConfig` (`beginMarker`/`endMarker`, `Split`, `split()`): existed only to keep a pre-#55 stale block "app-owned". Markers are never written now, so `classify()` scanning the whole source is **behavior-identical** for any current file (algebraically confirmed by both reviewers). A pre-#55 block now reads as foreign → Lua-owned → never seeded over (safe direction). **Owner-verified: no init.lua on disk carries a block, so no-op in practice.**

## Verified clean (no removal needed)
Event names, track verbs, and schema/version migration (none exists); profile/`gui.json` `decodeIfPresent` is legitimate sparse-config handling, not renamed-key tolerance.

## Review
Both `code-reviewer` + `architect-reviewer` per §3.6 — production change confirmed correct, config-classification seam holds, single-predicate (`isGuiManaged`) invariant intact (in fact simplified). Their findings (framing correction, stale prose, and a test-coverage shift) fixed: docstrings repointed honestly, and `structuredReloadReleasesRefs` **restores** coverage of `applyStructuredConfig`'s transactional ref reset (new canary passes — live path healthy).

`swift build && swift test` (2116) `&& scripts/lint.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)