### PR TITLE
fix(site): reset section padding on legal pages

### DIFF
--- a/site/src/components/Legal.astro
+++ b/site/src/components/Legal.astro
@@ -379,6 +379,10 @@ const kofi = "https://ko-fi.com/kiwicanopy";
       }
       .sec {
         margin-top: 2.25rem;
+        /* landing.css gives every bare <section> large marketing padding-block;
+           these legal sections are plain prose, so reset it — otherwise huge
+           vertical gaps open between numbered sections. */
+        padding-block: 0;
       }
       .sec h2 {
         margin: 0;


### PR DESCRIPTION
landing.css gives every bare `<section>` large marketing padding-block; the legal sections inherit it → huge vertical gaps between numbered sections. Reset `padding-block` on `.sec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)