### PR TITLE
fix(site): add legal links to the guide footer

### DIFF
--- a/site/src/components/Guide.astro
+++ b/site/src/components/Guide.astro
@@ -794,6 +794,8 @@ const jsonLd = [
           <a href="/docs/">{s.footer_docs}</a>
           <a href={repo} target="_blank" rel="noopener"
             >{s.footer_github}</a>
+          <a href={`${homeHref}imprint`}>{s.footer_impressum}</a>
+          <a href={`${homeHref}privacy`}>{s.footer_privacy}</a>
         </nav>
         <p class="footer__copy">{s.footer_copy}</p>
         <p class="footer__credit">


### PR DESCRIPTION
The Impressum + Datenschutz links were on the landing, docs, and legal-page footers but missing from the guide footer. The Impressum must be reachable from every page — added them (all locales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)