### PR TITLE
refactor(site): unify hero CTA to Get KiwiDesk; nerd close CTA → GitHub

### DIFF
--- a/site/src/components/Landing.astro
+++ b/site/src/components/Landing.astro
@@ -436,7 +436,7 @@ const jsonLd = [
           <h1>{t.hero_title}</h1>
           <p class="hero__sub">{t.hero_sub}</p>
           <div class="hero__cta">
-            <a class="btn btn--primary" href="#cta">
+            <a class="btn btn--primary" href="#start" data-install-bridge>
               {t.hero_cta_primary}
             </a>
             <a class="btn btn--ghost btn--ghost-light" href="#demo">
@@ -459,10 +459,8 @@ const jsonLd = [
           <h1>{t.hero_dev_title}</h1>
           <p class="hero__sub" set:html={t.hero_dev_sub}></p>
           <div class="hero__cta">
-            <a class="btn btn--primary" href="/docs/">
-              {t.hero_dev_cta_docs}
-              <Icon name="lucide:arrow-right" width={16} height={16}
-                aria-hidden="true" />
+            <a class="btn btn--primary" href="#start" data-install-bridge>
+              {t.hero_cta_primary}
             </a>
             <a class="btn btn--ghost btn--ghost-light" href={repo}
               target="_blank" rel="noopener">
@@ -857,11 +855,21 @@ KiwiDesk.bind(<span class="str">"cmd+alt+left"</span>, <span class="fn">function
                  middle-click, "copy link"); the mode toggle is
                  JS-driven anyway, so a JS-off visitor has no Nerd
                  view to be sent to in the first place. */}
-            <a class="btn btn--primary" href="#start"
+            <a class="btn btn--primary simple-only" href="#start"
               data-install-bridge>
               {t.cta_primary}
               <Icon name="lucide:arrow-right" width={16} height={16}
                 aria-hidden="true" />
+            </a>
+            {/* Nerd readers have already seen the install command above,
+                 so the closing CTA points at the repo instead. */}
+            <a class="btn btn--primary dev-only" href={repo}
+              target="_blank" rel="noopener">
+              <svg width="18" height="18" viewBox="0 0 24 24"
+                fill="currentColor" aria-hidden="true">
+                <path d="M12 .5a11.5 11.5 0 0 0-3.64 22.42c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.4-1.27.73-1.56-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.2-3.1-.12-.29-.52-1.46.11-3.05 0 0 .98-.31 3.2 1.18a11.1 11.1 0 0 1 5.82 0c2.22-1.49 3.2-1.18 3.2-1.18.63 1.59.23 2.76.11 3.05.75.81 1.2 1.84 1.2 3.1 0 4.43-2.69 5.4-5.26 5.69.41.36.78 1.07.78 2.15v3.19c0 .31.2.67.8.56A11.5 11.5 0 0 0 12 .5Z" />
+              </svg>
+              {t.hero_dev_cta_github}
             </a>
             <a class="btn btn--ghost dev-only" href={kofi}
               target="_blank" rel="noopener">

--- a/site/src/i18n/de.json
+++ b/site/src/i18n/de.json
@@ -186,7 +186,6 @@
   "guide_tour_spaces_title": "Spaces",
   "hero_cta_primary": "KiwiDesk holen",
   "hero_cta_secondary": "In Aktion ansehen",
-  "hero_dev_cta_docs": "Zur Doku",
   "hero_dev_cta_github": "Auf GitHub ansehen",
   "hero_dev_kicker": "Der Tiling-Manager für macOS der einfach funktioniert",
   "hero_dev_sub": "KiwiDesk verwaltet Fenster in <b>flachen Arrays</b>, nicht in i3-artigen Bäumen — <b>voll in Lua konfigurierbar</b>, mit <b>sieben Layouts</b> zum Umschalten. Und es <b>deaktiviert nie SIP</b>.",

--- a/site/src/i18n/en.json
+++ b/site/src/i18n/en.json
@@ -188,7 +188,6 @@
   "guide_tour_spaces_title": "Spaces",
   "hero_cta_primary": "Get KiwiDesk",
   "hero_cta_secondary": "See it in action",
-  "hero_dev_cta_docs": "Read the Docs",
   "hero_dev_cta_github": "View on GitHub",
   "hero_dev_kicker": "The tiling window manager for macOS that just works",
   "hero_dev_sub": "KiwiDesk manages windows in <b>flat arrays</b>, not i3-style trees — <b>fully Lua-configurable</b>, with <b>seven layouts</b> to switch between. And it <b>never disables SIP</b>.",

--- a/site/src/i18n/ja.json
+++ b/site/src/i18n/ja.json
@@ -186,7 +186,6 @@
   "guide_tour_spaces_title": "スペース",
   "hero_cta_primary": "KiwiDesk を入手",
   "hero_cta_secondary": "動いているところを見る",
-  "hero_dev_cta_docs": "ドキュメントを読む",
   "hero_dev_cta_github": "GitHub で見る",
   "hero_dev_kicker": "ちゃんと動く、macOS のためのタイル型ウインドウマネージャ",
   "hero_dev_sub": "KiwiDesk はウインドウを i3 のようなツリーではなく<b>フラットな配列</b>で管理します。<b>Lua で全面的に設定でき</b>、<b>7 つのレイアウト</b>を切り替えられます。そして<b>SIP を無効化しません</b>。",


### PR DESCRIPTION
- Both hero modes: one 'Get KiwiDesk' primary that scrolls to the Homebrew command (install-bridge; simple flips to nerd first).
- Nerd bottom CTA: 'View on GitHub' instead of 'Show me how to install' (they've already seen the command), keeping Ko-fi.
- Remove the now-unused hero docs-CTA string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)