### PR TITLE
feat(site): show the Public-beta pill in the nerd hero too

### DIFF
--- a/site/src/components/Landing.astro
+++ b/site/src/components/Landing.astro
@@ -471,6 +471,10 @@ const jsonLd = [
               {t.hero_dev_cta_github}
             </a>
           </div>
+          <span class="pill pill--light">
+            <span class="pill__dot" aria-hidden="true"></span>
+            {t.hero_pill}
+          </span>
         </div>
       </div>
       <div class="hero__seam" aria-hidden="true"></div>


### PR DESCRIPTION
The 'Public beta — available now' pill was only on the simple hero; mirror it in the nerd hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)