### PR TITLE
fix(site): add the kiwi to the guide's Public-beta badge

### DIFF
--- a/site/src/i18n/de.json
+++ b/site/src/i18n/de.json
@@ -1,5 +1,5 @@
 {
-  "beta_badge": "Öffentliche Beta",
+  "beta_badge": "🥝 Öffentliche Beta",
   "build_cmt": "# für Mitwirkende — Homebrew ist der einfache Weg",
   "build_code_aria": "KiwiDesk aus dem Quellcode bauen",
   "build_copy": "Kopieren",

--- a/site/src/i18n/en.json
+++ b/site/src/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "beta_badge": "Public beta",
+  "beta_badge": "🥝 Public beta",
   "build_body": "KiwiDesk is in public beta. Install it with Homebrew — one command, and the kiwidesk CLI comes with it. Homebrew also keeps it current with brew upgrade. A signed, notarized download follows once the app can update itself, so a direct download is never a dead end.",
   "build_cmt": "# for contributors — Homebrew is the easy path",
   "build_code_aria": "Build KiwiDesk from source",

--- a/site/src/i18n/ja.json
+++ b/site/src/i18n/ja.json
@@ -1,5 +1,5 @@
 {
-  "beta_badge": "パブリックベータ",
+  "beta_badge": "🥝 パブリックベータ",
   "build_cmt": "# コントリビューター向け — 手軽なのは Homebrew",
   "build_code_aria": "KiwiDesk をソースからビルドする",
   "build_copy": "コピー",


### PR DESCRIPTION
The guide's beta badge lacked the 🥝 the hero pill carries. Added for brand consistency (en/de/ja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)