### PR TITLE
feat(animation): promote smooth per-tick window grow to default (#47)

### DIFF
--- a/Sources/KiwiDeskCore/Animation/AnimationEngine+Teardown.swift
+++ b/Sources/KiwiDeskCore/Animation/AnimationEngine+Teardown.swift
@@ -1,0 +1,66 @@
+import AppKit
+
+/// Teardown paths: stopping one window, stopping everything, and
+/// reacting to a disconnected monitor. Split from the hot `tick`
+/// core (AGENTS.md §2 file-size ceiling); shares the engine's
+/// per-window bookkeeping through `clearState`.
+extension AnimationEngine {
+    /// Stops animating a window, leaving it where it is.
+    public func cancel(window: WindowID) {
+        if removeAnimation(for: window) != nil {
+            clearState(window)
+            onAnimationEnd(window)
+            notifyIfIdle()
+        }
+    }
+
+    /// Stops everything, snapping to targets when enabled.
+    /// Without `snapToTargets`, a window mid-exit-slide (#207)
+    /// is left half-visible until a retile re-parks it —
+    /// production callers should snap.
+    public func cancelAll(snapToTargets: Bool = false) {
+        for perWindow in animations.values {
+            for (id, animation) in perWindow {
+                if snapToTargets {
+                    apply(id, animation.targetFrame, true)
+                }
+                onAnimationEnd(id)
+            }
+        }
+        let wasActive = activeCount > 0
+        animations = [:]
+        lastApplied = [:]
+        heldSize = [:]
+        sizeElapsed = [:]
+        for driver in drivers.values {
+            driver.stop()
+        }
+        if wasActive {
+            onAllAnimationsEnded()
+        }
+    }
+
+    /// Drops display links for disconnected monitors. Their
+    /// in-flight animations complete instantly.
+    public func displaysChanged() {
+        let connected = Set(
+            NSScreen.screens.compactMap { $0.kiwiDisplay?.id }
+        )
+        for display in Array(drivers.keys)
+        where !connected.contains(display) {
+            drivers[display]?.invalidate()
+            drivers[display] = nil
+            var removedAny = false
+            for (id, animation) in animations[display] ?? [:] {
+                apply(id, animation.targetFrame, true)
+                clearState(id)
+                onAnimationEnd(id)
+                removedAny = true
+            }
+            animations[display] = nil
+            if removedAny {
+                notifyIfIdle()
+            }
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
+++ b/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
@@ -19,7 +19,9 @@ import CoreGraphics
 /// a growing one holds its start size until halfway and then
 /// grows in one frame, where the ongoing slide masks the jump.
 /// Every other frame is position-only — one AX call, and the
-/// target app never re-lays-out its content mid-flight.
+/// target app never re-lays-out its content mid-flight. The
+/// grow direction's policy is swappable (`growPolicy`, #47) for
+/// on-device comparison; the size math lives in `GrowSize`.
 @MainActor
 public final class AnimationEngine {
     /// Applies one interpolated frame to a real window.
@@ -41,6 +43,14 @@ public final class AnimationEngine {
     /// must wait until windows stop moving, like z-order
     /// restoration.
     public var onAllAnimationsEnded: @MainActor () -> Void = {}
+
+    /// Fired when one window's animation reaches its exact target
+    /// (the settle frame), with that target. The strand detector
+    /// (#47 safety net) reads the window back after a grace and
+    /// logs if the app didn't actually land there. Not fired on
+    /// cancel/teardown — only a clean settle has a target to check.
+    public var onWindowSettled: @MainActor (WindowID, CGRect) -> Void =
+        { _, _ in }
 
     /// Test seam: when false, `animate` applies the target
     /// frame synchronously instead of spring-animating it, so
@@ -71,16 +81,42 @@ public final class AnimationEngine {
         }
     }
 
+    /// Grow-direction size policy (#47). Default `.throttledSmooth`
+    /// at the per-tick rate below — a growing window follows the
+    /// spring smoothly. Engine-only (not persisted to a profile),
+    /// but Lua-overridable: `animations.set_grow_policy` drops to
+    /// `.midSlide` for a session (e.g. from `init.lua`) if a
+    /// slow-AX app misbehaves. The GUI never exposes it (expert
+    /// knob, like the bars' `dim_factor`).
+    public var growPolicy: GrowPolicy = .throttledSmooth
+
+    /// Optional size-set rate cap for `.throttledSmooth`, in Hz.
+    /// `nil` (default) = per-tick: the size channel emits every
+    /// display tick, keeping pace with the always-per-tick position
+    /// channel on any refresh rate (60, 120, …) without a magic
+    /// number. A non-nil value throttles *below* the refresh
+    /// (clamped 1–120) to bound a slow-AX app's reflow load. No
+    /// effect under `.midSlide`.
+    public var growRateHz: Int? {
+        get { storedGrowRateHz }
+        set { storedGrowRateHz = newValue.map { min(max($0, 1), 120) } }
+    }
+
     private var storedDurationMS = 250
     private var storedScrollDurationMS = 250
-    private var animations: [DisplayID: [WindowID: FrameAnimation]] = [:]
-    private var drivers: [DisplayID: DisplayLinkDriver] = [:]
+    private var storedGrowRateHz: Int?
+    /// Per-window seconds since the last throttled size-set (#47).
+    // Members below are read by the `+Teardown` extension, so they
+    // are module-internal rather than file-private.
+    var sizeElapsed: [WindowID: TimeInterval] = [:]
+    var animations: [DisplayID: [WindowID: FrameAnimation]] = [:]
+    var drivers: [DisplayID: DisplayLinkDriver] = [:]
     /// Last rounded frame sent per window, for no-op skipping.
-    private var lastApplied: [WindowID: CGRect] = [:]
+    var lastApplied: [WindowID: CGRect] = [:]
     /// The size a window actually has on screen right now:
     /// per axis, the target size once shrinking or past
     /// halfway, otherwise the start size held until then.
-    private var heldSize: [WindowID: CGSize] = [:]
+    var heldSize: [WindowID: CGSize] = [:]
 
     public init() {}
 
@@ -174,70 +210,19 @@ public final class AnimationEngine {
         startDriver(for: display, screen: screen)
     }
 
-    /// Stops animating a window, leaving it where it is.
-    public func cancel(window: WindowID) {
-        if removeAnimation(for: window) != nil {
-            lastApplied[window] = nil
-            heldSize[window] = nil
-            onAnimationEnd(window)
-            notifyIfIdle()
-        }
-    }
-
-    /// Stops everything, snapping to targets when enabled.
-    /// Without `snapToTargets`, a window mid-exit-slide (#207)
-    /// is left half-visible until a retile re-parks it —
-    /// production callers should snap.
-    public func cancelAll(snapToTargets: Bool = false) {
-        for perWindow in animations.values {
-            for (id, animation) in perWindow {
-                if snapToTargets {
-                    apply(id, animation.targetFrame, true)
-                }
-                onAnimationEnd(id)
-            }
-        }
-        let wasActive = activeCount > 0
-        animations = [:]
-        lastApplied = [:]
-        heldSize = [:]
-        for driver in drivers.values {
-            driver.stop()
-        }
-        if wasActive {
-            onAllAnimationsEnded()
-        }
-    }
-
-    /// Drops display links for disconnected monitors. Their
-    /// in-flight animations complete instantly.
-    public func displaysChanged() {
-        let connected = Set(
-            NSScreen.screens.compactMap { $0.kiwiDisplay?.id }
-        )
-        for display in Array(drivers.keys)
-        where !connected.contains(display) {
-            drivers[display]?.invalidate()
-            drivers[display] = nil
-            var removedAny = false
-            for (id, animation) in animations[display] ?? [:] {
-                apply(id, animation.targetFrame, true)
-                lastApplied[id] = nil
-                heldSize[id] = nil
-                onAnimationEnd(id)
-                removedAny = true
-            }
-            animations[display] = nil
-            if removedAny {
-                notifyIfIdle()
-            }
-        }
-    }
-
     // MARK: - Internals
 
+    /// Drops all per-window bookkeeping for `id` (no-op skip cache,
+    /// held size, throttle accumulator). Shared by every teardown
+    /// path so a new per-window map can't be forgotten in one.
+    func clearState(_ id: WindowID) {
+        lastApplied[id] = nil
+        heldSize[id] = nil
+        sizeElapsed[id] = nil
+    }
+
     @discardableResult
-    private func removeAnimation(
+    func removeAnimation(
         for window: WindowID
     ) -> FrameAnimation? {
         for display in animations.keys {
@@ -278,37 +263,40 @@ public final class AnimationEngine {
                 // the source of truth for the final frame.
                 apply(id, animation.frame, true)
                 perWindow[id] = nil
-                lastApplied[id] = nil
-                heldSize[id] = nil
+                clearState(id)
+                onWindowSettled(id, animation.frame)
                 onAnimationEnd(id)
             } else {
                 // Stepwise size, split per axis (issue #45).
                 // A shrinking axis takes its target size on the
                 // first frame — mid-flight overlap clears at
                 // once (siblings yielding room to a newly
-                // opened window). A growing axis holds its start
-                // size until halfway, then grows in one frame,
-                // where the ongoing slide masks the jump and the
-                // window sits near its final origin (any clamp
-                // there self-heals on the exact settle frame).
-                // Either way a single size-set lands mid-flight;
-                // interpolating per tick would instead make slow
+                // opened window). The grow direction follows the
+                // active `growPolicy`: `.midSlide` (default) lands
+                // a single size-set mid-flight, where the ongoing
+                // slide masks the jump; `.throttledSmooth` (#47)
+                // resamples the spring at a capped rate instead.
+                // Interpolating per tick would instead make slow
                 // AX responders (Electron/WebKit) re-lay-out
-                // continuously and fall seconds behind,
-                // stranding the window mid-size. Pure moves keep
-                // the sizes equal, so no resize is emitted.
+                // continuously and fall seconds behind, stranding
+                // the window mid-size — the cap bounds that load.
+                // Pure moves keep the sizes equal, so no resize is
+                // emitted.
                 let held =
                     heldSize[id]
                     ?? Self.rounded(animation.frame).size
-                let target = animation.targetFrame.size
-                let grown = animation.pastHalfway
-                let width =
-                    target.width <= held.width || grown
-                    ? target.width : held.width
-                let height =
-                    target.height <= held.height || grown
-                    ? target.height : held.height
-                let size = CGSize(width: width, height: height)
+                let stepped = GrowSize.step(
+                    policy: growPolicy,
+                    held: held,
+                    target: animation.targetFrame.size,
+                    spring: animation.frame.size,
+                    pastHalfway: animation.pastHalfway,
+                    rateHz: storedGrowRateHz,
+                    elapsed: sizeElapsed[id] ?? 0,
+                    dt: dt
+                )
+                sizeElapsed[id] = stepped.elapsed
+                let size = stepped.size
                 let setSize = size != heldSize[id]
                 heldSize[id] = size
                 let frame = CGRect(
@@ -333,7 +321,7 @@ public final class AnimationEngine {
 
     /// Fires `onAllAnimationsEnded` when nothing animates
     /// anymore, on any display.
-    private func notifyIfIdle() {
+    func notifyIfIdle() {
         if activeCount == 0 {
             onAllAnimationsEnded()
         }

--- a/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
+++ b/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
@@ -272,10 +272,11 @@ public final class AnimationEngine {
                 // first frame — mid-flight overlap clears at
                 // once (siblings yielding room to a newly
                 // opened window). The grow direction follows the
-                // active `growPolicy`: `.midSlide` (default) lands
-                // a single size-set mid-flight, where the ongoing
-                // slide masks the jump; `.throttledSmooth` (#47)
-                // resamples the spring at a capped rate instead.
+                // active `growPolicy`: `.throttledSmooth` (#47, the
+                // default) resamples the spring each tick (or at a
+                // capped rate); `.midSlide` (the legacy fallback)
+                // instead lands a single size-set mid-flight, where
+                // the ongoing slide masks the jump.
                 // Interpolating per tick would instead make slow
                 // AX responders (Electron/WebKit) re-lay-out
                 // continuously and fall seconds behind, stranding

--- a/Sources/KiwiDeskCore/Animation/GrowSize.swift
+++ b/Sources/KiwiDeskCore/Animation/GrowSize.swift
@@ -1,0 +1,87 @@
+import CoreGraphics
+import Foundation
+
+/// Which policy drives the *size* channel of an animation while a
+/// window grows (issue #47). Position is always spring-interpolated
+/// regardless.
+public enum GrowPolicy: Sendable, Equatable {
+    /// Legacy fallback (pre-#47). A growing axis holds its start
+    /// size until halfway, then grows in a single frame where the
+    /// ongoing slide masks the jump. One size-set lands mid-flight,
+    /// so slow-AX apps (Electron/WebKit) reflow exactly once. Kept
+    /// as a Lua-selectable escape hatch for an app that can't keep
+    /// pace with the smooth default.
+    case midSlide
+    /// Shipping default (#47). A growing axis follows the spring
+    /// continuously, size-sets throttled by `growRateHz` (default
+    /// 120 = per-tick). Slow-AX apps reflow at that rate rather
+    /// than once; lower the rate, or drop to `.midSlide`, if one
+    /// falls behind.
+    case throttledSmooth
+}
+
+/// Result of one size step: the size to render this frame plus the
+/// carried-forward throttle accumulator.
+struct GrowSizeStep {
+    let size: CGSize
+    /// Seconds accumulated since the last emitted size-set. The
+    /// engine stores this per window and feeds it back next tick.
+    let elapsed: TimeInterval
+}
+
+/// Pure size-channel policy, split per axis. A *shrinking* axis
+/// always snaps to its target on the first frame (overlap must
+/// clear at once); only the *growing* direction differs by policy.
+/// Actor-free and unit-tested — the engine owns the per-window
+/// accumulator and the rounding.
+enum GrowSize {
+    static func step(
+        policy: GrowPolicy,
+        held: CGSize,
+        target: CGSize,
+        spring: CGSize,
+        pastHalfway: Bool,
+        rateHz: Int?,
+        elapsed: TimeInterval,
+        dt: TimeInterval
+    ) -> GrowSizeStep {
+        switch policy {
+        case .midSlide:
+            let width =
+                target.width <= held.width || pastHalfway
+                ? target.width : held.width
+            let height =
+                target.height <= held.height || pastHalfway
+                ? target.height : held.height
+            return GrowSizeStep(
+                size: CGSize(width: width, height: height),
+                elapsed: 0
+            )
+        case .throttledSmooth:
+            // `nil` rate = per-tick: every call is "due", so the
+            // size follows the spring each frame and the
+            // accumulator stays unused (0). A rate throttles below
+            // the refresh: accrue dt and emit only when the
+            // interval has elapsed.
+            let acc = elapsed + dt
+            let due: Bool
+            if let rateHz {
+                due = acc >= 1.0 / Double(max(rateHz, 1))
+            } else {
+                due = true
+            }
+            let width =
+                target.width <= held.width
+                ? target.width
+                : (due ? spring.width : held.width)
+            let height =
+                target.height <= held.height
+                ? target.height
+                : (due ? spring.height : held.height)
+            return GrowSizeStep(
+                size: CGSize(width: width, height: height),
+                elapsed: due ? 0 : acc
+            )
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/Animation/GrowSize.swift
+++ b/Sources/KiwiDeskCore/Animation/GrowSize.swift
@@ -13,10 +13,11 @@ public enum GrowPolicy: Sendable, Equatable {
     /// pace with the smooth default.
     case midSlide
     /// Shipping default (#47). A growing axis follows the spring
-    /// continuously, size-sets throttled by `growRateHz` (default
-    /// 120 = per-tick). Slow-AX apps reflow at that rate rather
-    /// than once; lower the rate, or drop to `.midSlide`, if one
-    /// falls behind.
+    /// continuously. `growRateHz` caps the size-set rate; its
+    /// default `nil` means per **display tick** (60 on a 60 Hz
+    /// panel, 120 on a 120), matching the position channel. Slow-AX
+    /// apps reflow at that rate rather than once; lower the rate, or
+    /// drop to `.midSlide`, if one falls behind.
     case throttledSmooth
 }
 

--- a/Sources/KiwiDeskCore/Animation/StrandDetector.swift
+++ b/Sources/KiwiDeskCore/Animation/StrandDetector.swift
@@ -12,14 +12,20 @@ import Foundation
 /// Off unless `KIWIDESK_STRAND_LOG` is set, so it costs nothing in
 /// production: no timer is scheduled and no AX read is made. The
 /// read is deliberately post-grace and one-shot per settle.
+///
+/// Kept as a **permanent** net, not #47 scaffolding to remove: the
+/// per-tick default's heavy-app stranding risk is real on hardware
+/// we cannot all test, so leaving the probe wired (inert until the
+/// env flag) means any future regression stays observable without a
+/// rebuild. Module-internal — a Core diagnostic, not app API.
 @MainActor
-public final class StrandDetector {
+final class StrandDetector {
     /// Reads a window's actual on-screen frame (AX). Nil if the
     /// window is gone by the time the check fires.
-    public var frameReader: (WindowID) -> CGRect? = { _ in nil }
+    var frameReader: (WindowID) -> CGRect? = { _ in nil }
 
     /// Whether checks run. Driven from the environment at wiring.
-    public var isEnabled = false
+    var isEnabled = false
 
     /// Per-edge slack (pt). Matches the applier's echo tolerance —
     /// below this a difference is AX rounding, not a strand.
@@ -29,19 +35,24 @@ public final class StrandDetector {
     /// a legitimately-late final echo isn't misread as a strand.
     private let graceSeconds = 0.6
 
-    public init() {}
+    init() {}
 
     /// Enable from the environment (`KIWIDESK_STRAND_LOG` set to any
     /// non-empty value). Call once at wiring.
-    public func configureFromEnvironment() {
+    func configureFromEnvironment() {
         let value = ProcessInfo.processInfo
             .environment["KIWIDESK_STRAND_LOG"]
         isEnabled = !(value?.isEmpty ?? true)
     }
 
     /// Records a settled target and schedules the read-back check.
-    /// No-op when disabled — the hot path stays free.
-    public func windowSettled(_ id: WindowID, target: CGRect) {
+    /// No-op when disabled — the hot path stays free. Captures only
+    /// `id` + `target`, no generation token: if a retile relocates
+    /// the window inside the grace, the read-back compares the new
+    /// (correct) frame to the stale target and can log a false
+    /// strand. Acceptable for a QA logger — read a STRAND line as a
+    /// lead to confirm, not proof.
+    func windowSettled(_ id: WindowID, target: CGRect) {
         guard isEnabled else { return }
         DispatchQueue.main.asyncAfter(
             deadline: .now() + graceSeconds

--- a/Sources/KiwiDeskCore/Animation/StrandDetector.swift
+++ b/Sources/KiwiDeskCore/Animation/StrandDetector.swift
@@ -1,0 +1,75 @@
+import CoreGraphics
+import Foundation
+
+/// Safety net for the smooth-grow default (#47). When a window's
+/// animation settles we set its exact target, but a slow-AX app
+/// (Electron/WebKit) under load can drop or clamp that final set
+/// and strand the window a few points off — the failure mode the
+/// per-tick default risks. This reads the window back after a
+/// grace and logs any window that didn't actually land, turning
+/// device QA of the storm cases into pass/fail evidence.
+///
+/// Off unless `KIWIDESK_STRAND_LOG` is set, so it costs nothing in
+/// production: no timer is scheduled and no AX read is made. The
+/// read is deliberately post-grace and one-shot per settle.
+@MainActor
+public final class StrandDetector {
+    /// Reads a window's actual on-screen frame (AX). Nil if the
+    /// window is gone by the time the check fires.
+    public var frameReader: (WindowID) -> CGRect? = { _ in nil }
+
+    /// Whether checks run. Driven from the environment at wiring.
+    public var isEnabled = false
+
+    /// Per-edge slack (pt). Matches the applier's echo tolerance —
+    /// below this a difference is AX rounding, not a strand.
+    private let tolerance: CGFloat = 2
+
+    /// Delay before the read-back, past the applier's echo grace so
+    /// a legitimately-late final echo isn't misread as a strand.
+    private let graceSeconds = 0.6
+
+    public init() {}
+
+    /// Enable from the environment (`KIWIDESK_STRAND_LOG` set to any
+    /// non-empty value). Call once at wiring.
+    public func configureFromEnvironment() {
+        let value = ProcessInfo.processInfo
+            .environment["KIWIDESK_STRAND_LOG"]
+        isEnabled = !(value?.isEmpty ?? true)
+    }
+
+    /// Records a settled target and schedules the read-back check.
+    /// No-op when disabled — the hot path stays free.
+    public func windowSettled(_ id: WindowID, target: CGRect) {
+        guard isEnabled else { return }
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + graceSeconds
+        ) { [weak self] in
+            guard let self, let actual = self.frameReader(id)
+            else { return }
+            if !Self.landed(actual, on: target, within: tolerance) {
+                NSLog(
+                    "KiwiDesk STRAND: window %@ target %@ actual %@",
+                    String(describing: id),
+                    String(describing: target),
+                    String(describing: actual)
+                )
+            }
+        }
+    }
+
+    /// True when every edge of `actual` is within `slack` of the
+    /// target — i.e. the app landed where we set it. Pure math, so
+    /// `nonisolated` — callable off the main actor (tests).
+    nonisolated static func landed(
+        _ actual: CGRect,
+        on target: CGRect,
+        within slack: CGFloat
+    ) -> Bool {
+        abs(actual.minX - target.minX) <= slack
+            && abs(actual.minY - target.minY) <= slack
+            && abs(actual.width - target.width) <= slack
+            && abs(actual.height - target.height) <= slack
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
@@ -43,6 +43,15 @@ extension KiwiCore {
         tiler.animation.onAllAnimationsEnded = { [weak self] in
             self?.animationsDidSettle()
         }
+        strandDetector.configureFromEnvironment()
+        strandDetector.frameReader = { [weak self] id in
+            guard let element = self?.eventLoop.element(for: id)
+            else { return nil }
+            return AXHelper.frame(of: element)
+        }
+        tiler.animation.onWindowSettled = { [weak self] id, target in
+            self?.strandDetector.windowSettled(id, target: target)
+        }
         tiler.onFrameApplied = { [weak self] id, frame in
             self?.borders.follow(id, windowFrame: frame)
             self?.stickyMarks

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -30,7 +30,7 @@ public final class KiwiCore {
     /// On-window sticky marks (#414): a border sibling,
     /// driven by `updateStickyMarks()` inside `retile()`.
     public let stickyMarks = StickyMarkManager()
-    public let strandDetector = StrandDetector()
+    let strandDetector = StrandDetector()
     public let mouse = MouseTracker()
     public let profiles: ProfileManager
     public let crash: CrashRecovery

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -30,6 +30,7 @@ public final class KiwiCore {
     /// On-window sticky marks (#414): a border sibling,
     /// driven by `updateStickyMarks()` inside `retile()`.
     public let stickyMarks = StickyMarkManager()
+    public let strandDetector = StrandDetector()
     public let mouse = MouseTracker()
     public let profiles: ProfileManager
     public let crash: CrashRecovery

--- a/Sources/KiwiDeskCore/Commands/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/APIReference.swift
@@ -98,6 +98,7 @@ public enum APIReference {
             "set_on_space_change", "set_on_scrolling",
             "set_on_window_resize", "set_on_window_swap",
             "set_on_relayout",
+            "set_grow_policy", "set_grow_rate",
         ],
         "stack": [
             "promote", "demote",

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+SettingsCommands.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+SettingsCommands.swift
@@ -111,6 +111,30 @@ extension KiwiCore {
             }
             tiler.settings.animations.scrollSpeedMS = ms
             return .ok()
+        case "animations.set_grow_policy":
+            // Experimental (#47), engine-only — not persisted to a
+            // profile. Flip live to compare the throttled-smooth
+            // grow against the shipping mid-slide on device.
+            guard let raw = args.first?.stringValue else {
+                return .fail("expected \"mid_slide\" or \"smooth\"")
+            }
+            switch raw {
+            case "mid_slide": tiler.animation.growPolicy = .midSlide
+            case "smooth":
+                tiler.animation.growPolicy = .throttledSmooth
+            default:
+                return .fail("expected \"mid_slide\" or \"smooth\"")
+            }
+            return .ok()
+        case "animations.set_grow_rate":
+            // Size-set cap in Hz for `smooth` (#47), clamped 1–120.
+            // Zero or negative restores the per-tick default (no
+            // throttle), matching the engine's `nil`.
+            guard let hz = args.first?.intValue else {
+                return .fail("expected hertz")
+            }
+            tiler.animation.growRateHz = hz > 0 ? hz : nil
+            return .ok()
         default:
             break
         }

--- a/Sources/KiwiDeskCore/Tiling/AnimationSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/AnimationSettings.swift
@@ -1,11 +1,12 @@
 import Foundation
 
 /// Per-trigger animation toggles (issue #11), replacing the
-/// removed global `enable_animations`. Only position-only
-/// triggers are toggleable: an "off" size change would be an
-/// instant resize, which slow-AX apps (Electron/WebKit) clamp
-/// or drop — so window resize/swap always animate and have no
-/// toggle here.
+/// removed global `enable_animations`. Each trigger animates by
+/// default except the space switch; "off" snaps that trigger
+/// instantly. The instant resize/swap paths re-assert size via
+/// the EUI-bracketed size→position→size set (issue #50), so an
+/// un-animated landing is reliable on most apps — a few
+/// grid-snapping apps still clamp it.
 ///
 /// JSON shape follows the one-vocabulary rule (AGENTS.md §5):
 /// `animations.set_on_space_change` → `animations.on_space_change`

--- a/Tests/KiwiDeskCoreTests/AnimationTests.swift
+++ b/Tests/KiwiDeskCoreTests/AnimationTests.swift
@@ -115,13 +115,15 @@ struct AnimationEngineSizingTests {
     private func recordApplies(
         from: CGRect,
         to: CGRect,
-        policy: GrowPolicy = .throttledSmooth
+        policy: GrowPolicy = .throttledSmooth,
+        rateHz: Int? = nil
     ) -> [(frame: CGRect, setSize: Bool)]? {
         guard let screen = NSScreen.main,
             let display = screen.kiwiDisplay?.id
         else { return nil }
         let engine = AnimationEngine()
         engine.growPolicy = policy
+        engine.growRateHz = rateHz
         var applies: [(frame: CGRect, setSize: Bool)] = []
         engine.apply = { _, frame, setSize in
             applies.append((frame, setSize))
@@ -196,5 +198,69 @@ struct AnimationEngineSizingTests {
         #expect(applies.first?.frame.size == to.size)
         #expect(applies.last?.frame == to)
         #expect(applies.filter(\.setSize).count <= 2)
+    }
+
+    /// A throttle below the tick clock emits fewer size-sets than
+    /// per-tick, exercising the engine's `sizeElapsed` carry-over
+    /// (nil-default tests never drive it), yet still lands exact.
+    @Test("A throttled grow emits fewer size-sets than per-tick")
+    func throttledGrowEmitsFewer() throws {
+        let from = CGRect(x: 10, y: 20, width: 400, height: 300)
+        let to = CGRect(x: 10, y: 20, width: 900, height: 800)
+        guard let perTick = recordApplies(from: from, to: to),
+            let throttled = recordApplies(
+                from: from,
+                to: to,
+                rateHz: 25  // well below the 120 Hz tick clock
+            )
+        else { return }
+        let perTickSets = perTick.filter(\.setSize).count
+        let throttledSets = throttled.filter(\.setSize).count
+        #expect(throttledSets < perTickSets)
+        #expect(throttled.last?.frame == to)  // still exact
+    }
+
+    /// #45 regression guard: retargeting mid-grow preserves the
+    /// per-window held size / throttle state, and the window still
+    /// lands exactly on the *new* target — never stranded by the
+    /// interrupt (the failure that reverted per-tick before #47).
+    @Test("A retarget mid-grow still lands on the exact new target")
+    func retargetMidGrowLandsExact() throws {
+        guard let screen = NSScreen.main,
+            let display = screen.kiwiDisplay?.id
+        else { return }
+        let engine = AnimationEngine()
+        var applies: [(frame: CGRect, setSize: Bool)] = []
+        engine.apply = { _, frame, setSize in
+            applies.append((frame, setSize))
+        }
+        let from = CGRect(x: 0, y: 0, width: 400, height: 300)
+        let mid = CGRect(x: 0, y: 0, width: 1000, height: 900)
+        engine.animate(
+            window: WindowID(1),
+            on: screen,
+            from: from,
+            to: mid
+        )
+        for _ in 0..<12 {
+            engine.tick(display: display, dt: 1.0 / 120.0)
+        }
+        // Retarget: width now smaller than the grown size (snap),
+        // height larger (keep growing).
+        let final = CGRect(x: 0, y: 0, width: 500, height: 1100)
+        engine.animate(
+            window: WindowID(1),
+            on: screen,
+            from: mid,
+            to: final
+        )
+        var steps = 0
+        while engine.activeCount > 0, steps < 2000 {
+            engine.tick(display: display, dt: 1.0 / 120.0)
+            steps += 1
+        }
+        #expect(engine.activeCount == 0)
+        #expect(applies.last?.frame == final)
+        #expect(applies.last?.setSize == true)
     }
 }

--- a/Tests/KiwiDeskCoreTests/AnimationTests.swift
+++ b/Tests/KiwiDeskCoreTests/AnimationTests.swift
@@ -114,12 +114,14 @@ struct AnimationEngineSizingTests {
     /// no screen is available (headless CI).
     private func recordApplies(
         from: CGRect,
-        to: CGRect
+        to: CGRect,
+        policy: GrowPolicy = .throttledSmooth
     ) -> [(frame: CGRect, setSize: Bool)]? {
         guard let screen = NSScreen.main,
             let display = screen.kiwiDisplay?.id
         else { return nil }
         let engine = AnimationEngine()
+        engine.growPolicy = policy
         var applies: [(frame: CGRect, setSize: Bool)] = []
         engine.apply = { _, frame, setSize in
             applies.append((frame, setSize))
@@ -139,22 +141,46 @@ struct AnimationEngineSizingTests {
         return applies
     }
 
-    /// Issue #45: a growing window holds its start size, then
-    /// grows in a single frame at halfway (never interpolated
-    /// per tick, which would strand slow AX responders). The
-    /// grow lands mid-flight — before the settle frame — so the
-    /// slide masks it.
-    @Test("A pure grow resizes once, mid-flight")
+    /// Issue #45 (`.midSlide` fallback): a growing window holds
+    /// its start size, then grows in a single frame at halfway
+    /// (never interpolated per tick, which would strand slow AX
+    /// responders). The grow lands mid-flight — before the settle
+    /// frame — so the slide masks it. This is the legacy policy
+    /// kept as a Lua escape hatch; the default is smooth per-tick
+    /// (below).
+    @Test("A pure grow under .midSlide resizes once, mid-flight")
     func pureGrowResizesAtHalfway() throws {
         let from = CGRect(x: 10, y: 20, width: 400, height: 300)
         let to = CGRect(x: 10, y: 20, width: 900, height: 800)
-        guard let applies = recordApplies(from: from, to: to)
+        guard
+            let applies = recordApplies(
+                from: from,
+                to: to,
+                policy: .midSlide
+            )
         else { return }
         #expect(applies.last?.frame == to)
         #expect(applies.last?.setSize == true)
         // The grow lands before the final settle frame.
         #expect(applies.dropLast().contains { $0.setSize })
         #expect(applies.filter(\.setSize).count <= 2)
+    }
+
+    /// #47 default: a growing window follows the spring, emitting
+    /// a size-set on many frames (per-tick, since `growRateHz` is
+    /// nil) instead of one at halfway — the buttery grow. It still
+    /// lands exactly on the settle frame.
+    @Test("A pure grow under the smooth default resizes per tick")
+    func pureGrowSmoothInterpolates() throws {
+        let from = CGRect(x: 10, y: 20, width: 400, height: 300)
+        let to = CGRect(x: 10, y: 20, width: 900, height: 800)
+        guard let applies = recordApplies(from: from, to: to)
+        else { return }
+        #expect(applies.last?.frame == to)
+        #expect(applies.last?.setSize == true)
+        // Many size-sets across the grow, not a single mid-slide
+        // jump — the whole point of the smooth policy.
+        #expect(applies.filter(\.setSize).count > 5)
     }
 
     /// A shrinking window takes its target size on the first

--- a/Tests/KiwiDeskCoreTests/GrowSizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/GrowSizeTests.swift
@@ -9,7 +9,7 @@ struct GrowSizeTests {
     private let held = CGSize(width: 400, height: 300)
     private let target = CGSize(width: 800, height: 600)
 
-    // MARK: - midSlide (shipping default)
+    // MARK: - midSlide (legacy fallback)
 
     @Test("midSlide holds a growing axis until halfway")
     func midSlideHoldsBeforeHalfway() {

--- a/Tests/KiwiDeskCoreTests/GrowSizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/GrowSizeTests.swift
@@ -1,0 +1,180 @@
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+/// Pure size-channel policy math for the grow experiment (#47).
+@Suite("GrowSize")
+struct GrowSizeTests {
+    private let held = CGSize(width: 400, height: 300)
+    private let target = CGSize(width: 800, height: 600)
+
+    // MARK: - midSlide (shipping default)
+
+    @Test("midSlide holds a growing axis until halfway")
+    func midSlideHoldsBeforeHalfway() {
+        let step = GrowSize.step(
+            policy: .midSlide,
+            held: held,
+            target: target,
+            spring: CGSize(width: 600, height: 450),
+            pastHalfway: false,
+            rateHz: 25,
+            elapsed: 0,
+            dt: 1.0 / 120.0
+        )
+        #expect(step.size == held)
+    }
+
+    @Test("midSlide grows in one frame past halfway")
+    func midSlideGrowsPastHalfway() {
+        let step = GrowSize.step(
+            policy: .midSlide,
+            held: held,
+            target: target,
+            spring: CGSize(width: 600, height: 450),
+            pastHalfway: true,
+            rateHz: 25,
+            elapsed: 0,
+            dt: 1.0 / 120.0
+        )
+        #expect(step.size == target)
+    }
+
+    @Test("A shrinking axis snaps to target immediately")
+    func shrinkSnapsImmediately() {
+        // held larger than target on both axes → shrink.
+        for policy in [GrowPolicy.midSlide, .throttledSmooth] {
+            let step = GrowSize.step(
+                policy: policy,
+                held: target,
+                target: held,
+                spring: CGSize(width: 700, height: 500),
+                pastHalfway: false,
+                rateHz: 25,
+                elapsed: 0,
+                dt: 1.0 / 120.0
+            )
+            #expect(step.size == held)
+        }
+    }
+
+    // MARK: - throttledSmooth (#47)
+
+    @Test("A nil rate is per-tick: grow follows the spring each tick")
+    func perTickFollowsSpringEveryTick() {
+        let spring = CGSize(width: 612, height: 458)
+        let step = GrowSize.step(
+            policy: .throttledSmooth,
+            held: held,
+            target: target,
+            spring: spring,
+            pastHalfway: false,
+            rateHz: nil,  // per-tick default
+            elapsed: 0,
+            dt: 1.0 / 120.0
+        )
+        #expect(step.size == spring)
+        #expect(step.elapsed == 0)
+    }
+
+    @Test("Below the interval a growing axis holds and accrues")
+    func throttleHoldsUntilDue() {
+        let dt = 1.0 / 120.0
+        let step = GrowSize.step(
+            policy: .throttledSmooth,
+            held: held,
+            target: target,
+            spring: CGSize(width: 600, height: 450),
+            pastHalfway: false,
+            rateHz: 25,  // interval 40 ms; one 8.3 ms tick < that
+            elapsed: 0,
+            dt: dt
+        )
+        #expect(step.size == held)
+        #expect(step.elapsed == dt)
+    }
+
+    @Test("At the interval it resamples the spring and resets")
+    func throttleEmitsWhenDue() {
+        let spring = CGSize(width: 640, height: 470)
+        let step = GrowSize.step(
+            policy: .throttledSmooth,
+            held: held,
+            target: target,
+            spring: spring,
+            pastHalfway: false,
+            rateHz: 25,  // interval 40 ms
+            elapsed: 0.039,  // + a 8.3 ms tick crosses 40 ms
+            dt: 1.0 / 120.0
+        )
+        #expect(step.size == spring)
+        #expect(step.elapsed == 0)
+    }
+
+    @Test("A higher rate emits sooner (30 Hz vs 25 Hz band)")
+    func higherRateEmitsSooner() {
+        // 30 ms accrued, one 8.3 ms tick → 38.3 ms.
+        // 30 Hz interval is 33.3 ms (due); 25 Hz is 40 ms (not).
+        let args: (Int, Bool) -> Void = { hz, shouldEmit in
+            let step = GrowSize.step(
+                policy: .throttledSmooth,
+                held: held,
+                target: target,
+                spring: CGSize(width: 640, height: 470),
+                pastHalfway: false,
+                rateHz: hz,
+                elapsed: 0.030,
+                dt: 1.0 / 120.0
+            )
+            #expect((step.size != held) == shouldEmit)
+        }
+        args(30, true)
+        args(25, false)
+    }
+}
+
+/// The promoted #47 default and its rate clamp.
+@MainActor
+@Suite("Grow policy defaults")
+struct GrowDefaultsTests {
+    @Test("Engine ships smooth per-tick")
+    func shipsSmoothPerTick() {
+        let engine = AnimationEngine()
+        #expect(engine.growPolicy == .throttledSmooth)
+        #expect(engine.growRateHz == nil)
+    }
+
+    @Test("Rate clamps to 1…120; nil is per-tick")
+    func rateClamp() {
+        let engine = AnimationEngine()
+        engine.growRateHz = 500
+        #expect(engine.growRateHz == 120)
+        engine.growRateHz = -5
+        #expect(engine.growRateHz == 1)
+        engine.growRateHz = nil
+        #expect(engine.growRateHz == nil)
+    }
+}
+
+/// The strand detector's landed-vs-off comparison (#47 net).
+@Suite("StrandDetector.landed")
+struct StrandDetectorTests {
+    private let target = CGRect(x: 100, y: 200, width: 800, height: 600)
+
+    @Test("An exact / within-tolerance frame counts as landed")
+    func withinToleranceLands() {
+        #expect(StrandDetector.landed(target, on: target, within: 2))
+        let nudged = target.offsetBy(dx: 1.5, dy: -1.5)
+        #expect(StrandDetector.landed(nudged, on: target, within: 2))
+    }
+
+    @Test("An off-target edge counts as a strand")
+    func offTargetStrands() {
+        // App clamped the height short of the target.
+        let short = CGRect(x: 100, y: 200, width: 800, height: 540)
+        #expect(!StrandDetector.landed(short, on: target, within: 2))
+        let moved = target.offsetBy(dx: 30, dy: 0)
+        #expect(!StrandDetector.landed(moved, on: target, within: 2))
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,6 +140,8 @@ item's only appearance in CLI output.
 | | `animations.set_on_window_resize` | true\|false (default true) |
 | | `animations.set_on_window_swap` | true\|false (default true) |
 | | `animations.set_on_relayout` | true\|false (default true) |
+| | `animations.set_grow_policy` | smooth (default)\|mid_slide; grow size policy (#47), Lua-only, not persisted |
+| | `animations.set_grow_rate` | Hz (1–120; 0 = per-tick default); throttles `smooth` size-sets, Lua-only, not persisted |
 | Sleep/Wake | `enable_wake_restore` | true\|false |
 | | `set_wake_restore_delay` | ms |
 | Drag | `drag.set_ghost_enabled` | true\|false |

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -4070,6 +4070,55 @@ knob, also persisted per-profile).
 animations.set_scroll_speed(250)
 ```
 
+### animations.set_grow_policy
+
+**Expects:** `"smooth"` (default) or `"mid_slide"`.
+
+**Does:** picks how a window's size is applied *while it grows*
+(issue #47). Engine-only and **not persisted** to a profile — an
+expert knob (like the bars' `dim_factor`), Lua-only and absent from
+Settings. Set it from `init.lua` to make an override stick across
+launches.
+
+- `"smooth"` (default) — a growing axis follows the animation
+  continuously. By default the size updates **per display tick**
+  (matching the position channel, on any refresh rate), so slow-AX
+  apps (Electron/WebKit: VS Code, Slack, Discord, Chrome) reflow
+  once per frame. `animations.set_grow_rate` can throttle that.
+- `"mid_slide"` — the legacy fallback: a growing axis holds its
+  start size, then grows in a single frame at halfway, where the
+  ongoing slide masks the jump. Slow-AX apps reflow exactly once.
+  Drop to this for an app that can't keep pace with `"smooth"`.
+
+A shrinking axis snaps to its target on the first frame under
+either policy, and the exact target always lands on the settle
+frame.
+
+**Example:**
+
+```lua
+-- fall back to the legacy grow for a stubborn app
+animations.set_grow_policy("mid_slide")
+```
+
+### animations.set_grow_rate
+
+**Expects:** a number (hertz, clamped 1–120). `0` or negative
+restores the default **per-tick** behavior (no throttle).
+
+**Does:** caps how often the `"smooth"` grow policy emits a size-set,
+bounding a slow-AX app's reflow load. By default the size follows
+the display refresh (per-tick); set a lower rate only if a heavy app
+falls behind. No effect under `"mid_slide"`. Engine-only, not
+persisted (#47).
+
+**Example:**
+
+```lua
+animations.set_grow_rate(30)   -- throttle a heavy app
+animations.set_grow_rate(0)    -- back to per-tick default
+```
+
 ### animations.set_on_space_change
 
 **Expects:** `true` or `false` (default `false`).


### PR DESCRIPTION
Closes #47.

## What

Promotes **smooth per-tick window grow** to the default. A growing
window's size now follows the spring continuously instead of the
single mid-slide jump, so the size channel keeps pace with the
always-per-tick position channel. Owner-tested on a 120 Hz MacBook
Pro (native + VS Code/Slack/Discord, swaps & resizes) — noticeably
buttery vs mid-slide.

## Design

- `AnimationEngine.growPolicy` defaults to `.throttledSmooth`;
  `.midSlide` stays as a Lua-selectable fallback for a slow-AX app
  that can't keep up.
- `growRateHz: Int?` — `nil` (default) = per **display tick** (60 on
  a 60 Hz panel, 120 on a 120), self-adapting without a magic
  number; a value throttles below the refresh (clamped 1–120) to
  bound a slow-AX app's reflow load.
- Knobs are **Lua-only and not persisted** (expert knobs, like the
  bars' `dim_factor`): `animations.set_grow_policy`,
  `animations.set_grow_rate` (`0` = per-tick). Absent from the GUI.
- The grow-size math is a pure, unit-tested `GrowSize` helper; the
  engine's teardown paths moved to `AnimationEngine+Teardown.swift`
  to keep the hot `tick` core under the file ceiling.

## Managing the #45 risk

Per-tick size interpolation was reverted before (#45): it floods
slow-AX apps (Electron/WebKit), whose late echoes can strand a
window mid-size. Mitigations here:
- Every clean settle still applies the **exact target** with one
  authoritative size-set — the production self-heal.
- `.midSlide` fallback + the rate throttle are Lua escape hatches.
- A **`StrandDetector`** safety net (off unless `KIWIDESK_STRAND_LOG`
  is set) reads a window back past the echo grace and logs any
  off-target landing — turning storm-case device QA into pass/fail
  evidence. Kept as a permanent, inert-by-default probe.

## Review

`code-reviewer` + `architect-reviewer` both ran on the diff — no
correctness or robustness bugs; verdict structurally sound. Their
low-severity findings (stale "default" comments, `StrandDetector`
visibility, two coverage gaps) are folded in `e756fdf4`. Architect
flagged that the follow-up #593 (smooth shrink) will need a stored
trigger reason on `FrameAnimation` and a `Grow*`→`Size*` rename —
noted for that issue, out of scope here.

## Follow-ups filed

- #593 — experiment: buttery shrink for plain resizes (depends on
  this seam).
- #594 — bug: focus ring lags behind window during animation
  (independent; exposed, not caused, by this).

## Verify

`swift build` ✅ · `swift build -c release` ✅ · `swift test` ✅
(2128 + new grow/strand/coverage suites) · `scripts/lint.sh` ✅.
