### PR TITLE
fix(borders): ride the animation tick, not the laggy echo

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
@@ -53,9 +53,28 @@ extension KiwiCore {
             self?.strandDetector.windowSettled(id, target: target)
         }
         tiler.onFrameApplied = { [weak self] id, frame in
-            self?.borders.follow(id, windowFrame: frame)
-            self?.stickyMarks
-                .follow(id, windowFrame: frame)
+            self?.borders.follow(
+                id,
+                windowFrame: frame,
+                source: .animationTick
+            )
+            self?.stickyMarks.follow(
+                id,
+                windowFrame: frame,
+                source: .animationTick
+            )
+        }
+        // Mid-animation the commanded tick frame leads the real
+        // bounds on slow-AX apps (#594): while this answers
+        // true, the AX-echo follows and the WS reconcile stand
+        // down so the ring and mark ride the tick, not the lag.
+        borders.isAnimating = { [weak self] id in
+            self?.tiler.animation.isAnimating(window: id)
+                ?? false
+        }
+        stickyMarks.isAnimating = { [weak self] id in
+            self?.tiler.animation.isAnimating(window: id)
+                ?? false
         }
 
         socket.handler = { [weak self] command, args in

--- a/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
@@ -68,14 +68,21 @@ extension KiwiCore {
         // bounds on slow-AX apps (#594): while this answers
         // true, the AX-echo follows and the WS reconcile stand
         // down so the ring and mark ride the tick, not the lag.
-        borders.isAnimating = { [weak self] id in
+        // ONE closure for both managers, so ring and mark cannot
+        // diverge when this predicate is next refined (#596).
+        // Distinct from the drag pipeline's broader self-driven
+        // check (`KiwiCore+Drag`), which also spans trailing
+        // echoes via `didRecentlySetFrame` — narrower on
+        // purpose: folding that in would suppress the
+        // post-settle echo, the only carrier of ring updates
+        // after an instant `setFrame` under AX fallback (#596).
+        let animationDriven: @MainActor (WindowID) -> Bool = {
+            [weak self] id in
             self?.tiler.animation.isAnimating(window: id)
                 ?? false
         }
-        stickyMarks.isAnimating = { [weak self] id in
-            self?.tiler.animation.isAnimating(window: id)
-                ?? false
-        }
+        borders.isAnimating = animationDriven
+        stickyMarks.isAnimating = animationDriven
 
         socket.handler = { [weak self] command, args in
             self?.execute(command, args: args)

--- a/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
@@ -59,10 +59,19 @@ extension KiwiCore {
         case .windowMoved(let id, let frame):
             // Keep the ring glued to a window being moved. `follow`
             // self-suppresses when the WindowServer stream already
-            // tracks the ring (#285), so an AX echo can't rewind it
-            // behind the live bounds — the guard lives there, once.
-            borders.follow(id, windowFrame: frame)
-            stickyMarks.follow(id, windowFrame: frame)
+            // tracks the ring (#285) and while our own animation
+            // drives the window (#594), so a laggy AX echo can't
+            // rewind it — the guards live there, once.
+            borders.follow(
+                id,
+                windowFrame: frame,
+                source: .axEcho
+            )
+            stickyMarks.follow(
+                id,
+                windowFrame: frame,
+                source: .axEcho
+            )
             // A genuine user move (not the echo of our own
             // frame-set) supersedes a pending stash restore:
             // the user took the window over, so the captured
@@ -77,8 +86,16 @@ extension KiwiCore {
             }
             drag.windowMoved(id, frame: frame)
         case .windowResized(let id, let frame):
-            borders.follow(id, windowFrame: frame)
-            stickyMarks.follow(id, windowFrame: frame)
+            borders.follow(
+                id,
+                windowFrame: frame,
+                source: .axEcho
+            )
+            stickyMarks.follow(
+                id,
+                windowFrame: frame,
+                source: .axEcho
+            )
             // Same policy as .windowMoved above: a genuine
             // user resize takes the window over.
             if !tiler.didRecentlySetFrame(id),

--- a/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
@@ -77,6 +77,32 @@ extension BorderManager {
         }
     }
 
+    /// Re-reads the authoritative WindowServer bounds (the drag
+    /// stream, unhide). Floating windows do not retile, so their
+    /// final ring must be reconciled on button-up. Stands down
+    /// while OUR OWN animation drives the window (#594): the WS
+    /// bounds trail the commanded per-tick frame on slow-AX
+    /// apps, so mid-animation every event would rewind the ring
+    /// behind the motion. The first WS event after settle
+    /// reconciles any residual drift.
+    @discardableResult
+    func reconcile(
+        _ id: WindowID,
+        restoreVisibility: Bool = true
+    ) -> Bool {
+        guard !isAnimating(id) else { return false }
+        guard let frame = readWindowBounds(id) else {
+            return false
+        }
+        apply(
+            id,
+            windowFrame: frame,
+            restoreVisibility: restoreVisibility
+        )
+        onFrameReconciled(id, frame)
+        return true
+    }
+
     func updateSkyLightSubscription(
         _ borderWanted: Set<WindowID>
     ) {

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -76,6 +76,27 @@ public final class BorderManager {
     var skyLightActive = false
     var reportedTrackingActive: Bool?
     var onLog: @MainActor (String) -> Void = { _ in }
+    /// Whether OUR OWN animation currently drives this window
+    /// (#594). Wired to `AnimationEngine.isAnimating`; while
+    /// true, the per-tick commanded frame owns the ring — the
+    /// WS stream and the AX echo both trail it on slow-AX apps
+    /// — so `follow`'s echo path and the WS `reconcile` stand
+    /// down. A no-op default keeps the manager testable in
+    /// isolation.
+    var isAnimating: @MainActor (WindowID) -> Bool = { _ in false }
+    /// WindowServer bounds read behind `reconcile` — injectable
+    /// so tests can hand the manager deterministic bounds
+    /// without a live SkyLight connection.
+    var readWindowBounds: @MainActor (WindowID) -> CGRect? = { id in
+        guard let connection = SkyLight.connection,
+            let getBounds = SkyLight.getWindowBounds
+        else { return nil }
+        var frame = CGRect.zero
+        guard
+            getBounds(connection, id.raw, &frame) == .success
+        else { return nil }
+        return frame
+    }
     /// Tee of every WindowServer bounds re-read (`reconcile`) —
     /// the live-tracking hot path AX echoes lag behind. Wired
     /// to the sticky mark so it follows a dragged window at
@@ -171,22 +192,44 @@ public final class BorderManager {
         }
     }
 
-    /// Animation / AX-echo hot path: move an already-shown ring to
-    /// a window's current frame — UNLESS the WindowServer event
-    /// stream is already tracking it, since a coalesced AX echo
-    /// would rewind the ring behind the live WS bounds. This one
-    /// guard is the whole invariant, so no caller can forget it
-    /// (was hand-mirrored across three call sites). A no-op for
-    /// windows without a ring.
-    public func follow(_ id: WindowID, windowFrame: CGRect) {
-        guard !usesWindowServerTracking(id) else { return }
-        apply(id, windowFrame: windowFrame)
+    /// Animation / AX-echo hot path: move an already-shown ring
+    /// to a window's current frame. The guards live here, once,
+    /// so no caller can forget them (#285) — but they differ by
+    /// source. An AX echo stands down while the WindowServer
+    /// stream tracks the ring (a coalesced echo would rewind it
+    /// behind the live WS bounds), and also while OUR OWN
+    /// animation drives the window (#594): the echo trails the
+    /// commanded frame by 100–300 ms on slow-AX apps, so it
+    /// would drag the ring behind the motion. The per-tick
+    /// animation frame is the leading truth mid-flight and
+    /// always applies. A no-op for windows without a ring.
+    public func follow(
+        _ id: WindowID,
+        windowFrame: CGRect,
+        source: FollowSource
+    ) {
+        switch source {
+        case .animationTick:
+            apply(id, windowFrame: windowFrame)
+        case .axEcho:
+            guard !usesWindowServerTracking(id),
+                !isAnimating(id)
+            else { return }
+            apply(id, windowFrame: windowFrame)
+        }
+    }
+
+    /// The frame a window's ring last rendered against, for
+    /// tests that need to prove `follow` stood down (or didn't).
+    func lastFrame(_ id: WindowID) -> CGRect? {
+        overlays[id]?.lastRenderedFrame
     }
 
     /// Unguarded reposition — the WS bounds re-read (`reconcile`)
     /// and the steady-state `sync` own the ring's frame directly,
-    /// so they bypass the WS-tracking guard on `follow`.
-    private func apply(
+    /// so they bypass the guards on `follow`. Internal, not
+    /// private: `reconcile` lives in the `+SkyLight` extension.
+    func apply(
         _ id: WindowID,
         windowFrame: CGRect,
         restoreVisibility: Bool = false
@@ -216,30 +259,6 @@ public final class BorderManager {
             ?? GeometryUtils.systemWindowCornerRadius
         cornerRadii[id] = resolved
         return resolved
-    }
-
-    /// Re-reads the authoritative WindowServer bounds after a mouse
-    /// drag. Floating windows do not retile, so their final ring must
-    /// be reconciled explicitly on button-up.
-    @discardableResult
-    func reconcile(
-        _ id: WindowID,
-        restoreVisibility: Bool = true
-    ) -> Bool {
-        guard let connection = SkyLight.connection,
-            let getBounds = SkyLight.getWindowBounds
-        else { return false }
-        var frame = CGRect.zero
-        guard
-            getBounds(connection, id.raw, &frame) == .success
-        else { return false }
-        apply(
-            id,
-            windowFrame: frame,
-            restoreVisibility: restoreVisibility
-        )
-        onFrameReconciled(id, frame)
-        return true
     }
 
     /// Retires every ring at once. Used on shutdown (`stop()`)

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -87,15 +87,8 @@ public final class BorderManager {
     /// WindowServer bounds read behind `reconcile` — injectable
     /// so tests can hand the manager deterministic bounds
     /// without a live SkyLight connection.
-    var readWindowBounds: @MainActor (WindowID) -> CGRect? = { id in
-        guard let connection = SkyLight.connection,
-            let getBounds = SkyLight.getWindowBounds
-        else { return nil }
-        var frame = CGRect.zero
-        guard
-            getBounds(connection, id.raw, &frame) == .success
-        else { return nil }
-        return frame
+    var readWindowBounds: @MainActor (WindowID) -> CGRect? = {
+        SkyLight.windowBounds($0.raw)
     }
     /// Tee of every WindowServer bounds re-read (`reconcile`) —
     /// the live-tracking hot path AX echoes lag behind. Wired
@@ -193,30 +186,23 @@ public final class BorderManager {
     }
 
     /// Animation / AX-echo hot path: move an already-shown ring
-    /// to a window's current frame. The guards live here, once,
-    /// so no caller can forget them (#285) — but they differ by
-    /// source. An AX echo stands down while the WindowServer
-    /// stream tracks the ring (a coalesced echo would rewind it
-    /// behind the live WS bounds), and also while OUR OWN
-    /// animation drives the window (#594): the echo trails the
-    /// commanded frame by 100–300 ms on slow-AX apps, so it
-    /// would drag the ring behind the motion. The per-tick
-    /// animation frame is the leading truth mid-flight and
-    /// always applies. A no-op for windows without a ring.
+    /// to a window's current frame. The stand-down decision is
+    /// `FollowSource.applies` — one switch shared with the
+    /// sticky mark, so no caller re-implements it (#285) and the
+    /// two overlays cannot drift (#594). A no-op for windows
+    /// without a ring.
     public func follow(
         _ id: WindowID,
         windowFrame: CGRect,
         source: FollowSource
     ) {
-        switch source {
-        case .animationTick:
-            apply(id, windowFrame: windowFrame)
-        case .axEcho:
-            guard !usesWindowServerTracking(id),
-                !isAnimating(id)
-            else { return }
-            apply(id, windowFrame: windowFrame)
-        }
+        guard
+            source.applies(
+                wsTracked: usesWindowServerTracking(id),
+                animating: isAnimating(id)
+            )
+        else { return }
+        apply(id, windowFrame: windowFrame)
     }
 
     /// The frame a window's ring last rendered against, for

--- a/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
@@ -171,6 +171,10 @@ final class BorderOverlay {
         return false
     }
 
+    /// The last rendered frame — the manager's test seam for
+    /// proving the `follow` guards stood down (or didn't).
+    var lastRenderedFrame: CGRect? { lastFrame }
+
     /// Renders the ring around `frame` (AX coords). Takes the raw
     /// inputs, not a finished `BorderGeometry`, because the geometry
     /// depends on the current backend's order mode — the facade owns

--- a/Sources/KiwiDeskCore/Borders/FollowSource.swift
+++ b/Sources/KiwiDeskCore/Borders/FollowSource.swift
@@ -8,4 +8,33 @@ public enum FollowSource {
     case animationTick
     /// An AX `.windowMoved` / `.windowResized` echo.
     case axEcho
+
+    /// The one follow decision both managers share: does a
+    /// reported frame apply, given what currently owns the
+    /// window's frame? The tick is the leading truth mid-flight
+    /// and always applies; an echo stands down while the
+    /// WindowServer stream tracks the window (#285 — a coalesced
+    /// late echo would rewind the overlay behind the live
+    /// bounds) and while our own animation drives it (#594 —
+    /// the echo trails the commanded frame on slow-AX apps).
+    /// Hoisted here so the ring and the mark cannot drift: a
+    /// new decision INPUT changes this signature, and the
+    /// compiler then drags both managers through the change
+    /// (that is the mechanism — a guard bolted on beside the
+    /// call in one `follow` body is still possible, so review
+    /// for it). Each manager passes its own predicates
+    /// (`usesWindowServerTracking` vs the broader
+    /// `markUsesWindowServerTracking`); only the decision is
+    /// shared.
+    public func applies(
+        wsTracked: Bool,
+        animating: Bool
+    ) -> Bool {
+        switch self {
+        case .animationTick:
+            return true
+        case .axEcho:
+            return !wsTracked && !animating
+        }
+    }
 }

--- a/Sources/KiwiDeskCore/Borders/FollowSource.swift
+++ b/Sources/KiwiDeskCore/Borders/FollowSource.swift
@@ -1,0 +1,11 @@
+/// Who reported a followed frame — shared by the ring's and the
+/// sticky mark's `follow`. The follow guards differ by source
+/// (#594): mid-animation the commanded per-tick frame leads
+/// every echo on slow-AX apps, so it drives the ring and mark;
+/// the echo paths stand down.
+public enum FollowSource {
+    /// A per-tick commanded frame from `AnimationEngine.apply`.
+    case animationTick
+    /// An AX `.windowMoved` / `.windowResized` echo.
+    case axEcho
+}

--- a/Sources/KiwiDeskCore/Borders/StickyMarkManager.swift
+++ b/Sources/KiwiDeskCore/Borders/StickyMarkManager.swift
@@ -101,28 +101,22 @@ public final class StickyMarkManager {
     }
 
     /// AX-echo / animation hot path: re-corner an already-shown
-    /// mark on a fresh frame (the ring's `follow` guards,
-    /// mirrored). An AX echo stands down while the WindowServer
-    /// stream tracks the window (a coalesced echo would rewind
-    /// the mark behind the live WS bounds) and while our own
-    /// animation drives it (#594 — the echo trails the commanded
-    /// frame on slow-AX apps). The per-tick animation frame is
-    /// the leading truth mid-flight and always applies. A no-op
-    /// for unmarked windows.
+    /// mark on a fresh frame. The stand-down decision is
+    /// `FollowSource.applies` — one switch shared with the ring,
+    /// so the two overlays cannot drift (#285/#594). A no-op for
+    /// unmarked windows.
     public func follow(
         _ id: WindowID,
         windowFrame: CGRect,
         source: FollowSource
     ) {
-        switch source {
-        case .animationTick:
-            overlays[id]?.update(frame: windowFrame)
-        case .axEcho:
-            guard !isWindowServerTracked(id),
-                !isAnimating(id)
-            else { return }
-            overlays[id]?.update(frame: windowFrame)
-        }
+        guard
+            source.applies(
+                wsTracked: isWindowServerTracked(id),
+                animating: isAnimating(id)
+            )
+        else { return }
+        overlays[id]?.update(frame: windowFrame)
     }
 
     /// Unguarded reposition — the WindowServer bounds re-read

--- a/Sources/KiwiDeskCore/Borders/StickyMarkManager.swift
+++ b/Sources/KiwiDeskCore/Borders/StickyMarkManager.swift
@@ -49,6 +49,17 @@ public final class StickyMarkManager {
         false
     }
 
+    /// Whether OUR OWN animation currently drives this window —
+    /// wired to `AnimationEngine.isAnimating` (the ring's guard,
+    /// mirrored, #594). While true the per-tick commanded frame
+    /// owns the mark, so the AX-echo `follow` stands down; the
+    /// WS `reposition` tee already stands down upstream (the
+    /// ring's `reconcile` gate). A no-op default keeps the
+    /// manager testable in isolation.
+    public var isAnimating: @MainActor (WindowID) -> Bool = { _ in
+        false
+    }
+
     public init() {}
 
     /// Windows currently wearing the mark — the contract
@@ -90,13 +101,28 @@ public final class StickyMarkManager {
     }
 
     /// AX-echo / animation hot path: re-corner an already-shown
-    /// mark on a fresh frame — UNLESS the WindowServer stream
-    /// already tracks it, since a coalesced AX echo would rewind
-    /// the mark behind the live WS bounds (the ring's `follow`
-    /// guard, mirrored). A no-op for unmarked windows.
-    public func follow(_ id: WindowID, windowFrame: CGRect) {
-        guard !isWindowServerTracked(id) else { return }
-        overlays[id]?.update(frame: windowFrame)
+    /// mark on a fresh frame (the ring's `follow` guards,
+    /// mirrored). An AX echo stands down while the WindowServer
+    /// stream tracks the window (a coalesced echo would rewind
+    /// the mark behind the live WS bounds) and while our own
+    /// animation drives it (#594 — the echo trails the commanded
+    /// frame on slow-AX apps). The per-tick animation frame is
+    /// the leading truth mid-flight and always applies. A no-op
+    /// for unmarked windows.
+    public func follow(
+        _ id: WindowID,
+        windowFrame: CGRect,
+        source: FollowSource
+    ) {
+        switch source {
+        case .animationTick:
+            overlays[id]?.update(frame: windowFrame)
+        case .axEcho:
+            guard !isWindowServerTracked(id),
+                !isAnimating(id)
+            else { return }
+            overlays[id]?.update(frame: windowFrame)
+        }
     }
 
     /// Unguarded reposition — the WindowServer bounds re-read

--- a/Sources/KiwiDeskCore/OS/SkyLight+WindowBounds.swift
+++ b/Sources/KiwiDeskCore/OS/SkyLight+WindowBounds.swift
@@ -1,0 +1,26 @@
+import CoreGraphics
+
+/// Composed WindowServer bounds read for the focus border's
+/// reconcile path (#594), mirroring `windowCornerRadius`'s shape:
+/// the raw `SLSGetWindowBounds` symbol stays in `+Borders`; this
+/// wraps the connection guard and out-param so consumers get one
+/// optional-returning call instead of hand-composing the
+/// primitives (a second hand-rolled copy is how the `.success`
+/// check gets lost). A nil answer falls back per the OS-layer
+/// contract — here, the caller skips the reconcile and the AX
+/// echo path keeps updating the overlay.
+extension SkyLight {
+    /// The authoritative WindowServer bounds (AX coordinates)
+    /// for `wid`, or `nil` when the private surface is
+    /// unavailable or the query fails.
+    static func windowBounds(_ wid: CGWindowID) -> CGRect? {
+        guard let connection,
+            let getBounds = getWindowBounds
+        else { return nil }
+        var frame = CGRect.zero
+        guard
+            getBounds(connection, wid, &frame) == .success
+        else { return nil }
+        return frame
+    }
+}

--- a/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingEngine.swift
@@ -61,11 +61,13 @@ public final class TilingEngine {
 
     /// Tee off every animated frame (AX coords), fired per tick
     /// from `AnimationEngine.apply`. Wired to the focus border
-    /// overlays as the AX/AppKit fallback so a ring stays glued to
-    /// its window mid-slide; healthy WindowServer tracking ignores
-    /// this commanded frame and reads the real bounds instead. A
-    /// no-op by default. The instant `setFrame` path does not tee;
-    /// its AX or WindowServer geometry event updates the ring.
+    /// overlays so a ring stays glued to its window mid-slide:
+    /// mid-animation this commanded frame is the leading truth —
+    /// the WindowServer stream and AX echo both trail it on
+    /// slow-AX apps (#594) — so it drives the ring even under
+    /// healthy WS tracking. A no-op by default. The instant
+    /// `setFrame` path does not tee; its AX or WindowServer
+    /// geometry event updates the ring.
     public var onFrameApplied: @MainActor (WindowID, CGRect) -> Void =
         { _, _ in }
 

--- a/Tests/KiwiDeskCoreTests/BorderFollowAnimationTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderFollowAnimationTests.swift
@@ -42,6 +42,18 @@ struct BorderFollowAnimationTests {
             source: .animationTick
         )
         #expect(border.lastFrame(WindowID(1)) == tick)
+        // And with both suppressors down (a teardown snap, the
+        // no-display fallback): the tick still applies — pins
+        // the unconditional branch of `applies`.
+        border.skyLightActive = false
+        border.isAnimating = { _ in false }
+        let snap = CGRect(x: 60, y: 60, width: 400, height: 300)
+        border.follow(
+            WindowID(1),
+            windowFrame: snap,
+            source: .animationTick
+        )
+        #expect(border.lastFrame(WindowID(1)) == snap)
     }
 
     @Test("AX echo stands down while our animation drives it")

--- a/Tests/KiwiDeskCoreTests/BorderFollowAnimationTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderFollowAnimationTests.swift
@@ -1,0 +1,129 @@
+import AppKit
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The ring's `follow` guards, by source (#285/#594): mid-flight
+/// of OUR OWN animation the commanded per-tick frame is the
+/// leading truth — the WindowServer stream and the AX echo both
+/// trail it on slow-AX apps — so the tick always applies while
+/// the echo stands down. Steady-state, the WS stream owns the
+/// frame and the echo stands down behind it.
+@Suite("Border follow animation guards")
+@MainActor
+struct BorderFollowAnimationTests {
+    private func spec(_ id: UInt32) -> BorderManager.Spec {
+        BorderManager.Spec(
+            window: WindowID(id),
+            frame: CGRect(x: 0, y: 0, width: 400, height: 300),
+            colorHex: "#FF0000",
+            width: 4,
+            cornerStyle: .rounded
+        )
+    }
+
+    @Test("Animation tick drives the ring even under WS tracking")
+    func animationTickAppliesUnderTracking() {
+        let border = BorderManager()
+        border.sync([spec(1)])
+        // Force the stream live AFTER sync (`sync` re-runs the
+        // subscription, which resets `skyLightActive` while the
+        // private runtime is not started in unit tests).
+        border.skyLightActive = true
+        border.isAnimating = { _ in true }
+        let tick = CGRect(x: 40, y: 40, width: 400, height: 300)
+        // Pre-#594, `usesWindowServerTracking` swallowed this
+        // frame and the ring trailed the motion on the laggy
+        // WS/echo path, snapping only at settle.
+        border.follow(
+            WindowID(1),
+            windowFrame: tick,
+            source: .animationTick
+        )
+        #expect(border.lastFrame(WindowID(1)) == tick)
+    }
+
+    @Test("AX echo stands down while our animation drives it")
+    func axEchoSuppressedWhileAnimating() {
+        let border = BorderManager()
+        border.sync([spec(1)])
+        // Stream down (AX fallback path) — the WS guard alone
+        // would let this echo through; the animation guard must
+        // hold it back so it can't rewind the per-tick frames.
+        border.skyLightActive = false
+        border.isAnimating = { $0 == WindowID(1) }
+        let echo = CGRect(x: 7, y: 7, width: 7, height: 7)
+        border.follow(
+            WindowID(1),
+            windowFrame: echo,
+            source: .axEcho
+        )
+        #expect(border.lastFrame(WindowID(1)) != echo)
+        // Settled: the echo path resumes.
+        border.isAnimating = { _ in false }
+        border.follow(
+            WindowID(1),
+            windowFrame: echo,
+            source: .axEcho
+        )
+        #expect(border.lastFrame(WindowID(1)) == echo)
+    }
+
+    @Test("AX echo stands down while the WindowServer tracks it")
+    func axEchoSuppressedWhenTracked() {
+        let border = BorderManager()
+        border.sync([spec(1)])
+        border.skyLightActive = true
+        let echo = CGRect(x: 9, y: 9, width: 9, height: 9)
+        // Idle but WS-tracked: the #285 guard — a coalesced late
+        // echo must not rewind the ring behind the live bounds.
+        border.follow(
+            WindowID(1),
+            windowFrame: echo,
+            source: .axEcho
+        )
+        #expect(border.lastFrame(WindowID(1)) != echo)
+    }
+}
+
+/// The WS bounds re-read (`reconcile`) stands down mid-animation
+/// (#594): the real bounds trail the commanded per-tick frame on
+/// slow-AX apps, so reconciling every WS event would rewind the
+/// ring behind the motion the tick just applied.
+@Suite("Border reconcile animation guard")
+@MainActor
+struct BorderReconcileAnimationTests {
+    private func spec(_ id: UInt32) -> BorderManager.Spec {
+        BorderManager.Spec(
+            window: WindowID(id),
+            frame: CGRect(x: 0, y: 0, width: 400, height: 300),
+            colorHex: "#FF0000",
+            width: 4,
+            cornerStyle: .rounded
+        )
+    }
+
+    @Test("reconcile stands down mid-animation, resumes settled")
+    func reconcileGatedOnAnimation() {
+        let border = BorderManager()
+        border.sync([spec(1)])
+        let real = CGRect(x: 20, y: 20, width: 400, height: 300)
+        border.readWindowBounds = { _ in real }
+        var teed: [CGRect] = []
+        border.onFrameReconciled = { _, frame in
+            teed.append(frame)
+        }
+        border.isAnimating = { _ in true }
+        // Mid-animation: no bounds re-read, no sticky tee, and
+        // the ring keeps the frame the tick last applied.
+        #expect(border.reconcile(WindowID(1)) == false)
+        #expect(border.lastFrame(WindowID(1)) != real)
+        #expect(teed.isEmpty)
+        // Settled: the WS bounds own the ring again.
+        border.isAnimating = { _ in false }
+        #expect(border.reconcile(WindowID(1)) == true)
+        #expect(border.lastFrame(WindowID(1)) == real)
+        #expect(teed == [real])
+    }
+}

--- a/Tests/KiwiDeskCoreTests/StickyMarkWindowServerTests.swift
+++ b/Tests/KiwiDeskCoreTests/StickyMarkWindowServerTests.swift
@@ -112,7 +112,11 @@ struct StickyChipManagerEntryPointTests {
         // WS-tracked: the laggy AX-echo `follow` must NOT move the
         // mark (the WS `reposition` owns the frame). Without the
         // guard this call would advance `lastFrame` to `moved`.
-        manager.follow(WindowID(1), windowFrame: moved)
+        manager.follow(
+            WindowID(1),
+            windowFrame: moved,
+            source: .axEcho
+        )
         #expect(manager.lastFrame(WindowID(1)) != moved)
         // The unguarded WS path always advances it.
         manager.reposition(WindowID(1), windowFrame: moved)
@@ -120,7 +124,55 @@ struct StickyChipManagerEntryPointTests {
         // And untracked, the AX echo is free to move it again.
         manager.isWindowServerTracked = { _ in false }
         let axFrame = CGRect(x: 5, y: 5, width: 5, height: 5)
-        manager.follow(WindowID(1), windowFrame: axFrame)
+        manager.follow(
+            WindowID(1),
+            windowFrame: axFrame,
+            source: .axEcho
+        )
         #expect(manager.lastFrame(WindowID(1)) == axFrame)
+    }
+
+    @Test("Animation tick drives the mark even under WS tracking")
+    func animationTickAppliesUnderTracking() {
+        let manager = StickyMarkManager()
+        let tick = CGRect(x: 40, y: 40, width: 400, height: 300)
+        manager.sync([spec(1)])
+        manager.isWindowServerTracked = { _ in true }
+        manager.isAnimating = { _ in true }
+        // Mid-animation the commanded per-tick frame leads the
+        // WS bounds on slow-AX apps (#594) — it must move the
+        // mark even while the stream claims the window.
+        manager.follow(
+            WindowID(1),
+            windowFrame: tick,
+            source: .animationTick
+        )
+        #expect(manager.lastFrame(WindowID(1)) == tick)
+    }
+
+    @Test("AX echo stands down while our animation drives it")
+    func axEchoSuppressedWhileAnimating() {
+        let manager = StickyMarkManager()
+        let echo = CGRect(x: 7, y: 7, width: 7, height: 7)
+        manager.sync([spec(1)])
+        // Stream down (AX fallback), but our animation owns the
+        // window: the trailing echo must not rewind the mark
+        // behind the per-tick frames (#594).
+        manager.isWindowServerTracked = { _ in false }
+        manager.isAnimating = { $0 == WindowID(1) }
+        manager.follow(
+            WindowID(1),
+            windowFrame: echo,
+            source: .axEcho
+        )
+        #expect(manager.lastFrame(WindowID(1)) != echo)
+        // Settled: the echo path resumes.
+        manager.isAnimating = { _ in false }
+        manager.follow(
+            WindowID(1),
+            windowFrame: echo,
+            source: .axEcho
+        )
+        #expect(manager.lastFrame(WindowID(1)) == echo)
     }
 }

--- a/Tests/KiwiDeskCoreTests/StickyMarkWindowServerTests.swift
+++ b/Tests/KiwiDeskCoreTests/StickyMarkWindowServerTests.swift
@@ -148,6 +148,17 @@ struct StickyChipManagerEntryPointTests {
             source: .animationTick
         )
         #expect(manager.lastFrame(WindowID(1)) == tick)
+        // And with both suppressors down: the tick still
+        // applies — pins the unconditional branch of `applies`.
+        manager.isWindowServerTracked = { _ in false }
+        manager.isAnimating = { _ in false }
+        let snap = CGRect(x: 60, y: 60, width: 400, height: 300)
+        manager.follow(
+            WindowID(1),
+            windowFrame: snap,
+            source: .animationTick
+        )
+        #expect(manager.lastFrame(WindowID(1)) == snap)
     }
 
     @Test("AX echo stands down while our animation drives it")


### PR DESCRIPTION
## Description

The focus ring trailed the window during our own animations and
snapped into place at settle, worst on Electron/WebKit apps
(#594). Root cause: `BorderManager.follow`'s #285 suppression
stood the per-tick animation frame down whenever the WindowServer
stream tracked the window, handing an animating window's ring to
the WS/AX-echo path — which trails the commanded frame by
100–300 ms on slow-AX apps.

Fix: `follow` now takes a `FollowSource` — the per-tick commanded
frame (`.animationTick`) is the leading truth mid-flight and
always applies; an AX echo (`.axEcho`) stands down while the WS
stream tracks the window (#285 preserved) and now also while our
own animation drives it. The WS `reconcile` stands down
mid-animation too, so a WS event can't rewind the ring between
ticks; the first post-settle event corrects residual drift. The
sticky mark mirrors the ring through the same shared decision
(`FollowSource.applies` — one switch, both managers), driven by
one `animationDriven` closure so the two overlays cannot diverge.
`SkyLight.windowBounds` lifts the bounds read to the OS layer;
`readWindowBounds` is injectable so the reconcile gate is
testable without a live SkyLight connection.

Review (2× code-reviewer + 2× architect-reviewer rounds): no
HIGH; all MEDIUMs fixed in the second commit; the settle-tail
cluster (post-settle echo hiccup on the AX-fallback path,
stranded-ring heal timing, mid-flight `sync` rewind) is
consciously deferred to #596 pending device evidence.

## Related Issue(s)

Closes #594. Follow-up filed: #596.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/` (n/a — a
  lag bugfix, no behavior contract change)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build green — run locally (new @MainActor
  closure seams)
- [x] PR is focused; refactors separated from features
  (mechanical review follow-ups live in their own commit)

## How I verified

Owner device QA on a 120 Hz MacBook Pro with the #47 smooth-grow
default: swaps/resizes of VS Code/Slack windows with
`WindowServer border tracking active` (the exact pre-fix
suppression condition) — ring stays glued mid-motion, no trail,
no settle snap. Sticky mark tracks likewise. Full suite: 2136 +
14 (ExecTests) green; lint OK; release build green.

## Notes for Reviewer

- The tick/echo split is compile-enforced: `source:` has no
  default, so every caller declares itself.
- `FollowSource.applies` is the one stand-down decision for ring
  and mark; a new decision input changes its signature and drags
  both managers through the compiler.
- Reviewer transcripts' remaining LOWs are wording-level and
  addressed; #596 records the deferred settle-tail work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)