### PR TITLE
fix(borders): cure the focus-ring settle tail

### DIFF
--- a/.claude/rules/borders.md
+++ b/.claude/rules/borders.md
@@ -1,0 +1,116 @@
+---
+paths:
+  - "Sources/KiwiDeskCore/Borders/**"
+---
+
+# Focus ring & sticky mark overlays
+
+Canonical for this subsystem (AGENTS.md §5 indexes it). Two
+overlay families — the focus ring (#278) and the sticky mark
+(#414) — track the same windows through the same three channels,
+so they share their decisions rather than mirroring them.
+
+The *product* rulings about these overlays (who gets a ring, why
+glow forces the AppKit renderer, why a fullscreen window gets
+none) live in `docs/design-decisions.md`. This file is the
+engineering side: which input owns an overlay's frame, and when.
+
+## One type owns "which frame does an overlay render"
+
+`FollowSource` holds both decisions — `applies` for a *reported*
+frame, `syncFrame` for the steady-state rebuild — and the ring and
+the mark call the same code for each. Do not re-implement either
+beside a call site, and do not bolt a guard on next to one: that
+is the drift the type exists to prevent, and it is invisible in
+review because each manager reads fine alone.
+
+**A new decision INPUT is what the compiler can enforce.** Adding
+an input changes the signature and drags both managers through the
+change. Adding an enum *case* does not — exhaustiveness fires
+inside `FollowSource`, never at a call site, so wiring one manager
+and forgetting the other still builds green. That is why
+`syncFrame` is a whole-choice hoist (one body, called from both)
+rather than a case on `applies`: `sync` asks a different question
+and returns a frame, not a bool.
+
+## Three writers, in descending authority mid-animation
+
+While *our own* animation drives a window, the commanded per-tick
+frame is the leading truth — every other channel trails it, by
+100–300 ms on slow-AX apps (Electron/WebKit). So:
+
+| Writer | Mid-animation |
+|---|---|
+| `follow(.animationTick)` | always applies — it *is* the truth |
+| `follow(.axEcho)` | stands down (#594), and also while WindowServer-tracked (#285) |
+| `reconcile` (WS bounds re-read) | stands down (#594) |
+| `sync` (`updateBorders()` / `updateStickyMarks()`) | geometry stands down (#596); create, recolor, re-order and retire still run |
+
+`sync` is the easy one to miss, because it reads as a rebuild
+rather than a move — its frame is `state.windows[id]?.frame`,
+written only by AX echoes, so a retile burst or focus change
+landing mid-flight snapped the overlay back to the pre-motion
+frame (~31 pt on device) until the next tick dragged it forward.
+
+Whatever holds the frame must also resolve **`screen` from the
+same rect**: it selects the backing scale, so a held frame paired
+with the spec's screen rasterizes the ring at the wrong display's
+scale during a cross-display move.
+
+## Two settle passes, two deferred keys
+
+They do different jobs and want opposite timing, so they are not
+one pass and must not share a slot — sharing let whichever landed
+second cancel the other:
+
+- **Visibility, early** (`scheduleBorderDropReconcile`,
+  `.borderDropSettle`). WindowServer can order a ring out with no
+  matching unhide; `sync`'s trailing `order(relativeTo:)` is what
+  un-hides it. Landing mid-flight is safe *because* geometry
+  stands down above.
+- **Geometry, late** (`scheduleBorderResync`, `.borderResync`).
+  Rides `AnimationEngine.onAllAnimationsEnded`, never a duration
+  guess — a spring's visual settle is ~2× its response, so
+  `durationMS + 50` lands mid-flight. Then a grace sized to a slow
+  app's post-settle catch-up, not to the animation: read sooner
+  and it reads bounds the app has not reached yet, which is the
+  same backward snap one moment later. This is the heal for a
+  window whose app accepted no AX write at all — the ring rode our
+  commanded frames to the target while the window never moved, and
+  no echo and no WindowServer event is coming.
+
+## No echo is suppressed to smooth the settle tail
+
+The untreated case is the post-settle echo that arrives while the
+app is still catching up: in principle it pulls the overlay
+backward before later echoes walk it forward. Leave it alone.
+
+It did not appear under `KIWIDESK_NO_WS_TRACKING` (the QA lever
+that forces the AX-fallback path on a healthy Mac, since the
+symptoms are fallback-only) at the default duration, at the
+shortest, or with an app frozen across the whole flight and
+resumed after settle — the harshest case the mechanism allows,
+where its catch-up echoes walked the ring *forward* onto the real
+frame. And the guard has a known cost: after an instant
+`setFrame` the echo is the **only** carrier of overlay updates
+under AX fallback (`onFrameApplied` tees from inside
+`animation.apply` alone), so suppressing it freezes the ring in a
+case that works today. Re-open only with a device capture of the
+backward pull; if one arrives it is an
+`docs/accepted-limitations.md` row before it is a new guard.
+
+Caveat worth keeping: that observation was made *with* the grace
+in place, so it partly measures the grace. An app whose catch-up
+outlasts it would have the re-sync read a partly-caught-up frame —
+the same pull, one step smaller. That is a reason to keep the
+grace pinned by its test, not a reason to reopen.
+
+## Exercising the fallback path
+
+`KIWIDESK_NO_WS_TRACKING=<anything>` keeps `skyLightActive` false
+for the whole run: the subscription never attaches and never
+watches, because a live one keeps feeding `reconcile`, which heals
+the very drift the fallback path exists to expose. The startup log
+line names the lever, so a QA run cannot mistake it for a real
+WindowServer failure. Device QA procedure is in
+[tests.md](tests.md).

--- a/.claude/rules/borders.md
+++ b/.claude/rules/borders.md
@@ -1,6 +1,13 @@
 ---
 paths:
   - "Sources/KiwiDeskCore/Borders/**"
+  # The settle passes below are driven from App/, not Borders/ —
+  # scoping this file to Borders/ alone would mean it never loads
+  # for the exact file where someone would re-merge the two keys.
+  - "Sources/KiwiDeskCore/App/KiwiCore+Borders.swift"
+  - "Sources/KiwiDeskCore/App/KiwiCore+Settle.swift"
+  - "Sources/KiwiDeskCore/App/KiwiCore+StickyMarks.swift"
+  - "Sources/KiwiDeskCore/App/DeferredTasks.swift"
 ---
 
 # Focus ring & sticky mark overlays
@@ -67,7 +74,10 @@ second cancel the other:
   `.borderDropSettle`). WindowServer can order a ring out with no
   matching unhide; `sync`'s trailing `order(relativeTo:)` is what
   un-hides it. Landing mid-flight is safe *because* geometry
-  stands down above.
+  stands down above — precisely: it cannot move the ring of a
+  window our own animation is driving. It still re-reads state
+  for every other ring, exactly as the `updateBorders()` at the
+  end of each `retile()` does.
 - **Geometry, late** (`scheduleBorderResync`, `.borderResync`).
   Rides `AnimationEngine.onAllAnimationsEnded`, never a duration
   guess — a spring's visual settle is ~2× its response, so

--- a/.claude/rules/borders.md
+++ b/.claude/rules/borders.md
@@ -74,10 +74,12 @@ second cancel the other:
   `.borderDropSettle`). WindowServer can order a ring out with no
   matching unhide; `sync`'s trailing `order(relativeTo:)` is what
   un-hides it. Landing mid-flight is safe *because* geometry
-  stands down above — precisely: it cannot move the ring of a
-  window our own animation is driving. It still re-reads state
-  for every other ring, exactly as the `updateBorders()` at the
-  end of each `retile()` does.
+  stands down above — precisely, and only, for a window **our own
+  animation** is driving. It still re-reads state for every other
+  ring, exactly as the `updateBorders()` at the end of each
+  `retile()` does, and that includes the residual named below: a
+  window the user is dragging under a live WindowServer stream is
+  not guarded here either.
 - **Geometry, late** (`scheduleBorderResync`, `.borderResync`).
   Rides `AnimationEngine.onAllAnimationsEnded`, never a duration
   guess — a spring's visual settle is ~2× its response, so
@@ -88,6 +90,29 @@ second cancel the other:
   window whose app accepted no AX write at all — the ring rode our
   commanded frames to the target while the window never moved, and
   no echo and no WindowServer event is coming.
+
+## Never gate an overlay pass on the global animation count
+
+`AnimationEngine.activeCount` is a poor proxy for "is *this*
+window moving?", and the per-window predicate (`syncFrame`,
+`isAnimating`) is always available. Two concrete reasons:
+
+- A global gate discards a whole pass because of one window,
+  stranding every window that did settle.
+- The count has an **absorbing state**. An animation that never
+  settles keeps ticking forever, so the count never returns to
+  zero — and `notifyIfIdle` only emits `onAllAnimationsEnded` at
+  zero, so the settle signal itself dies with it. The diverged
+  spring below ~80 ms on a 60 Hz display (#599) reaches it. Note
+  what this does *not* mean: ungating a consumer does not rescue
+  it, because the arming path is behind the same signal. The fix
+  belongs in the engine.
+
+This is scoped to using the count as a **proxy**. Waiting on it
+for a genuinely global precondition is correct and stays —
+`scheduleZOrderRestore` and the deferred focus raise both do,
+because a raise issued while any frames are still landing arrives
+late on slow apps.
 
 ## No echo is suppressed to smooth the settle tail
 

--- a/.claude/rules/input-and-animation.md
+++ b/.claude/rules/input-and-animation.md
@@ -15,3 +15,9 @@ editing here:
   taps are only for mouse drag tracking.
 - Use **one `DisplayLink` per monitor** (mixed refresh rates).
   Never drive animations from a single global timer.
+- Two env levers exist for device QA of this subsystem —
+  `KIWIDESK_STRAND_LOG` (logs a window that did not land on its
+  settled target, #47) and `KIWIDESK_NO_WS_TRACKING` (forces the
+  overlays' AX-fallback path, #596). Both are documented in
+  [tests.md](tests.md), which is scoped to `Tests/**` and so does
+  not load while you are editing here.

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -150,3 +150,18 @@ the binary hash, which drops the TCC Accessibility grant (re-grant
 in System Settings), and a restart flattens session state (spaces,
 float flags) — plan QA around it; #89's signed `.app` is the
 durable fix.
+
+Two env levers exist for device QA, both off by default and both
+read once at wiring:
+
+| Lever | Does |
+|---|---|
+| `KIWIDESK_STRAND_LOG` | Logs any window that did not land on its settled target (#47). Purely a logger — inert otherwise. |
+| `KIWIDESK_NO_WS_TRACKING` | Forces the ring and mark onto the **AX-fallback** path for the whole run (#596), so fallback-only symptoms are reachable on a healthy Mac. Kills a production fast path — see [borders.md](borders.md). |
+
+Window geometry can be sampled without any screen-recording
+grant: `CGWindowListCopyWindowInfo` returns frames for every
+on-screen window, so a small poller that logs only frame
+*changes* turns "does the overlay lag or wobble?" into a diff. A
+ring's frame is its window's outset by `border.width`, so the two
+can be compared arithmetically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,7 @@ touch a matching path.
 | `OS`, `SkyLight*.swift` | [os-private-apis.md](.claude/rules/os-private-apis.md) | Resolve private symbols with `dlsym`, never `@_silgen_name`; every private path needs a public fallback |
 | `Lua` | [lua.md](.claude/rules/lua.md) | The watchdog cannot interrupt blocking C calls; registry refs never cross interpreters |
 | `Keys`, `Events`, `Animation` | [input-and-animation.md](.claude/rules/input-and-animation.md) | Carbon hotkeys (no Input Monitoring permission), one `DisplayLink` per monitor |
+| `Borders` | [borders.md](.claude/rules/borders.md) | `FollowSource` owns which frame the ring AND mark render — never re-implement it beside a call site; mid-animation the commanded tick leads and every state-reading channel (echo, WS re-read, `sync` geometry) stands down; the settle passes are two keys, early visibility and late geometry |
 | `Sources/KiwiDesk` (the GUI) | [gui.md](.claude/rules/gui.md) | North-star and settled conventions; grey don't hide; `NSCursor.set()` never push/pop; keep `body` shallow or the CI type-checker dies |
 | `Localization`, `Resources/Locales`, `scripts/*key*` | [localization.md](.claude/rules/localization.md) | Never hand-edit a catalog — the scripts own them; positional specifiers only; eight content guards with no exemption file; Core names, the GUI narrates (#96) |
 | `Tests/**` | [tests.md](.claude/rules/tests.md) | Pin the display in every geometry fixture (#531); split suites early; generous hang-guards, never tight deadlines (#344); run the suite as two commands |

--- a/Sources/KiwiDeskCore/App/DeferredTasks.swift
+++ b/Sources/KiwiDeskCore/App/DeferredTasks.swift
@@ -31,9 +31,19 @@ final class DeferredTasks {
         /// Layout + focus re-assert after a native desktop
         /// switch (`settleAfterNativeSwitch`).
         case nativeSpaceSettle
-        /// Re-orders every desired focus ring after a drag/drop
-        /// transition (`scheduleBorderDropReconcile`).
+        /// Re-asserts every desired focus ring's VISIBILITY and
+        /// stacking after a drag/drop or animated transition
+        /// (`scheduleBorderDropReconcile`) — early on purpose, and
+        /// geometry-free while a window animates.
         case borderDropSettle
+        /// Re-syncs ring AND mark GEOMETRY from real window state
+        /// a grace after the last animation ends
+        /// (`scheduleBorderResync`, #596). A separate slot from
+        /// `borderDropSettle` deliberately: they run at different
+        /// delays for different reasons, so sharing one would let
+        /// whichever landed second cancel the other — silently
+        /// dropping either the un-hide or the sticky mark's heal.
+        case borderResync
         /// Coalesced re-raise of the float layer after focus lands
         /// on a tiled window (`raiseFloatsAbove`) — a burst of focus
         /// changes collapses to one raise for the final target.

--- a/Sources/KiwiDeskCore/App/DeferredTasks.swift
+++ b/Sources/KiwiDeskCore/App/DeferredTasks.swift
@@ -15,7 +15,7 @@ import Foundation
 final class DeferredTasks {
     /// One slot per deferred job; scheduling a key replaces
     /// (cancels) whatever that key was still waiting on.
-    enum Key: Hashable {
+    enum Key: Hashable, CaseIterable {
         /// Deferred switch to a hidden window's virtual space
         /// (`scheduleFocusFollow`).
         case focusFollow

--- a/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
@@ -26,6 +26,9 @@ extension KiwiCore {
         borders.onLog = { [weak self] message in
             self?.onLog(message)
         }
+        // QA lever (#596), read once: `KIWIDESK_NO_WS_TRACKING`
+        // pins the ring and mark to the AX-fallback path.
+        borders.configureFromEnvironment()
         wireDrag()
         appBars.onSelect = { [weak self] id in
             self?.focusWindow(id, warp: true)

--- a/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
@@ -100,20 +100,67 @@ extension KiwiCore {
         }
     }
 
+    /// How long after the animation clock settles the overlays are
+    /// re-synced from real window state (#596). Not a guess at the
+    /// motion's length — the settle signal already tells us that —
+    /// but at how long a slow-AX app keeps applying queued frames
+    /// past it (100–300 ms on Electron/WebKit; 213 ms measured on
+    /// device for a frozen-then-resumed app). Reading sooner reads
+    /// bounds the app has not caught up to, which is the backward
+    /// snap this issue is about; reading later costs nothing in
+    /// the common case, because the post-settle AX echoes are
+    /// already walking the overlay onto the real frame — this pass
+    /// is the backstop for the app that sends no echo at all.
+    static let borderResyncDelayMS = 300
+
     /// WindowServer can briefly order the swap target out while a
     /// drag/drop retile and focus raise overlap. Its hide notification
     /// hides that target's ring, but macOS does not always send a
-    /// matching unhide. Re-assert the complete desired ring set after
-    /// the swap animation (or one short event turn when unanimated).
+    /// matching unhide. Re-assert the complete desired ring set one
+    /// short event turn later.
+    ///
+    /// Only for the UNANIMATED drop. When something animates, the
+    /// re-assert rides `scheduleBorderResync` off the settle signal
+    /// instead: this used to fire at `durationMS + 50`, but a
+    /// spring's visual settle is ~2× its response, so that landed
+    /// mid-flight — where `updateBorders()` is precisely the
+    /// backward snap of #596 item 3, and where it is far too early
+    /// to heal anything.
     func scheduleBorderDropReconcile() {
-        let animationMS =
-            tiler.animation.activeCount > 0
-            ? tiler.settings.animations.durationMS : 0
+        guard tiler.animation.activeCount == 0 else { return }
         deferred.schedule(
             .borderDropSettle,
-            after: .milliseconds(animationMS + 50)
+            after: .milliseconds(50)
         ) { [weak self] in
             self?.updateBorders()
+        }
+    }
+
+    /// Re-syncs both overlay families from real window state a
+    /// grace after the last animation ends — the heal for a window
+    /// whose app accepted no AX write during the flight (#596
+    /// item 2). The ring rode our commanded per-tick frames to the
+    /// target while the window never moved, and with no echo and
+    /// no WindowServer event there is nothing else to correct it;
+    /// this pass reads the state the window actually has and glues
+    /// the ring and mark back onto it.
+    ///
+    /// Drops the pass when a new animation started inside the
+    /// grace: reading a moving window is the very mistake this
+    /// delay exists to avoid, and nothing is lost — that
+    /// animation ends with its own `onAllAnimationsEnded`, which
+    /// schedules this again. Never re-arm from here; that would
+    /// poll the grace away for the whole of a long animation.
+    func scheduleBorderResync() {
+        deferred.schedule(
+            .borderDropSettle,
+            after: .milliseconds(Self.borderResyncDelayMS)
+        ) { [weak self] in
+            guard let self,
+                tiler.animation.activeCount == 0
+            else { return }
+            updateBorders()
+            updateStickyMarks()
         }
     }
 

--- a/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
@@ -174,23 +174,29 @@ extension KiwiCore {
     ///
     /// Deliberately UNGATED on the animation count. The obvious
     /// guard — bail if something started animating inside the
-    /// grace — is redundant with the fix this ships:
-    /// `FollowSource.syncFrame` already refuses to move a window
-    /// our animation is driving, per window, which is strictly
-    /// better than one global count. It is also dangerous,
-    /// because `activeCount` has an absorbing state: an animation
-    /// that never settles (the spring integrator diverges below
-    /// ~80 ms on a 60 Hz display, #599) pins the count above zero,
-    /// and a global gate would then kill the geometry heal
-    /// **app-wide** for the rest of the session while `syncFrame`
-    /// held that window's overlays frozen forever. Before #596
-    /// this method's ancestor was the un-gated healer that kept
-    /// the ring roughly right in exactly that state; closing that
-    /// hatch would turn a cosmetic bug into a permanent freeze.
+    /// grace — discards the whole pass because of ONE window,
+    /// stranding every other window that did settle. Nothing is
+    /// bought by it: `FollowSource.syncFrame` already refuses to
+    /// move a window our animation is driving, per window, which
+    /// is what the count was standing in for. That is the general
+    /// shape — never gate on the global count as a proxy for a
+    /// per-window question. (Waiting on the count for a genuinely
+    /// global precondition is a different thing and stays
+    /// correct: the z-order restore and the deferred focus raise
+    /// both do it, because a raise issued while any frames are
+    /// still landing arrives late on slow apps.)
     ///
     /// The cost of running early is one read of a window that
     /// settled seconds ago, and the in-flight animation's own
     /// settle arms another pass behind it.
+    ///
+    /// This does NOT rescue the diverged-spring case (#599). The
+    /// arming path sits behind the same signal — `notifyIfIdle`
+    /// only fires `onAllAnimationsEnded` at `activeCount == 0` —
+    /// so when an animation never settles this pass is never
+    /// scheduled, gate or no gate, and the same is true of the
+    /// deferred focus raise and the z-order restore. That wants
+    /// the engine-level fix tracked on #599, not a gate here.
     func runBorderResync() {
         updateBorders()
         updateStickyMarks()

--- a/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
@@ -111,10 +111,10 @@ extension KiwiCore {
     /// the common case, because the post-settle AX echoes are
     /// already walking the overlay onto the real frame — this pass
     /// is the backstop for the app that sends no echo at all.
-    /// (The live value is `borderResyncDelayMS`, a stored seam on
-    /// the main type so a test can prove the guards without
-    /// sleeping the production delay.)
-    static let defaultBorderResyncDelayMS = 300
+    /// No mutable seam sits beside it: `runBorderResync` is
+    /// directly callable, so a test drives the body rather than
+    /// waiting the delay out.
+    static let borderResyncDelayMS = 300
 
     /// WindowServer can briefly order the swap target out while a
     /// drag/drop retile and focus raise overlap. Its hide
@@ -128,10 +128,15 @@ extension KiwiCore {
     /// ring, so the sooner it runs the shorter a wrongly-hidden
     /// ring stays invisible. Landing mid-flight used to make it
     /// the backward snap of #596 item 3 — it no longer can,
-    /// because `FollowSource.syncFrame` holds an animating
-    /// window's geometry, so this pass re-orders and un-hides
-    /// without moving anything. That is why both passes exist:
-    /// this one restores VISIBILITY early and cannot fix
+    /// because `FollowSource.syncFrame` holds the geometry of a
+    /// window OUR OWN animation is driving, so this pass
+    /// re-orders and un-hides without moving that window's ring.
+    /// (It still re-reads state for every non-animating ring in
+    /// the space — the same thing the unconditional
+    /// `updateBorders()` at the end of every `retile()` does.)
+    ///
+    /// That is why both passes exist: this one restores
+    /// VISIBILITY early and cannot fix an animating window's
     /// geometry; `scheduleBorderResync` fixes GEOMETRY late and
     /// would be far too slow for a hidden ring. Separate deferred
     /// keys, so neither can cancel the other.
@@ -158,7 +163,7 @@ extension KiwiCore {
     func scheduleBorderResync() {
         deferred.schedule(
             .borderResync,
-            after: .milliseconds(borderResyncDelayMS)
+            after: .milliseconds(Self.borderResyncDelayMS)
         ) { [weak self] in
             self?.runBorderResync()
         }
@@ -167,14 +172,26 @@ extension KiwiCore {
     /// The re-sync body. Named rather than inlined so a test can
     /// drive it directly instead of waiting out the grace.
     ///
-    /// Drops the pass when a new animation started inside the
-    /// grace: reading a moving window is the very mistake the
-    /// delay exists to avoid, and nothing is lost — that
-    /// animation ends with its own `onAllAnimationsEnded`, which
-    /// schedules this again. Never re-arm from here; that would
-    /// poll the grace away for the whole of a long animation.
+    /// Deliberately UNGATED on the animation count. The obvious
+    /// guard — bail if something started animating inside the
+    /// grace — is redundant with the fix this ships:
+    /// `FollowSource.syncFrame` already refuses to move a window
+    /// our animation is driving, per window, which is strictly
+    /// better than one global count. It is also dangerous,
+    /// because `activeCount` has an absorbing state: an animation
+    /// that never settles (the spring integrator diverges below
+    /// ~80 ms on a 60 Hz display, #599) pins the count above zero,
+    /// and a global gate would then kill the geometry heal
+    /// **app-wide** for the rest of the session while `syncFrame`
+    /// held that window's overlays frozen forever. Before #596
+    /// this method's ancestor was the un-gated healer that kept
+    /// the ring roughly right in exactly that state; closing that
+    /// hatch would turn a cosmetic bug into a permanent freeze.
+    ///
+    /// The cost of running early is one read of a window that
+    /// settled seconds ago, and the in-flight animation's own
+    /// settle arms another pass behind it.
     func runBorderResync() {
-        guard tiler.animation.activeCount == 0 else { return }
         updateBorders()
         updateStickyMarks()
     }

--- a/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
@@ -111,26 +111,37 @@ extension KiwiCore {
     /// the common case, because the post-settle AX echoes are
     /// already walking the overlay onto the real frame — this pass
     /// is the backstop for the app that sends no echo at all.
-    static let borderResyncDelayMS = 300
+    /// (The live value is `borderResyncDelayMS`, a stored seam on
+    /// the main type so a test can prove the guards without
+    /// sleeping the production delay.)
+    static let defaultBorderResyncDelayMS = 300
 
     /// WindowServer can briefly order the swap target out while a
-    /// drag/drop retile and focus raise overlap. Its hide notification
-    /// hides that target's ring, but macOS does not always send a
-    /// matching unhide. Re-assert the complete desired ring set one
-    /// short event turn later.
+    /// drag/drop retile and focus raise overlap. Its hide
+    /// notification hides that target's ring, but macOS does not
+    /// always send a matching unhide. Re-assert the complete
+    /// desired ring set once the swap animation is well under way
+    /// (or one short event turn later when nothing animates).
     ///
-    /// Only for the UNANIMATED drop. When something animates, the
-    /// re-assert rides `scheduleBorderResync` off the settle signal
-    /// instead: this used to fire at `durationMS + 50`, but a
-    /// spring's visual settle is ~2× its response, so that landed
-    /// mid-flight — where `updateBorders()` is precisely the
-    /// backward snap of #596 item 3, and where it is far too early
-    /// to heal anything.
+    /// This is the VISIBILITY pass, and it is deliberately early:
+    /// `sync`'s trailing `order(relativeTo:)` is what un-hides a
+    /// ring, so the sooner it runs the shorter a wrongly-hidden
+    /// ring stays invisible. Landing mid-flight used to make it
+    /// the backward snap of #596 item 3 — it no longer can,
+    /// because `FollowSource.syncFrame` holds an animating
+    /// window's geometry, so this pass re-orders and un-hides
+    /// without moving anything. That is why both passes exist:
+    /// this one restores VISIBILITY early and cannot fix
+    /// geometry; `scheduleBorderResync` fixes GEOMETRY late and
+    /// would be far too slow for a hidden ring. Separate deferred
+    /// keys, so neither can cancel the other.
     func scheduleBorderDropReconcile() {
-        guard tiler.animation.activeCount == 0 else { return }
+        let animationMS =
+            tiler.animation.activeCount > 0
+            ? tiler.settings.animations.durationMS : 0
         deferred.schedule(
             .borderDropSettle,
-            after: .milliseconds(50)
+            after: .milliseconds(animationMS + 50)
         ) { [weak self] in
             self?.updateBorders()
         }
@@ -144,24 +155,28 @@ extension KiwiCore {
     /// no WindowServer event there is nothing else to correct it;
     /// this pass reads the state the window actually has and glues
     /// the ring and mark back onto it.
+    func scheduleBorderResync() {
+        deferred.schedule(
+            .borderResync,
+            after: .milliseconds(borderResyncDelayMS)
+        ) { [weak self] in
+            self?.runBorderResync()
+        }
+    }
+
+    /// The re-sync body. Named rather than inlined so a test can
+    /// drive it directly instead of waiting out the grace.
     ///
     /// Drops the pass when a new animation started inside the
-    /// grace: reading a moving window is the very mistake this
+    /// grace: reading a moving window is the very mistake the
     /// delay exists to avoid, and nothing is lost — that
     /// animation ends with its own `onAllAnimationsEnded`, which
     /// schedules this again. Never re-arm from here; that would
     /// poll the grace away for the whole of a long animation.
-    func scheduleBorderResync() {
-        deferred.schedule(
-            .borderDropSettle,
-            after: .milliseconds(Self.borderResyncDelayMS)
-        ) { [weak self] in
-            guard let self,
-                tiler.animation.activeCount == 0
-            else { return }
-            updateBorders()
-            updateStickyMarks()
-        }
+    func runBorderResync() {
+        guard tiler.animation.activeCount == 0 else { return }
+        updateBorders()
+        updateStickyMarks()
     }
 
     /// The rings to show for one space. Focused window always

--- a/Sources/KiwiDeskCore/App/KiwiCore+Retile.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Retile.swift
@@ -1,0 +1,65 @@
+import CoreGraphics
+
+/// The one place a layout pass is driven from (`KiwiCore.retile`).
+/// Everything a reflow must keep in step — the persisted scroll
+/// offset, both bars, both overlay families, the float clamp —
+/// runs here in a fixed order, so a new caller cannot forget half
+/// of it. Split out of `KiwiCore.swift` to keep that file under
+/// the size ceiling.
+extension KiwiCore {
+    /// `animated: nil` (the default for a bare `retile()`) means
+    /// "a structural reflow" — window open/close, mode / gap /
+    /// param change — and obeys `animations.on_relayout`. Callers
+    /// that own a more specific trigger (space switch, swap,
+    /// resize, focus slide) pass an explicit `animated:` and are
+    /// gated by their own toggle instead.
+    public func retile(
+        animated: Bool? = nil,
+        force: Bool = false,
+        newlyCreatedWindow: WindowID? = nil,
+        stashAnimated: Bool = false
+    ) {
+        tiler.retile(
+            state: state,
+            animated: animated
+                ?? tiler.settings.animations.onRelayout,
+            force: force,
+            newlyCreatedWindow: newlyCreatedWindow,
+            stashAnimated: stashAnimated
+        )
+        // Scrolling reads back its own last offset (#66); other
+        // modes never write `scrollOffset`, so this is a no-op
+        // for them.
+        persistScrollOffset()
+        updateAppBar()
+        updateSpaceBar()
+        // Rings ride the same freshness as the bar: every
+        // structural / focus / mode / settings retile. Runs after
+        // the layout above so it reads the just-updated state
+        // frames (steady state); per-tick moves come from the
+        // animation tee (`tiler.onFrameApplied`).
+        updateBorders()
+        // The sticky marks ride the same freshness (#414).
+        updateStickyMarks()
+        // An animated relayout (spawn, close, mode/gap change)
+        // restacks windows, so WindowServer fires the same
+        // hide/reorder events as a drag-swap — which can leave a
+        // ring hidden with no matching unhide. Re-assert the full
+        // ring set while the motion is under way (keyed, so a
+        // burst of retiles collapses to one). Only when something
+        // animates: a static retile moves nothing, so no restack,
+        // no drop. The geometry half of the heal is separate and
+        // lands after the motion stops (`scheduleBorderResync`,
+        // #596) — this pass is visibility only, and cannot move an
+        // animating window's ring.
+        if tiler.animation.activeCount > 0 {
+            scheduleBorderDropReconcile()
+        }
+        // Floats sit outside the layout loop above, so a bar just
+        // switched on (or a window just turned floating) can leave
+        // one hidden under a top strip; correct it here. Must run
+        // after `updateAppBar()`: the clamp reads the strips it
+        // just painted (#242).
+        clampFloatsClearOfBars()
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore+Settle.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Settle.swift
@@ -1,0 +1,40 @@
+/// What runs when the last animation stops
+/// (`AnimationEngine.onAllAnimationsEnded`).
+///
+/// The engine offers a single callback slot by design, so this
+/// method IS the dispatch. It lives here rather than beside any
+/// one client: it now serves three subsystems (z-order, focus,
+/// borders), and nesting it under one of them hid it from the
+/// other two.
+extension KiwiCore {
+    /// Fork this into a real dispatcher when a client needs
+    /// something this shape cannot express: to be **run
+    /// conditionally** on state the dispatcher would have to
+    /// know, to be **ordered** against another runner, or to be
+    /// **scoped** narrower than the global count-zero signal
+    /// (per-monitor, per-space).
+    ///
+    /// Stated as properties rather than as a list of who is
+    /// excused, deliberately: a trigger list that grows an
+    /// exemption per client stops being a rule. Today none of the
+    /// three trips them — the two raises carry their own pending
+    /// flags and re-validate at fire time, and the border re-sync
+    /// only arms a deferred task.
+    ///
+    /// Order-independence is the one property worth re-checking
+    /// when adding a runner. The two raises are order-insensitive
+    /// (the z-order restore's async pile raises end by
+    /// re-asserting the focused window on top, healing any
+    /// interleaving with the synchronous focus raise). The border
+    /// re-sync only schedules, so it cannot interleave here —
+    /// though its body can still land while a long pile raise is
+    /// draining (`performZOrderSequence` walks a background AX
+    /// queue at 1–20 ms a window), leaving ring and mark one
+    /// restack behind until the next event. Harmless, and the
+    /// next event is close.
+    func animationsDidSettle() {
+        runPendingZOrderRestore()
+        runPendingFocusRaise()
+        scheduleBorderResync()
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -77,6 +77,13 @@ public final class KiwiCore {
     /// target raises (see runPendingFocusRaise).
     var pendingFocusRaise: WindowID?
 
+    /// The post-settle overlay re-sync grace in ms (#596) — see
+    /// `KiwiCore.defaultBorderResyncDelayMS` for what the number
+    /// is sized to. Stored purely as a test seam: a scheduling
+    /// test lowers it so it can prove the guards without sleeping
+    /// the real delay. Production never writes it.
+    var borderResyncDelayMS = KiwiCore.defaultBorderResyncDelayMS
+
     /// Window ids KiwiDesk's own AX raises issued but whose focus
     /// echoes have not yet landed (#152). A matching echo is
     /// self-inflicted, not a user action: it must not supersede a
@@ -294,56 +301,5 @@ public final class KiwiCore {
         self.crash = CrashRecovery(directory: directory)
 
         bootstrapCoreServices()
-    }
-
-    /// `animated: nil` (the default for a bare `retile()`) means
-    /// "a structural reflow" — window open/close, mode / gap /
-    /// param change — and obeys `animations.on_relayout`. Callers
-    /// that own a more specific trigger (space switch, swap,
-    /// resize, focus slide) pass an explicit `animated:` and are
-    /// gated by their own toggle instead.
-    public func retile(
-        animated: Bool? = nil,
-        force: Bool = false,
-        newlyCreatedWindow: WindowID? = nil,
-        stashAnimated: Bool = false
-    ) {
-        tiler.retile(
-            state: state,
-            animated: animated
-                ?? tiler.settings.animations.onRelayout,
-            force: force,
-            newlyCreatedWindow: newlyCreatedWindow,
-            stashAnimated: stashAnimated
-        )
-        // Scrolling reads back its own last offset (#66); other
-        // modes never write `scrollOffset`, so this is a no-op
-        // for them.
-        persistScrollOffset()
-        updateAppBar()
-        updateSpaceBar()
-        // Rings ride the same freshness as the bar: every
-        // structural / focus / mode / settings retile. Runs after
-        // the layout above so it reads the just-updated state
-        // frames (steady state); per-tick moves come from the
-        // animation tee (`tiler.onFrameApplied`).
-        updateBorders()
-        // The sticky marks ride the same freshness (#414).
-        updateStickyMarks()
-        // An animated relayout (spawn, close, mode/gap change)
-        // restacks windows, so WindowServer fires the same
-        // hide/reorder events as a drag-swap — which can leave a
-        // ring hidden with no matching unhide. No call needed here
-        // any more: an animated retile ends in
-        // `onAllAnimationsEnded`, and `scheduleBorderResync` does
-        // that re-assert off the settle signal (#596), keyed so a
-        // burst of retiles still collapses to one. A static retile
-        // moves nothing, so there is no restack and no drop.
-        // Floats sit outside the layout loop above, so a bar just
-        // switched on (or a window just turned floating) can leave
-        // one hidden under a top strip; correct it here. Must run
-        // after `updateAppBar()`: the clamp reads the strips it
-        // just painted (#242).
-        clampFloatsClearOfBars()
     }
 }

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -77,13 +77,6 @@ public final class KiwiCore {
     /// target raises (see runPendingFocusRaise).
     var pendingFocusRaise: WindowID?
 
-    /// The post-settle overlay re-sync grace in ms (#596) — see
-    /// `KiwiCore.defaultBorderResyncDelayMS` for what the number
-    /// is sized to. Stored purely as a test seam: a scheduling
-    /// test lowers it so it can prove the guards without sleeping
-    /// the real delay. Production never writes it.
-    var borderResyncDelayMS = KiwiCore.defaultBorderResyncDelayMS
-
     /// Window ids KiwiDesk's own AX raises issued but whose focus
     /// echoes have not yet landed (#152). A matching echo is
     /// self-inflicted, not a user action: it must not supersede a

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -333,13 +333,12 @@ public final class KiwiCore {
         // An animated relayout (spawn, close, mode/gap change)
         // restacks windows, so WindowServer fires the same
         // hide/reorder events as a drag-swap — which can leave a
-        // ring hidden with no matching unhide. Re-assert the full
-        // ring set once the motion settles (keyed, so a burst of
-        // retiles collapses to one). Only when something animates:
-        // a static retile moves nothing, so no restack, no drop.
-        if tiler.animation.activeCount > 0 {
-            scheduleBorderDropReconcile()
-        }
+        // ring hidden with no matching unhide. No call needed here
+        // any more: an animated retile ends in
+        // `onAllAnimationsEnded`, and `scheduleBorderResync` does
+        // that re-assert off the settle signal (#596), keyed so a
+        // burst of retiles still collapses to one. A static retile
+        // moves nothing, so there is no restack and no drop.
         // Floats sit outside the layout loop above, so a bar just
         // switched on (or a window just turned floating) can leave
         // one hidden under a top strip; correct it here. Must run

--- a/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
@@ -17,9 +17,17 @@ extension BorderManager {
     /// Reads the `KIWIDESK_NO_WS_TRACKING` QA lever (#596). Any
     /// non-empty value keeps `skyLightActive` false for the whole
     /// run, so the ring and mark exercise the AX-fallback path
-    /// the settle-tail symptoms live on. Call once at wiring; the
-    /// environment parameter is the test seam (the strand
-    /// detector's `configureFromEnvironment`, mirrored).
+    /// the settle-tail symptoms live on — the same fallback
+    /// `os-private-apis.md` requires every private path to have,
+    /// and otherwise unreachable on a healthy Mac.
+    ///
+    /// Named after `StrandDetector.configureFromEnvironment` but
+    /// NOT its twin, in two ways worth keeping straight: this one
+    /// takes the environment as a parameter (that one reads
+    /// `ProcessInfo` directly), and where `KIWIDESK_STRAND_LOG`
+    /// only turns on logging and is otherwise inert, this kills a
+    /// production fast path for the whole run. Call once at
+    /// wiring.
     func configureFromEnvironment(
         _ environment: [String: String] = ProcessInfo.processInfo
             .environment

--- a/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
@@ -14,6 +14,20 @@ import AppKit
 /// deliberate deferral; a THIRD would be the trigger to extract a
 /// standalone `WindowServerWatch` service with peer subscribers (#414).
 extension BorderManager {
+    /// Reads the `KIWIDESK_NO_WS_TRACKING` QA lever (#596). Any
+    /// non-empty value keeps `skyLightActive` false for the whole
+    /// run, so the ring and mark exercise the AX-fallback path
+    /// the settle-tail symptoms live on. Call once at wiring; the
+    /// environment parameter is the test seam (the strand
+    /// detector's `configureFromEnvironment`, mirrored).
+    func configureFromEnvironment(
+        _ environment: [String: String] = ProcessInfo.processInfo
+            .environment
+    ) {
+        let value = environment["KIWIDESK_NO_WS_TRACKING"]
+        windowServerTrackingDisabled = !(value?.isEmpty ?? true)
+    }
+
     /// Geometry tracking is independent of rendering. If a raw SLS
     /// window falls back to AppKit, that panel can still follow real
     /// bounds from a healthy WindowServer event stream.
@@ -113,26 +127,45 @@ extension BorderManager {
         // Sticky marks ride the same stream as rings (#414 QA), so
         // their windows join the watch set even without a ring.
         let wanted = borderWanted.union(stickyTracked)
-        if !triedEventSource, !wanted.isEmpty {
-            triedEventSource = true
-            eventSource = SkyLightWindowEvents.shared
-            eventSource?.attach(self)
-        }
         let wasActive = skyLightActive
-        skyLightActive = eventSource?.watch(wanted) == true
+        if windowServerTrackingDisabled {
+            // Never attach or watch under the lever: a live
+            // subscription would keep feeding `reconcile`, which
+            // heals exactly the drift the fallback path is meant
+            // to expose.
+            skyLightActive = false
+        } else {
+            if !triedEventSource, !wanted.isEmpty {
+                triedEventSource = true
+                eventSource = SkyLightWindowEvents.shared
+                eventSource?.attach(self)
+            }
+            skyLightActive = eventSource?.watch(wanted) == true
+        }
         if reportedTrackingActive != skyLightActive {
             reportedTrackingActive = skyLightActive
-            let mode =
-                skyLightActive
-                ? "WindowServer border tracking active"
-                : "WindowServer border tracking unavailable; "
-                    + "using AX fallback"
-            onLog(mode)
+            onLog(trackingStatusMessage)
         }
         if wasActive, !skyLightActive {
             for overlay in overlays.values {
                 overlay.useAppKitFallback()
             }
         }
+    }
+
+    /// The one line that tells a QA run which path it is on.
+    /// Names the lever explicitly when it is what forced the
+    /// fallback: an unexplained "unavailable" on a healthy Mac
+    /// would read as a real WindowServer failure.
+    private var trackingStatusMessage: String {
+        if skyLightActive {
+            return "WindowServer border tracking active"
+        }
+        if windowServerTrackingDisabled {
+            return "WindowServer border tracking disabled by "
+                + "KIWIDESK_NO_WS_TRACKING; using AX fallback"
+        }
+        return "WindowServer border tracking unavailable; "
+            + "using AX fallback"
     }
 }

--- a/Sources/KiwiDeskCore/Borders/BorderManager+Sync.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager+Sync.swift
@@ -1,17 +1,20 @@
 import AppKit
 
-/// The frame paths of `BorderManager` — everything that decides
-/// WHERE a ring is drawn and who is allowed to move it. Split out
-/// of `BorderManager.swift` to keep each file under the size
-/// ceiling; the main type keeps the store, the lifecycle and the
-/// per-window caches those paths read.
+/// `BorderManager`'s ring-rendering paths: the steady-state
+/// `sync` (which also creates and retires overlays), the
+/// animation / AX-echo `follow`, the unguarded `apply`, and the
+/// test seams that read back what was rendered. Split out when
+/// #596's additions pushed `BorderManager.swift` past the 350
+/// line ceiling; the main type keeps the stores, the app
+/// lifecycle, the draw-order flip and the per-window caches
+/// these read.
 ///
-/// Three entry points, in descending order of authority while our
+/// The three writers, in descending order of authority while our
 /// own animation drives a window (#594/#596): `apply` is
 /// unguarded and belongs to whoever owns the frame outright (the
 /// WindowServer re-read); `follow` carries a `FollowSource` and
-/// asks the shared decision; `sync` is the steady-state rebuild
-/// and stands down on geometry alone.
+/// asks the shared decision; `sync` rebuilds everything but
+/// holds an animating window's geometry.
 extension BorderManager {
     /// Shows exactly `desired` — one ring per window — and retires
     /// the overlays of any window no longer in the set (an empty
@@ -28,13 +31,27 @@ extension BorderManager {
         for spec in desired {
             specs[spec.window] = spec
             let overlay = overlay(for: spec.window)
+            // Geometry stands down mid-animation (#596) — the one
+            // decision the mark's `sync` shares. Everything else
+            // here (create, recolor, re-order, retire) runs
+            // unconditionally: only the frame is held back.
+            // `screen` MUST derive from the same rect, not from
+            // `spec.frame`: it selects the backing scale, so on a
+            // cross-display animated move a held frame paired with
+            // the spec's screen rasterizes the ring at the wrong
+            // display's scale.
+            let frame = FollowSource.syncFrame(
+                spec: spec.frame,
+                held: overlay.lastRenderedFrame,
+                animating: isAnimating(spec.window)
+            )
             overlay.update(
-                frame: syncFrame(for: spec, overlay: overlay),
+                frame: frame,
                 width: spec.width,
                 cornerStyle: spec.cornerStyle,
                 cornerRadius: cornerRadius(for: spec.window),
                 colorHex: spec.colorHex,
-                screen: screen(for: spec.frame),
+                screen: screen(for: frame),
                 glowBlur: spec.glowBlur
             )
             // Re-assert stacking each sync (focus change, retile,
@@ -42,31 +59,6 @@ extension BorderManager {
             // window order since the ring last positioned.
             overlay.order(relativeTo: spec.window.raw)
         }
-    }
-
-    /// The frame a steady-state `sync` renders a ring at. Normally
-    /// the spec's; while OUR OWN animation drives the window the
-    /// ring holds where the last tick put it instead, because the
-    /// spec carries the echo-fed frame the motion has already left
-    /// behind (`FollowSource.steadySync`, #596). Everything else
-    /// `sync` does — create, recolor, re-order, retire — is
-    /// unaffected: only the geometry stands down.
-    ///
-    /// A ring being CREATED mid-flight (a focus change during a
-    /// pan) has no held frame and takes the spec's, one tick
-    /// behind; there is nothing better to show it, and the next
-    /// tick corrects it.
-    private func syncFrame(
-        for spec: Spec,
-        overlay: BorderOverlay
-    ) -> CGRect {
-        if FollowSource.steadySync.applies(
-            wsTracked: usesWindowServerTracking(spec.window),
-            animating: isAnimating(spec.window)
-        ) {
-            return spec.frame
-        }
-        return overlay.lastRenderedFrame ?? spec.frame
     }
 
     /// Animation / AX-echo hot path: move an already-shown ring
@@ -101,10 +93,12 @@ extension BorderManager {
         overlays[id]?.lastRenderedColorHex
     }
 
-    /// Unguarded reposition — the WS bounds re-read (`reconcile`)
-    /// and the steady-state `sync` own the ring's frame directly,
-    /// so they bypass the guards on `follow`. Internal, not
-    /// private: `reconcile` lives in the `+SkyLight` extension.
+    /// Unguarded reposition — the WS bounds re-read
+    /// (`reconcile`) owns the ring's frame outright, so it
+    /// bypasses the guards on `follow`. Internal, not private:
+    /// `reconcile` lives in the `+SkyLight` extension. `sync`
+    /// does NOT come through here; it asks
+    /// `FollowSource.syncFrame` first (#596).
     func apply(
         _ id: WindowID,
         windowFrame: CGRect,

--- a/Sources/KiwiDeskCore/Borders/BorderManager+Sync.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager+Sync.swift
@@ -1,0 +1,126 @@
+import AppKit
+
+/// The frame paths of `BorderManager` — everything that decides
+/// WHERE a ring is drawn and who is allowed to move it. Split out
+/// of `BorderManager.swift` to keep each file under the size
+/// ceiling; the main type keeps the store, the lifecycle and the
+/// per-window caches those paths read.
+///
+/// Three entry points, in descending order of authority while our
+/// own animation drives a window (#594/#596): `apply` is
+/// unguarded and belongs to whoever owns the frame outright (the
+/// WindowServer re-read); `follow` carries a `FollowSource` and
+/// asks the shared decision; `sync` is the steady-state rebuild
+/// and stands down on geometry alone.
+extension BorderManager {
+    /// Shows exactly `desired` — one ring per window — and retires
+    /// the overlays of any window no longer in the set (an empty
+    /// array retires them all).
+    public func sync(_ desired: [Spec]) {
+        let wanted = Set(desired.map(\.window))
+        updateSkyLightSubscription(wanted)
+        for (id, overlay) in overlays where !wanted.contains(id) {
+            overlay.hide()
+            overlays[id] = nil
+            specs[id] = nil
+            cornerRadii[id] = nil
+        }
+        for spec in desired {
+            specs[spec.window] = spec
+            let overlay = overlay(for: spec.window)
+            overlay.update(
+                frame: syncFrame(for: spec, overlay: overlay),
+                width: spec.width,
+                cornerStyle: spec.cornerStyle,
+                cornerRadius: cornerRadius(for: spec.window),
+                colorHex: spec.colorHex,
+                screen: screen(for: spec.frame),
+                glowBlur: spec.glowBlur
+            )
+            // Re-assert stacking each sync (focus change, retile,
+            // z-order restore) — the target may have moved in the
+            // window order since the ring last positioned.
+            overlay.order(relativeTo: spec.window.raw)
+        }
+    }
+
+    /// The frame a steady-state `sync` renders a ring at. Normally
+    /// the spec's; while OUR OWN animation drives the window the
+    /// ring holds where the last tick put it instead, because the
+    /// spec carries the echo-fed frame the motion has already left
+    /// behind (`FollowSource.steadySync`, #596). Everything else
+    /// `sync` does — create, recolor, re-order, retire — is
+    /// unaffected: only the geometry stands down.
+    ///
+    /// A ring being CREATED mid-flight (a focus change during a
+    /// pan) has no held frame and takes the spec's, one tick
+    /// behind; there is nothing better to show it, and the next
+    /// tick corrects it.
+    private func syncFrame(
+        for spec: Spec,
+        overlay: BorderOverlay
+    ) -> CGRect {
+        if FollowSource.steadySync.applies(
+            wsTracked: usesWindowServerTracking(spec.window),
+            animating: isAnimating(spec.window)
+        ) {
+            return spec.frame
+        }
+        return overlay.lastRenderedFrame ?? spec.frame
+    }
+
+    /// Animation / AX-echo hot path: move an already-shown ring
+    /// to a window's current frame. The stand-down decision is
+    /// `FollowSource.applies` — one switch shared with the
+    /// sticky mark, so no caller re-implements it (#285) and the
+    /// two overlays cannot drift (#594). A no-op for windows
+    /// without a ring.
+    public func follow(
+        _ id: WindowID,
+        windowFrame: CGRect,
+        source: FollowSource
+    ) {
+        guard
+            source.applies(
+                wsTracked: usesWindowServerTracking(id),
+                animating: isAnimating(id)
+            )
+        else { return }
+        apply(id, windowFrame: windowFrame)
+    }
+
+    /// The frame a window's ring last rendered against, for
+    /// tests that need to prove `follow` stood down (or didn't).
+    func lastFrame(_ id: WindowID) -> CGRect? {
+        overlays[id]?.lastRenderedFrame
+    }
+
+    /// Its colour sibling — for proving a `sync` that stood down
+    /// on geometry still recolored (#596).
+    func lastColorHex(_ id: WindowID) -> String? {
+        overlays[id]?.lastRenderedColorHex
+    }
+
+    /// Unguarded reposition — the WS bounds re-read (`reconcile`)
+    /// and the steady-state `sync` own the ring's frame directly,
+    /// so they bypass the guards on `follow`. Internal, not
+    /// private: `reconcile` lives in the `+SkyLight` extension.
+    func apply(
+        _ id: WindowID,
+        windowFrame: CGRect,
+        restoreVisibility: Bool = false
+    ) {
+        guard let overlay = overlays[id], let spec = specs[id]
+        else { return }
+        overlay.update(
+            frame: windowFrame,
+            width: spec.width,
+            cornerStyle: spec.cornerStyle,
+            cornerRadius: cornerRadius(for: id),
+            colorHex: spec.colorHex,
+            screen: screen(for: windowFrame),
+            glowBlur: spec.glowBlur,
+            restoreVisibility: restoreVisibility
+        )
+    }
+}

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -57,13 +57,17 @@ public final class BorderManager {
     /// Last synced spec per window, so the per-tick `follow` can
     /// recompute geometry from a fresh frame while reusing the
     /// window's color / width / corner style.
-    private var specs: [WindowID: Spec] = [:]
+    /// Internal, not private: the frame paths that read it
+    /// live in the `BorderManager+Sync` extension.
+    var specs: [WindowID: Spec] = [:]
     /// Each window's real corner radius, resolved once per window and
     /// reused. A window's radius is a fixed OS attribute, and a query
     /// that comes back empty (a square/borderless window reporting no
     /// radius) is a permanent answer, not a transient one — so a
     /// resolved default is cached too, never re-queried every sync.
-    private var cornerRadii: [WindowID: CGFloat] = [:]
+    /// Internal for the same reason as `specs` above: `sync`
+    /// retires a window's radius alongside its ring.
+    var cornerRadii: [WindowID: CGFloat] = [:]
     /// The draw order every ring is currently built for (#367).
     /// Global, not per-window: flipping it retires all overlays so
     /// each rebuilds for the new order at the next `sync`. Both
@@ -163,86 +167,6 @@ public final class BorderManager {
         activeOrder = mapped
     }
 
-    /// Shows exactly `desired` — one ring per window — and retires
-    /// the overlays of any window no longer in the set (an empty
-    /// array retires them all).
-    public func sync(_ desired: [Spec]) {
-        let wanted = Set(desired.map(\.window))
-        updateSkyLightSubscription(wanted)
-        for (id, overlay) in overlays where !wanted.contains(id) {
-            overlay.hide()
-            overlays[id] = nil
-            specs[id] = nil
-            cornerRadii[id] = nil
-        }
-        for spec in desired {
-            specs[spec.window] = spec
-            let overlay = overlay(for: spec.window)
-            overlay.update(
-                frame: spec.frame,
-                width: spec.width,
-                cornerStyle: spec.cornerStyle,
-                cornerRadius: cornerRadius(for: spec.window),
-                colorHex: spec.colorHex,
-                screen: screen(for: spec.frame),
-                glowBlur: spec.glowBlur
-            )
-            // Re-assert stacking each sync (focus change, retile,
-            // z-order restore) — the target may have moved in the
-            // window order since the ring last positioned.
-            overlay.order(relativeTo: spec.window.raw)
-        }
-    }
-
-    /// Animation / AX-echo hot path: move an already-shown ring
-    /// to a window's current frame. The stand-down decision is
-    /// `FollowSource.applies` — one switch shared with the
-    /// sticky mark, so no caller re-implements it (#285) and the
-    /// two overlays cannot drift (#594). A no-op for windows
-    /// without a ring.
-    public func follow(
-        _ id: WindowID,
-        windowFrame: CGRect,
-        source: FollowSource
-    ) {
-        guard
-            source.applies(
-                wsTracked: usesWindowServerTracking(id),
-                animating: isAnimating(id)
-            )
-        else { return }
-        apply(id, windowFrame: windowFrame)
-    }
-
-    /// The frame a window's ring last rendered against, for
-    /// tests that need to prove `follow` stood down (or didn't).
-    func lastFrame(_ id: WindowID) -> CGRect? {
-        overlays[id]?.lastRenderedFrame
-    }
-
-    /// Unguarded reposition — the WS bounds re-read (`reconcile`)
-    /// and the steady-state `sync` own the ring's frame directly,
-    /// so they bypass the guards on `follow`. Internal, not
-    /// private: `reconcile` lives in the `+SkyLight` extension.
-    func apply(
-        _ id: WindowID,
-        windowFrame: CGRect,
-        restoreVisibility: Bool = false
-    ) {
-        guard let overlay = overlays[id], let spec = specs[id]
-        else { return }
-        overlay.update(
-            frame: windowFrame,
-            width: spec.width,
-            cornerStyle: spec.cornerStyle,
-            cornerRadius: cornerRadius(for: id),
-            colorHex: spec.colorHex,
-            screen: screen(for: windowFrame),
-            glowBlur: spec.glowBlur,
-            restoreVisibility: restoreVisibility
-        )
-    }
-
     /// The window's real corner radius so the ring's arc hugs it,
     /// resolved once and cached (#357). Falls back to the shared
     /// default when SkyLight reports none — that default is cached
@@ -287,7 +211,7 @@ public final class BorderManager {
         cornerRadii[id] = nil
     }
 
-    private func overlay(for window: WindowID) -> BorderOverlay {
+    func overlay(for window: WindowID) -> BorderOverlay {
         if let existing = overlays[window] { return existing }
         let overlay = makeOverlay(for: window)
         overlays[window] = overlay

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -74,6 +74,15 @@ public final class BorderManager {
     var triedEventSource = false
     var privateRuntimeStarted = false
     var skyLightActive = false
+    /// QA lever (#596): forces the WindowServer border-tracking
+    /// path off so `skyLightActive` stays false and the ring and
+    /// mark run the AX-fallback path on a healthy machine. Set
+    /// from `KIWIDESK_NO_WS_TRACKING` at wiring — the settle-tail
+    /// symptoms this issue chases are AX-fallback-only, and the
+    /// WS stream is up on every developer Mac, so without a lever
+    /// they are unobservable. Off by default: the flag is read
+    /// once and costs nothing after.
+    var windowServerTrackingDisabled = false
     var reportedTrackingActive: Bool?
     var onLog: @MainActor (String) -> Void = { _ in }
     /// Whether OUR OWN animation currently drives this window

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -6,9 +6,11 @@ import AppKit
 /// retires one `BorderOverlay` per window, keyed by `WindowID` —
 /// mirroring `AppBarManager`'s diff-sync.
 ///
-/// Two entry points: `sync` for steady state (create / recolor /
-/// destroy), and `follow` for the animation hot path (move an
-/// existing ring to a fresh window frame, no create / destroy).
+/// The rendering paths — `sync` for steady state (create /
+/// recolor / destroy), `follow` for the animation hot path, and
+/// the unguarded `apply` — live in the `+Sync` extension; the
+/// WindowServer integration in `+SkyLight`; the dead-end bounce
+/// in `+DeadEnd`. This file owns the stores they share.
 @MainActor
 public final class BorderManager {
     /// One window's desired ring. Frames are in AX coordinates,
@@ -211,6 +213,13 @@ public final class BorderManager {
         cornerRadii[id] = nil
     }
 
+    /// The window's ring, CREATING and storing one if it has
+    /// none — a mutating getter, so only `sync` may call it (it
+    /// alone knows the window should have a ring). The dead-end
+    /// bounce deliberately routes around it via `makeOverlay`
+    /// into a separate store, so a concurrent `sync` can never
+    /// adopt or stomp its transient. Internal, not private:
+    /// `sync` lives in the `+Sync` extension.
     func overlay(for window: WindowID) -> BorderOverlay {
         if let existing = overlays[window] { return existing }
         let overlay = makeOverlay(for: window)

--- a/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
@@ -175,6 +175,12 @@ final class BorderOverlay {
     /// proving the `follow` guards stood down (or didn't).
     var lastRenderedFrame: CGRect? { lastFrame }
 
+    /// The last rendered colour — its sibling seam, for proving
+    /// that a `sync` standing down on GEOMETRY still recolored
+    /// (#596): both ride the one `update` call, so a guard placed
+    /// a level too high would silently eat the recolor.
+    var lastRenderedColorHex: String { lastColorHex }
+
     /// Renders the ring around `frame` (AX coords). Takes the raw
     /// inputs, not a finished `BorderGeometry`, because the geometry
     /// depends on the current backend's order mode — the facade owns

--- a/Sources/KiwiDeskCore/Borders/FollowSource.swift
+++ b/Sources/KiwiDeskCore/Borders/FollowSource.swift
@@ -8,6 +8,11 @@ public enum FollowSource {
     case animationTick
     /// An AX `.windowMoved` / `.windowResized` echo.
     case axEcho
+    /// The steady-state `sync` pass (`updateBorders()` /
+    /// `updateStickyMarks()`), whose frame is
+    /// `state.windows[id]?.frame` — echo-fed, so mid-animation it
+    /// is the frame the motion has already left behind (#596).
+    case steadySync
 
     /// The one follow decision both managers share: does a
     /// reported frame apply, given what currently owns the
@@ -26,6 +31,17 @@ public enum FollowSource {
     /// (`usesWindowServerTracking` vs the broader
     /// `markUsesWindowServerTracking`); only the decision is
     /// shared.
+    ///
+    /// `steadySync` stands down mid-animation for the same
+    /// reason the echo does, one step further out: its frame is
+    /// the same echo-fed state, so any `sync` landing mid-flight
+    /// (a focus change, a retile burst) snaps the overlay back to
+    /// where the window was before the motion started, until the
+    /// next tick (≤16 ms) drags it forward again. Observed on
+    /// device as a ~31 pt backward snap (#596). Unlike the echo
+    /// it ignores `wsTracked`: WindowServer tracking says who
+    /// owns the frame in steady state, and this is only about the
+    /// window that our own animation is currently moving.
     public func applies(
         wsTracked: Bool,
         animating: Bool
@@ -35,6 +51,8 @@ public enum FollowSource {
             return true
         case .axEcho:
             return !wsTracked && !animating
+        case .steadySync:
+            return !animating
         }
     }
 }

--- a/Sources/KiwiDeskCore/Borders/FollowSource.swift
+++ b/Sources/KiwiDeskCore/Borders/FollowSource.swift
@@ -1,18 +1,20 @@
+import CoreGraphics
+
 /// Who reported a followed frame — shared by the ring's and the
 /// sticky mark's `follow`. The follow guards differ by source
 /// (#594): mid-animation the commanded per-tick frame leads
 /// every echo on slow-AX apps, so it drives the ring and mark;
 /// the echo paths stand down.
+///
+/// This type owns every "which frame does an overlay render"
+/// decision — `applies` for a *reported* frame, `syncFrame` for
+/// the steady-state rebuild — so the ring and the mark cannot
+/// answer either question differently.
 public enum FollowSource {
     /// A per-tick commanded frame from `AnimationEngine.apply`.
     case animationTick
     /// An AX `.windowMoved` / `.windowResized` echo.
     case axEcho
-    /// The steady-state `sync` pass (`updateBorders()` /
-    /// `updateStickyMarks()`), whose frame is
-    /// `state.windows[id]?.frame` — echo-fed, so mid-animation it
-    /// is the frame the motion has already left behind (#596).
-    case steadySync
 
     /// The one follow decision both managers share: does a
     /// reported frame apply, given what currently owns the
@@ -31,17 +33,6 @@ public enum FollowSource {
     /// (`usesWindowServerTracking` vs the broader
     /// `markUsesWindowServerTracking`); only the decision is
     /// shared.
-    ///
-    /// `steadySync` stands down mid-animation for the same
-    /// reason the echo does, one step further out: its frame is
-    /// the same echo-fed state, so any `sync` landing mid-flight
-    /// (a focus change, a retile burst) snaps the overlay back to
-    /// where the window was before the motion started, until the
-    /// next tick (≤16 ms) drags it forward again. Observed on
-    /// device as a ~31 pt backward snap (#596). Unlike the echo
-    /// it ignores `wsTracked`: WindowServer tracking says who
-    /// owns the frame in steady state, and this is only about the
-    /// window that our own animation is currently moving.
     public func applies(
         wsTracked: Bool,
         animating: Bool
@@ -51,8 +42,50 @@ public enum FollowSource {
             return true
         case .axEcho:
             return !wsTracked && !animating
-        case .steadySync:
-            return !animating
         }
+    }
+
+    /// The frame a steady-state `sync` should render an overlay
+    /// at (#596). `spec` is the desired frame the rebuild
+    /// computed — `state.windows[id]?.frame`, which is written
+    /// only by AX move/resize echoes — and `held` is where the
+    /// overlay currently sits, `nil` for one being created now.
+    ///
+    /// While our own animation drives the window the commanded
+    /// per-tick frame is the leading truth, and `spec` is the
+    /// echo-fed frame the motion has already left behind. So a
+    /// `sync` landing mid-flight (a focus change, a retile burst)
+    /// snapped the overlay back to where the window sat before
+    /// the motion started, until the next tick (≤16 ms) dragged
+    /// it forward — ~31 pt on device. The overlay holds instead,
+    /// and takes `spec` the moment the motion stops, which is
+    /// also the pass that heals a window whose app never moved.
+    ///
+    /// A WHOLE-CHOICE hoist, not just the predicate, and
+    /// deliberately so: a `sync` is not a *reported* frame, so it
+    /// cannot ride `applies` (different question, different
+    /// return type), and an enum case would have bought nothing —
+    /// exhaustiveness fires inside this type, never at a call
+    /// site, so wiring one manager and forgetting the other still
+    /// compiles. One body called from both is the only shape that
+    /// actually holds them together.
+    ///
+    /// **Takes no `wsTracked`, and that is a real residual.**
+    /// With a live WindowServer stream and no animation of ours —
+    /// a user drag — `spec` still lags the live WS bounds, so a
+    /// `sync` there snaps the overlay back exactly as above. It is
+    /// left alone rather than guarded: standing down on
+    /// `wsTracked` would mean `sync` never moves overlay geometry
+    /// while the private stream is up, leaning the whole steady
+    /// state on it and against the public-fallback doctrine. The
+    /// drag path already re-reads WS bounds continuously
+    /// (`reconcile`), so it self-corrects within an event.
+    public static func syncFrame(
+        spec: CGRect,
+        held: CGRect?,
+        animating: Bool
+    ) -> CGRect {
+        guard animating else { return spec }
+        return held ?? spec
     }
 }

--- a/Sources/KiwiDeskCore/Borders/StickyMarkManager.swift
+++ b/Sources/KiwiDeskCore/Borders/StickyMarkManager.swift
@@ -92,37 +92,22 @@ public final class StickyMarkManager {
             overlays[spec.window] = overlay
             overlay.setMarkColor(spec.color)
             overlay.setSymbol(spec.symbolName)
-            // Geometry stands down mid-animation — the spec's
-            // frame is the echo-fed one the motion already left
-            // behind, so the mark holds where the last tick put
-            // it (the ring's `syncFrame`, mirrored, #596).
-            // Colour, symbol, stacking and retirement are
+            // Geometry stands down mid-animation (#596) — the
+            // same call the ring's `sync` makes, not a mirror of
+            // it. Colour, symbol, stacking and retirement are
             // unaffected.
             overlay.update(
-                frame: syncFrame(for: spec, overlay: overlay)
+                frame: FollowSource.syncFrame(
+                    spec: spec.frame,
+                    held: overlay.lastFrame,
+                    animating: isAnimating(spec.window)
+                )
             )
             // Re-assert stacking each sync (focus change,
             // retile, z-order restore) — never per follow
             // tick (the mark lags otherwise).
             overlay.order()
         }
-    }
-
-    /// The frame a steady-state `sync` renders a mark at — the
-    /// ring's `syncFrame`, mirrored through the same shared
-    /// decision (`FollowSource.steadySync`, #596). A mark being
-    /// CREATED mid-flight has no held frame and takes the spec's.
-    private func syncFrame(
-        for spec: Spec,
-        overlay: StickyMarkOverlay
-    ) -> CGRect {
-        if FollowSource.steadySync.applies(
-            wsTracked: isWindowServerTracked(spec.window),
-            animating: isAnimating(spec.window)
-        ) {
-            return spec.frame
-        }
-        return overlay.lastFrame ?? spec.frame
     }
 
     /// AX-echo / animation hot path: re-corner an already-shown

--- a/Sources/KiwiDeskCore/Borders/StickyMarkManager.swift
+++ b/Sources/KiwiDeskCore/Borders/StickyMarkManager.swift
@@ -92,12 +92,37 @@ public final class StickyMarkManager {
             overlays[spec.window] = overlay
             overlay.setMarkColor(spec.color)
             overlay.setSymbol(spec.symbolName)
-            overlay.update(frame: spec.frame)
+            // Geometry stands down mid-animation — the spec's
+            // frame is the echo-fed one the motion already left
+            // behind, so the mark holds where the last tick put
+            // it (the ring's `syncFrame`, mirrored, #596).
+            // Colour, symbol, stacking and retirement are
+            // unaffected.
+            overlay.update(
+                frame: syncFrame(for: spec, overlay: overlay)
+            )
             // Re-assert stacking each sync (focus change,
             // retile, z-order restore) — never per follow
             // tick (the mark lags otherwise).
             overlay.order()
         }
+    }
+
+    /// The frame a steady-state `sync` renders a mark at — the
+    /// ring's `syncFrame`, mirrored through the same shared
+    /// decision (`FollowSource.steadySync`, #596). A mark being
+    /// CREATED mid-flight has no held frame and takes the spec's.
+    private func syncFrame(
+        for spec: Spec,
+        overlay: StickyMarkOverlay
+    ) -> CGRect {
+        if FollowSource.steadySync.applies(
+            wsTracked: isWindowServerTracked(spec.window),
+            animating: isAnimating(spec.window)
+        ) {
+            return spec.frame
+        }
+        return overlay.lastFrame ?? spec.frame
     }
 
     /// AX-echo / animation hot path: re-corner an already-shown

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+FocusRaise.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+FocusRaise.swift
@@ -12,34 +12,13 @@ import Foundation
 /// front and keyboard focus land when the pan does.
 ///
 /// Timing rides the same settle signal as the z-order restore
-/// (`AnimationEngine.onAllAnimationsEnded` — the shared slot in
-/// `KiwiCore.init` runs both). Known trade, documented in the
-/// Lua reference and accepted limitations: keystrokes during
-/// the slide (one animation length, 50–1000 ms) still reach
-/// the previously focused app; Carbon hotkeys are unaffected.
+/// (`AnimationEngine.onAllAnimationsEnded`, dispatched by
+/// `animationsDidSettle` in `KiwiCore+Settle`). Known trade,
+/// documented in the Lua reference and accepted limitations:
+/// keystrokes during the slide (one animation length,
+/// 50–1000 ms) still reach the previously focused app; Carbon
+/// hotkeys are unaffected.
 extension KiwiCore {
-    /// The one `onAllAnimationsEnded` consumer — the slot is a
-    /// single callback by design; this method IS the dispatch.
-    /// Two pending-flag clients today, order-insensitive (the
-    /// z-order restore's async pile raises end by re-asserting
-    /// the focused window on top, healing any interleaving
-    /// with the synchronous focus raise). Fork this into a
-    /// real dispatcher only when (a) a third pending consumer
-    /// appears, (b) ordering between the runners becomes
-    /// semantic, or (c) a client needs per-monitor/per-space
-    /// settle instead of the global count-zero signal.
-    ///
-    /// The border re-sync (#596) is a third runner but not a
-    /// third *pending* client — it carries no flag, arms
-    /// unconditionally, and only schedules a task, so it neither
-    /// trips (a) nor (b): it cannot interleave with the two
-    /// raises above, which are done before its grace elapses.
-    func animationsDidSettle() {
-        runPendingZOrderRestore()
-        runPendingFocusRaise()
-        scheduleBorderResync()
-    }
-
     /// Fires a pending deferred raise. Called when animations
     /// settle, and directly by `focusWindow` when no animation
     /// started. Re-validates at fire time: a newer focus

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+FocusRaise.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+FocusRaise.swift
@@ -28,9 +28,16 @@ extension KiwiCore {
     /// appears, (b) ordering between the runners becomes
     /// semantic, or (c) a client needs per-monitor/per-space
     /// settle instead of the global count-zero signal.
+    ///
+    /// The border re-sync (#596) is a third runner but not a
+    /// third *pending* client — it carries no flag, arms
+    /// unconditionally, and only schedules a task, so it neither
+    /// trips (a) nor (b): it cannot interleave with the two
+    /// raises above, which are done before its grace elapses.
     func animationsDidSettle() {
         runPendingZOrderRestore()
         runPendingFocusRaise()
+        scheduleBorderResync()
     }
 
     /// Fires a pending deferred raise. Called when animations

--- a/Tests/KiwiDeskCoreTests/BorderResyncSchedulingTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderResyncSchedulingTests.swift
@@ -4,15 +4,41 @@ import Testing
 
 @testable import KiwiDeskCore
 
-/// The border re-sync's timing (#596 item 2). The old heal fired
-/// at `durationMS + 50`, but a spring's visual settle is ~2× its
-/// response, so it landed mid-flight — too early to heal anything
-/// and, being an `updateBorders()`, itself the backward snap of
-/// item 3. It now rides the settle signal the animation engine
-/// already emits.
-@Suite("Border re-sync scheduling")
+/// The border settle passes (#596). The old single heal fired at
+/// `durationMS + 50` and did both jobs badly: a spring's visual
+/// settle is ~2× its response, so it landed mid-flight — far too
+/// early to re-read a slow app's bounds, and (pre-`syncFrame`)
+/// itself a backward snap. They are now two passes with separate
+/// deferred slots: an early VISIBILITY re-assert, and a late
+/// GEOMETRY re-sync off the settle signal.
+@Suite("Border settle scheduling")
 @MainActor
 struct BorderResyncSchedulingTests {
+    /// A single tracked, focused window on the active space, at a
+    /// known frame — enough for `updateBorders()` /
+    /// `updateStickyMarks()` to produce one spec each.
+    private func seed(
+        _ core: KiwiCore,
+        frame: CGRect,
+        isSticky: Bool = false
+    ) -> WindowID {
+        let id = WindowID(1)
+        core.state.workspaces.ensureSpace("1")
+        core.state.workspaces.activate("1")
+        var window = ManagedWindow(
+            id: id,
+            pid: 100,
+            appName: "App",
+            title: "Title",
+            stickyScope: isSticky ? .global : .none
+        )
+        window.frame = frame
+        core.state.windows.upsert(window)
+        core.state.workspaces.add(id, to: "1")
+        core.state.workspaces.focus(id, in: "1")
+        return id
+    }
+
     /// Puts one animation in flight without a display link, so
     /// `activeCount` is non-zero for the guards under test.
     private func startAnimation(_ core: KiwiCore) {
@@ -28,50 +54,97 @@ struct BorderResyncSchedulingTests {
         ]
     }
 
-    @Test("The drop reconcile stands down while animating")
-    func dropReconcileStandsDownWhileAnimating() {
+    @Test("The two passes hold separate deferred slots")
+    func passesDoNotShareASlot() {
+        let core = makeTestCore()
+        core.scheduleBorderResync()
+        core.scheduleBorderDropReconcile()
+        // Sharing one key let whichever landed second cancel the
+        // other — silently dropping either the un-hide or the
+        // sticky mark's half of the heal.
+        #expect(core.deferred.task(for: .borderResync) != nil)
+        #expect(core.deferred.task(for: .borderDropSettle) != nil)
+        core.deferred.cancelAll()
+    }
+
+    @Test("The visibility pass still fires mid-animation")
+    func dropReconcileSchedulesWhileAnimating() {
         let core = makeTestCore()
         startAnimation(core)
         #expect(core.tiler.animation.activeCount == 1)
-        core.scheduleBorderDropReconcile()
-        // Nothing scheduled: the settle signal owns this case now.
-        // Pre-#596 this armed a `durationMS + 50` timer that fired
-        // mid-flight.
-        #expect(core.deferred.task(for: .borderDropSettle) == nil)
-    }
-
-    @Test("An unanimated drop still gets its short event turn")
-    func dropReconcileSchedulesWhenIdle() {
-        let core = makeTestCore()
-        #expect(core.tiler.animation.activeCount == 0)
+        // Deliberately early: `sync`'s trailing `order` is what
+        // un-hides a ring, and `FollowSource.syncFrame` keeps it
+        // from moving an animating window's geometry — so landing
+        // mid-flight is safe and the un-hide should not wait for
+        // the motion to end.
         core.scheduleBorderDropReconcile()
         #expect(core.deferred.task(for: .borderDropSettle) != nil)
         core.deferred.cancelAll()
     }
 
-    @Test("Settling schedules the re-sync")
+    @Test("Settling schedules the geometry re-sync")
     func settleSchedulesResync() {
         let core = makeTestCore()
         core.animationsDidSettle()
-        #expect(core.deferred.task(for: .borderDropSettle) != nil)
+        #expect(core.deferred.task(for: .borderResync) != nil)
         core.deferred.cancelAll()
     }
 
-    @Test("The re-sync drops itself if a new animation started")
-    func resyncDropsWhenAnimationRestarted() async {
+    @Test("The re-sync body stands down if a new animation began")
+    func resyncBodyGuardsOnActiveAnimation() {
         let core = makeTestCore()
-        core.animationsDidSettle()
-        // A new animation begins inside the grace: reading a
-        // moving window is the mistake the grace exists to avoid.
-        // Dropping loses nothing — that animation ends with its
-        // own settle, which schedules this again. Proven by the
-        // slot being clear afterwards: a re-arm would leave a
-        // fresh pending task and poll the grace away.
+        let id = WindowID(1)
+        core.borders.sync([
+            BorderManager.Spec(
+                window: id,
+                frame: CGRect(x: 0, y: 0, width: 400, height: 300),
+                colorHex: "#FF0000",
+                width: 4,
+                cornerStyle: .rounded
+            )
+        ])
+        let held = CGRect(x: 90, y: 90, width: 400, height: 300)
+        core.borders.apply(id, windowFrame: held)
+        // A new animation started inside the grace: reading a
+        // moving window is the mistake the delay exists to avoid.
+        // Nothing is lost — that animation ends with its own
+        // settle, which schedules this again.
         startAnimation(core)
-        let pending = core.deferred.task(for: .borderDropSettle)
-        await pending?.value
-        #expect(core.tiler.animation.activeCount == 1)
-        #expect(core.deferred.task(for: .borderDropSettle) == pending)
+        core.runBorderResync()
+        #expect(core.borders.lastFrame(id) == held)
+    }
+
+    @Test("The re-sync re-glues a stranded ring to real state")
+    func resyncHealsAStrandedRing() {
+        let core = makeTestCore()
+        let real = CGRect(x: 12, y: 34, width: 500, height: 400)
+        let id = seed(core, frame: real)
+        core.tiler.settings.borderStyle.enabled = true
+        core.updateBorders()
+        // The ring rode our commanded frames out to a target the
+        // app never applied — the #596 item 2 strand.
+        let stranded = CGRect(x: 900, y: 900, width: 500, height: 400)
+        core.borders.apply(id, windowFrame: stranded)
+        #expect(core.borders.lastFrame(id) == stranded)
+        core.runBorderResync()
+        // Back onto the frame the window actually has.
+        #expect(core.borders.lastFrame(id) == real)
+    }
+
+    @Test("The re-sync heals the sticky mark too")
+    func resyncHealsAStrandedMark() {
+        let core = makeTestCore()
+        let real = CGRect(x: 12, y: 34, width: 500, height: 400)
+        let id = seed(core, frame: real, isSticky: true)
+        core.tiler.settings.stickyStyle.mark = true
+        core.updateStickyMarks()
+        let stranded = CGRect(x: 900, y: 900, width: 500, height: 400)
+        core.stickyMarks.reposition(id, windowFrame: stranded)
+        #expect(core.stickyMarks.lastFrame(id) == stranded)
+        // Deleting `updateStickyMarks()` from the body leaves the
+        // ring's heal green and the mark stranded forever.
+        core.runBorderResync()
+        #expect(core.stickyMarks.lastFrame(id) == real)
     }
 
     @Test("The grace outlasts a slow app's post-settle catch-up")
@@ -79,6 +152,12 @@ struct BorderResyncSchedulingTests {
         // 100–300 ms on Electron/WebKit; 213 ms measured on device
         // for a frozen-then-resumed app. Reading sooner reads
         // bounds the app has not caught up to — the backward snap.
-        #expect(KiwiCore.borderResyncDelayMS >= 300)
+        #expect(KiwiCore.defaultBorderResyncDelayMS >= 300)
+        // And the live value is that default until a test lowers
+        // it — production never writes the seam.
+        #expect(
+            makeTestCore().borderResyncDelayMS
+                == KiwiCore.defaultBorderResyncDelayMS
+        )
     }
 }

--- a/Tests/KiwiDeskCoreTests/BorderResyncSchedulingTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderResyncSchedulingTests.swift
@@ -1,0 +1,84 @@
+import AppKit
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The border re-sync's timing (#596 item 2). The old heal fired
+/// at `durationMS + 50`, but a spring's visual settle is ~2× its
+/// response, so it landed mid-flight — too early to heal anything
+/// and, being an `updateBorders()`, itself the backward snap of
+/// item 3. It now rides the settle signal the animation engine
+/// already emits.
+@Suite("Border re-sync scheduling")
+@MainActor
+struct BorderResyncSchedulingTests {
+    /// Puts one animation in flight without a display link, so
+    /// `activeCount` is non-zero for the guards under test.
+    private func startAnimation(_ core: KiwiCore) {
+        core.tiler.animation.animations[DisplayID(1)] = [
+            WindowID(1): FrameAnimation(
+                from: CGRect(x: 0, y: 0, width: 10, height: 10),
+                to: CGRect(x: 100, y: 0, width: 10, height: 10),
+                spring: Spring(
+                    response: 0.35,
+                    dampingFraction: 0.85
+                )
+            )
+        ]
+    }
+
+    @Test("The drop reconcile stands down while animating")
+    func dropReconcileStandsDownWhileAnimating() {
+        let core = makeTestCore()
+        startAnimation(core)
+        #expect(core.tiler.animation.activeCount == 1)
+        core.scheduleBorderDropReconcile()
+        // Nothing scheduled: the settle signal owns this case now.
+        // Pre-#596 this armed a `durationMS + 50` timer that fired
+        // mid-flight.
+        #expect(core.deferred.task(for: .borderDropSettle) == nil)
+    }
+
+    @Test("An unanimated drop still gets its short event turn")
+    func dropReconcileSchedulesWhenIdle() {
+        let core = makeTestCore()
+        #expect(core.tiler.animation.activeCount == 0)
+        core.scheduleBorderDropReconcile()
+        #expect(core.deferred.task(for: .borderDropSettle) != nil)
+        core.deferred.cancelAll()
+    }
+
+    @Test("Settling schedules the re-sync")
+    func settleSchedulesResync() {
+        let core = makeTestCore()
+        core.animationsDidSettle()
+        #expect(core.deferred.task(for: .borderDropSettle) != nil)
+        core.deferred.cancelAll()
+    }
+
+    @Test("The re-sync drops itself if a new animation started")
+    func resyncDropsWhenAnimationRestarted() async {
+        let core = makeTestCore()
+        core.animationsDidSettle()
+        // A new animation begins inside the grace: reading a
+        // moving window is the mistake the grace exists to avoid.
+        // Dropping loses nothing — that animation ends with its
+        // own settle, which schedules this again. Proven by the
+        // slot being clear afterwards: a re-arm would leave a
+        // fresh pending task and poll the grace away.
+        startAnimation(core)
+        let pending = core.deferred.task(for: .borderDropSettle)
+        await pending?.value
+        #expect(core.tiler.animation.activeCount == 1)
+        #expect(core.deferred.task(for: .borderDropSettle) == pending)
+    }
+
+    @Test("The grace outlasts a slow app's post-settle catch-up")
+    func resyncDelayCoversTheCatchUpWindow() {
+        // 100–300 ms on Electron/WebKit; 213 ms measured on device
+        // for a frozen-then-resumed app. Reading sooner reads
+        // bounds the app has not caught up to — the backward snap.
+        #expect(KiwiCore.borderResyncDelayMS >= 300)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/BorderResyncSchedulingTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderResyncSchedulingTests.swift
@@ -23,6 +23,12 @@ struct BorderResyncSchedulingTests {
         isSticky: Bool = false
     ) -> WindowID {
         let id = WindowID(1)
+        // Pin the display: the heal path runs the real layout
+        // through `calculatedFrames`, so an inherited `NSScreen`
+        // would make this assert whatever the host happens to be.
+        core.tiler.visibleBounds = { _ in
+            CGRect(x: 0, y: 0, width: 1600, height: 1000)
+        }
         core.state.workspaces.ensureSpace("1")
         core.state.workspaces.activate("1")
         var window = ManagedWindow(
@@ -90,28 +96,25 @@ struct BorderResyncSchedulingTests {
         core.deferred.cancelAll()
     }
 
-    @Test("The re-sync body stands down if a new animation began")
-    func resyncBodyGuardsOnActiveAnimation() {
+    @Test("A window animating inside the grace keeps its frame")
+    func resyncLeavesAnAnimatingWindowAlone() {
         let core = makeTestCore()
-        let id = WindowID(1)
-        core.borders.sync([
-            BorderManager.Spec(
-                window: id,
-                frame: CGRect(x: 0, y: 0, width: 400, height: 300),
-                colorHex: "#FF0000",
-                width: 4,
-                cornerStyle: .rounded
-            )
-        ])
-        let held = CGRect(x: 90, y: 90, width: 400, height: 300)
-        core.borders.apply(id, windowFrame: held)
-        // A new animation started inside the grace: reading a
-        // moving window is the mistake the delay exists to avoid.
-        // Nothing is lost — that animation ends with its own
-        // settle, which schedules this again.
+        let real = CGRect(x: 12, y: 34, width: 500, height: 400)
+        let id = seed(core, frame: real)
+        core.tiler.settings.borderStyle.enabled = true
+        core.updateBorders()
+        let commanded = CGRect(x: 700, y: 500, width: 500, height: 400)
+        core.borders.apply(id, windowFrame: commanded)
+        // A new animation began inside the grace. The body runs
+        // anyway — it is deliberately UNGATED on the animation
+        // count — and the window is protected per-window by
+        // `FollowSource.syncFrame`, which is strictly better: a
+        // global gate has an absorbing state (an animation that
+        // never settles pins the count and kills the heal
+        // app-wide forever, #599).
         startAnimation(core)
         core.runBorderResync()
-        #expect(core.borders.lastFrame(id) == held)
+        #expect(core.borders.lastFrame(id) == commanded)
     }
 
     @Test("The re-sync re-glues a stranded ring to real state")
@@ -152,12 +155,6 @@ struct BorderResyncSchedulingTests {
         // 100–300 ms on Electron/WebKit; 213 ms measured on device
         // for a frozen-then-resumed app. Reading sooner reads
         // bounds the app has not caught up to — the backward snap.
-        #expect(KiwiCore.defaultBorderResyncDelayMS >= 300)
-        // And the live value is that default until a test lowers
-        // it — production never writes the seam.
-        #expect(
-            makeTestCore().borderResyncDelayMS
-                == KiwiCore.defaultBorderResyncDelayMS
-        )
+        #expect(KiwiCore.borderResyncDelayMS >= 300)
     }
 }

--- a/Tests/KiwiDeskCoreTests/BorderSteadySyncTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderSteadySyncTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import KiwiDeskCore
 
-/// `FollowSource.steadySync` (#596 item 3): a steady-state `sync`
+/// `FollowSource.syncFrame` (#596 item 3): a steady-state `sync`
 /// carries `state.windows[id]?.frame` — the echo-fed frame — so
 /// one landing mid-animation snapped the overlay back to where
 /// the window was before the motion started, until the next tick
@@ -134,6 +134,26 @@ struct StickyMarkSteadySyncTests {
             StickyMarkManager.Spec(window: WindowID(1), frame: stale)
         ])
         #expect(marks.lastFrame(WindowID(1)) == tick)
+        marks.isAnimating = { _ in false }
+        marks.sync([
+            StickyMarkManager.Spec(window: WindowID(1), frame: stale)
+        ])
+        #expect(marks.lastFrame(WindowID(1)) == stale)
+    }
+
+    @Test("Idle and WS-tracked, sync still moves the mark")
+    func markSyncAppliesWhenTrackedAndIdle() {
+        let marks = StickyMarkManager()
+        let start = CGRect(x: 0, y: 0, width: 400, height: 300)
+        let stale = CGRect(x: 5, y: 5, width: 400, height: 300)
+        marks.sync([
+            StickyMarkManager.Spec(window: WindowID(1), frame: start)
+        ])
+        // The mark keeps a live `isWindowServerTracked` closure
+        // for `follow`, so the ring's twin mistake — bolting a
+        // WS-tracked stand-down onto `sync` — is reachable here
+        // too, and would freeze every tracked mark permanently.
+        marks.isWindowServerTracked = { _ in true }
         marks.isAnimating = { _ in false }
         marks.sync([
             StickyMarkManager.Spec(window: WindowID(1), frame: stale)

--- a/Tests/KiwiDeskCoreTests/BorderSteadySyncTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderSteadySyncTests.swift
@@ -1,0 +1,126 @@
+import AppKit
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+/// `FollowSource.steadySync` (#596 item 3): a steady-state `sync`
+/// carries `state.windows[id]?.frame` — the echo-fed frame — so
+/// one landing mid-animation snapped the overlay back to where
+/// the window was before the motion started, until the next tick
+/// dragged it forward again (observed on device as a ~31 pt
+/// backward jump). Geometry stands down; everything else `sync`
+/// does must not.
+@Suite("Border steady-sync animation guard")
+@MainActor
+struct BorderSteadySyncTests {
+    private func spec(
+        _ id: UInt32,
+        frame: CGRect,
+        color: String = "#FF0000"
+    ) -> BorderManager.Spec {
+        BorderManager.Spec(
+            window: WindowID(id),
+            frame: frame,
+            colorHex: color,
+            width: 4,
+            cornerStyle: .rounded
+        )
+    }
+
+    private let start = CGRect(x: 0, y: 0, width: 400, height: 300)
+    private let stale = CGRect(x: 5, y: 5, width: 400, height: 300)
+    private let tick = CGRect(x: 200, y: 200, width: 400, height: 300)
+
+    @Test("A sync mid-animation holds the last commanded frame")
+    func syncHoldsFrameWhileAnimating() {
+        let border = BorderManager()
+        border.sync([spec(1, frame: start)])
+        border.isAnimating = { _ in true }
+        // The ring rides the tick out to the target...
+        border.follow(
+            WindowID(1),
+            windowFrame: tick,
+            source: .animationTick
+        )
+        #expect(border.lastFrame(WindowID(1)) == tick)
+        // ...and a retile burst / focus change mid-flight must
+        // not drag it back to the frame state still holds.
+        border.sync([spec(1, frame: stale)])
+        #expect(border.lastFrame(WindowID(1)) == tick)
+        // Settled, the same sync owns the ring again — this is
+        // the pass that heals a window whose app never moved.
+        border.isAnimating = { _ in false }
+        border.sync([spec(1, frame: stale)])
+        #expect(border.lastFrame(WindowID(1)) == stale)
+    }
+
+    @Test("Only geometry stands down — sync still recolors")
+    func syncStillRecolorsWhileAnimating() {
+        let border = BorderManager()
+        border.sync([spec(1, frame: start)])
+        border.isAnimating = { _ in true }
+        border.follow(
+            WindowID(1),
+            windowFrame: tick,
+            source: .animationTick
+        )
+        border.sync([spec(1, frame: stale, color: "#00FF00")])
+        // Held frame, new colour: the recolor rode the same
+        // `overlay.update` call the frame guard sits inside, so a
+        // guard placed one level too high would have eaten it.
+        #expect(border.lastFrame(WindowID(1)) == tick)
+        #expect(border.lastColorHex(WindowID(1)) == "#00FF00")
+    }
+
+    @Test("A ring created mid-animation takes the spec frame")
+    func newRingMidAnimationUsesSpec() {
+        let border = BorderManager()
+        border.isAnimating = { _ in true }
+        // No held frame to prefer — one tick behind beats no ring.
+        border.sync([spec(2, frame: stale)])
+        #expect(border.lastFrame(WindowID(2)) == stale)
+    }
+
+    @Test("Retirement is unaffected mid-animation")
+    func retirementUnaffectedWhileAnimating() {
+        let border = BorderManager()
+        border.sync([spec(1, frame: start), spec(2, frame: stale)])
+        border.isAnimating = { _ in true }
+        border.sync([spec(1, frame: start)])
+        #expect(border.borderedWindows == [WindowID(1)])
+    }
+}
+
+/// The sticky mark mirrors the ring through the same shared
+/// decision, so the two overlays cannot drift (#285/#594/#596).
+@Suite("Sticky mark steady-sync animation guard")
+@MainActor
+struct StickyMarkSteadySyncTests {
+    @Test("A sync mid-animation holds the mark's last frame")
+    func markSyncHoldsFrameWhileAnimating() {
+        let marks = StickyMarkManager()
+        let start = CGRect(x: 0, y: 0, width: 400, height: 300)
+        let stale = CGRect(x: 5, y: 5, width: 400, height: 300)
+        let tick = CGRect(x: 200, y: 200, width: 400, height: 300)
+        marks.sync([
+            StickyMarkManager.Spec(window: WindowID(1), frame: start)
+        ])
+        marks.isAnimating = { _ in true }
+        marks.follow(
+            WindowID(1),
+            windowFrame: tick,
+            source: .animationTick
+        )
+        #expect(marks.lastFrame(WindowID(1)) == tick)
+        marks.sync([
+            StickyMarkManager.Spec(window: WindowID(1), frame: stale)
+        ])
+        #expect(marks.lastFrame(WindowID(1)) == tick)
+        marks.isAnimating = { _ in false }
+        marks.sync([
+            StickyMarkManager.Spec(window: WindowID(1), frame: stale)
+        ])
+        #expect(marks.lastFrame(WindowID(1)) == stale)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/BorderSteadySyncTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderSteadySyncTests.swift
@@ -73,23 +73,6 @@ struct BorderSteadySyncTests {
         #expect(border.lastColorHex(WindowID(1)) == "#00FF00")
     }
 
-    @Test("Idle and WS-tracked, sync still moves the ring")
-    func syncAppliesWhenTrackedAndIdle() {
-        let border = BorderManager()
-        border.sync([spec(1, frame: start)])
-        // Force the stream live AFTER sync (`sync` re-runs the
-        // subscription, which resets `skyLightActive`).
-        border.skyLightActive = true
-        border.isAnimating = { _ in false }
-        border.sync([spec(1, frame: stale)])
-        // Pins that the stand-down is keyed on OUR animation
-        // alone. "Harmonizing" it to also stand down while
-        // WS-tracked reads plausible and passes every other test
-        // here — and would freeze every tracked ring at its last
-        // frame permanently, `sync` being the steady-state path.
-        #expect(border.lastFrame(WindowID(1)) == stale)
-    }
-
     @Test("A ring created mid-animation takes the spec frame")
     func newRingMidAnimationUsesSpec() {
         let border = BorderManager()
@@ -149,10 +132,24 @@ struct StickyMarkSteadySyncTests {
         marks.sync([
             StickyMarkManager.Spec(window: WindowID(1), frame: start)
         ])
-        // The mark keeps a live `isWindowServerTracked` closure
-        // for `follow`, so the ring's twin mistake — bolting a
-        // WS-tracked stand-down onto `sync` — is reachable here
-        // too, and would freeze every tracked mark permanently.
+        // The one live guard against a plausible future
+        // "harmonization": making `sync` also stand down while
+        // WindowServer-tracked, which reads sensible and would
+        // freeze every tracked overlay at its last frame
+        // permanently, `sync` being the steady-state path.
+        //
+        // This test lives on the MARK, not the ring, and that
+        // asymmetry is the point. `BorderManager.sync` opens with
+        // `updateSkyLightSubscription`, which recomputes
+        // `skyLightActive` from scratch — so a ring-side version
+        // of this test reads `false` no matter what it set, and
+        // could never fail in the direction it claims (a guard
+        // that cannot fire is worse than none). The mark's
+        // `isWindowServerTracked` is a plain injected closure its
+        // `sync` never recomputes, so here the mistake really
+        // does trip. The shared `FollowSource.syncFrame` takes no
+        // `wsTracked` at all, so introducing one would change a
+        // signature both managers call — and fail this.
         marks.isWindowServerTracked = { _ in true }
         marks.isAnimating = { _ in false }
         marks.sync([

--- a/Tests/KiwiDeskCoreTests/BorderSteadySyncTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderSteadySyncTests.swift
@@ -73,6 +73,23 @@ struct BorderSteadySyncTests {
         #expect(border.lastColorHex(WindowID(1)) == "#00FF00")
     }
 
+    @Test("Idle and WS-tracked, sync still moves the ring")
+    func syncAppliesWhenTrackedAndIdle() {
+        let border = BorderManager()
+        border.sync([spec(1, frame: start)])
+        // Force the stream live AFTER sync (`sync` re-runs the
+        // subscription, which resets `skyLightActive`).
+        border.skyLightActive = true
+        border.isAnimating = { _ in false }
+        border.sync([spec(1, frame: stale)])
+        // Pins that the stand-down is keyed on OUR animation
+        // alone. "Harmonizing" it to also stand down while
+        // WS-tracked reads plausible and passes every other test
+        // here — and would freeze every tracked ring at its last
+        // frame permanently, `sync` being the steady-state path.
+        #expect(border.lastFrame(WindowID(1)) == stale)
+    }
+
     @Test("A ring created mid-animation takes the spec frame")
     func newRingMidAnimationUsesSpec() {
         let border = BorderManager()

--- a/Tests/KiwiDeskCoreTests/BorderTrackingLeverTests.swift
+++ b/Tests/KiwiDeskCoreTests/BorderTrackingLeverTests.swift
@@ -1,0 +1,52 @@
+import AppKit
+import CoreGraphics
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The `KIWIDESK_NO_WS_TRACKING` QA lever (#596): the settle-tail
+/// symptoms are AX-fallback-only, and the WindowServer stream is
+/// up on every developer Mac, so the fallback path needs a way to
+/// be forced on a healthy machine.
+@Suite("Border WindowServer tracking lever")
+@MainActor
+struct BorderTrackingLeverTests {
+    @Test("Any non-empty value arms the lever; absent leaves it off")
+    func environmentDecode() {
+        let border = BorderManager()
+        border.configureFromEnvironment([:])
+        #expect(!border.windowServerTrackingDisabled)
+        // Present-but-empty is "not set" (the strand detector's
+        // rule, mirrored) — `env VAR= app` must not arm it.
+        border.configureFromEnvironment([
+            "KIWIDESK_NO_WS_TRACKING": ""
+        ])
+        #expect(!border.windowServerTrackingDisabled)
+        border.configureFromEnvironment([
+            "KIWIDESK_NO_WS_TRACKING": "1"
+        ])
+        #expect(border.windowServerTrackingDisabled)
+    }
+
+    @Test("Armed, the subscription never attaches or goes active")
+    func subscriptionStandsDown() {
+        let border = BorderManager()
+        border.configureFromEnvironment([
+            "KIWIDESK_NO_WS_TRACKING": "yes"
+        ])
+        // Past the dormant-runtime guard, so the lever is what
+        // holds the stream down — not the unit-test environment.
+        border.start()
+        border.skyLightActive = true
+        border.updateSkyLightSubscription([WindowID(1)])
+        #expect(!border.skyLightActive)
+        // No attach: a live subscription would keep feeding
+        // `reconcile`, healing the drift the lever exposes.
+        #expect(!border.triedEventSource)
+        // And the predicates both consumers read follow it down,
+        // so the AX echo becomes the ring's and mark's carrier.
+        #expect(!border.usesWindowServerTracking(WindowID(1)))
+        #expect(!border.markUsesWindowServerTracking(WindowID(1)))
+        border.stop()
+    }
+}

--- a/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
+++ b/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
@@ -85,11 +85,10 @@ struct DeferredTasksTests {
         let owner = DeferredTasks()
         var fired = false
         let body: @MainActor () -> Void = { fired = true }
-        let keys: [DeferredTasks.Key] = [
-            .focusFollow, .startupSweep,
-            .spaceSettle, .nativeSpaceSettle,
-            .borderDropSettle, .borderResync,
-        ]
+        // Discovered, not enumerated: a hand-listed sweep is one
+        // more place to forget a new key (parity-tests.md prefers
+        // discovery for exactly this reason).
+        let keys = DeferredTasks.Key.allCases
         for key in keys {
             owner.schedule(key, after: .milliseconds(5), body)
         }

--- a/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
+++ b/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
@@ -88,7 +88,7 @@ struct DeferredTasksTests {
         let keys: [DeferredTasks.Key] = [
             .focusFollow, .startupSweep,
             .spaceSettle, .nativeSpaceSettle,
-            .borderDropSettle,
+            .borderDropSettle, .borderResync,
         ]
         for key in keys {
             owner.schedule(key, after: .milliseconds(5), body)

--- a/Tests/KiwiDeskCoreTests/TestCore.swift
+++ b/Tests/KiwiDeskCoreTests/TestCore.swift
@@ -71,5 +71,13 @@ func makeTestCore(
     // silently turn a KiwiCore test's animations into instant
     // snaps (same host-state-leak class as the hotkey registrar).
     core.tiler.animation.reduceMotion = { false }
+    // Same class again (#596): bootstrap reads the
+    // `KIWIDESK_NO_WS_TRACKING` QA lever from the real process
+    // environment, so a developer who has it exported would get a
+    // different core in every test. Inert today — the private
+    // runtime never starts under test, so `skyLightActive` is
+    // already false — but neutralized here so it stays that way
+    // if the lever ever gains a second effect.
+    core.borders.windowServerTrackingDisabled = false
     return core
 }

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -483,6 +483,50 @@ the ring and target together. No private symbol is linked at launch,
 and the optimization never changes SIP requirements or the layout/state
 model.
 
+**Everything that reads window state stands down mid-animation —
+including `sync` (#596):** while our own animation drives a
+window the commanded per-tick frame owns its ring and mark
+(#594). The AX echo and the WindowServer re-read already stand
+down; the third reader is the steady-state `sync`, whose frame is
+that same echo-fed state. It is the easy one to miss, because
+`sync` reads as a rebuild rather than a move — so a retile burst
+or focus change mid-flight snapped the overlay back to where the
+window sat before the motion started (~31 pt on device) until the
+next tick dragged it forward. The case is routed through the one
+shared decision (`FollowSource.steadySync`) rather than guarded
+at each `sync`, which is what forces the sticky mark through the
+same change: it had the identical defect. Only geometry stands
+down — create, recolor, re-order and retire must not.
+
+**The heal rides the settle signal, not a duration guess
+(#596):** once the motion stops the overlays need one re-sync
+from real state, because an app that accepted no AX write for the
+whole flight leaves the ring parked over empty space with no echo
+and no WindowServer event left to correct it. The old
+`durationMS + 50` timer predates that signal and is wrong in both
+directions — a spring's visual settle is ~2× its response, so it
+landed mid-flight, too early to heal anything and itself the
+snap above. The replacement waits for `onAllAnimationsEnded`,
+then a grace sized to a **slow-AX app's post-settle catch-up**,
+not to the animation: read sooner and it reads bounds the app has
+not reached yet, which is the same backward snap one moment
+later.
+
+**No echo is suppressed to smooth that tail (#596).** The
+untreated case is the post-settle echo that arrives while the app
+is still catching up — in principle it pulls the ring backward
+before later echoes walk it forward. Suppressing echoes for a
+grace would be a heuristic guarding a symptom that did not appear
+under a lever forcing the AX-fallback path
+(`KIWIDESK_NO_WS_TRACKING`), including with an app frozen across
+the whole flight, where its catch-up echoes walked the ring
+*forward* onto the real frame. And it is the one guard with a
+known cost: after an instant `setFrame` the echo is the *only*
+carrier of ring updates under AX fallback, so suppressing it
+freezes the ring in a case that works today. The delayed re-sync
+buys the same smoothness without silencing anything. Re-open only
+with a device capture of the backward pull.
+
 **Two vocabularies, one split (#185 review, 2026-07-12):**
 *navigation* (`focus`, window `swap`) is spatial and
 layout-agnostic — left/right/up/down everywhere, per the table

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -483,50 +483,6 @@ the ring and target together. No private symbol is linked at launch,
 and the optimization never changes SIP requirements or the layout/state
 model.
 
-**Everything that reads window state stands down mid-animation —
-including `sync` (#596):** while our own animation drives a
-window the commanded per-tick frame owns its ring and mark
-(#594). The AX echo and the WindowServer re-read already stand
-down; the third reader is the steady-state `sync`, whose frame is
-that same echo-fed state. It is the easy one to miss, because
-`sync` reads as a rebuild rather than a move — so a retile burst
-or focus change mid-flight snapped the overlay back to where the
-window sat before the motion started (~31 pt on device) until the
-next tick dragged it forward. The case is routed through the one
-shared decision (`FollowSource.steadySync`) rather than guarded
-at each `sync`, which is what forces the sticky mark through the
-same change: it had the identical defect. Only geometry stands
-down — create, recolor, re-order and retire must not.
-
-**The heal rides the settle signal, not a duration guess
-(#596):** once the motion stops the overlays need one re-sync
-from real state, because an app that accepted no AX write for the
-whole flight leaves the ring parked over empty space with no echo
-and no WindowServer event left to correct it. The old
-`durationMS + 50` timer predates that signal and is wrong in both
-directions — a spring's visual settle is ~2× its response, so it
-landed mid-flight, too early to heal anything and itself the
-snap above. The replacement waits for `onAllAnimationsEnded`,
-then a grace sized to a **slow-AX app's post-settle catch-up**,
-not to the animation: read sooner and it reads bounds the app has
-not reached yet, which is the same backward snap one moment
-later.
-
-**No echo is suppressed to smooth that tail (#596).** The
-untreated case is the post-settle echo that arrives while the app
-is still catching up — in principle it pulls the ring backward
-before later echoes walk it forward. Suppressing echoes for a
-grace would be a heuristic guarding a symptom that did not appear
-under a lever forcing the AX-fallback path
-(`KIWIDESK_NO_WS_TRACKING`), including with an app frozen across
-the whole flight, where its catch-up echoes walked the ring
-*forward* onto the real frame. And it is the one guard with a
-known cost: after an instant `setFrame` the echo is the *only*
-carrier of ring updates under AX fallback, so suppressing it
-freezes the ring in a case that works today. The delayed re-sync
-buys the same smoothness without silencing anything. Re-open only
-with a device capture of the backward pull.
-
 **Two vocabularies, one split (#185 review, 2026-07-12):**
 *navigation* (`focus`, window `swap`) is spatial and
 layout-agnostic — left/right/up/down everywhere, per the table


### PR DESCRIPTION
Closes the #596 settle-tail cluster: the three symptoms at the
temporal edge of the #594 guard, where the animation clock settles
while a slow-AX app is still applying queued frames.

## What the device evidence changed

The issue proposed an animation-scoped **grace suppressing echoes**
for item 1, explicitly gated on getting evidence first. The opening
commit adds that instrument — `KIWIDESK_NO_WS_TRACKING`, which
forces the AX-fallback path the symptoms live on (the WindowServer
stream is up on every developer Mac, so they are otherwise
unobservable). What it found:

- **Item 1 (post-settle backward echo) never appeared** — not at
  the default duration, not at the shortest, and not under the
  harshest case the mechanism allows: an app `SIGSTOP`ped across
  the whole flight and resumed after settle, whose catch-up echoes
  walked the ring *forward* onto the real frame. **So no echo is
  suppressed.** The guard has a known cost — after an instant
  `setFrame` the echo is the *only* carrier of ring updates under
  AX fallback — and it would have been guarding a symptom nothing
  produced.
- **Item 3 (mid-flight `sync` rewind) reproduced twice**, ~31 pt,
  and **its trigger was item 2's own `durationMS + 50` timer**:
  retile ≈390 ms + 300 ms predicted 690–710 ms, observed 704 ms.
  The three items were one loop.

## The change

**`FollowSource.syncFrame`** — a steady-state `sync` carries
`state.windows[id]?.frame`, the echo-fed frame, so one landing
mid-flight snapped the overlay back to the pre-motion frame until
the next tick. The decision is hoisted into one static both
managers call, which is what actually holds them together: an enum
*case* would not have, since exhaustiveness fires inside the type
and never at a call site. `updateStickyMarks()` had the identical
defect. Only geometry stands down — create, recolor, re-order and
retire still run.

**Two settle passes, two deferred keys** — visibility early
(`durationMS + 50`, re-orders and un-hides; safe mid-flight
*because* geometry now stands down) and geometry late, off
`onAllAnimationsEnded` plus a grace sized to a slow app's
post-settle catch-up rather than to the animation. The old single
heal did both jobs badly from one mid-flight timer.

The geometry pass is **ungated on the animation count**: a global
gate discards the whole pass because one window started moving,
and `syncFrame` already protects per window. It does not rescue
the diverged-spring case — the arming path is behind the same
signal — which is #599's to fix.

## Verification

Full gate green on the rebased branch: `swift build`, 2155 tests +
14 `ExecTests`, `scripts/lint.sh` exit 0, release build clean (CI
billing is still down, so run locally).

Device QA under the lever, on a frozen Electron window:

| criterion | result |
|---|---|
| No mid-flight backward snap | gone — ring rides ticks monotonically where it previously snapped twice |
| Stranded ring healed | **new** — returns onto the frozen window's real frame at ~2.5 s and holds it |
| Freeze test still heals after CONT | not regressed — ends exactly glued |
| No post-settle backward wobble | none in any probe |

## Review

Both reviewers, two rounds. Findings that changed the code rather
than the prose: the `screen`/`frame` inconsistency on a
cross-display move; the early visibility pass restored after the
reviewer showed my reason for deleting it was obsoleted by this
PR's own fix; the shared deferred key that let one pass cancel the
other; and the `activeCount` gate, whose absorbing state would
have frozen the overlays permanently. One test that could not fail
in the direction it claimed was deleted rather than propped up.

Filed, deliberately not fixed here: **#599** (the spring integrator
diverges below ~80 ms on a 60 Hz display — spectral radius > 1, and
it kills the settle signal for four consumers) and **#601** (a
`core-boundaries.md` invariant six files falsify, with no guard).

Fixes #596
