### PR TITLE
fix(settings): give a revealed card the pane's own top gutter

### DIFF
--- a/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
@@ -50,7 +50,7 @@ struct AppRulesSection: View {
                     addRow
                 }
             }
-            .padding(16)
+            .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
         }
     }
 

--- a/Sources/KiwiDesk/Settings/Sections/AppearanceSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppearanceSection.swift
@@ -22,7 +22,7 @@ struct AppearanceSection: View {
                 FocusBorderEditor(model: model)
                 StickyMarkEditor(model: model)
             }
-            .padding(16)
+            .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
         }
     }
 }

--- a/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
@@ -36,7 +36,7 @@ struct BarsSection: View {
                     SpaceBarEditorGroup(model: model)
                 }
             }
-            .padding(16)
+            .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
         }
     }
 

--- a/Sources/KiwiDesk/Settings/Sections/BehaviorSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BehaviorSection.swift
@@ -21,7 +21,7 @@ struct BehaviorSection: View {
                 animationsSection
                 quitSection
             }
-            .padding(16)
+            .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
         }
     }
 

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection.swift
@@ -22,7 +22,7 @@ struct GeneralSection: View {
                 aboutSection
                 advancedSection
             }
-            .padding(16)
+            .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
         }
     }
 

--- a/Sources/KiwiDesk/Settings/Sections/LayoutDefaultsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/LayoutDefaultsSection.swift
@@ -51,7 +51,7 @@ struct LayoutDefaultsSection: View {
                 tabStrip
                 editor
             }
-            .padding(16)
+            .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
         }
         // Land on the profile's most-used mode, then leave the tab
         // alone (mirrors `ShortcutsSection.ensureSelection`).

--- a/Sources/KiwiDesk/Settings/Sections/MonitorsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/MonitorsSection.swift
@@ -28,7 +28,7 @@ struct MonitorsSection: View {
                     advancedSection
                 }
             }
-            .padding(16)
+            .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
         }
     }
 

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
@@ -36,7 +36,7 @@ struct ProfilesSection: View {
                 .default,
                 value: model.profileSummaries.isEmpty
             )
-            .padding(16)
+            .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
         }
     }
 

--- a/Sources/KiwiDesk/Settings/Sections/ShortcutsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ShortcutsSection.swift
@@ -74,7 +74,7 @@ struct ShortcutsSection: View {
                     )
                     advancedDrawer
                 }
-                .padding(16)
+                .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
                 .environment(
                     \.keybindingOverrideBase,
                     model.overrideBaseRows(mode: selected)

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection.swift
@@ -59,7 +59,7 @@ struct SpacesSection: View {
             VStack(alignment: .leading, spacing: 20) {
                 spacesSection
             }
-            .padding(16)
+            .padding([.horizontal, .bottom], SettingsMetrics.paneInset)
             .coordinateSpace(name: Self.listSpace)
             .onPreferenceChange(SpaceRowFrames.self) {
                 rowFrames = $0

--- a/Sources/KiwiDesk/Settings/SettingsMetrics.swift
+++ b/Sources/KiwiDesk/Settings/SettingsMetrics.swift
@@ -33,6 +33,31 @@ enum SettingsMetrics {
     /// every language regardless.
     static let labelColumn: CGFloat = 210
 
+    /// The gutter around a destination pane's scrolling content.
+    /// Horizontal and bottom are ordinary padding on the content;
+    /// the TOP is spent as the scroll viewport's content margin
+    /// instead (`SettingsView.detailPane`), which is what gives a
+    /// revealed card the same gutter above it that a pane's first
+    /// card has at rest.
+    ///
+    /// `scrollTo(anchor: .top)` aligns the target's top edge with
+    /// the viewport's, so before the margin existed any card but
+    /// a pane's first landed flush — and the reveal wash, which
+    /// bleeds 4 pt past its content, had its rounded top corners
+    /// clipped into a flat edge by the scroll view's own bounds.
+    /// Spending the gutter as a margin rather than as padding is
+    /// what fixes both.
+    ///
+    /// ONE number for both roles, and that is the design, not a
+    /// shortcut: a content margin moves what "top of the
+    /// viewport" means, so it cannot give a revealed card a
+    /// different gutter from a resting one. Tried 30 on device to
+    /// give reveals more room — it reads as too airy at rest,
+    /// because it moves every pane too. The equality is the point:
+    /// a revealed card should look like a pane you scrolled to the
+    /// top yourself, not like a bespoke state.
+    static let paneInset: CGFloat = 16
+
     /// `OverrideChrome`'s leading padding and checkbox
     /// spacing — consumed by the chrome itself, so retuning
     /// the chrome moves `overrideLabelColumn` in lockstep.

--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -184,6 +184,25 @@ struct SettingsView: View {
             // wrappers would buy nothing and drift.
             ScrollViewReader { proxy in
                 detail
+                    // The panes' top gutter, spent here rather
+                    // than as padding inside each one: a content
+                    // margin moves what "top of the viewport"
+                    // means, so `scrollTo(anchor: .top)` lands a
+                    // revealed card with the same gutter above it
+                    // that a pane's first card has at rest —
+                    // where padding would only have pushed the
+                    // resting content down and left the scrolled
+                    // card just as flush.
+                    //
+                    // One call site, not ten: the margin
+                    // propagates to every scroll view below,
+                    // which is the same reach the one
+                    // `ScrollViewReader` above already relies on.
+                    .contentMargins(
+                        .top,
+                        SettingsMetrics.paneInset,
+                        for: .scrollContent
+                    )
                     .environment(\.settingsFlash, model.nav.flash)
                     .environment(
                         \.settingsRevealTarget,


### PR DESCRIPTION
Found on device while QA-ing #573's reveal: a search hit scrolled
its card **flush** against the top of the pane.

`scrollTo(anchor: .top)` aligns the target's top edge with the
viewport's, and the scroll view carried no content margin — so
every card except a pane's first landed with zero clearance.

It was also clipping the wash. `SearchRevealFlash` bleeds 4 pt
past its content on every side, so on a flush-landed card that
bled above the viewport and the scroll view's bounds cut the
wash's rounded top corners into a hard flat edge. Same missing
gutter, and probably half of what made it look wrong.

## The fix

Spend the pane's top gutter as the scroll viewport's **content
margin** instead of as padding on its content. A margin moves
what "top of the viewport" means, so the reveal honours it;
padding would only have pushed resting content down and left a
scrolled card just as flush. The ten panes' `.padding(16)` drops
its top edge in exchange, so resting spacing is exactly where it
was.

One call site at `detailPane`, not ten — the margin propagates to
every scroll view below it, the same reach the single
`ScrollViewReader` there already depends on.

## Why 16, and why it can't be reveal-only

The margin sets a pane's first card at rest **and** a revealed
card's landing, and no value separates them. 30 was tried on
device to give reveals more room and rejected — it reads as too
airy at rest, because it moves every pane. That equality is the
point: a revealed card should look like a pane you scrolled to
the top yourself, not like a bespoke state. Recorded in the
constant's doc so it is not re-run.

## Not fixed here

An `.inline` drawer reveal still scrolls its parent section's
heading off-screen — filed as #610, and it wants a design call
rather than a constant.

## Verification

`swift build`, 2155 tests, `scripts/lint.sh` exit 0, release
build. Owner eye-confirmed on device at both 16 and 30; 16 ships.

CI is expected red — Actions billing quota, jobs exit in 2s with
`steps=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)