### PR TITLE
fix(settings): hoist an inline drawer's reveal to its section top (#610)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Appearance/GapsEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/Appearance/GapsEditor.swift
@@ -26,7 +26,10 @@ struct GapsEditor: View {
     }
 
     var body: some View {
-        SettingsSection(SettingsCatalog.appearance.gapsCard) {
+        SettingsSection(
+            SettingsCatalog.appearance.gapsCard,
+            revealTargets: [perEdge.control, perAxis.control]
+        ) {
             GapsDiagram(outer: outer, inner: inner)
             masterRow(
                 label: L("gaps.outer", "Outer gap"),
@@ -35,7 +38,8 @@ struct GapsEditor: View {
             )
             SettingsDisclosure(
                 perEdge,
-                isExpanded: outerDisclosure
+                isExpanded: outerDisclosure,
+                scrollHoisted: true
             ) {
                 VStack(alignment: .leading, spacing: 6) {
                     GapRow(
@@ -69,7 +73,8 @@ struct GapsEditor: View {
             )
             SettingsDisclosure(
                 perAxis,
-                isExpanded: innerDisclosure
+                isExpanded: innerDisclosure,
+                scrollHoisted: true
             ) {
                 VStack(alignment: .leading, spacing: 6) {
                     GapRow(

--- a/Sources/KiwiDesk/Settings/Components/Appearance/GapsEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/Appearance/GapsEditor.swift
@@ -26,10 +26,7 @@ struct GapsEditor: View {
     }
 
     var body: some View {
-        SettingsSection(
-            SettingsCatalog.appearance.gapsCard,
-            revealTargets: [perEdge.control, perAxis.control]
-        ) {
+        SettingsSection(SettingsCatalog.appearance.gapsCard) {
             GapsDiagram(outer: outer, inner: inner)
             masterRow(
                 label: L("gaps.outer", "Outer gap"),

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarGroups.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarGroups.swift
@@ -95,7 +95,8 @@ struct GlobalAppBarGroup: View {
         }
         SettingsSection(
             SettingsCatalog.bars.appBarColorsCard,
-            help: anyBarShown ? nil : noBarHelp
+            help: anyBarShown ? nil : noBarHelp,
+            revealTargets: [SettingsCatalog.bars.advancedColors.control]
         ) {
             AppBarColorGrid { inlineColors }
                 .modifier(
@@ -119,7 +120,8 @@ struct GlobalAppBarGroup: View {
             SettingsDisclosure(
                 SettingsCatalog.bars.advancedColors,
                 chrome: .inline(font: .subheadline),
-                isExpanded: $advancedColorsExpanded
+                isExpanded: $advancedColorsExpanded,
+                scrollHoisted: true
             ) {
                 AppBarColorGrid { advancedColors }
                     .padding(.top, 8)

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarGroups.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarGroups.swift
@@ -95,8 +95,7 @@ struct GlobalAppBarGroup: View {
         }
         SettingsSection(
             SettingsCatalog.bars.appBarColorsCard,
-            help: anyBarShown ? nil : noBarHelp,
-            revealTargets: [SettingsCatalog.bars.advancedColors.control]
+            help: anyBarShown ? nil : noBarHelp
         ) {
             AppBarColorGrid { inlineColors }
                 .modifier(

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarLayoutGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarLayoutGroup.swift
@@ -51,7 +51,8 @@ struct LayoutAppBarGroup: View {
             // anchor: every `?` in the dimmed rows is dead.
             SettingsDisclosure(
                 overridesDrawer,
-                isExpanded: $overridesExpanded
+                isExpanded: $overridesExpanded,
+                scrollHoisted: true
             ) {
                 overrides
                     .modifier(

--- a/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarColorsGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarColorsGroup.swift
@@ -48,7 +48,8 @@ struct SpaceBarColorsGroup: View {
         SettingsDisclosure(
             SettingsCatalog.bars.advancedColors,
             chrome: .inline(font: .subheadline),
-            isExpanded: $advancedColorsExpanded
+            isExpanded: $advancedColorsExpanded,
+            scrollHoisted: true
         ) {
             AppBarColorGrid { advancedColors }
                 .padding(.top, 8)

--- a/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarGroups.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarGroups.swift
@@ -74,8 +74,7 @@ struct SpaceBarEditorGroup: View {
         }
         SettingsSection(
             SettingsCatalog.bars.spaceBarColorsCard,
-            help: enabled ? nil : offHelp,
-            revealTargets: [SettingsCatalog.bars.advancedColors.control]
+            help: enabled ? nil : offHelp
         ) {
             // Gate passed IN, not wrapped around: the group has
             // to keep its "Advanced colors" disclosure label

--- a/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarGroups.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarGroups.swift
@@ -74,7 +74,8 @@ struct SpaceBarEditorGroup: View {
         }
         SettingsSection(
             SettingsCatalog.bars.spaceBarColorsCard,
-            help: enabled ? nil : offHelp
+            help: enabled ? nil : offHelp,
+            revealTargets: [SettingsCatalog.bars.advancedColors.control]
         ) {
             // Gate passed IN, not wrapped around: the group has
             // to keep its "Advanced colors" disclosure label

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsDisclosure.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsDisclosure.swift
@@ -23,6 +23,14 @@ import SwiftUI
 /// on the card's edge, not 12 pt inside it — the mistake the
 /// part-1 comment block in `SettingsReveal` existed to spell
 /// out.
+///
+/// An `.inline` drawer sits *below* its section's heading, so
+/// anchoring its own body would scroll that heading off screen
+/// (#610). Such a drawer sets `scrollHoisted` and gives up its
+/// scroll id; its `SettingsSection` mounts the matching
+/// `searchScrollAnchor` marker at its top via `revealTargets`, so
+/// the reveal lands the section — heading first — while the
+/// drawer keeps its own wash.
 struct SettingsDisclosure<Content: View, Accessory: View>: View {
     enum Chrome {
         /// Inside a section card; `font` styles the label
@@ -37,6 +45,14 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
     private let control: SettingsControl
     private let childIDs: Set<String>
     private let chrome: Chrome
+    /// `.inline` only: the scroll id is hoisted to the enclosing
+    /// section's top (#610), so this drawer keeps its wash but
+    /// gives up its own `searchAnchorCard`. The section mounts the
+    /// matching `searchScrollAnchor` marker; feeding `revealTargets`
+    /// there and setting this flag are two halves of one call —
+    /// see `SettingsSection`. A `.card` drawer paints its own card
+    /// and anchors it, so it ignores this.
+    private let scrollHoisted: Bool
     /// Call-site expansion state, for a drawer with its own
     /// rules (Gaps force-expands while its values are mixed);
     /// nil means this view owns it.
@@ -51,12 +67,14 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
         _ drawer: SettingsDrawer<Children>,
         chrome: Chrome = .inline(font: nil),
         isExpanded: Binding<Bool>? = nil,
+        scrollHoisted: Bool = false,
         @ViewBuilder content: @escaping () -> Content,
         @ViewBuilder accessory: @escaping () -> Accessory
     ) {
         self.control = drawer.control
         self.childIDs = drawer.childIDs
         self.chrome = chrome
+        self.scrollHoisted = scrollHoisted
         self.externalExpansion = isExpanded
         self.content = content
         self.accessory = accessory
@@ -66,12 +84,14 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
         _ drawer: SettingsDrawer<Children>,
         chrome: Chrome = .inline(font: nil),
         isExpanded: Binding<Bool>? = nil,
+        scrollHoisted: Bool = false,
         @ViewBuilder content: @escaping () -> Content
     ) where Accessory == EmptyView {
         self.init(
             drawer,
             chrome: chrome,
             isExpanded: isExpanded,
+            scrollHoisted: scrollHoisted,
             content: content,
             accessory: { EmptyView() }
         )
@@ -80,7 +100,16 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
     var body: some View {
         switch chrome {
         case .inline:
-            group.searchAnchorCard(control)
+            // Hoisted (#610): the scroll id lives on the section's
+            // top marker, so anchoring here too would give
+            // `scrollTo` a second candidate and land the bare
+            // drawer at the top — the very bug. The wash stays, on
+            // the label inside `group`.
+            if scrollHoisted {
+                group
+            } else {
+                group.searchAnchorCard(control)
+            }
         case .card:
             group
                 .padding(12)

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsDisclosure.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsDisclosure.swift
@@ -26,11 +26,12 @@ import SwiftUI
 ///
 /// An `.inline` drawer sits *below* its section's heading, so
 /// anchoring its own body would scroll that heading off screen
-/// (#610). Such a drawer sets `scrollHoisted` and gives up its
-/// scroll id; its `SettingsSection` mounts the matching
-/// `searchScrollAnchor` marker at its top via `revealTargets`, so
-/// the reveal lands the section — heading first — while the
-/// drawer keeps its own wash.
+/// (#610). Such a drawer sets `scrollHoisted`: it gives up its
+/// scroll id and publishes its control through
+/// `HoistedRevealAnchorsKey`, which its enclosing `SettingsSection`
+/// turns into a top-of-section `searchScrollAnchor` marker, so the
+/// reveal lands the section — heading first — while the drawer
+/// keeps its own wash.
 struct SettingsDisclosure<Content: View, Accessory: View>: View {
     enum Chrome {
         /// Inside a section card; `font` styles the label
@@ -47,11 +48,10 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
     private let chrome: Chrome
     /// `.inline` only: the scroll id is hoisted to the enclosing
     /// section's top (#610), so this drawer keeps its wash but
-    /// gives up its own `searchAnchorCard`. The section mounts the
-    /// matching `searchScrollAnchor` marker; feeding `revealTargets`
-    /// there and setting this flag are two halves of one call —
-    /// see `SettingsSection`. A `.card` drawer paints its own card
-    /// and anchors it, so it ignores this.
+    /// gives up its own `searchAnchorCard`, publishing its control
+    /// through `HoistedRevealAnchorsKey` for the section to anchor.
+    /// A `.card` drawer paints its own card and anchors it, so it
+    /// ignores this.
     private let scrollHoisted: Bool
     /// Call-site expansion state, for a drawer with its own
     /// rules (Gaps force-expands while its values are mixed);
@@ -100,13 +100,18 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
     var body: some View {
         switch chrome {
         case .inline:
-            // Hoisted (#610): the scroll id lives on the section's
-            // top marker, so anchoring here too would give
-            // `scrollTo` a second candidate and land the bare
-            // drawer at the top — the very bug. The wash stays, on
-            // the label inside `group`.
+            // Hoisted (#610): publish this control so the enclosing
+            // section mounts the scroll marker at its top, and DON'T
+            // anchor here — a second candidate would let `scrollTo`
+            // land the bare drawer at the top, the very bug. The
+            // wash stays, on the label inside `group`. Emitting only
+            // from `.inline` also means `scrollHoisted` on a `.card`
+            // drawer is inert rather than a double anchor.
             if scrollHoisted {
-                group
+                group.preference(
+                    key: HoistedRevealAnchorsKey.self,
+                    value: [control]
+                )
             } else {
                 group.searchAnchorCard(control)
             }

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsSection.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsSection.swift
@@ -44,14 +44,6 @@ struct SettingsSection<Content: View>: View {
     let caption: String?
     let subsection: Bool
     let help: String?
-    /// Inline drawers whose scroll id is hoisted to this section's
-    /// top (#610). Each mounts a zero-size `searchScrollAnchor`
-    /// marker above the heading, so revealing that drawer scrolls
-    /// the section — heading first — into view rather than the
-    /// bare drawer label. The drawer keeps its own wash; this is
-    /// only its scroll half. Pass a drawer's `.control`; empty for
-    /// a section with no inline drawer to lift.
-    private let revealTargets: [SettingsControl]
     @ViewBuilder let content: Content
 
     /// Computed-title init: renders identically but is NOT a
@@ -74,7 +66,6 @@ struct SettingsSection<Content: View>: View {
         self.caption = caption
         self.subsection = subsection
         self.help = help
-        self.revealTargets = []
         self.content = content()
     }
 
@@ -88,7 +79,6 @@ struct SettingsSection<Content: View>: View {
         caption: String? = nil,
         subsection: Bool = false,
         help: String? = nil,
-        revealTargets: [SettingsControl] = [],
         @ViewBuilder content: () -> Content
     ) {
         self.title = control.text
@@ -97,7 +87,6 @@ struct SettingsSection<Content: View>: View {
         self.caption = caption
         self.subsection = subsection
         self.help = help
-        self.revealTargets = revealTargets
         self.content = content()
     }
 
@@ -129,20 +118,43 @@ struct SettingsSection<Content: View>: View {
                     )
             )
         }
-        // The hoisted scroll markers (#610), pinned to the top
-        // edge ABOVE the heading and zero-size, so a reveal of an
-        // inline drawer inside `content` lands the section's top —
-        // heading first — while the drawer's own wash paints
-        // below. Non-interactive; they only give `scrollTo` an id.
-        .overlay(alignment: .top) { revealMarkers }
+        // The hoisted scroll markers (#610): any `scrollHoisted`
+        // inline drawer inside `content` publishes its control up
+        // `HoistedRevealAnchorsKey`, and each becomes a zero-size
+        // marker pinned to the top edge ABOVE the heading — so a
+        // reveal of that drawer lands the section's top, heading
+        // first, while the drawer's own wash paints below. The id
+        // is the drawer's own, so scroll and wash cannot disagree.
+        // Then consume the value, so a section nested in another
+        // never re-collects the same id and doubles the marker.
+        .overlayPreferenceValue(HoistedRevealAnchorsKey.self) {
+            anchors in
+            revealMarkers(anchors)
+        }
+        .transformPreference(HoistedRevealAnchorsKey.self) {
+            $0 = []
+        }
     }
 
-    @ViewBuilder private var revealMarkers: some View {
-        ForEach(revealTargets, id: \.id) { target in
-            Color.clear
-                .frame(width: 0, height: 0)
-                .searchScrollAnchor(target)
+    private func revealMarkers(
+        _ anchors: [SettingsControl]
+    ) -> some View {
+        // Fill the section and top-pin the markers, so this does
+        // not lean on `overlayPreferenceValue`'s default centering
+        // — the markers must sit at the section's top edge for
+        // `scrollTo(anchor: .top)` to land the heading.
+        VStack(spacing: 0) {
+            ForEach(anchors, id: \.id) { target in
+                Color.clear
+                    .frame(width: 0, height: 0)
+                    .searchScrollAnchor(target)
+            }
         }
+        .frame(
+            maxWidth: .infinity,
+            maxHeight: .infinity,
+            alignment: .top
+        )
         .allowsHitTesting(false)
     }
 

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsSection.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsSection.swift
@@ -44,6 +44,14 @@ struct SettingsSection<Content: View>: View {
     let caption: String?
     let subsection: Bool
     let help: String?
+    /// Inline drawers whose scroll id is hoisted to this section's
+    /// top (#610). Each mounts a zero-size `searchScrollAnchor`
+    /// marker above the heading, so revealing that drawer scrolls
+    /// the section — heading first — into view rather than the
+    /// bare drawer label. The drawer keeps its own wash; this is
+    /// only its scroll half. Pass a drawer's `.control`; empty for
+    /// a section with no inline drawer to lift.
+    private let revealTargets: [SettingsControl]
     @ViewBuilder let content: Content
 
     /// Computed-title init: renders identically but is NOT a
@@ -66,6 +74,7 @@ struct SettingsSection<Content: View>: View {
         self.caption = caption
         self.subsection = subsection
         self.help = help
+        self.revealTargets = []
         self.content = content()
     }
 
@@ -79,6 +88,7 @@ struct SettingsSection<Content: View>: View {
         caption: String? = nil,
         subsection: Bool = false,
         help: String? = nil,
+        revealTargets: [SettingsControl] = [],
         @ViewBuilder content: () -> Content
     ) {
         self.title = control.text
@@ -87,6 +97,7 @@ struct SettingsSection<Content: View>: View {
         self.caption = caption
         self.subsection = subsection
         self.help = help
+        self.revealTargets = revealTargets
         self.content = content()
     }
 
@@ -118,6 +129,21 @@ struct SettingsSection<Content: View>: View {
                     )
             )
         }
+        // The hoisted scroll markers (#610), pinned to the top
+        // edge ABOVE the heading and zero-size, so a reveal of an
+        // inline drawer inside `content` lands the section's top —
+        // heading first — while the drawer's own wash paints
+        // below. Non-interactive; they only give `scrollTo` an id.
+        .overlay(alignment: .top) { revealMarkers }
+    }
+
+    @ViewBuilder private var revealMarkers: some View {
+        ForEach(revealTargets, id: \.id) { target in
+            Color.clear
+                .frame(width: 0, height: 0)
+                .searchScrollAnchor(target)
+        }
+        .allowsHitTesting(false)
     }
 
     /// A catalog-declared section is a search anchor by existing

--- a/Sources/KiwiDesk/Settings/SettingsReveal.swift
+++ b/Sources/KiwiDesk/Settings/SettingsReveal.swift
@@ -74,6 +74,31 @@ extension EnvironmentValues {
     }
 }
 
+/// The scroll ids an inline drawer wants **hoisted to its
+/// enclosing section's top** (#610). A hoisted `SettingsDisclosure`
+/// contributes its own `SettingsControl`; the nearest
+/// `SettingsSection` collects the list and mounts a
+/// `searchScrollAnchor` marker per id above its heading, then
+/// consumes the value so an outer section never re-collects it.
+///
+/// The point of routing it through a preference rather than a
+/// call-site parameter: the marker's id is the drawer's OWN
+/// control by construction, so a hoisted drawer's scroll id and
+/// its wash id are the same control with no second list to keep in
+/// step — the same "seal it, don't guard it" the `fileprivate`
+/// halves buy for the co-located pair (#573). The section
+/// auto-discovers whichever drawer is mounted, so the shared
+/// surface-free `advancedColors` drawer needs no static parent.
+struct HoistedRevealAnchorsKey: PreferenceKey {
+    static let defaultValue: [SettingsControl] = []
+    static func reduce(
+        value: inout [SettingsControl],
+        nextValue: () -> [SettingsControl]
+    ) {
+        value.append(contentsOf: nextValue())
+    }
+}
+
 /// Paints the reveal wash behind the anchored content while the
 /// environment names it.
 ///
@@ -217,14 +242,17 @@ extension View {
     /// off screen — the disembodiment the #277 top-alignment
     /// ruling exists to prevent. So the drawer keeps its wash
     /// (`searchFlashHeader`, on its own label) but gives up its
-    /// scroll id, and its enclosing `SettingsSection` mounts this
-    /// zero-size marker at its top instead. `scrollTo` then aligns
-    /// the section's top edge — heading first — and the drawer
-    /// label still washes below it.
+    /// scroll id, publishing its control through
+    /// `HoistedRevealAnchorsKey`; its enclosing `SettingsSection`
+    /// collects that and mounts this zero-size marker at its top.
+    /// `scrollTo` then aligns the section's top edge — heading
+    /// first — and the drawer label still washes below it.
     ///
-    /// Scroll-only by construction, so the pair is split across
-    /// two views (this marker scrolls, the drawer label washes)
-    /// over one control — confined to the container shapes by
+    /// Scroll-only, so the pair is split across two views (this
+    /// marker scrolls, the drawer label washes) — but over the
+    /// same control by construction, because the marker's id comes
+    /// from the drawer's own published control, not a second list.
+    /// Confined to the container shapes by
     /// `SettingsAnchorPrimitiveTests`, the same seal the paired
     /// halves carry.
     func searchScrollAnchor(

--- a/Sources/KiwiDesk/Settings/SettingsReveal.swift
+++ b/Sources/KiwiDesk/Settings/SettingsReveal.swift
@@ -206,4 +206,30 @@ extension View {
     ) -> some View {
         searchFlash(control.id)
     }
+
+    /// A **hoisted scroll target** for a drawer whose scroll id is
+    /// lifted to the top of its enclosing section (#610).
+    ///
+    /// An `.inline` `SettingsDisclosure` lives inside a section
+    /// card, below that section's heading. Anchoring its own body
+    /// makes `scrollTo(anchor: .top)` land the bare drawer label
+    /// at the viewport top and scroll the heading that names it
+    /// off screen — the disembodiment the #277 top-alignment
+    /// ruling exists to prevent. So the drawer keeps its wash
+    /// (`searchFlashHeader`, on its own label) but gives up its
+    /// scroll id, and its enclosing `SettingsSection` mounts this
+    /// zero-size marker at its top instead. `scrollTo` then aligns
+    /// the section's top edge — heading first — and the drawer
+    /// label still washes below it.
+    ///
+    /// Scroll-only by construction, so the pair is split across
+    /// two views (this marker scrolls, the drawer label washes)
+    /// over one control — confined to the container shapes by
+    /// `SettingsAnchorPrimitiveTests`, the same seal the paired
+    /// halves carry.
+    func searchScrollAnchor(
+        _ control: SettingsControl
+    ) -> some View {
+        searchAnchor(control.id)
+    }
 }

--- a/Sources/KiwiDesk/Settings/SettingsReveal.swift
+++ b/Sources/KiwiDesk/Settings/SettingsReveal.swift
@@ -89,6 +89,12 @@ extension EnvironmentValues {
 /// halves buy for the co-located pair (#573). The section
 /// auto-discovers whichever drawer is mounted, so the shared
 /// surface-free `advancedColors` drawer needs no static parent.
+///
+/// Known limit: a hoisted drawer with no enclosing
+/// `SettingsSection` publishes to nobody, mounts no marker and
+/// scrolls nowhere — a nonsensical placement (an inline drawer's
+/// premise is that it lives in a section card), but a silent one,
+/// so keep hoisted drawers inside a section.
 struct HoistedRevealAnchorsKey: PreferenceKey {
     static let defaultValue: [SettingsControl] = []
     static func reduce(

--- a/Tests/KiwiDeskGuiTests/SettingsAnchorPrimitiveTests.swift
+++ b/Tests/KiwiDeskGuiTests/SettingsAnchorPrimitiveTests.swift
@@ -194,6 +194,11 @@ struct SettingsAnchorPrimitiveTests {
     func containerHalvesAreConfined() throws {
         for needle in [
             ".searchAnchorCard(", ".searchFlashHeader(",
+            // The hoisted scroll half (#610): a bare scroll anchor
+            // with its wash on the drawer label a level down. Just
+            // as much a scroll-without-a-local-wash at a rogue call
+            // site as the card half, so it earns the same seal.
+            ".searchScrollAnchor(",
         ] {
             let hits = try occurrences(
                 of: needle,
@@ -211,6 +216,67 @@ struct SettingsAnchorPrimitiveTests {
                 )
             )
         }
+    }
+
+    /// #610's hoisted pair is split across two views: an inline
+    /// drawer sets `scrollHoisted` and drops its scroll id, while
+    /// its enclosing section lists it in `revealTargets` and mounts
+    /// the `searchScrollAnchor` marker. Neither half is any use
+    /// alone — a flag without a marker scrolls nowhere, a marker
+    /// without the flag mounts a second view carrying the drawer's
+    /// id and `scrollTo` picks arbitrarily (the exact undefined-id
+    /// harm `alternatelyMounted` guards on the other side). The
+    /// types cannot tie the two (different views, different files),
+    /// so a count does: one listed reveal target per hoisted
+    /// drawer, and vice versa.
+    @Test("every hoisted drawer pairs with a section marker")
+    func hoistedDrawersPairWithMarkers() throws {
+        var flags = 0
+        var targets = 0
+        for file in try SourceScan.swiftSources(under: guiDir) {
+            let source = SourceScan.stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            flags += source.occurrences(of: "scrollHoisted: true")
+            // The definition file spells `revealTargets:` in its
+            // stored property and inits; only call sites pass a
+            // populated list, so it alone carries the real count.
+            if file.lastPathComponent != "SettingsSection.swift" {
+                targets += revealTargetCount(in: source)
+            }
+        }
+        #expect(
+            flags == targets && flags >= 4,
+            Comment(
+                rawValue:
+                    "scrollHoisted: true ×\(flags) but "
+                    + "\(targets) reveal target(s) listed — each "
+                    + "hoisted inline drawer needs exactly one "
+                    + "section revealTargets entry (#610), and the "
+                    + "four shipped ones must not silently drop"
+            )
+        )
+    }
+
+    /// Sums the entries across every `revealTargets: [ … ]` list
+    /// in one source (single-line lists, comma-separated).
+    private func revealTargetCount(in source: String) -> Int {
+        var total = 0
+        var rest = Substring(source)
+        while let hit = rest.range(of: "revealTargets:") {
+            let after = rest[hit.upperBound...]
+            guard
+                let open = after.firstIndex(of: "["),
+                let close = after[open...].firstIndex(of: "]")
+            else { break }
+            let inner = after[after.index(after: open)..<close]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !inner.isEmpty {
+                total += inner.split(separator: ",").count
+            }
+            rest = after[close...]
+        }
+        return total
     }
 
     /// The whole-pair primitive must stay reached-for: at zero

--- a/Tests/KiwiDeskGuiTests/SettingsAnchorPrimitiveTests.swift
+++ b/Tests/KiwiDeskGuiTests/SettingsAnchorPrimitiveTests.swift
@@ -218,67 +218,6 @@ struct SettingsAnchorPrimitiveTests {
         }
     }
 
-    /// #610's hoisted pair is split across two views: an inline
-    /// drawer sets `scrollHoisted` and drops its scroll id, while
-    /// its enclosing section lists it in `revealTargets` and mounts
-    /// the `searchScrollAnchor` marker. Neither half is any use
-    /// alone — a flag without a marker scrolls nowhere, a marker
-    /// without the flag mounts a second view carrying the drawer's
-    /// id and `scrollTo` picks arbitrarily (the exact undefined-id
-    /// harm `alternatelyMounted` guards on the other side). The
-    /// types cannot tie the two (different views, different files),
-    /// so a count does: one listed reveal target per hoisted
-    /// drawer, and vice versa.
-    @Test("every hoisted drawer pairs with a section marker")
-    func hoistedDrawersPairWithMarkers() throws {
-        var flags = 0
-        var targets = 0
-        for file in try SourceScan.swiftSources(under: guiDir) {
-            let source = SourceScan.stripComments(
-                try String(contentsOf: file, encoding: .utf8)
-            )
-            flags += source.occurrences(of: "scrollHoisted: true")
-            // The definition file spells `revealTargets:` in its
-            // stored property and inits; only call sites pass a
-            // populated list, so it alone carries the real count.
-            if file.lastPathComponent != "SettingsSection.swift" {
-                targets += revealTargetCount(in: source)
-            }
-        }
-        #expect(
-            flags == targets && flags >= 4,
-            Comment(
-                rawValue:
-                    "scrollHoisted: true ×\(flags) but "
-                    + "\(targets) reveal target(s) listed — each "
-                    + "hoisted inline drawer needs exactly one "
-                    + "section revealTargets entry (#610), and the "
-                    + "four shipped ones must not silently drop"
-            )
-        )
-    }
-
-    /// Sums the entries across every `revealTargets: [ … ]` list
-    /// in one source (single-line lists, comma-separated).
-    private func revealTargetCount(in source: String) -> Int {
-        var total = 0
-        var rest = Substring(source)
-        while let hit = rest.range(of: "revealTargets:") {
-            let after = rest[hit.upperBound...]
-            guard
-                let open = after.firstIndex(of: "["),
-                let close = after[open...].firstIndex(of: "]")
-            else { break }
-            let inner = after[after.index(after: open)..<close]
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            if !inner.isEmpty {
-                total += inner.split(separator: ",").count
-            }
-            rest = after[close...]
-        }
-        return total
-    }
-
     /// The whole-pair primitive must stay reached-for: at zero
     /// call sites the next self-anchoring control has nothing to
     /// copy and reaches for `.id()` instead. Counts SITES, not

--- a/Tests/KiwiDeskGuiTests/SettingsAnchorPrimitiveTests.swift
+++ b/Tests/KiwiDeskGuiTests/SettingsAnchorPrimitiveTests.swift
@@ -242,4 +242,66 @@ struct SettingsAnchorPrimitiveTests {
             )
         )
     }
+
+    /// The hoisted-reveal door (#610) is a new reveal shape, so it
+    /// earns the same confinement every other one carries. Confining
+    /// the KEY NAME to its three blessed files — declared in
+    /// `SettingsReveal`, published from `SettingsDisclosure`,
+    /// collected in `SettingsSection` — closes the whole door at
+    /// once: a feature file that cannot name `HoistedRevealAnchorsKey`
+    /// can neither publish a spurious marker nor read one. That
+    /// bubbling-`.preference` mistake is invisible to
+    /// `containerHalvesAreConfined`, since the marker's own mount is
+    /// legitimately in the section shape. Naming the key, not each
+    /// modifier, keeps this robust to how the calls wrap.
+    private let hoistKeyFiles: Set<String> = [
+        "SettingsReveal.swift",
+        "SettingsDisclosure.swift",
+        "SettingsSection.swift",
+    ]
+
+    @Test("the hoisted-reveal key stays inside its shapes")
+    func hoistedRevealKeyIsConfined() throws {
+        let hits = try occurrences(
+            of: "HoistedRevealAnchorsKey",
+            excluding: hoistKeyFiles
+        )
+        #expect(
+            hits.isEmpty,
+            Comment(
+                rawValue:
+                    "HoistedRevealAnchorsKey named outside its "
+                    + "three shapes (declare/publish/collect) — a "
+                    + "feature site naming it can mount or read a "
+                    + "spurious hoisted marker: " + describe(hits)
+            )
+        )
+    }
+
+    /// #610 must stay reached-for, the same floor
+    /// `thePrimitiveStaysReachedFor` holds for `searchAnchored`.
+    /// The id-pairing guard the old count check also did is now
+    /// sealed by construction (marker id == the drawer's own
+    /// published control), but its non-vacuity half is not — drop
+    /// `scrollHoisted: true` from a call site and that drawer
+    /// silently disembodies its heading again with a green suite.
+    /// Five: Gaps ×2, the two bar colour drawers, App Bar overrides.
+    @Test("hoisted drawers stay reached-for")
+    func hoistedDrawersStayReachedFor() throws {
+        let hits = try occurrences(
+            of: "scrollHoisted: true",
+            excluding: []
+        )
+        let sites = hits.reduce(0) { $0 + $1.count }
+        #expect(
+            sites >= 5,
+            Comment(
+                rawValue:
+                    "scrollHoisted: true at \(sites) site(s); "
+                    + "expected at least the five shipped hoists "
+                    + "(Gaps per-edge/per-axis, App/Space bar "
+                    + "colours, App Bar overrides): " + describe(hits)
+            )
+        )
+    }
 }

--- a/docs/ui-patterns.md
+++ b/docs/ui-patterns.md
@@ -722,6 +722,15 @@ drops the cross-fade only: the wash still shows for the same
 ≈1.2 s and then simply disappears, because a flat tint shown and
 removed is not motion.
 
+"That place's card" presupposes the place *has* a card. An
+**inline drawer** does not — it lives below its section's heading,
+inside that section's card — so its scroll target is its enclosing
+section, hoisted to the section's top. Revealing an inline drawer
+keeps the heading that names it on screen and washes the drawer's
+own label below it, rather than scrolling the bare disclosure to
+the top and the heading off (#610). The wash stays precise (the
+searched label alone); only the scroll unit moves up a level.
+
 Three things this must not become. **Not a ring or halo** — that
 is this app's vocabulary for "this input is armed"
 (`RecorderButtonChrome`, the search field's focus stroke), and


### PR DESCRIPTION
Fixes #610.

## Problem

An `.inline` `SettingsDisclosure` sits inside a `SettingsSection` card, below that section's heading. A search-reveal of the drawer's own label anchored the bare drawer and scrolled it to the viewport top, pushing the heading that names it off screen — the #277 top-alignment "a control landing without its heading reads as disembodied" failure, by construction. Affected: Gaps' `Per-edge…`/`Per-axis…`, the App/Space Bar `Advanced colors` drawers, and (found in review) the App Bar layout `Overrides` drawers.

## Approach — hoist the scroll anchor to the section top

The drawer keeps its wash (flash on its own label) but gives up its scroll `.id`, publishing its own `SettingsControl` up the tree via a `HoistedRevealAnchorsKey` preference. The enclosing `SettingsSection` collects it, mounts one zero-size `searchScrollAnchor` marker at its top (above the heading), then consumes the value so a nested section can't double-collect. `scrollTo` then lands the section — heading first — while the searched label still washes below. **Search is unchanged.**

The marker's id is the drawer's own control by construction, so scroll-id == wash-id with no second list to keep in step — sealed like the subsystem's other reveal pairs (#573), not guarded by a count. Collection is automatic and needs no catalog-typed section, so the shared surface-free `advancedColors` drawer works from whichever bar editor is mounted, and the `Overrides` drawer under the unindexed `%1$@ bar` section is hoisted for free.

### Design note
Chosen over (a) redirecting the search anchor + splitting the shared `advancedColors` per editor, and (b) the issue comment's "same id on section and drawer" — which duplicates the `.id` (undefined `scrollTo`) and can't handle the runtime-parent `advancedColors`. The preference seam dissolves both.

Interior-control reveals (searching `Top` inside a drawer) are deliberately left scrolling to the interior row — the same #277 class one level deeper, out of scope here (noted in #610).

## Tests / gate
- New guards: `HoistedRevealAnchorsKey` confined to its three shapes; `scrollHoisted: true` floored at the five shipped hoists.
- `swift build`, both test halves (2180 tests), `scripts/lint.sh` — all green. No concurrency touched.
- Two-round review (`code-reviewer` + `architect-reviewer`), all findings addressed.

## ⚠️ Needs device QA before merge
The `overlayPreferenceValue` + zero-size `Color.clear` marker as a `ScrollViewReader` target is sound in logic but a runtime SwiftUI behavior unit tests can't confirm. On device, verify searching **Per-edge…**, **Advanced colors**, and **Overrides**:
1. scrolls the section **heading** into view (not the bare drawer), and
2. the searched drawer label still washes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)