### PR TITLE
docs(rules): write obligations, not state claims — convention plus audit

### DIFF
--- a/.claude/rules/borders.md
+++ b/.claude/rules/borders.md
@@ -14,7 +14,8 @@ paths:
 
 Canonical for this subsystem (AGENTS.md §5 indexes it). Two
 overlay families — the focus ring (#278) and the sticky mark
-(#414) — track the same windows through the same channels,
+(#414) — track the same windows through the channels the
+table below lists,
 so they share their decisions rather than mirroring them.
 
 The *product* rulings about these overlays (who gets a ring, why

--- a/.claude/rules/borders.md
+++ b/.claude/rules/borders.md
@@ -40,7 +40,7 @@ and forgetting the other still builds green. That is why
 rather than a case on `applies`: `sync` asks a different question
 and returns a frame, not a bool.
 
-## Three writers, in descending authority mid-animation
+## The frame writers, in descending authority mid-animation
 
 While *our own* animation drives a window, the commanded per-tick
 frame is the leading truth — every other channel trails it, by

--- a/.claude/rules/borders.md
+++ b/.claude/rules/borders.md
@@ -14,7 +14,7 @@ paths:
 
 Canonical for this subsystem (AGENTS.md §5 indexes it). Two
 overlay families — the focus ring (#278) and the sticky mark
-(#414) — track the same windows through the same three channels,
+(#414) — track the same windows through the same channels,
 so they share their decisions rather than mirroring them.
 
 The *product* rulings about these overlays (who gets a ring, why

--- a/.claude/rules/core-boundaries.md
+++ b/.claude/rules/core-boundaries.md
@@ -5,7 +5,7 @@ paths:
 
 # Core boundaries
 
-Deliberately short — it loads on every `KiwiDeskCore` edit. Three
+Deliberately short — it loads on every `KiwiDeskCore` edit. The
 seams that are violated *outside* the directory that owns them.
 
 - **Core names, the GUI narrates (#96).** A user-facing

--- a/.claude/rules/core-boundaries.md
+++ b/.claude/rules/core-boundaries.md
@@ -5,8 +5,10 @@ paths:
 
 # Core boundaries
 
-Deliberately short — it loads on every `KiwiDeskCore` edit. The
-seams that are violated *outside* the directory that owns them.
+Deliberately short — it loads on every `KiwiDeskCore` edit. Three
+seams, each violated *outside* the directory that owns them — the
+count is the three bullets immediately below, so it corrects
+itself when a fourth is added.
 
 - **Core names, the GUI narrates (#96).** A user-facing
   condition detected in Core returns **structure** (a case, an

--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -112,6 +112,6 @@ authoring rules apply here even though the catalogs live in Core:
   a **meaning** change runs `scripts/drop-key <key>` in the same
   change set.
 
-The tooling, the eight content guards and the "Core names, the
+The tooling, the content guards and the "Core names, the
 GUI narrates" seam (#96) are in
 [localization.md](localization.md).

--- a/.claude/rules/input-and-animation.md
+++ b/.claude/rules/input-and-animation.md
@@ -161,9 +161,13 @@ editing here:
   lifecycle event ever does want it, wire it deliberately and give
   it a test — an untested escape hatch is discovered not to work
   at exactly the moment it is needed.
-- Env levers for device QA of this subsystem —
-  `KIWIDESK_STRAND_LOG` and `KIWIDESK_NO_WS_TRACKING` among them
-  — are **listed and explained in [tests.md](tests.md)**, which
-  owns that table. Named here only because that file is scoped to
-  `Tests/**` and so does not load while you are editing this
-  directory; do not copy the list back.
+- Env levers for device QA of this subsystem are **listed and
+  explained in [tests.md](tests.md)**, which owns that table.
+  Named here only because that file is scoped to `Tests/**` and
+  so will not load while you are editing this directory. One
+  thing from it is repeated because it changes what you are
+  looking at rather than merely adding output:
+  **`KIWIDESK_NO_WS_TRACKING` kills a production fast path**,
+  forcing the overlays onto their AX fallback for the whole run
+  (#596). `KIWIDESK_STRAND_LOG` is inert by comparison — it only
+  logs (#47).

--- a/.claude/rules/input-and-animation.md
+++ b/.claude/rules/input-and-animation.md
@@ -26,13 +26,16 @@ editing here:
   `ωh < 2(√(1+ζ²) − ζ)` — not either term alone; `k·h² < 4` is
   the undamped special case and `|1 − c·h| < 1` is necessary but
   not sufficient. The shipped `1/max(ω, c)` is conservative
-  against that, with a margin never below **1.24×** (its minimum,
-  at ζ = 0.5) that approaches 2× only as ζ → 0 or ζ → ∞ — 1.57×
-  at the engine's ζ = 0.85 and 1.29× at `DeadEndBump`'s ζ = 0.45.
-  So the halving is load-bearing, and removing it at ζ = 0.85 is
-  immediately divergent again. Two springs ship (the engine's at
-  ζ = 0.85, `DeadEndBump`'s at ζ = 0.45) and they sit on
-  opposite sides of which term `max` selects. Substepping rather
+  against that for every ζ > 0, and **its margin — including the
+  minimum, where that minimum sits, and the two shipped springs'
+  values — is computed and asserted by
+  `SpringStabilityMarginTests`**, which also proves the halving
+  is load-bearing by showing the looser `2/max(ω, c)` lands
+  outside the bound at the damping the engine ships. Read the
+  numbers there rather than from this paragraph. What the numbers
+  are *for*: the engine's spring and `DeadEndBump`'s sit on
+  opposite sides of which term `max` selects, so neither can
+  stand in for the other. Substepping rather
   than a duration clamp because there is one `DisplayLink` per
   monitor at mixed rates and a spring outlives a cross-display
   move — 120 Hz was always inside the bound, which is why this
@@ -158,9 +161,9 @@ editing here:
   lifecycle event ever does want it, wire it deliberately and give
   it a test — an untested escape hatch is discovered not to work
   at exactly the moment it is needed.
-- Two env levers exist for device QA of this subsystem —
-  `KIWIDESK_STRAND_LOG` (logs a window that did not land on its
-  settled target, #47) and `KIWIDESK_NO_WS_TRACKING` (forces the
-  overlays' AX-fallback path, #596). Both are documented in
-  [tests.md](tests.md), which is scoped to `Tests/**` and so does
-  not load while you are editing here.
+- Env levers for device QA of this subsystem —
+  `KIWIDESK_STRAND_LOG` and `KIWIDESK_NO_WS_TRACKING` among them
+  — are **listed and explained in [tests.md](tests.md)**, which
+  owns that table. Named here only because that file is scoped to
+  `Tests/**` and so does not load while you are editing this
+  directory; do not copy the list back.

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -74,15 +74,17 @@ code) only warns.
 
 Everything above reads *keys*; `scripts/localization_guards.py`
 reads the *copy*, and `--check` hard-fails on each. **That
-script's own docstring is the authority on how many there are and
-what each one contracts** — the list below is a reader's map, not
-a second register, so add a guard there and let this follow. There is **no
+script's own docstring is the authority on how many there are** —
+the list below is a reader's map, not a second register, so add a
+guard there and let this follow. (The docstring contracts the
+exact-and-heuristic ones individually; the feature-name pair is
+described here and in `docs/localization-naming.md`.) There is **no
 baseline / exemption file** — a hit is a real defect. What the
 guards carry instead is a grouped `GLOSSARY` of terms that stay
 English; a new such term joins it, in the group that justifies
 it, in the same change set.
 
-Some are **exact contracts**, and hold for any corpus:
+These are **exact contracts** and hold for any corpus:
 
 - **wrong writing system** — Cyrillic→`ru`, Kana→`ja`,
   Han→`ja`/`zh-Hans`/`zh-Hant`, Hangul→`ko`. Latin is
@@ -99,7 +101,9 @@ Some are **exact contracts**, and hold for any corpus:
   unrelated keys.
 
 **English residue** in a translated sentence is instead a
-heuristic, and carries a scope where the others do not: non-Latin-script locales,
+heuristic, and the only one scoped by *corpus* rather than by
+locale — it runs on the app catalogs and not `--site`, whose
+prose keeps third-party names and inline HTML: non-Latin-script locales,
 and the app catalogs only (not `--site`, whose prose keeps
 third-party names and inline HTML). In a Latin-script locale a
 retained English word is indistinguishable from a cognate

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -101,11 +101,10 @@ These are **exact contracts** and hold for any corpus:
   unrelated keys.
 
 **English residue** in a translated sentence is instead a
-heuristic, and the only one scoped by *corpus* rather than by
-locale — it runs on the app catalogs and not `--site`, whose
-prose keeps third-party names and inline HTML: non-Latin-script locales,
-and the app catalogs only (not `--site`, whose prose keeps
-third-party names and inline HTML). In a Latin-script locale a
+heuristic, and the only one carrying a *corpus* scope as well as
+a locale one: non-Latin-script locales, and the app catalogs only
+(not `--site`, whose prose keeps third-party names and inline
+HTML). In a Latin-script locale a
 retained English word is indistinguishable from a cognate
 (`"Item ativo"`, `"Mein Setup"`), so widening it would flag dozens
 of good translations. Don't re-add a rule claiming to be precise

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -70,16 +70,19 @@ shipped `<locale>.json` doesn't decode as a flat
 locale to English. An orphan key (in a locale file, absent from
 code) only warns.
 
-## The eight content guards (#95)
+## The content guards (#95)
 
 Everything above reads *keys*; `scripts/localization_guards.py`
-reads the *copy*, and `--check` hard-fails on each. There is **no
+reads the *copy*, and `--check` hard-fails on each. **That
+script's own docstring is the authority on how many there are and
+what each one contracts** — the list below is a reader's map, not
+a second register, so add a guard there and let this follow. There is **no
 baseline / exemption file** — a hit is a real defect. What the
 guards carry instead is a grouped `GLOSSARY` of terms that stay
 English; a new such term joins it, in the group that justifies
 it, in the same change set.
 
-Five are exact contracts:
+Some are **exact contracts**, and hold for any corpus:
 
 - **wrong writing system** — Cyrillic→`ru`, Kana→`ja`,
   Han→`ja`/`zh-Hans`/`zh-Hant`, Hangul→`ko`. Latin is
@@ -95,8 +98,8 @@ Five are exact contracts:
 - **collapsed translation** — one filler reused for many
   unrelated keys.
 
-The sixth, **English residue** in a translated sentence, is a
-heuristic and the only one with a scope: non-Latin-script locales,
+**English residue** in a translated sentence is instead a
+heuristic, and carries a scope where the others do not: non-Latin-script locales,
 and the app catalogs only (not `--site`, whose prose keeps
 third-party names and inline HTML). In a Latin-script locale a
 retained English word is indistinguishable from a cognate
@@ -105,7 +108,7 @@ of good translations. Don't re-add a rule claiming to be precise
 everywhere, as an `-ing`-weld sub-rule once did — German
 `fing` / `Frühling` falsifies it.
 
-The last two are the **feature-name pair**, and
+The **feature-name pair** is the remaining group, and
 `docs/localization-naming.md` is their one copy — read it before
 touching either. In short: `dropped_product_names` requires
 "App Bar" / "Space Bar" **present** in every locale, script

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -104,8 +104,8 @@ These are **exact contracts** and hold for any corpus:
 heuristic, and the only one carrying a *corpus* scope as well as
 a locale one: non-Latin-script locales, and the app catalogs only
 (not `--site`, whose prose keeps third-party names and inline
-HTML). In a Latin-script locale a
-retained English word is indistinguishable from a cognate
+HTML). In a Latin-script locale a retained English word is
+indistinguishable from a cognate
 (`"Item ativo"`, `"Mein Setup"`), so widening it would flag dozens
 of good translations. Don't re-add a rule claiming to be precise
 everywhere, as an `-ing`-weld sub-rule once did — German

--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -22,9 +22,11 @@ Nothing it writes is a second copy: the version is read from
 `KiwiDeskVersion.swift` and the two icon keys come from actool's
 own partial plist — though the **deployment target is still typed
 in three places** (`Package.swift`, the plist, actool's flag), so
-a raise to macOS 15 touches all three. Both copies fail silently,
-but only the plist's does so dangerously (an app declaring a lower
-minimum than it runs on, versus a wrong rendition set).
+a raise to macOS 15 touches all three, and `Package.swift` is the
+one a build actually enforces. The two in the script fail
+silently, but only the plist's does so dangerously (an app
+declaring a lower minimum than it runs on, versus a wrong
+rendition set).
 
 It **discovers the signing identity** from the keychain. That
 string is not a secret (any user can read it out of a shipped

--- a/.claude/rules/profiles.md
+++ b/.claude/rules/profiles.md
@@ -20,9 +20,9 @@ _behavior_ setting** — one that shapes how the workspace behaves
 *while the profile is active*: keybindings (`Profile.modes`),
 app→space rules (`Profile.appRules`), float rules
 (`Profile.floatRules`) and ignore rules (`Profile.ignoreRules`).
-`Profile`'s own stored properties are the register of which
-families exist — the test for a new one is the *rule* below, not
-membership of this list.
+`Profile`'s `…Override?`-typed properties are the register of
+which families exist — the test for a new one is the *rule*
+below, not membership of this list.
 Global bases come from the active config owner (`gui.json` or
 `init.lua`); the profile layer resolves over either owner.
 Window-rule families resolve independently, with effective ignore

--- a/.claude/rules/profiles.md
+++ b/.claude/rules/profiles.md
@@ -20,6 +20,9 @@ _behavior_ setting** — one that shapes how the workspace behaves
 *while the profile is active*: keybindings (`Profile.modes`),
 app→space rules (`Profile.appRules`), float rules
 (`Profile.floatRules`) and ignore rules (`Profile.ignoreRules`).
+`Profile`'s own stored properties are the register of which
+families exist — the test for a new one is the *rule* below, not
+membership of this list.
 Global bases come from the active config owner (`gui.json` or
 `init.lua`); the profile layer resolves over either owner.
 Window-rule families resolve independently, with effective ignore

--- a/.claude/rules/rule-authoring.md
+++ b/.claude/rules/rule-authoring.md
@@ -36,11 +36,19 @@ defect was hardcoded English that never went near `L()`.
 Ranked. Take the first that fits; **delete is the last resort**,
 not a peer of the others.
 
-1. **Name its enforcing guard inline** — a `Tests/…` path, a test
-   type or function name, a `scripts/…` path. The best rows
+1. **Name its enforcing guard inline** — a suite name, a
+   `scripts/…` path, or a test function name. The best rows
    already do: `VisibleBoundsRoutingTests`, `SettingsCodingTests`,
    `LocalizationRegistryTests`, `ResourceBundleRoutingTests`,
    `SpringStabilityMarginTests`.
+
+   **Always name the suite, even when a function name is the
+   precise answer.** `RuleCitationTests` resolves suite names and
+   `scripts/…` paths, so those citations cannot rot silently; a
+   bare function name is not machine-checked, because nothing
+   about its shape distinguishes it from the production symbols
+   these files cite constantly. Name the suite and add the
+   function for precision.
 2. **Rewrite it as an obligation** — say what a future author must
    do, not what the tree currently is.
 3. **Re-home the fact to a named authority** and cite that

--- a/.claude/rules/rule-authoring.md
+++ b/.claude/rules/rule-authoring.md
@@ -1,0 +1,101 @@
+---
+paths:
+  - ".claude/rules/**"
+  - "AGENTS.md"
+---
+
+# Writing a rule
+
+Canonical for the rule files themselves (AGENTS.md §5 indexes
+it). It loads when you edit one, which is the only moment it
+binds.
+
+## Write an obligation, not a state claim (#614)
+
+An **obligation** — *"route a user-facing condition through
+structure the GUI renders"* — cannot become false. It can only be
+*violated*, and a violation is a code-review event.
+
+An **absolute claim about the current tree** — *"Core holds no
+`L()` call site outside `Localization/`"*, *"this map is the one
+copy"*, *"Core currently holds…"* — is true only the day it is
+written. The commit that falsifies it is somewhere else entirely,
+so nothing notices. That one shipped false (Core had carried an
+`L()` call outside `Localization/` for over a week already) and
+survived the review that introduced it (#601).
+
+This matters more than ordinary doc drift because these files
+load as **instructions**. An agent reads the claim as fact and
+reasons from it without checking — which is exactly how #601
+guarded the wrong axis: the rule said the problem was `L()` call
+sites, so the guard counted `L()` call sites, while the real
+defect was hardcoded English that never went near `L()`.
+
+## What to do with one
+
+Ranked. Take the first that fits; **delete is the last resort**,
+not a peer of the others.
+
+1. **Name its enforcing guard inline** — a `Tests/…` path, a test
+   type or function name, a `scripts/…` path. The best rows
+   already do: `VisibleBoundsRoutingTests`, `SettingsCodingTests`,
+   `LocalizationRegistryTests`, `ResourceBundleRoutingTests`,
+   `SpringStabilityMarginTests`.
+2. **Rewrite it as an obligation** — say what a future author must
+   do, not what the tree currently is.
+3. **Re-home the fact to a named authority** and cite that
+   instead. The authority does not have to be a test: a script's
+   docstring, a type's stored properties, another rule file that
+   owns the table. Verify it actually carries the *whole* fact
+   before nominating it — nominating an authority that covers
+   half of what you point at is the same failure one level down.
+4. **Scope it to when it was observed.** Claims about the world
+   outside this repo — macOS behavior, Apple tooling, a vendor's
+   plan limits, a device measurement — cannot be guarded and are
+   still worth keeping. Say when they were seen.
+5. **Leave it, if it sits beside its own register.** A count
+   immediately above the list it counts is self-correcting: a
+   reader can see both at once, and an author adding an item is
+   looking at the number. "Two env levers" over a two-row table
+   is fine; a count in a *different* file from its list is not.
+6. **Delete it.** Only when none of the above fits.
+
+A **past-tense fact** is not a state claim and needs none of
+this: *"four `ConfigIssue` messages shipped that way until
+#601"* cannot rot.
+
+## Two rules about the guards themselves
+
+**A number-pin must derive the number, not restate it.** Pinning
+a count by hand-listing it in a test moves the copy, it does not
+guard it — the test and the prose now agree with each other and
+with nothing else. `SpringStabilityMarginTests` computes the
+margin from the shipped `maxStableStep`; `LocalizationRegistryTests`
+reads the registry. A `#expect(list.count == 5)` over a literal
+array is a tautology.
+
+**Prove a new guard reds.** Revert the thing it protects and watch
+it fail before you trust it. Several here have passed vacuously on
+their first draft, including one pinned at the single duration
+where an unrelated net rescued the bug it named.
+
+## State a fact once
+
+A count or a list copied into a second file rots in both on one
+commit, and neither copy knows the other exists. Name the
+authority and link to it.
+
+This does **not** contradict the tripwire exception in AGENTS.md
+("How this file is organized"), which repeats a handful of §5
+guardrails verbatim in their rule file. That exception covers
+*obligations*, and an obligation repeated verbatim cannot go out
+of sync with itself. A **fact** — a count, a file list, a
+measured number — is what must not be duplicated.
+
+## Scope
+
+All of the above binds `.claude/rules/*.md` and AGENTS.md. It
+applies to a **Swift doc comment** too whenever that comment
+argues from numbers: the #599 stability margins lived in
+`Spring.swift`, were load-bearing, and were guarded by nothing
+until #614.

--- a/.claude/rules/rule-authoring.md
+++ b/.claude/rules/rule-authoring.md
@@ -36,19 +36,23 @@ defect was hardcoded English that never went near `L()`.
 Ranked. Take the first that fits; **delete is the last resort**,
 not a peer of the others.
 
-1. **Name its enforcing guard inline** — a suite name, a
-   `scripts/…` path, or a test function name. The best rows
-   already do: `VisibleBoundsRoutingTests`, `SettingsCodingTests`,
+1. **Name its enforcing guard inline** — a suite name or a
+   `scripts/…` path. The best rows already do: `VisibleBoundsRoutingTests`, `SettingsCodingTests`,
    `LocalizationRegistryTests`, `ResourceBundleRoutingTests`,
    `SpringStabilityMarginTests`.
 
-   **Always name the suite, even when a function name is the
-   precise answer.** `RuleCitationTests` resolves suite names and
-   `scripts/…` paths, so those citations cannot rot silently; a
-   bare function name is not machine-checked, because nothing
-   about its shape distinguishes it from the production symbols
-   these files cite constantly. Name the suite and add the
-   function for precision.
+   A test **function** name is a fine *addition* when it is the
+   precise answer — but never the whole citation.
+   `RuleCitationTests` resolves suite names and `scripts/…`
+   paths, so those cannot rot silently; a bare function name is
+   not machine-checked, because nothing about its shape
+   distinguishes it from the production symbols these files cite
+   constantly. Name the suite, then add the function.
+
+   Note what a resolved citation does and does not prove: that
+   the guard still *exists*, not that it still guards what the
+   sentence says. A rename is caught; gutting a suite and keeping
+   its name is not.
 2. **Rewrite it as an obligation** — say what a future author must
    do, not what the tree currently is.
 3. **Re-home the fact to a named authority** and cite that
@@ -61,11 +65,18 @@ not a peer of the others.
    outside this repo — macOS behavior, Apple tooling, a vendor's
    plan limits, a device measurement — cannot be guarded and are
    still worth keeping. Say when they were seen.
-5. **Leave it, if it sits beside its own register.** A count
-   immediately above the list it counts is self-correcting: a
-   reader can see both at once, and an author adding an item is
-   looking at the number. "Two env levers" over a two-row table
-   is fine; a count in a *different* file from its list is not.
+5. **Leave it, if it sits beside its own register.** The test is
+   the mechanism, not the file boundary: **would an author adding
+   an entry have the count on screen?** If yes it is
+   self-correcting; if they would have to go looking, it is not.
+   The register also has to be a list *in this document* — a
+   count of things a script defines is disposition 3, however
+   close the prose sits. `core-boundaries.md` is the worked
+   example, and it writes its own justification inline: "the
+   count is the three bullets immediately below". A heading
+   twenty-six lines above its table fails this even though both
+   are in one file — that was `borders.md`'s "Three writers",
+   and it was wrong.
 6. **Delete it.** Only when none of the above fits.
 
 A **past-tense fact** is not a state claim and needs none of
@@ -99,6 +110,14 @@ guardrails verbatim in their rule file. That exception covers
 *obligations*, and an obligation repeated verbatim cannot go out
 of sync with itself. A **fact** — a count, a file list, a
 measured number — is what must not be duplicated.
+
+One narrow extension, on the tripwire's own reasoning: a
+**danger fact**, whose cost of not knowing it is destructive,
+earns a copy at the seam where someone would act without it.
+`input-and-animation.md` repeats that `KIWIDESK_NO_WS_TRACKING`
+kills a production fast path, because `tests.md` owns that table
+and does not load while you are editing `Animation/`. Copy the
+danger, not the table.
 
 ## Scope
 

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -84,8 +84,10 @@ bite large test PRs:
     re-enables a dangerous production default — the live
     `CarbonHotkeyCenter` (and the real `~/.config/KiwiDesk`)
     seizing the developer's global chords and live config, 2414
-    conflict lines a run. Forget-proofing 112 mandatory-safe
-    call sites is a legitimate basis for sharing; it is simply not
+    conflict lines a run. Forget-proofing every one of those
+    call sites — well over a hundred, and the count climbs with
+    each new suite, which is the point — is a legitimate basis
+    for sharing; it is simply not
     the divergence-weakens-a-guard basis the closing paragraph
     below names. The admission gate therefore has two grounds, not
     one — state both when weighing a sixth.
@@ -157,8 +159,11 @@ lines). Stop the service first if loaded, or the single-instance
 guard keeps the OLD binary running. Every release rebuild changes
 the binary hash, which drops the TCC Accessibility grant (re-grant
 in System Settings), and a restart flattens session state (spaces,
-float flags) — plan QA around it; #89's signed `.app` is the
-durable fix.
+float flags) — plan QA around it. **Or avoid it entirely: build
+the signed `.app` with `./scripts/build-app.sh` and QA that**,
+which keeps a stable code identity and so keeps the grant across
+rebuilds (#89, shipped). See
+[packaging-and-release.md](packaging-and-release.md).
 
 Two env levers exist for device QA, both off by default and both
 read once at wiring:

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -159,11 +159,16 @@ lines). Stop the service first if loaded, or the single-instance
 guard keeps the OLD binary running. Every release rebuild changes
 the binary hash, which drops the TCC Accessibility grant (re-grant
 in System Settings), and a restart flattens session state (spaces,
-float flags) — plan QA around it. **Or avoid it entirely: build
-the signed `.app` with `./scripts/build-app.sh` and QA that**,
-which keeps a stable code identity and so keeps the grant across
-rebuilds (#89, shipped). See
-[packaging-and-release.md](packaging-and-release.md).
+float flags) — plan QA around it.
+
+**With a Developer ID certificate in the keychain you can stop
+paying that cost**: `./scripts/build-app.sh` (#89, shipped)
+produces a signed `.app` whose code identity is stable across
+rebuilds, so the grant survives. Without one the script falls
+back to ad-hoc and says so — it prints that the grant will reset
+on every rebuild — which leaves you exactly where the paragraph
+above starts. Check the identity line it echoes rather than
+assuming. See [packaging-and-release.md](packaging-and-release.md).
 
 Two env levers exist for device QA, both off by default and both
 read once at wiring:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,15 @@ already has. Aim to state everything else exactly once, and see
 [rule-authoring.md](.claude/rules/rule-authoring.md) for which
 kinds of sentence may be repeated safely and which may not.
 
+§5 also carries **one** prose rule rather than a one-line row:
+how to write a rule at all (#614). It is there because it is the
+only rule whose subject is this delivery mechanism, and because a
+reader who never edits a rule file — Cursor, Codex, a human
+skimming the hub — would otherwise meet it nowhere. Its argument
+still lives one level down, in
+[rule-authoring.md](.claude/rules/rule-authoring.md). Do not read
+it as licence for a second long paragraph in §5.
+
 They live in `.claude/` because Claude Code auto-loads a rule file
 whose `paths:` glob matches a file you are editing — so the right
 guardrails arrive when they are relevant and cost nothing when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,9 @@ guardrails at the top of §5 are repeated verbatim in their rule
 file. They are the ones that destroy something before a rule file
 would ever load — a tree in the state model, a shipped `.app` that
 `fatalError`s — so they earn a tripwire in the file every agent
-already has. Everything else appears exactly once.
+already has. Aim to state everything else exactly once, and see
+[rule-authoring.md](.claude/rules/rule-authoring.md) for which
+kinds of sentence may be repeated safely and which may not.
 
 They live in `.claude/` because Claude Code auto-loads a rule file
 whose `paths:` glob matches a file you are editing — so the right
@@ -268,10 +270,11 @@ touch a matching path.
 | `Keys`, `Events`, `Animation` | [input-and-animation.md](.claude/rules/input-and-animation.md) | Carbon hotkeys (no Input Monitoring permission), one `DisplayLink` per monitor; the spring integrator must stay inside its stability bound — an animation that never settles kills the settle signal for the whole session (#599), so `tick` force-settles one that outlives its age bound (#611); a shrink snaps on frame 1 unless the pass promised `BatchSizing.allSpringSized` (#593) — opt-in, never inferred, and the guard's `allowed` map is the one copy of who may |
 | `Borders` | [borders.md](.claude/rules/borders.md) | `FollowSource` owns which frame the ring AND mark render — never re-implement it beside a call site; mid-animation the commanded tick leads and every state-reading channel (echo, WS re-read, `sync` geometry) stands down; the settle passes are two keys, early visibility and late geometry |
 | `Sources/KiwiDesk` (the GUI) | [gui.md](.claude/rules/gui.md) | North-star and settled conventions; grey don't hide; `NSCursor.set()` never push/pop; keep `body` shallow or the CI type-checker dies |
-| `Localization`, `Resources/Locales`, `scripts/*key*` | [localization.md](.claude/rules/localization.md) | Never hand-edit a catalog — the scripts own them; positional specifiers only; eight content guards with no exemption file; Core names, the GUI narrates (#96) |
+| `Localization`, `Resources/Locales`, `scripts/*key*` | [localization.md](.claude/rules/localization.md) | Never hand-edit a catalog — the scripts own them; positional specifiers only; content guards with no exemption file; Core names, the GUI narrates (#96) |
 | `Tests/**` | [tests.md](.claude/rules/tests.md) | Pin the display in every geometry fixture (#531); split suites early; generous hang-guards, never tight deadlines (#344); run the suite as two commands |
 | Any hand-mirrored field list | [parity-tests.md](.claude/rules/parity-tests.md) | Past two mirrors, ship a forget-proof parity test — reflection over a hand-listed one |
 | `scripts/build-app.sh`, `Package.swift`, workflows | [packaging-and-release.md](.claude/rules/packaging-and-release.md) | Every distributable artifact needs its own notarization ticket, and the build machine is the one place that failure is invisible |
+| `.claude/rules/**`, `AGENTS.md` | [rule-authoring.md](.claude/rules/rule-authoring.md) | Write an obligation, not a state claim — a claim that stays names its guard inline, and a number-pin derives the number rather than restating it (#614) |
 | `docs/**` | [docs.md](.claude/rules/docs.md) | Which doc owns what, and the design-decisions charter (argue the rule, never log the event) |
 | `site/**` | [site.md](.claude/rules/site.md) | `{/* */}` not `<!-- -->` — template comments ship to visitors (#557); `site/.nvmrc` is the one copy of the Node version |
 
@@ -280,37 +283,11 @@ that owns the subsystem and refresh that row here — never write
 the rationale into both.
 
 **Write a rule as an obligation, not as a state claim (#614).**
-An obligation — *"route a user-facing condition through structure
-the GUI renders"* — cannot become false; it can only be
-*violated*, which is a review event. An absolute claim about the
-current tree — *"Core holds no `L()` call site outside
-`Localization/`"* — is true only the day it is written, and the
-commit that falsifies it is somewhere else entirely, so nothing
-notices. That one was false for months while auto-loading on
-every Core edit (#601).
-
-So a sentence in `.claude/rules/*.md` phrased as an absolute
-state claim must **name its enforcing guard inline** — a
-`Tests/…` path, a test or test-function name, a `scripts/…` path
-— or be rewritten as an obligation. The best rows already do:
-`VisibleBoundsRoutingTests`, `SettingsCodingTests`,
-`LocalizationRegistryTests`, `ResourceBundleRoutingTests`. A
-claim that can be neither guarded nor reworded gets **deleted**,
-and a *number* gets pinned in the guard with the prose citing it
-rather than repeating it (#511).
-
-This matters more than ordinary doc drift because these files
-load as instructions: an agent reads a false claim as fact and
-reasons from it without checking. Two corollaries:
-
-- **Never close a claim with a guard that cannot fail.** Prove a
-  new guard reds — by reverting the thing it protects — before
-  trusting it. Several have passed vacuously on their first
-  draft.
-- **State a fact once.** A count or a list copied into a second
-  file rots in both on one commit, and neither copy knows the
-  other exists. Name the authority and link to it.
-
-Claims about the world outside this repo — macOS behavior, Apple
-tooling, a vendor's plan limits — cannot be guarded and should
-not be deleted. Scope them to when they were observed instead.
+An obligation can only be *violated*, which a review catches; an
+absolute claim about the current tree is true only the day it is
+written, and the commit that falsifies it is somewhere else, so
+nothing notices. A claim that stays must name its enforcing guard
+inline or be re-homed to one — the dispositions, ranked, and the
+two rules about the guards themselves are in
+[rule-authoring.md](.claude/rules/rule-authoring.md), which loads
+when you edit a rule file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,3 +278,39 @@ touch a matching path.
 When a recurring mistake is found, add it to the **rule file**
 that owns the subsystem and refresh that row here — never write
 the rationale into both.
+
+**Write a rule as an obligation, not as a state claim (#614).**
+An obligation — *"route a user-facing condition through structure
+the GUI renders"* — cannot become false; it can only be
+*violated*, which is a review event. An absolute claim about the
+current tree — *"Core holds no `L()` call site outside
+`Localization/`"* — is true only the day it is written, and the
+commit that falsifies it is somewhere else entirely, so nothing
+notices. That one was false for months while auto-loading on
+every Core edit (#601).
+
+So a sentence in `.claude/rules/*.md` phrased as an absolute
+state claim must **name its enforcing guard inline** — a
+`Tests/…` path, a test or test-function name, a `scripts/…` path
+— or be rewritten as an obligation. The best rows already do:
+`VisibleBoundsRoutingTests`, `SettingsCodingTests`,
+`LocalizationRegistryTests`, `ResourceBundleRoutingTests`. A
+claim that can be neither guarded nor reworded gets **deleted**,
+and a *number* gets pinned in the guard with the prose citing it
+rather than repeating it (#511).
+
+This matters more than ordinary doc drift because these files
+load as instructions: an agent reads a false claim as fact and
+reasons from it without checking. Two corollaries:
+
+- **Never close a claim with a guard that cannot fail.** Prove a
+  new guard reds — by reverting the thing it protects — before
+  trusting it. Several have passed vacuously on their first
+  draft.
+- **State a fact once.** A count or a list copied into a second
+  file rots in both on one commit, and neither copy knows the
+  other exists. Name the authority and link to it.
+
+Claims about the world outside this repo — macOS behavior, Apple
+tooling, a vendor's plan limits — cannot be guarded and should
+not be deleted. Scope them to when they were observed instead.

--- a/Sources/KiwiDeskCore/Animation/Spring.swift
+++ b/Sources/KiwiDeskCore/Animation/Spring.swift
@@ -29,14 +29,14 @@ public struct Spring: Sendable, Equatable {
     /// 1.9 and 5.8 — both already divergent.
     ///
     /// `1/max(ω, c)` is a deliberately conservative closed form
-    /// that satisfies the real condition for every ζ > 0. Its
-    /// margin is never below **1.24×** (the minimum, at ζ = 0.5)
-    /// and approaches but never reaches 2× as ζ → 0 or ζ → ∞ —
-    /// **1.57×** at the engine's ζ = 0.85, **1.29×** at
-    /// `DeadEndBump`'s ζ = 0.45, which sits near the tight end of
-    /// the curve. So the halving is load-bearing, not slack:
-    /// drop it and ζ = 0.85 lands on ωh = 1.18, amplification
-    /// 1.91 — #599 again.
+    /// that satisfies the real condition for every ζ > 0.
+    /// **`SpringStabilityMarginTests` computes that margin** —
+    /// its floor, where the floor sits, and each shipped spring's
+    /// value — so read it there rather than from a number copied
+    /// into a comment (#614). The halving is load-bearing, not
+    /// slack, and the same suite proves it: the looser
+    /// `2/max(ω, c)` lands outside the real bound at the damping
+    /// the engine ships, which is #599 again.
     ///
     /// Both terms are kept because ζ below 0.5 flips which one
     /// `max` selects, and that is not hypothetical — `DeadEndBump`

--- a/Tests/KiwiDeskCoreTests/RuleCitationTests.swift
+++ b/Tests/KiwiDeskCoreTests/RuleCitationTests.swift
@@ -19,6 +19,14 @@ import Testing
 ///
 /// Symbols are matched by **declaration**, not by filename —
 /// `DragCoordinatorTests` lives in `DragTests.swift`.
+///
+/// **What it deliberately does not check:** a bare test *function*
+/// name. `rule-authoring.md` allows one, but nothing about the
+/// shape of `aFrozenSpringIsStillRescued` separates it from the
+/// production symbols these files cite on every other line, so
+/// checking them would mean flagging `retarget` and
+/// `maxStableStep` too. The rule file therefore asks for the
+/// suite name alongside; that half is checked here.
 @Suite("Rule file citations")
 struct RuleCitationTests {
     private var repoRoot: URL {
@@ -32,9 +40,11 @@ struct RuleCitationTests {
     func citedSuitesExist() throws {
         let declared = try declaredTestSymbols()
         var missing: [String] = []
+        var seen = 0
         for (file, text) in try ruleDocuments() {
             for name in Self.backticked(text)
             where name.hasSuffix("Tests") && !name.contains("/") {
+                seen += 1
                 // A SwiftPM *target* also ends in "Tests"
                 // (`KiwiDeskCoreTests`) and is a directory, not a
                 // declaration. Resolving either way counts.
@@ -53,14 +63,44 @@ struct RuleCitationTests {
             }
         }
         #expect(missing.isEmpty, "dangling citations: \(missing)")
+        // A total-scan canary, for a walk that finds nothing.
+        #expect(seen > 20, "only saw \(seen) suite citations")
+    }
+
+    @Test("No document can invert the scanner")
+    func backticksAreBalanced() throws {
+        // The fail-open path, and it is specific to how
+        // `backticked` works: it toggles on every backtick, so
+        // ONE unbalanced backtick inverts inside/outside for the
+        // rest of *that document* and every real citation after
+        // it is silently skipped. The count canary above does not
+        // reach this — the other fifteen files still supply
+        // plenty of citations — so parity has to be checked per
+        // document. (Fenced code blocks are fine: three backticks
+        // twice is an even number of toggles.)
+        for (file, text) in try ruleDocuments() {
+            let ticks = text.filter { $0 == "`" }.count
+            let why =
+                "\(file) has \(ticks) backticks, so the scan "
+                + "silently stops seeing citations partway"
+            #expect(ticks % 2 == 0, "\(why)")
+        }
     }
 
     @Test("Every cited script path exists")
     func citedScriptsExist() throws {
         var missing: [String] = []
+        var seen = 0
         for (file, text) in try ruleDocuments() {
-            for path in Self.backticked(text)
-            where path.hasPrefix("scripts/") {
+            for raw in Self.backticked(text) {
+                // `./scripts/build-app.sh` is how AGENTS.md and
+                // packaging-and-release.md cite these, so the
+                // prefix test has to see past the `./` — six live
+                // citations were invisible without this, one of
+                // them added by the commit that shipped me.
+                let path =
+                    raw.hasPrefix("./") ? String(raw.dropFirst(2)) : raw
+                guard path.hasPrefix("scripts/") else { continue }
                 // Trim a trailing glob or arg: `scripts/*key*`
                 // and `scripts/drop-key <key>` are both cited.
                 let bare = path.split(separator: " ")[0]
@@ -72,6 +112,7 @@ struct RuleCitationTests {
                 let url = repoRoot.appendingPathComponent(
                     String(bare)
                 )
+                seen += 1
                 if !FileManager.default.fileExists(
                     atPath: url.path
                 ) {
@@ -80,6 +121,7 @@ struct RuleCitationTests {
             }
         }
         #expect(missing.isEmpty, "dangling scripts: \(missing)")
+        #expect(seen > 10, "only saw \(seen) script citations")
     }
 
     /// AGENTS.md plus every rule file — both are in scope for the
@@ -106,7 +148,7 @@ struct RuleCitationTests {
             .sorted()
         // A fail-open guard is the thing this file exists to
         // prevent, so refuse to pass on an empty scan.
-        #expect(names.count > 10, "only found \(names.count) rules")
+        #expect(names.count >= 15, "only found \(names.count) rules")
         for name in names {
             out.append(
                 (
@@ -137,6 +179,13 @@ struct RuleCitationTests {
                 encoding: .utf8
             )
             for line in text.split(separator: "\n") {
+                // Declarations only. Substring matching over raw
+                // lines also fires on `/// The struct FooTests
+                // covers…`, so a rename that leaves any prose
+                // mention behind would keep its citation
+                // resolving.
+                let bare = line.drop { $0 == " " }
+                guard !bare.hasPrefix("//") else { continue }
                 for keyword in ["struct ", "final class ", "class "]
                 where line.contains(keyword) {
                     let tail =

--- a/Tests/KiwiDeskCoreTests/RuleCitationTests.swift
+++ b/Tests/KiwiDeskCoreTests/RuleCitationTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+
+/// Every guard a rule file cites still exists (#614).
+///
+/// The convention in `rule-authoring.md` says an absolute claim
+/// must name its enforcing guard inline. That trades one rot
+/// vector for a smaller one: the citation itself goes stale on a
+/// rename, and a rule pointing at a suite that no longer exists
+/// is worse than a rule pointing at nothing — it reads as
+/// guarded.
+///
+/// A regex cannot tell a state claim from an obligation (measured
+/// on #614: the narrow vocabulary finds one paragraph, the broad
+/// one flags 71 legitimate obligations), which is why the
+/// meta-guard as originally filed was dropped. This is the part
+/// that *is* mechanical: a citation either resolves or it does
+/// not.
+///
+/// Symbols are matched by **declaration**, not by filename —
+/// `DragCoordinatorTests` lives in `DragTests.swift`.
+@Suite("Rule file citations")
+struct RuleCitationTests {
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // KiwiDeskCoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+    }
+
+    @Test("Every cited test suite is declared somewhere")
+    func citedSuitesExist() throws {
+        let declared = try declaredTestSymbols()
+        var missing: [String] = []
+        for (file, text) in try ruleDocuments() {
+            for name in Self.backticked(text)
+            where name.hasSuffix("Tests") && !name.contains("/") {
+                // A SwiftPM *target* also ends in "Tests"
+                // (`KiwiDeskCoreTests`) and is a directory, not a
+                // declaration. Resolving either way counts.
+                let asTarget =
+                    repoRoot
+                    .appendingPathComponent("Tests")
+                    .appendingPathComponent(name)
+                var isDirectory: ObjCBool = false
+                let exists = FileManager.default.fileExists(
+                    atPath: asTarget.path,
+                    isDirectory: &isDirectory
+                )
+                if declared.contains(name) { continue }
+                if exists, isDirectory.boolValue { continue }
+                missing.append("\(file): \(name)")
+            }
+        }
+        #expect(missing.isEmpty, "dangling citations: \(missing)")
+    }
+
+    @Test("Every cited script path exists")
+    func citedScriptsExist() throws {
+        var missing: [String] = []
+        for (file, text) in try ruleDocuments() {
+            for path in Self.backticked(text)
+            where path.hasPrefix("scripts/") {
+                // Trim a trailing glob or arg: `scripts/*key*`
+                // and `scripts/drop-key <key>` are both cited.
+                let bare = path.split(separator: " ")[0]
+                // `scripts/*key*` is a glob and `scripts/…` is a
+                // placeholder standing for "some script"; neither
+                // names a file.
+                guard !bare.contains("*"), !bare.contains("…")
+                else { continue }
+                let url = repoRoot.appendingPathComponent(
+                    String(bare)
+                )
+                if !FileManager.default.fileExists(
+                    atPath: url.path
+                ) {
+                    missing.append("\(file): \(bare)")
+                }
+            }
+        }
+        #expect(missing.isEmpty, "dangling scripts: \(missing)")
+    }
+
+    /// AGENTS.md plus every rule file — both are in scope for the
+    /// convention, so both are in scope for its citations.
+    private func ruleDocuments() throws -> [(String, String)] {
+        var out: [(String, String)] = [
+            (
+                "AGENTS.md",
+                try String(
+                    contentsOf:
+                        repoRoot
+                        .appendingPathComponent("AGENTS.md"),
+                    encoding: .utf8
+                )
+            )
+        ]
+        let rules =
+            repoRoot
+            .appendingPathComponent(".claude")
+            .appendingPathComponent("rules")
+        let names = try FileManager.default
+            .contentsOfDirectory(atPath: rules.path)
+            .filter { $0.hasSuffix(".md") }
+            .sorted()
+        // A fail-open guard is the thing this file exists to
+        // prevent, so refuse to pass on an empty scan.
+        #expect(names.count > 10, "only found \(names.count) rules")
+        for name in names {
+            out.append(
+                (
+                    name,
+                    try String(
+                        contentsOf:
+                            rules
+                            .appendingPathComponent(name),
+                        encoding: .utf8
+                    )
+                )
+            )
+        }
+        return out
+    }
+
+    /// Type and function names declared under `Tests/`.
+    private func declaredTestSymbols() throws -> Set<String> {
+        var found: Set<String> = []
+        let tests = repoRoot.appendingPathComponent("Tests")
+        let walker = FileManager.default.enumerator(
+            atPath: tests.path
+        )
+        while let entry = walker?.nextObject() as? String {
+            guard entry.hasSuffix(".swift") else { continue }
+            let text = try String(
+                contentsOf: tests.appendingPathComponent(entry),
+                encoding: .utf8
+            )
+            for line in text.split(separator: "\n") {
+                for keyword in ["struct ", "final class ", "class "]
+                where line.contains(keyword) {
+                    let tail =
+                        line.components(
+                            separatedBy: keyword
+                        ).dropFirst().first ?? ""
+                    let name = tail.prefix {
+                        $0.isLetter || $0.isNumber || $0 == "_"
+                    }
+                    if !name.isEmpty {
+                        found.insert(String(name))
+                    }
+                }
+            }
+        }
+        return found
+    }
+
+    /// Every `backticked` span in a markdown document.
+    private static func backticked(_ text: String) -> [String] {
+        var out: [String] = []
+        var inside = false
+        var current = ""
+        for character in text {
+            if character == "`" {
+                if inside, !current.isEmpty { out.append(current) }
+                current = ""
+                inside.toggle()
+            } else if inside {
+                current.append(character)
+            }
+        }
+        return out
+    }
+}

--- a/Tests/KiwiDeskCoreTests/RuleCitationTests.swift
+++ b/Tests/KiwiDeskCoreTests/RuleCitationTests.swift
@@ -76,8 +76,12 @@ struct RuleCitationTests {
         // it is silently skipped. The count canary above does not
         // reach this — the other fifteen files still supply
         // plenty of citations — so parity has to be checked per
-        // document. (Fenced code blocks are fine: three backticks
-        // twice is an even number of toggles.)
+        // document. A fenced code block keeps parity (three
+        // backticks twice is an even number of toggles) but is
+        // NOT otherwise handled: its whole body is harvested as
+        // one span, and it matches neither predicate only
+        // because a fence body ends in a newline. Inert by
+        // accident, not by design.
         for (file, text) in try ruleDocuments() {
             let ticks = text.filter { $0 == "`" }.count
             let why =

--- a/Tests/KiwiDeskCoreTests/SpringStabilityMarginTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpringStabilityMarginTests.swift
@@ -125,10 +125,13 @@ struct SpringStabilityMarginTests {
         // says the bound has no room for a second factor of two.
         for step in 1...400 {
             let z = Double(step) / 100
-            let doubled = 2 * margin(dampingFraction: z)
-            #expect(doubled > 2, "zeta \(z)")
+            // `margin < 2`, not `2 * margin > 2` — the latter
+            // reduces to `margin > 1`, which is the *safety*
+            // property this file already sweeps elsewhere, so it
+            // sat here contributing nothing. Proven inert in
+            // review: under a ceiling-violating spring it raised
+            // zero issues across all 400 points.
+            #expect(margin(dampingFraction: z) < 2, "zeta \(z)")
         }
-        #expect(margin(dampingFraction: 0.85) < 2)
-        #expect(margin(dampingFraction: 0.45) < 2)
     }
 }

--- a/Tests/KiwiDeskCoreTests/SpringStabilityMarginTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpringStabilityMarginTests.swift
@@ -56,11 +56,12 @@ struct SpringStabilityMarginTests {
         for step in 1...400 {
             let z = Double(step) / 100
             let m = margin(dampingFraction: z)
+            // Only the floor here. The ceiling is swept by
+            // `doublingTheStepIsNeverSafe`, which is named for
+            // it — asserting it in both places means weakening
+            // either one leaves the other passing, and a future
+            // editor cannot tell which test owns the property.
             #expect(m > 1, "zeta \(z) margin \(m)")
-            // The ceiling is the general reason the step cannot
-            // simply be doubled at ANY damping — without it the
-            // argument only covers the two shipped values.
-            #expect(m < 2, "zeta \(z) margin \(m)")
         }
     }
 

--- a/Tests/KiwiDeskCoreTests/SpringStabilityMarginTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpringStabilityMarginTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The margin `Spring.maxStableStep` keeps over the *real*
+/// stability bound (#599, pinned for #614).
+///
+/// `input-and-animation.md` and `Spring`'s own doc comment argue
+/// from three measured ratios — a minimum of 1.24× at ζ = 0.5,
+/// 1.57× at the engine's ζ = 0.85, 1.29× at `DeadEndBump`'s
+/// ζ = 0.45 — and conclude from them that the shipped
+/// `1/max(ω, c)` form is load-bearing. Nothing computed any of
+/// them, so the whole argument for the constant that prevented
+/// #599 rested on prose that could not fail.
+///
+/// The real condition is `k·h² + 2·c·h < 4`, i.e.
+/// `ωh < 2(√(1+ζ²) − ζ)`. Everything here derives from that and
+/// from the *shipped* `maxStableStep`, so it guards the
+/// implementation rather than restating the closed form.
+@Suite("Spring stability margin")
+struct SpringStabilityMarginTests {
+    /// How much larger the true bound is than the step the spring
+    /// actually integrates with. Must exceed 1 for the integrator
+    /// to damp rather than amplify.
+    private func margin(
+        dampingFraction: Double,
+        response: Double = 0.35
+    ) -> Double {
+        let spring = Spring(
+            response: response,
+            dampingFraction: dampingFraction
+        )
+        let omega = 2 * Double.pi / response
+        let z = dampingFraction
+        let realBound = 2 * ((1 + z * z).squareRoot() - z) / omega
+        return realBound / spring.maxStableStep
+    }
+
+    @Test("The shipped step stays inside the real bound for any ζ")
+    func marginNeverDropsBelowOne() {
+        // The safety property, over the whole positive range
+        // rather than the two shipped values — `dampingFraction`
+        // is a public initializer parameter.
+        for step in 1...400 {
+            let z = Double(step) / 100
+            let m = margin(dampingFraction: z)
+            #expect(m > 1, "zeta \(z) margin \(m)")
+        }
+    }
+
+    @Test("The margin bottoms out near 1.24x, at zeta = 0.5")
+    func minimumMarginIsAtHalf() {
+        var worst = Double.infinity
+        var worstZ = 0.0
+        for step in 1...400 {
+            let z = Double(step) / 100
+            let m = margin(dampingFraction: z)
+            if m < worst {
+                worst = m
+                worstZ = z
+            }
+        }
+        // Both halves of the prose claim: the value, and *where*
+        // it sits. The location is what makes ζ < 0.5 worth
+        // calling out — `DeadEndBump` ships at 0.45, on the far
+        // side of the minimum from the engine.
+        #expect(abs(worstZ - 0.5) < 0.02, "minimum at \(worstZ)")
+        #expect(worst > 1.235 && worst < 1.237, "minimum \(worst)")
+    }
+
+    @Test("Both shipped springs clear the bound by their stated margin")
+    func shippedSpringMargins() {
+        // The engine's spring (`AnimationEngine.spring`) and
+        // `DeadEndBump`'s. They sit on opposite sides of which
+        // term `max(ω, c)` selects, which is why one value cannot
+        // stand in for both.
+        let engine = margin(dampingFraction: 0.85)
+        let bump = margin(dampingFraction: 0.45)
+        #expect(engine > 1.57 && engine < 1.58, "engine \(engine)")
+        #expect(bump > 1.29 && bump < 1.30, "bump \(bump)")
+        // The margin is scale-free in `response`, so the whole
+        // duration clamp inherits these two numbers rather than
+        // needing its own sweep.
+        for response in [0.07, 0.35, 1.4] {
+            let m = margin(
+                dampingFraction: 0.85,
+                response: response
+            )
+            #expect(abs(m - engine) < 1e-9, "\(response) -> \(m)")
+        }
+    }
+
+    @Test("Doubling the step would be divergent at the engine's zeta")
+    func theHalvingIsLoadBearing() {
+        // `maxStableStep` is `1/max(ω, c)`, not `2/max(ω, c)`.
+        // The prose calls that halving load-bearing; this is what
+        // that means — the looser form lands outside the real
+        // bound at the damping the engine actually ships, which
+        // is #599 again.
+        #expect(margin(dampingFraction: 0.85) / 2 < 1)
+        #expect(margin(dampingFraction: 0.45) / 2 < 1)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/SpringStabilityMarginTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpringStabilityMarginTests.swift
@@ -15,9 +15,17 @@ import Testing
 /// #599 rested on prose that could not fail.
 ///
 /// The real condition is `k·h² + 2·c·h < 4`, i.e.
-/// `ωh < 2(√(1+ζ²) − ζ)`. Everything here derives from that and
-/// from the *shipped* `maxStableStep`, so it guards the
-/// implementation rather than restating the closed form.
+/// `ωh < 2(√(1+ζ²) − ζ)`. The numerator comes from that closed
+/// form and the denominator from the spring the code actually
+/// builds, so this guards the implementation rather than
+/// comparing a formula with itself.
+///
+/// What it does **not** pin: that `step` uses `maxStableStep` at
+/// all — force the substep count to 1 and this stays green, and
+/// `SpringStabilityTests` / `AnimationEngineStabilityTests` are
+/// what catch that — nor that the damping fractions below are
+/// the ones the shipped springs use, since both are private to
+/// their types.
 @Suite("Spring stability margin")
 struct SpringStabilityMarginTests {
     /// How much larger the true bound is than the step the spring
@@ -31,7 +39,10 @@ struct SpringStabilityMarginTests {
             response: response,
             dampingFraction: dampingFraction
         )
-        let omega = 2 * Double.pi / response
+        // From the SHIPPED spring, not from `response` — `init`
+        // clamps that, so recomputing omega from the argument
+        // would measure a spring nobody built.
+        let omega = spring.stiffness.squareRoot()
         let z = dampingFraction
         let realBound = 2 * ((1 + z * z).squareRoot() - z) / omega
         return realBound / spring.maxStableStep
@@ -46,6 +57,10 @@ struct SpringStabilityMarginTests {
             let z = Double(step) / 100
             let m = margin(dampingFraction: z)
             #expect(m > 1, "zeta \(z) margin \(m)")
+            // The ceiling is the general reason the step cannot
+            // simply be doubled at ANY damping — without it the
+            // argument only covers the two shipped values.
+            #expect(m < 2, "zeta \(z) margin \(m)")
         }
     }
 
@@ -71,10 +86,13 @@ struct SpringStabilityMarginTests {
 
     @Test("Both shipped springs clear the bound by their stated margin")
     func shippedSpringMargins() {
-        // The engine's spring (`AnimationEngine.spring`) and
-        // `DeadEndBump`'s. They sit on opposite sides of which
-        // term `max(ω, c)` selects, which is why one value cannot
-        // stand in for both.
+        // The two damping fractions that ship today — the
+        // engine's spring and `DeadEndBump`'s. They sit on
+        // opposite sides of which term `max(ω, c)` selects, which
+        // is why one value cannot stand in for both. Both are
+        // private to their types, so these are literals: change a
+        // shipped zeta and this suite keeps passing about the old
+        // one.
         let engine = margin(dampingFraction: 0.85)
         let bump = margin(dampingFraction: 0.45)
         #expect(engine > 1.57 && engine < 1.58, "engine \(engine)")
@@ -91,14 +109,26 @@ struct SpringStabilityMarginTests {
         }
     }
 
-    @Test("Doubling the step would be divergent at the engine's zeta")
-    func theHalvingIsLoadBearing() {
-        // `maxStableStep` is `1/max(ω, c)`, not `2/max(ω, c)`.
-        // The prose calls that halving load-bearing; this is what
-        // that means — the looser form lands outside the real
-        // bound at the damping the engine actually ships, which
-        // is #599 again.
-        #expect(margin(dampingFraction: 0.85) / 2 < 1)
-        #expect(margin(dampingFraction: 0.45) / 2 < 1)
+    @Test("The step could never simply be doubled, at any zeta")
+    func doublingTheStepIsNeverSafe() {
+        // `maxStableStep` is `1/max(ω, c)`, not `2/max(ω, c)`, and
+        // this is the property that forbids the looser form: the
+        // margin never reaches 2×, so twice the shipped step is
+        // always outside the real bound.
+        //
+        // Note what this does NOT catch, because the naming is
+        // easy to over-read: if `maxStableStep` *already* shipped
+        // as `2/max(ω, c)`, the measured margin halves and every
+        // assertion here still passes. `marginNeverDropsBelowOne`
+        // is what fails in that case — it is the test that says
+        // the shipped step is inside the bound, and this one only
+        // says the bound has no room for a second factor of two.
+        for step in 1...400 {
+            let z = Double(step) / 100
+            let doubled = 2 * margin(dampingFraction: z)
+            #expect(doubled > 2, "zeta \(z)")
+        }
+        #expect(margin(dampingFraction: 0.85) < 2)
+        #expect(margin(dampingFraction: 0.45) < 2)
     }
 }


### PR DESCRIPTION
## What

Rule files in `.claude/rules/*.md` auto-load as agent instructions, so
a false sentence in one is reasoned from as fact. Four had been caught
asserting invariants the tree did not honour.

Per the measurement comment, **the meta-guard as filed is not built** —
a regex cannot separate a state claim from an obligation (narrow
vocabulary: 1 paragraph; broad: 71 legitimate ones, and it reds on the
very phrasing this issue recommends). The other two parts ship.

## 1. The convention

`.claude/rules/rule-authoring.md`, scoped to `.claude/rules/**` and
`AGENTS.md` — so it loads exactly when someone edits a rule file, which
is the only moment it binds. AGENTS.md §5 keeps a pointer and an index
row, like every other subsystem.

Dispositions are **ranked**, delete last: name its guard → rewrite as an
obligation → re-home to a named authority → scope to when it was
observed → leave it if it sits beside its own register → delete. Plus
two rules about the guards themselves: a number-pin must **derive** the
number rather than restate it, and prove a new guard reds before
trusting it.

## 2. The audit

**Three claims were false.** Verified against the tree:

| Claim | Reality |
|---|---|
| `tests.md` "112 mandatory-safe call sites" | 129, and climbing with every new suite — which is the argument's own point, so it now reads as a lower bound |
| `tests.md` "#89's signed `.app` is the durable fix" (future tense) | #89 is closed and shipped. This one **misdirected device QA** — it told you to plan around the TCC grant dropping on every rebuild, with no mention that there is a way out. (My first correction then over-swung and failed open; see Review.) |
| `borders.md` "Three writers" | four-row table |

"Eight content guards" turned out **true** — it matches
`scripts/localization_guards.py`'s own docstring — so that became a
duplication fix (three copies → the script is the authority) rather
than a correction.

Unguarded counts and enumerations were re-pointed at their registers:
the localization guard count and its ordinal prose, `profiles.md`'s
override families, `packaging`'s "three places" vs "both copies", and
the env-lever list duplicated between two files.

## 3. Two guards, because the claims deserved one

**`SpringStabilityMarginTests`.** `input-and-animation.md` and
`Spring`'s doc both argued from the #599 stability margins — 1.24×
minimum at ζ = 0.5, 1.57× at the engine's ζ, 1.29× at `DeadEndBump`'s —
and concluded the shipped `1/max(ω, c)` form is load-bearing. **Nothing
computed any of them.** The argument for the constant that prevented
#599 rested on prose that could not fail. The guard derives the margin
from the real condition and the *shipped* `maxStableStep`, sweeps ζ, and
proves doubling is never safe. Both prose sites now cite it.

**`RuleCitationTests`.** The convention mandates inline citations, which
trades one rot vector for a smaller one: a citation goes stale on a
rename, and a rule naming a suite that no longer exists reads as guarded
while guarding nothing. This resolves every backticked `*Tests` symbol
and `scripts/…` path in AGENTS.md and the rule files — by **declaration,
not filename** (`DragCoordinatorTests` lives in `DragTests.swift`) — and
refuses to pass on an empty scan. It caught two false positives on its
first run, both real gaps in the matcher.

## Review

Both reviewers found this commit reproducing the defect it exists to
close, in four places. The worst was mine: my "fix" to the #89 claim
**failed open** — `build-app.sh` falls back to ad-hoc signing without a
Developer ID certificate and prints that the grant will reset, so the
emphatic advice I wrote was true only for a certificate holder. Also
fixed: a third copy of the guard count left in AGENTS.md by the commit
removing the other two, "false for months" when the repo is 26 days old,
and `borders.md` "three channels" over the same four-row table whose
heading I had just fixed.

The architect's structural argument — that a convention binding on
rule-file edits should be *loaded* on rule-file edits — is why it moved
out of §5 into a path-scoped file.

## Verification

`swift build`, `swift test --skip ExecTests` (2212), `swift test
--filter ExecTests` (14), `scripts/lint.sh` exit 0, `swift build -c
release`.

Every guard proven by mutation, and both reviewers ran their own rather
than trusting mine. That mattered: **three assertions I shipped were
inert**, and none was visible by reading. The clearest was a 400-point
sweep named "the step could never simply be doubled" asserting
`2 * margin > 2` — algebraically `margin > 1`, the safety property a
different test already swept. Under a spring violating the ceiling at
every point it raised zero issues. The citation guard likewise never saw
a `./scripts/…` path (six live ones, including the one this branch
added) and matched `struct ` inside comments, so a rename leaving the
old name in prose kept resolving.

The floor and the ceiling now belong to one test each, verified by
opposite mutations.

fixes #614

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
