### PR TITLE
fix(core): default every onLog seam to the syslog sink

### DIFF
--- a/.claude/rules/core-boundaries.md
+++ b/.claude/rules/core-boundaries.md
@@ -38,16 +38,11 @@ itself when a fifth is added.
   contract, not UI copy. The deliberate exception to the above.
 - **A `var onLog` seam is wired in `KiwiCore+Bootstrap`**, in
   the group where all of them are, and in the same change that
-  declares it — and it **defaults to `CoreLog.emit`** (#624), so
-  that forgetting costs a line which skips the sink rather than
-  a line that is dropped. `LogSeamWiringTests` guards the wiring
-  and its `allowed` map is the exemption list; `LogSeamDefaultTests`
-  guards the default. They fail on opposite mistakes and neither
-  implies the other, so both stay; each docstring carries its own
-  argument. The default buys down the *size* of the failure, not
-  its existence — an unwired seam still bypasses the sink a GUI
-  console reads from, which is why the wiring rule is the one
-  written as an obligation.
+  declares it — and it **defaults to `CoreLog.write`**, which is
+  never called directly. `LogSeamWiringTests` guards the wiring
+  and its `allowed` map is the exemption list;
+  `LogSeamDefaultTests` guards the default and the no-direct-call
+  half. The argument for both is on `CoreLog`.
   Bootstrap-time only: a seam wired later (`KiwiCore+Lifecycle`,
   after the AX grant) is invisible to that guard, and `onLog`
   needs no permission to be useful.

--- a/.claude/rules/core-boundaries.md
+++ b/.claude/rules/core-boundaries.md
@@ -38,12 +38,16 @@ itself when a fifth is added.
   contract, not UI copy. The deliberate exception to the above.
 - **A `var onLog` seam is wired in `KiwiCore+Bootstrap`**, in
   the group where all of them are, and in the same change that
-  declares it. Leaving one unassigned fails by **doing
-  nothing** — a seam whose default is a no-op lets its subsystem
-  compile, ship, run and drop every line it logs, with no red and
-  no symptom beyond a diagnostic that was never going to
-  appear. `LogSeamWiringTests` is the guard, its `allowed` map
-  is the exemption list, and its docstring carries the argument.
+  declares it — and it **defaults to `CoreLog.emit`** (#624), so
+  that forgetting costs a line which skips the sink rather than
+  a line that is dropped. `LogSeamWiringTests` guards the wiring
+  and its `allowed` map is the exemption list; `LogSeamDefaultTests`
+  guards the default. They fail on opposite mistakes and neither
+  implies the other, so both stay; each docstring carries its own
+  argument. The default buys down the *size* of the failure, not
+  its existence — an unwired seam still bypasses the sink a GUI
+  console reads from, which is why the wiring rule is the one
+  written as an obligation.
   Bootstrap-time only: a seam wired later (`KiwiCore+Lifecycle`,
   after the AX grant) is invisible to that guard, and `onLog`
   needs no permission to be useful.

--- a/.claude/rules/core-boundaries.md
+++ b/.claude/rules/core-boundaries.md
@@ -41,8 +41,10 @@ itself when a fifth is added.
   declares it — and it **defaults to `CoreLog.write`**, which is
   never called directly. `LogSeamWiringTests` guards the wiring
   and its `allowed` map is the exemption list;
-  `LogSeamDefaultTests` guards the default and the no-direct-call
-  half. The argument for both is on `CoreLog`.
+  `LogSeamDefaultTests` guards the default, and
+  `LogSeamSinkTests` guards the sink itself — that its body still
+  writes, and that Core never calls it outside a seam
+  declaration. The argument for all of it is on `CoreLog`.
   Bootstrap-time only: a seam wired later (`KiwiCore+Lifecycle`,
   after the AX grant) is invisible to that guard, and `onLog`
   needs no permission to be useful.

--- a/.claude/rules/input-and-animation.md
+++ b/.claude/rules/input-and-animation.md
@@ -127,11 +127,11 @@ editing here:
 
   Report both nets through `AnimationEngine.onLog` (wired in
   `KiwiCore+Bootstrap`, asserted end-to-end by
-  `engineLogReachesTheCore` — a seam that is declared and never
-  wired logs nothing in production while every unit test that
-  sets it by hand stays green). A rescue that fires silently
-  removes the symptom that made #599 findable and leaves only a
-  visible jump.
+  `AnimationNetLoggingTests.engineLogReachesTheCore` — a seam
+  declared and never wired bypasses the sink in production while
+  every unit test that sets it by hand stays green). A rescue
+  that fires silently removes the symptom that made #599
+  findable and leaves only a visible jump.
 - **A shrinking axis snaps to target on frame 1 unless the
   caller promised `BatchSizing.allSpringSized` (#593), and that
   promise is opt-in, never inferred.** The full argument — why

--- a/.claude/rules/input-and-animation.md
+++ b/.claude/rules/input-and-animation.md
@@ -127,9 +127,9 @@ editing here:
 
   Report both nets through `AnimationEngine.onLog` (wired in
   `KiwiCore+Bootstrap`, asserted end-to-end by
-  `AnimationNetLoggingTests.engineLogReachesTheCore` — a seam
-  declared and never wired bypasses the sink in production while
-  every unit test that sets it by hand stays green). A rescue
+  `AnimationNetLoggingTests`, in `engineLogReachesTheCore` — a
+  seam declared and never wired bypasses the sink in production
+  while every unit test that sets it by hand stays green). A rescue
   that fires silently removes the symptom that made #599
   findable and leaves only a visible jump.
 - **A shrinking axis snaps to target on frame 1 unless the

--- a/.claude/rules/rule-authoring.md
+++ b/.claude/rules/rule-authoring.md
@@ -73,7 +73,7 @@ not a peer of the others.
    count of things a script defines is disposition 3, however
    close the prose sits. `core-boundaries.md` is the worked
    example, and it writes its own justification inline: "the
-   count is the three bullets immediately below". A heading
+   count is the four bullets immediately below". A heading
    twenty-six lines above its table fails this even though both
    are in one file — that was `borders.md`'s "Three writers",
    and it was wrong.

--- a/.claude/rules/rule-authoring.md
+++ b/.claude/rules/rule-authoring.md
@@ -72,8 +72,10 @@ not a peer of the others.
    The register also has to be a list *in this document* — a
    count of things a script defines is disposition 3, however
    close the prose sits. `core-boundaries.md` is the worked
-   example, and it writes its own justification inline: "the
-   count is the four bullets immediately below". A heading
+   example, and it writes its own justification inline — its
+   opening count says it is "the … bullets immediately below",
+   naming the register rather than a number this file would then
+   hold a second copy of. A heading
    twenty-six lines above its table fails this even though both
    are in one file — that was `borders.md`'s "Three writers",
    and it was wrong.

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -141,13 +141,15 @@ its run state is irrelevant to them.
 `log stream` during one shows test diagnostics that read exactly
 like the app's. Most come through `KiwiCore.onLog`, whose default
 has always been the syslog write; since #624 a subsystem
-constructed bare — `AnimationEngine()`, `KeybindingManager(…)` —
-adds its own, because a seam defaults to `CoreLog.write` rather
-than to a no-op (`LogSeamDefaultTests`). That is the intended
-trade (a test
-triggering the settle watchdog prints the rescue instead of
-swallowing it), and a suite that wants quiet assigns
-`onLog = { _ in }` on the instance it builds. Do not read a
+constructed bare — `KeybindingManager(registrar:)`,
+`CrashRecovery(directory:)` — adds its own, because a seam
+defaults to `CoreLog.write` rather than to a no-op
+(`LogSeamDefaultTests`). That is the intended trade: a suite
+triggering a diagnostic path prints it instead of swallowing it,
+which is how the settle-watchdog fixtures came to assert on the
+line they were silently dropping. A suite that wants quiet
+assigns `onLog = { _ in }` on the instance it builds, and one
+that wants the coverage captures instead. Do not read a
 `keybinding conflict` or `unclean shutdown detected` line seen
 during a run as the app misbehaving.
 

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -142,8 +142,9 @@ its run state is irrelevant to them.
 like the app's. Most come through `KiwiCore.onLog`, whose default
 has always been the syslog write; since #624 a subsystem
 constructed bare — `AnimationEngine()`, `KeybindingManager(…)` —
-adds its own, because every seam now defaults to `CoreLog.write`
-rather than to a no-op. That is the intended trade (a test
+adds its own, because a seam defaults to `CoreLog.write` rather
+than to a no-op (`LogSeamDefaultTests`). That is the intended
+trade (a test
 triggering the settle watchdog prints the rescue instead of
 swallowing it), and a suite that wants quiet assigns
 `onLog = { _ in }` on the instance it builds. Do not read a

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -137,6 +137,19 @@ a temp config dir, throwaway sockets; the service tests only parse
 `launchctl` strings. **Unit tests never need the running app**;
 its run state is irrelevant to them.
 
+**A run writes `KiwiDesk: …` lines to the unified log**, so a
+`log stream` during one shows test diagnostics that read exactly
+like the app's. Most come through `KiwiCore.onLog`, whose default
+has always been the syslog write; since #624 a subsystem
+constructed bare — `AnimationEngine()`, `KeybindingManager(…)` —
+adds its own, because every seam now defaults to `CoreLog.write`
+rather than to a no-op. That is the intended trade (a test
+triggering the settle watchdog prints the rescue instead of
+swallowing it), and a suite that wants quiet assigns
+`onLog = { _ in }` on the instance it builds. Do not read a
+`keybinding conflict` or `unclean shutdown detected` line seen
+during a run as the app misbehaving.
+
 Run the full suite as two commands:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,7 +269,7 @@ touch a matching path.
 
 | Touching | Read | The rule, in one line |
 |---|---|---|
-| Anywhere in `Sources/KiwiDeskCore` | [core-boundaries.md](.claude/rules/core-boundaries.md) | Core returns structure and the GUI renders the sentence (#96); CLI/IPC errors stay English; never `Bundle.module`; a declared `onLog` seam is wired in `KiwiCore+Bootstrap` |
+| Anywhere in `Sources/KiwiDeskCore` | [core-boundaries.md](.claude/rules/core-boundaries.md) | Core returns structure and the GUI renders the sentence (#96); CLI/IPC errors stay English; never `Bundle.module`; a declared `onLog` seam defaults to `CoreLog.emit` and is wired in `KiwiCore+Bootstrap` |
 | `State`, `Tiling`, `Layouts`, `Commands`, `App`, `Tabs` | [state-and-layout.md](.claude/rules/state-and-layout.md) | Flat array, pure layouts; display bounds only via `TilingEngine.visibleBounds` (#531) and spans via `layoutBounds(on:)` (#537) — the guards' `allowed` maps are the one copy of who is exempt; a native tab switch is a re-key, not destroy+create (#308); an explicit `set_*` apply forces the retile; only a pass whose windows are all spring-sized may promise `BatchSizing.allSpringSized` (#593) |
 | `Config`, `Profiles`, `Commands` | [profiles.md](.claude/rules/profiles.md) | A profile owns tiling plus *sparse behavior overrides*, never anything that routes or selects the profile itself; `isGuiManaged` is the one ownership predicate |
 | Any setting name, `CodingKeys`, user-facing noun | [config-vocabulary.md](.claude/rules/config-vocabulary.md) | Pick the Lua name first and derive the JSON key from it; groups are singular; reuse the noun glossary instead of coining a synonym |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,7 +269,7 @@ touch a matching path.
 
 | Touching | Read | The rule, in one line |
 |---|---|---|
-| Anywhere in `Sources/KiwiDeskCore` | [core-boundaries.md](.claude/rules/core-boundaries.md) | Core returns structure and the GUI renders the sentence (#96); CLI/IPC errors stay English; never `Bundle.module`; a declared `onLog` seam defaults to `CoreLog.emit` and is wired in `KiwiCore+Bootstrap` |
+| Anywhere in `Sources/KiwiDeskCore` | [core-boundaries.md](.claude/rules/core-boundaries.md) | Core returns structure and the GUI renders the sentence (#96); CLI/IPC errors stay English; never `Bundle.module`; a declared `onLog` seam defaults to `CoreLog.write` and is wired in `KiwiCore+Bootstrap` |
 | `State`, `Tiling`, `Layouts`, `Commands`, `App`, `Tabs` | [state-and-layout.md](.claude/rules/state-and-layout.md) | Flat array, pure layouts; display bounds only via `TilingEngine.visibleBounds` (#531) and spans via `layoutBounds(on:)` (#537) — the guards' `allowed` maps are the one copy of who is exempt; a native tab switch is a re-key, not destroy+create (#308); an explicit `set_*` apply forces the retile; only a pass whose windows are all spring-sized may promise `BatchSizing.allSpringSized` (#593) |
 | `Config`, `Profiles`, `Commands` | [profiles.md](.claude/rules/profiles.md) | A profile owns tiling plus *sparse behavior overrides*, never anything that routes or selects the profile itself; `isGuiManaged` is the one ownership predicate |
 | Any setting name, `CodingKeys`, user-facing noun | [config-vocabulary.md](.claude/rules/config-vocabulary.md) | Pick the Lua name first and derive the JSON key from it; groups are singular; reuse the noun glossary instead of coining a synonym |

--- a/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
+++ b/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
@@ -64,9 +64,10 @@ public final class AnimationEngine {
     /// wedged state, and a net that fires silently converts the
     /// loud failure that made #599 findable into a quiet one —
     /// leaving only a visible jump and no way to tell a rescue
-    /// from a retile. Unwired it is inert, so unit suites that
-    /// never set it see nothing.
-    public var onLog: @MainActor (String) -> Void = { _ in }
+    /// from a retile. Unwired it goes to syslog rather than
+    /// nowhere (`CoreLog`, #624), so a unit suite that never
+    /// sets it prints the rescue instead of swallowing it.
+    public var onLog: @MainActor (String) -> Void = CoreLog.emit
 
     /// Test seam: when false, `animate` applies the target
     /// frame synchronously instead of spring-animating it, so

--- a/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
+++ b/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
@@ -67,7 +67,7 @@ public final class AnimationEngine {
     /// from a retile. Unwired it goes to syslog rather than
     /// nowhere (`CoreLog`, #624), so a unit suite that never
     /// sets it prints the rescue instead of swallowing it.
-    public var onLog: @MainActor (String) -> Void = CoreLog.emit
+    public var onLog: @MainActor (String) -> Void = CoreLog.write
 
     /// Test seam: when false, `animate` applies the target
     /// frame synchronously instead of spring-animating it, so

--- a/Sources/KiwiDeskCore/App/CoreLog.swift
+++ b/Sources/KiwiDeskCore/App/CoreLog.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// The syslog write under every `var onLog` seam in Core, and
+/// under `KiwiCore.onLog` itself.
+///
+/// It is a **default**, not a bypass. Bootstrap overwrites every
+/// seam with a closure forwarding to `KiwiCore.onLog`
+/// (`KiwiCore+Bootstrap`), whose own default is this function, so
+/// a wired seam's line travels `subsystem.onLog → KiwiCore.onLog
+/// → CoreLog.emit`. What the default decides is only what happens
+/// when that wiring never runs.
+///
+/// **Why every seam defaults here rather than to `{ _ in }`.**
+/// The omission `LogSeamWiringTests` exists to catch — a seam
+/// declared and never assigned, compiling and shipping while it
+/// drops every line it logs — costs *silence* under a no-op
+/// default: no red, no warning, and the only symptom is a
+/// diagnostic that was never going to appear, missed months
+/// later by whoever needed it. Under this one the same omission
+/// costs a routing inconsistency instead: the line still reaches
+/// syslog, it just skips the sink a GUI console would read from.
+/// Same mistake, lower stakes — which is the whole of the
+/// argument, and it is worth being precise that it buys
+/// robustness against a *future* omission rather than fixing a
+/// present silence. `LogSeamDefaultTests` keeps the seams on this
+/// default; `LogSeamWiringTests` keeps them wired.
+///
+/// A namespace of its own rather than `KiwiCore`'s default
+/// hoisted to a static on `KiwiCore`, so that leaf subsystems do
+/// not name the composition root in their property defaults.
+public enum CoreLog {
+    /// Writes one diagnostic line to syslog, under the
+    /// `KiwiDesk:` prefix every Core log line carries.
+    ///
+    /// Left `nonisolated`: it touches nothing isolated, so it
+    /// converts into the seams' `@MainActor (String) -> Void`
+    /// without pinning the write itself to the main actor.
+    public static func emit(_ message: String) {
+        NSLog("KiwiDesk: %@", message)
+    }
+}

--- a/Sources/KiwiDeskCore/App/CoreLog.swift
+++ b/Sources/KiwiDeskCore/App/CoreLog.swift
@@ -3,39 +3,54 @@ import Foundation
 /// The syslog write under every `var onLog` seam in Core, and
 /// under `KiwiCore.onLog` itself.
 ///
-/// It is a **default**, not a bypass. Bootstrap overwrites every
-/// seam with a closure forwarding to `KiwiCore.onLog`
-/// (`KiwiCore+Bootstrap`), whose own default is this function, so
-/// a wired seam's line travels `subsystem.onLog → KiwiCore.onLog
-/// → CoreLog.emit`. What the default decides is only what happens
-/// when that wiring never runs.
+/// **Where the default is actually operative.** Not, as it is
+/// tempting to say, "whenever someone forgets to wire a seam":
+/// bootstrap assigns all of them and `LogSeamWiringTests` reds if
+/// one is missed, so in every case that guard *sees*, this
+/// default never runs. It is load-bearing precisely in that
+/// guard's documented open limits — a second instance of a
+/// seam-owning type, an entry in its `allowed` map, and a seam
+/// wired later than bootstrap, which
+/// `.claude/rules/core-boundaries.md` explicitly carves out. In
+/// those a seam really does run on its default, and the choice
+/// between this and `{ _ in }` is the choice between a line that
+/// skips the sink and a line that is dropped.
 ///
-/// **Why every seam defaults here rather than to `{ _ in }`.**
-/// The omission `LogSeamWiringTests` exists to catch — a seam
-/// declared and never assigned, compiling and shipping while it
-/// drops every line it logs — costs *silence* under a no-op
-/// default: no red, no warning, and the only symptom is a
-/// diagnostic that was never going to appear, missed months
-/// later by whoever needed it. Under this one the same omission
-/// costs a routing inconsistency instead: the line still reaches
-/// syslog, it just skips the sink a GUI console would read from.
-/// Same mistake, lower stakes — which is the whole of the
-/// argument, and it is worth being precise that it buys
-/// robustness against a *future* omission rather than fixing a
-/// present silence. `LogSeamDefaultTests` keeps the seams on this
-/// default; `LogSeamWiringTests` keeps them wired.
+/// That is a smaller failure, not the absence of one: a seam
+/// running on this default still bypasses `KiwiCore.onLog`, so
+/// test capture and the GUI console `KiwiCore.onLog`'s own
+/// comment anticipates would not carry it. The wiring rule stays
+/// the obligation; this only sets what a violation costs.
 ///
-/// A namespace of its own rather than `KiwiCore`'s default
-/// hoisted to a static on `KiwiCore`, so that leaf subsystems do
-/// not name the composition root in their property defaults.
-public enum CoreLog {
-    /// Writes one diagnostic line to syslog, under the
-    /// `KiwiDesk:` prefix every Core log line carries.
+/// A namespace of its own rather than a static on `KiwiCore`
+/// because `KiwiCore` is already a class spread over thirty-odd
+/// `KiwiCore+*.swift` extensions, and hanging general-purpose
+/// primitives on it is how it got that way — not because a leaf
+/// naming another subsystem is itself a problem, which this tree
+/// does freely (`BorderManager.readWindowBounds` defaults to
+/// `SkyLight.windowBounds`).
+enum CoreLog {
+    /// Writes one diagnostic line to syslog, under the same
+    /// `KiwiDesk:` prefix the seams' lines already carried.
+    ///
+    /// `write`, not `emit`: this codebase spends `emit` on
+    /// publishing to the `EventBus` (`EventBus.emit`, and the
+    /// `KiwiCore.emit*` family), and a logger borrowing that verb
+    /// for something that reaches no subscriber reads as an
+    /// event that quietly goes nowhere.
     ///
     /// Left `nonisolated`: it touches nothing isolated, so it
     /// converts into the seams' `@MainActor (String) -> Void`
     /// without pinning the write itself to the main actor.
-    public static func emit(_ message: String) {
+    ///
+    /// Not `public`, and `LogSeamDefaultTests` keeps it a default
+    /// rather than a bypass — it asserts this body still writes,
+    /// and that Core reaches this symbol only through a seam
+    /// declaration. Both matter: gutting the body would restore
+    /// the pre-#624 behaviour with every seam still naming it,
+    /// and a direct call would put a diagnostic in syslog that
+    /// `KiwiCore.onLog` never sees.
+    static func write(_ message: String) {
         NSLog("KiwiDesk: %@", message)
     }
 }

--- a/Sources/KiwiDeskCore/App/CoreLog.swift
+++ b/Sources/KiwiDeskCore/App/CoreLog.swift
@@ -43,13 +43,15 @@ enum CoreLog {
     /// converts into the seams' `@MainActor (String) -> Void`
     /// without pinning the write itself to the main actor.
     ///
-    /// Not `public`, and `LogSeamDefaultTests` keeps it a default
+    /// Not `public`, and `LogSeamSinkTests` keeps it a default
     /// rather than a bypass — it asserts this body still writes,
     /// and that Core reaches this symbol only through a seam
     /// declaration. Both matter: gutting the body would restore
     /// the pre-#624 behaviour with every seam still naming it,
     /// and a direct call would put a diagnostic in syslog that
-    /// `KiwiCore.onLog` never sees.
+    /// `KiwiCore.onLog` never sees. `LogSeamDefaultTests` is the
+    /// other half — that every seam names this in the first
+    /// place.
     static func write(_ message: String) {
         NSLog("KiwiDesk: %@", message)
     }

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -252,10 +252,10 @@ public final class KiwiCore {
     /// `bind_profile_to_native_space`.
     public internal(set) var nativeSpaceBindings: [Int: String] = [:]
 
-    /// Log line consumer (GUI console later; syslog now).
-    public var onLog: @MainActor (String) -> Void = { message in
-        NSLog("KiwiDesk: %@", message)
-    }
+    /// Log line consumer (GUI console later; syslog now) — the
+    /// sink every Core seam is wired to forward *into*, which is
+    /// why it is exempt from the wiring guard.
+    public var onLog: @MainActor (String) -> Void = CoreLog.emit
 
     /// Problems from the last config load (#68): a broken
     /// init.lua, an unreadable gui.json, invalid profile JSONs.

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -253,9 +253,8 @@ public final class KiwiCore {
     public internal(set) var nativeSpaceBindings: [Int: String] = [:]
 
     /// Log line consumer (GUI console later; syslog now) — the
-    /// sink every Core seam is wired to forward *into*, which is
-    /// why it is exempt from the wiring guard.
-    public var onLog: @MainActor (String) -> Void = CoreLog.emit
+    /// sink every Core seam is wired to forward *into*.
+    public var onLog: @MainActor (String) -> Void = CoreLog.write
 
     /// Problems from the last config load (#68): a broken
     /// init.lua, an unreadable gui.json, invalid profile JSONs.

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -90,7 +90,7 @@ public final class BorderManager {
     /// once and costs nothing after.
     var windowServerTrackingDisabled = false
     var reportedTrackingActive: Bool?
-    var onLog: @MainActor (String) -> Void = CoreLog.emit
+    var onLog: @MainActor (String) -> Void = CoreLog.write
     /// Whether OUR OWN animation currently drives this window
     /// (#594). Wired to `AnimationEngine.isAnimating`; while
     /// true, the per-tick commanded frame owns the ring — the

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -90,7 +90,7 @@ public final class BorderManager {
     /// once and costs nothing after.
     var windowServerTrackingDisabled = false
     var reportedTrackingActive: Bool?
-    var onLog: @MainActor (String) -> Void = { _ in }
+    var onLog: @MainActor (String) -> Void = CoreLog.emit
     /// Whether OUR OWN animation currently drives this window
     /// (#594). Wired to `AnimationEngine.isAnimating`; while
     /// true, the per-tick commanded frame owns the ring — the

--- a/Sources/KiwiDeskCore/Events/EventBus.swift
+++ b/Sources/KiwiDeskCore/Events/EventBus.swift
@@ -32,9 +32,7 @@ public final class EventBus {
         @MainActor (KiwiNotification, JSONValue) -> Void
 
     public var lua: LuaInterpreter?
-    public var onLog: @MainActor (String) -> Void = { message in
-        NSLog("KiwiDesk: %@", message)
-    }
+    public var onLog: @MainActor (String) -> Void = CoreLog.emit
 
     private var luaCallbacks: [KiwiNotification: [Int32]] = [:]
     private var sinks: [UUID: Sink] = [:]

--- a/Sources/KiwiDeskCore/Events/EventBus.swift
+++ b/Sources/KiwiDeskCore/Events/EventBus.swift
@@ -32,7 +32,7 @@ public final class EventBus {
         @MainActor (KiwiNotification, JSONValue) -> Void
 
     public var lua: LuaInterpreter?
-    public var onLog: @MainActor (String) -> Void = CoreLog.emit
+    public var onLog: @MainActor (String) -> Void = CoreLog.write
 
     private var luaCallbacks: [KiwiNotification: [Int32]] = [:]
     private var sinks: [UUID: Sink] = [:]

--- a/Sources/KiwiDeskCore/IPC/SocketServer.swift
+++ b/Sources/KiwiDeskCore/IPC/SocketServer.swift
@@ -16,7 +16,7 @@ public final class SocketServer {
         .fail("server not wired")
     }
     public weak var bus: EventBus?
-    public var onLog: @MainActor (String) -> Void = { _ in }
+    public var onLog: @MainActor (String) -> Void = CoreLog.emit
 
     private let path: String
     private var listener: NWListener?

--- a/Sources/KiwiDeskCore/IPC/SocketServer.swift
+++ b/Sources/KiwiDeskCore/IPC/SocketServer.swift
@@ -16,7 +16,7 @@ public final class SocketServer {
         .fail("server not wired")
     }
     public weak var bus: EventBus?
-    public var onLog: @MainActor (String) -> Void = CoreLog.emit
+    public var onLog: @MainActor (String) -> Void = CoreLog.write
 
     private let path: String
     private var listener: NWListener?

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
@@ -22,7 +22,7 @@ public final class KeybindingManager {
     public static let defaultMode = "default"
 
     public var lua: LuaInterpreter?
-    public var onLog: @MainActor (String) -> Void = CoreLog.emit
+    public var onLog: @MainActor (String) -> Void = CoreLog.write
     /// GUI indicator hook (mode name).
     public var onModeChange: @MainActor (String) -> Void = {
         _ in

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
@@ -22,7 +22,7 @@ public final class KeybindingManager {
     public static let defaultMode = "default"
 
     public var lua: LuaInterpreter?
-    public var onLog: @MainActor (String) -> Void = { _ in }
+    public var onLog: @MainActor (String) -> Void = CoreLog.emit
     /// GUI indicator hook (mode name).
     public var onModeChange: @MainActor (String) -> Void = {
         _ in

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -35,7 +35,7 @@ public final class ExecLauncher {
     public typealias ExitHandler =
         @MainActor @Sendable (Int32, String, String) -> Void
 
-    public var onLog: @MainActor (String) -> Void = CoreLog.emit
+    public var onLog: @MainActor (String) -> Void = CoreLog.write
 
     /// A launched child and its optional timeout watchdog, kept
     /// together so the two can never desync — one table, one

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -35,10 +35,7 @@ public final class ExecLauncher {
     public typealias ExitHandler =
         @MainActor @Sendable (Int32, String, String) -> Void
 
-    public var onLog: @MainActor (String) -> Void = {
-        message in
-        NSLog("KiwiDesk: %@", message)
-    }
+    public var onLog: @MainActor (String) -> Void = CoreLog.emit
 
     /// A launched child and its optional timeout watchdog, kept
     /// together so the two can never desync — one table, one

--- a/Sources/KiwiDeskCore/Power/CrashRecovery.swift
+++ b/Sources/KiwiDeskCore/Power/CrashRecovery.swift
@@ -13,7 +13,7 @@ public final class CrashRecovery {
         { nil }
     public var restoreState: @MainActor (StateSnapshot) -> Void =
         { _ in }
-    public var onLog: @MainActor (String) -> Void = { _ in }
+    public var onLog: @MainActor (String) -> Void = CoreLog.emit
 
     private let fileURL: URL
     /// Arrangement saved on CLEAN shutdown, restored on the

--- a/Sources/KiwiDeskCore/Power/CrashRecovery.swift
+++ b/Sources/KiwiDeskCore/Power/CrashRecovery.swift
@@ -13,7 +13,7 @@ public final class CrashRecovery {
         { nil }
     public var restoreState: @MainActor (StateSnapshot) -> Void =
         { _ in }
-    public var onLog: @MainActor (String) -> Void = CoreLog.emit
+    public var onLog: @MainActor (String) -> Void = CoreLog.write
 
     private let fileURL: URL
     /// Arrangement saved on CLEAN shutdown, restored on the

--- a/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
+++ b/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
@@ -42,7 +42,7 @@ public final class ProfileManager {
     private let directory: URL
 
     /// Invalid profile files reported while listing (#31).
-    public var onLog: @MainActor (String) -> Void = CoreLog.emit
+    public var onLog: @MainActor (String) -> Void = CoreLog.write
 
     public init(directory: URL) {
         self.directory = directory

--- a/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
+++ b/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
@@ -42,7 +42,7 @@ public final class ProfileManager {
     private let directory: URL
 
     /// Invalid profile files reported while listing (#31).
-    public var onLog: @MainActor (String) -> Void = { _ in }
+    public var onLog: @MainActor (String) -> Void = CoreLog.emit
 
     public init(directory: URL) {
         self.directory = directory

--- a/Tests/KiwiDeskCoreTests/AnimationNetLoggingTests.swift
+++ b/Tests/KiwiDeskCoreTests/AnimationNetLoggingTests.swift
@@ -12,9 +12,10 @@ import Testing
 /// say it did.
 ///
 /// The last test is the one that matters most and is easiest to
-/// forget: a seam that is declared but never wired logs nothing
-/// in production while every unit test that sets it by hand stays
-/// green. `SocketServer.onLog` is already in that state.
+/// forget: a seam that is declared but never wired bypasses the
+/// sink in production while every unit test that sets it by hand
+/// stays green. `SocketServer.onLog` sat unwired from the day it
+/// was written until #622.
 @Suite("Animation net logging")
 @MainActor
 struct AnimationNetLoggingTests {
@@ -100,9 +101,10 @@ struct AnimationNetLoggingTests {
     func engineLogReachesTheCore() {
         // Every other assertion here sets `engine.onLog` by hand,
         // so all of them stay green if `KiwiCore+Bootstrap` stops
-        // connecting it — and then both nets go silent in
-        // production, which is the exact failure this issue
-        // exists to end. Assert the wiring, not just the seam.
+        // connecting it — and then both nets report past the sink
+        // (`CoreLog.write`, #624) rather than into it, so nothing
+        // the GUI console would show carries them. Assert the
+        // wiring, not just the seam.
         let core = makeTestCore()
         var logs: [String] = []
         core.onLog = { logs.append($0) }

--- a/Tests/KiwiDeskCoreTests/AnimationSettleWatchdogTests.swift
+++ b/Tests/KiwiDeskCoreTests/AnimationSettleWatchdogTests.swift
@@ -78,6 +78,8 @@ struct AnimationSettleWatchdogTests {
     func wedgedAnimationReleasesTheSettleSignal() {
         let window = WindowID(7)
         let engine = AnimationEngine()
+        var log: [String] = []
+        engine.onLog = { log.append($0) }
         var ended = false
         var settledOn: [WindowID: CGRect] = [:]
         var animationEnded: [WindowID] = []
@@ -105,6 +107,13 @@ struct AnimationSettleWatchdogTests {
         // Long enough that no real motion could reach it, short
         // enough to be a blip rather than a dead session.
         #expect(seconds > 4 && seconds < 7, "fired at \(seconds)s")
+        // The rescue is only useful if it says it happened —
+        // input-and-animation.md writes that as an obligation
+        // ("report both nets through `AnimationEngine.onLog`"),
+        // and every other assertion here would hold on a silent
+        // watchdog.
+        #expect(log.count == 1, "\(log)")
+        #expect(log.first?.contains("window#7") == true, "\(log)")
     }
 
     @Test("Both terms of the age bound are load-bearing")
@@ -127,6 +136,8 @@ struct AnimationSettleWatchdogTests {
         ]
         for row in cases {
             let engine = AnimationEngine()
+            var log: [String] = []
+            engine.onLog = { log.append($0) }
             engine.animations[display] = [
                 WindowID(1): wedge(response: row.response)
             ]
@@ -136,6 +147,7 @@ struct AnimationSettleWatchdogTests {
                 seconds > row.low && seconds < row.high,
                 "response \(row.response)s fired at \(seconds)s"
             )
+            #expect(log.count == 1, "\(row.response): \(log)")
         }
     }
 
@@ -149,12 +161,15 @@ struct AnimationSettleWatchdogTests {
         // motivating case is a spring built directly, which is
         // exactly what this is.
         let engine = AnimationEngine()
+        var log: [String] = []
+        engine.onLog = { log.append($0) }
         engine.animations[display] = [
             WindowID(1): wedge(response: 1_000_000)
         ]
         let seconds = drain(engine)
         #expect(engine.activeCount == 0)
         #expect(seconds < 70, "fired at \(seconds)s")
+        #expect(log.count == 1, "\(log)")
     }
 
     @Test("No healthy duration trips it, at 30, 60 or 120 Hz")

--- a/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
@@ -1,35 +1,20 @@
 import Foundation
 import Testing
 
-/// `CoreLog.write` is every seam's default and nothing else
-/// (#624).
+/// Every `var onLog:` declaration under `Sources/KiwiDeskCore`
+/// defaults to `CoreLog.write` (#624).
 ///
-/// Three assertions, because the invariant has three halves and
-/// each fails on its own:
-///
-/// 1. **Every `var onLog:` defaults to it.** `{ _ in }` is the
-///    obvious thing to type when declaring a new seam, it
-///    compiles, and the subsystem it silences is the one nobody
-///    was reading yet — six of the eight seams carried exactly
-///    that default until #624.
-/// 2. **Its body still writes.** Nothing else in the tree looks
-///    at what `CoreLog.write` *does*: the other seam guards all
-///    assign `core.onLog` themselves, so none of them ever runs
-///    the default. Gut the `NSLog` and the tree returns to its
-///    pre-#624 behaviour with every seam still naming
-///    `CoreLog.write` and every other guard green — and the
-///    pressure to do exactly that is real, since these lines land
-///    in the unified log during test runs.
-/// 3. **Core reaches it only through a seam declaration.** It is
-///    `internal`, but internal is the whole of `KiwiDeskCore`. A
-///    direct `CoreLog.write("…")` call site would put a
-///    diagnostic in syslog that `KiwiCore.onLog` never sees,
-///    which is the routing failure the wiring rule exists to
-///    prevent, wearing a blessed-looking spelling.
+/// `{ _ in }` is the
+/// obvious thing to type when declaring a new seam, it compiles,
+/// and the subsystem it silences is the one nobody was reading
+/// yet — six of the eight seams carried exactly that default
+/// until #624.
 ///
 /// The argument for the default itself is on `CoreLog`, where an
 /// author reaches it; the seam discovery is shared with
-/// `LogSeamWiringTests` through `SourceScan.logSeamDeclarations`.
+/// `LogSeamWiringTests` through `SourceScan.logSeamDeclarations`;
+/// and `LogSeamSinkTests` owns the two invariants about the sink
+/// itself (its body still writes, and Core never calls it).
 ///
 /// Companion to `LogSeamWiringTests`, not a duplicate: that one
 /// catches a seam nobody wired, this one catches a seam whose
@@ -83,194 +68,6 @@ struct LogSeamDefaultTests {
         }
     }
 
-    @Test("CoreLog.write still writes")
-    func theDefaultStillReachesSyslog() throws {
-        let source = try String(
-            contentsOf: coreRoot.appendingPathComponent(
-                "App/CoreLog.swift"
-            ),
-            encoding: .utf8
-        )
-        // The **balanced** body, not "everything after the
-        // signature". `components(separatedBy:)` would run to
-        // EOF, so a sibling declaration below carrying its own
-        // `NSLog(` would satisfy this while `write` itself was
-        // gutted — the guard passing for exactly the reason it
-        // exists to catch. It passes today only because `write`
-        // happens to be the file's last declaration, which is
-        // not a property anything holds still.
-        let body = try functionBody(
-            of: "static func write",
-            in: SourceScan.stripComments(source)
-        )
-        #expect(
-            body?.contains("NSLog(") == true,
-            Comment(
-                rawValue: "`CoreLog.write` no longer calls "
-                    + "`NSLog`. Nothing else in the tree asserts "
-                    + "what this body does, so gutting it "
-                    + "restores the pre-#624 silence with every "
-                    + "seam still naming `CoreLog.write`. If the "
-                    + "write is deliberately moving to `os_log` "
-                    + "or similar, change this guard in the same "
-                    + "commit rather than around it."
-            )
-        )
-        #expect(
-            body?.contains("#if") != true,
-            Comment(
-                rawValue: "`CoreLog.write`'s body is "
-                    + "conditionally compiled — a build where "
-                    + "the write vanishes is the failure this "
-                    + "guard exists to catch"
-            )
-        )
-    }
-
-    /// The nearest non-blank line above `index`, or "" at the
-    /// top of the file.
-    private func previousCodeLine(
-        before index: Int,
-        in lines: [Substring]
-    ) -> Substring {
-        var cursor = index - 1
-        while cursor >= 0,
-            lines[cursor].trimmingCharacters(in: .whitespaces)
-                .isEmpty
-        {
-            cursor -= 1
-        }
-        return cursor >= 0 ? lines[cursor] : ""
-    }
-
-    /// The balanced `{ … }` run following `signature`, or nil
-    /// when the signature is not there — which the caller reds
-    /// on, rather than silently checking an empty string.
-    private func functionBody(
-        of signature: String,
-        in source: String
-    ) throws -> String? {
-        guard let range = source.range(of: signature) else {
-            Issue.record(
-                Comment(
-                    rawValue: "CoreLog no longer declares "
-                        + "`\(signature)` — this guard reads its "
-                        + "body and cannot find it"
-                )
-            )
-            return nil
-        }
-        let characters = Array(source)
-        var cursor = source.distance(
-            from: source.startIndex,
-            to: range.upperBound
-        )
-        // Step over the parameter list, then take the brace run.
-        guard
-            SourceScan.balanced(
-                characters,
-                from: &cursor,
-                open: "(",
-                close: ")"
-            ) != nil
-        else { return nil }
-        return SourceScan.balanced(
-            characters,
-            from: &cursor,
-            open: "{",
-            close: "}"
-        )
-    }
-
-    @Test("Core reaches CoreLog only through a seam default")
-    func theDefaultIsNeverCalledDirectly() throws {
-        // Keyed on the full path, not the basename: two files of
-        // one name under `Sources/KiwiDeskCore` would otherwise
-        // let a declaration in the first mask a real direct call
-        // at the same line number in the second. Nothing has that
-        // shape today, which is exactly when it is cheap to rule
-        // out.
-        let declarationLines = Set(
-            try SourceScan.logSeamDeclarations(under: coreRoot)
-                .map { "\($0.file.path):\($0.line)" }
-        )
-        var callSites: [String] = []
-        for file in try SourceScan.swiftSources(under: coreRoot)
-        where file.lastPathComponent != "CoreLog.swift" {
-            let lines = SourceScan.stripComments(
-                try String(contentsOf: file, encoding: .utf8)
-            )
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            for index in lines.indices
-            where lines[index].contains("CoreLog.") {
-                guard
-                    !declarationLines.contains(
-                        "\(file.path):\(index + 1)"
-                    )
-                else { continue }
-                // A wrapped declaration puts the default on its
-                // own line, which is not a call site. Without
-                // this, that shape reds twice: once correctly
-                // ("cannot read a default from") and once telling
-                // the author to log through `onLog`, which is
-                // what they were already doing.
-                guard
-                    !previousCodeLine(before: index, in: lines)
-                        .contains("var onLog:")
-                else { continue }
-                callSites.append(
-                    "\(file.lastPathComponent):\(index + 1)"
-                )
-            }
-        }
-        #expect(
-            callSites.isEmpty,
-            Comment(
-                rawValue: "\(callSites.sorted().joined(separator: ", ")) "
-                    + "names `CoreLog` outside a `var onLog:` "
-                    + "declaration. It is a default, not a "
-                    + "logging API — a direct call writes to "
-                    + "syslog without passing `KiwiCore.onLog`, "
-                    + "so nothing capturing that sink sees it. "
-                    + "Log through the subsystem's own `onLog`."
-            )
-        )
-    }
-
-    /// The canary over the collection these tests consume.
-    ///
-    /// `SourceScan.swiftSources` answers `[]` for a directory that
-    /// does not exist rather than throwing, so a mistyped root — or
-    /// a narrowed file predicate, the harm `tests.md` names for
-    /// this helper family — leaves the loops above asserting
-    /// nothing at all.
-    ///
-    /// Two checks, and the algebra of the first is worth being
-    /// careful about, because the obvious version reds a correct
-    /// tree.
-    ///
-    /// **Distinct receivers, and `>=` not `>`.** Every receiver
-    /// bootstrap assigns must be declared somewhere, so the
-    /// declarations cannot be fewer than the distinct receivers.
-    /// Counting raw assignments and demanding strictly more
-    /// declarations looks tighter and is wrong: it spends a
-    /// margin of exactly one, which two legitimate changes
-    /// consume — wiring two instances of one seam-owning type
-    /// (the shape `LogSeamWiringTests` documents as plausible)
-    /// and assigning one seam in a second
-    /// `KiwiCore+Bootstrap*.swift` (which its prefix match exists
-    /// to allow). Both would then red naming a scan bug that is
-    /// not there.
-    ///
-    /// **And an anchor in `App/`.** The count alone still passes
-    /// a scan narrowed to skip `App/` entirely, which drops the
-    /// bootstrap files and the sink together and so shrinks both
-    /// sides at once. Requiring the sink's own declaration pins
-    /// the one directory that failure hides in.
-    ///
-    /// Between them: a mistyped root reds, a narrowed file
-    /// predicate reds, and neither bound has to be edited when a
-    /// seam is added.
     private func assertScanReachedTheTree(
         _ declarations: [LogSeamDeclaration]
     ) throws {
@@ -303,7 +100,7 @@ struct LogSeamDefaultTests {
             )
         )
         #expect(
-            declarations.count >= receivers.count,
+            declarations.count > receivers.count,
             Comment(
                 rawValue: "found \(declarations.count) `var "
                     + "onLog:` declaration(s) but bootstrap "
@@ -314,12 +111,12 @@ struct LogSeamDefaultTests {
             )
         )
         #expect(
-            declarations.contains { $0.owner == "KiwiCore" },
+            declarations.contains { $0.file.path.contains("/App/") },
             Comment(
-                rawValue: "the scan found no `var onLog:` in "
-                    + "`KiwiCore` itself, so it did not reach "
-                    + "`App/` — where the sink and every "
-                    + "bootstrap file live"
+                rawValue: "the scan found no `var onLog:` under "
+                    + "`App/`, where the sink and every bootstrap "
+                    + "file live, so it did not reach that "
+                    + "directory"
             )
         )
     }

--- a/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
@@ -1,36 +1,45 @@
 import Foundation
 import Testing
 
-/// Every `var onLog` declaration under `Sources/KiwiDeskCore`
-/// defaults to `CoreLog.emit` (#624).
+/// `CoreLog.write` is every seam's default and nothing else
+/// (#624).
 ///
-/// The argument for that default is on `CoreLog` itself, where an
-/// author reaches it. What this guard adds is that the default
-/// cannot drift back one seam at a time: `{ _ in }` is the
-/// obvious thing to type when declaring a new seam, it compiles,
-/// and the subsystem it silences is the one nobody was reading
-/// yet. Six of the eight seams carried exactly that default
-/// until #624.
+/// Three assertions, because the invariant has three halves and
+/// each fails on its own:
 ///
-/// It is the **companion** to `LogSeamWiringTests`, not a
-/// duplicate of it, and the two fail on opposite mistakes: that
-/// one catches a seam nobody wired, this one catches a seam whose
-/// unwired state would be silent. Neither implies the other — a
-/// seam can be wired and still declare a no-op default (harmless
-/// today, a silent drop the moment someone forgets the wiring),
-/// and a seam can default here and never be wired (loud, but
-/// bypassing the sink a GUI console reads from).
+/// 1. **Every `var onLog:` defaults to it.** `{ _ in }` is the
+///    obvious thing to type when declaring a new seam, it
+///    compiles, and the subsystem it silences is the one nobody
+///    was reading yet — six of the eight seams carried exactly
+///    that default until #624.
+/// 2. **Its body still writes.** Nothing else in the tree looks
+///    at what `CoreLog.write` *does*: the other seam guards all
+///    assign `core.onLog` themselves, so none of them ever runs
+///    the default. Gut the `NSLog` and the tree returns to its
+///    pre-#624 behaviour with every seam still naming
+///    `CoreLog.write` and every other guard green — and the
+///    pressure to do exactly that is real, since these lines land
+///    in the unified log during test runs.
+/// 3. **Core reaches it only through a seam declaration.** It is
+///    `internal`, but internal is the whole of `KiwiDeskCore`. A
+///    direct `CoreLog.write("…")` call site would put a
+///    diagnostic in syslog that `KiwiCore.onLog` never sees,
+///    which is the routing failure the wiring rule exists to
+///    prevent, wearing a blessed-looking spelling.
 ///
-/// Deliberately line-scoped: it reads the default off the same
-/// line as the declaration and **gaps** — reds naming what it
-/// could not read — on a declaration whose `=` is not there. A
-/// wrapped or otherwise unrecognised shape therefore fails shut
-/// with an honest message rather than as "does not default to
-/// `CoreLog.emit`", which would send the reader looking at the
-/// wrong thing.
+/// The argument for the default itself is on `CoreLog`, where an
+/// author reaches it; the seam discovery is shared with
+/// `LogSeamWiringTests` through `SourceScan.logSeamDeclarations`.
 ///
-/// It lives in the GUI test target because `SourceScan` does, as
-/// `LogSeamWiringTests` and `VisibleBoundsRoutingTests` do.
+/// Companion to `LogSeamWiringTests`, not a duplicate: that one
+/// catches a seam nobody wired, this one catches a seam whose
+/// unwired state would be silent. Neither implies the other.
+///
+/// Deliberately line-scoped: it reads the default off the
+/// declaration's own line and **gaps** — reds naming what it
+/// could not read — on a declaration whose `=` is elsewhere, so a
+/// wrapped shape fails shut with an honest message rather than as
+/// "does not default to `CoreLog.write`".
 @Suite("Log-seam defaults")
 struct LogSeamDefaultTests {
     private var coreRoot: URL {
@@ -38,25 +47,13 @@ struct LogSeamDefaultTests {
             .appendingPathComponent("Sources/KiwiDeskCore")
     }
 
-    @Test("Every onLog seam defaults to CoreLog.emit")
+    @Test("Every onLog seam defaults to CoreLog.write")
     func everySeamDefaultsToTheSyslogWrite() throws {
-        let declarations = try onLogDeclarations()
-
-        // The canary over the collection this test consumes.
-        // `SourceScan.swiftSources` answers `[]` for a directory
-        // that does not exist rather than throwing, so a mistyped
-        // `coreRoot` yields no declarations and every loop below
-        // passes without asserting once. No count is pinned: the
-        // set is meant to grow, and a hand-written total would
-        // red on the next honest seam.
-        #expect(
-            !declarations.isEmpty,
-            Comment(
-                rawValue: "no `var onLog` declaration found "
-                    + "under \(coreRoot) — the scan reached "
-                    + "nothing, so nothing below was checked"
-            )
+        let declarations = try SourceScan.logSeamDeclarations(
+            under: coreRoot
         )
+
+        try assertScanReachedTheTree(declarations)
 
         for declaration in declarations {
             guard let defaultValue = declaration.defaultValue
@@ -73,69 +70,153 @@ struct LogSeamDefaultTests {
                 continue
             }
             #expect(
-                defaultValue == "CoreLog.emit",
+                defaultValue == "CoreLog.write",
                 Comment(
                     rawValue: "\(declaration.site) defaults its "
                         + "`onLog` seam to `\(defaultValue)`. "
-                        + "Every seam defaults to `CoreLog.emit` "
-                        + "so that forgetting to wire one costs "
-                        + "a routing inconsistency rather than "
-                        + "silence — see `CoreLog`."
+                        + "Every seam defaults to `CoreLog.write` "
+                        + "so that a seam running on its default "
+                        + "skips the sink rather than dropping "
+                        + "the line — see `CoreLog`."
                 )
             )
         }
     }
 
-    // MARK: - Discovery
-
-    private struct Declaration {
-        /// `File.swift:12`, for a message that can be clicked.
-        let site: String
-        /// The text right of `=`, or nil when the line has none.
-        let defaultValue: String?
+    @Test("CoreLog.write still writes")
+    func theDefaultStillReachesSyslog() throws {
+        let source = try String(
+            contentsOf: coreRoot.appendingPathComponent(
+                "App/CoreLog.swift"
+            ),
+            encoding: .utf8
+        )
+        let body = SourceScan.stripComments(source)
+            .components(separatedBy: "static func write(")
+        #expect(
+            body.count == 2,
+            Comment(
+                rawValue: "CoreLog no longer declares `static "
+                    + "func write(` — this guard reads its body "
+                    + "and cannot find it"
+            )
+        )
+        #expect(
+            body.last?.contains("NSLog(") == true,
+            Comment(
+                rawValue: "`CoreLog.write` no longer calls "
+                    + "`NSLog`. Nothing else in the tree asserts "
+                    + "what this body does, so gutting it "
+                    + "restores the pre-#624 silence with every "
+                    + "seam still naming `CoreLog.write`. If the "
+                    + "write is deliberately moving to `os_log` "
+                    + "or similar, change this guard in the same "
+                    + "commit rather than around it."
+            )
+        )
+        #expect(
+            body.last?.contains("#if") != true,
+            Comment(
+                rawValue: "`CoreLog.write`'s body is "
+                    + "conditionally compiled — a build where "
+                    + "the write vanishes is the failure this "
+                    + "guard exists to catch"
+            )
+        )
     }
 
-    /// Every `var onLog:` declaration and the default it carries.
-    ///
-    /// The colon is load-bearing exactly as it is in
-    /// `LogSeamWiringTests`: without it a future `onLogLevel`
-    /// registers as a seam and is asked for a default it has no
-    /// use for.
-    private func onLogDeclarations() throws -> [Declaration] {
-        var found: [Declaration] = []
-        for file in try SourceScan.swiftSources(under: coreRoot) {
-            let source = SourceScan.stripComments(
+    @Test("Core reaches CoreLog only through a seam default")
+    func theDefaultIsNeverCalledDirectly() throws {
+        let declarationLines = Set(
+            try SourceScan.logSeamDeclarations(under: coreRoot)
+                .map(\.site)
+        )
+        var callSites: [String] = []
+        for file in try SourceScan.swiftSources(under: coreRoot)
+        where file.lastPathComponent != "CoreLog.swift" {
+            let lines = SourceScan.stripComments(
                 try String(contentsOf: file, encoding: .utf8)
             )
-            let lines = source.split(
-                separator: "\n",
-                omittingEmptySubsequences: false
-            )
+            .split(separator: "\n", omittingEmptySubsequences: false)
             for index in lines.indices
-            where lines[index].contains("var onLog:") {
-                found.append(
-                    Declaration(
-                        site: "\(file.lastPathComponent):"
-                            + "\(index + 1)",
-                        defaultValue: defaultValue(
-                            on: lines[index]
-                        )
-                    )
-                )
+            where lines[index].contains("CoreLog.") {
+                let site = "\(file.lastPathComponent):\(index + 1)"
+                guard !declarationLines.contains(site) else {
+                    continue
+                }
+                callSites.append(site)
             }
         }
-        return found
+        #expect(
+            callSites.isEmpty,
+            Comment(
+                rawValue: "\(callSites.sorted().joined(separator: ", ")) "
+                    + "names `CoreLog` outside a `var onLog:` "
+                    + "declaration. It is a default, not a "
+                    + "logging API — a direct call writes to "
+                    + "syslog without passing `KiwiCore.onLog`, "
+                    + "so nothing capturing that sink sees it. "
+                    + "Log through the subsystem's own `onLog`."
+            )
+        )
     }
 
-    /// The trimmed text after the first `=`, or nil when the
-    /// line carries none. `(String) -> Void` holds no `=`, so
-    /// the first one is the assignment's.
-    private func defaultValue(on line: Substring) -> String? {
-        guard let equals = line.firstIndex(of: "=") else {
-            return nil
+    /// The canary over the collection these tests consume.
+    ///
+    /// `SourceScan.swiftSources` answers `[]` for a directory that
+    /// does not exist rather than throwing, so a mistyped root — or
+    /// a narrowed file predicate, the harm `tests.md` names for
+    /// this helper family — leaves the loops above asserting
+    /// nothing at all.
+    ///
+    /// The floor is **derived, not restated**: the seams outnumber
+    /// bootstrap's assignments, because `KiwiCore.onLog` is a
+    /// declaration that is never assigned. So a scan that lost even
+    /// one declaration reds here, and the bound moves on its own
+    /// when a seam is added. A hand-written total would instead red
+    /// on the next honest seam, and `!isEmpty` would be satisfied
+    /// by a single surviving declaration while eight went
+    /// unchecked.
+    private func assertScanReachedTheTree(
+        _ declarations: [LogSeamDeclaration]
+    ) throws {
+        let bootstrap = try SourceScan.swiftSources(
+            under: coreRoot.appendingPathComponent("App")
+        )
+        .filter {
+            $0.lastPathComponent.hasPrefix("KiwiCore+Bootstrap")
         }
-        let value = line[line.index(after: equals)...]
-            .trimmingCharacters(in: .whitespaces)
-        return value.isEmpty ? nil : value
+        var assignments = 0
+        for file in bootstrap {
+            assignments +=
+                SourceScan.allMatches(
+                    in: SourceScan.stripComments(
+                        try String(contentsOf: file, encoding: .utf8)
+                    ),
+                    pattern: #"(\.onLog)\s*="#
+                ).count
+        }
+
+        #expect(
+            assignments > 0,
+            Comment(
+                rawValue: "no `.onLog =` assignment found in any "
+                    + "KiwiCore+Bootstrap file under \(coreRoot) "
+                    + "— the scan reached nothing, so nothing "
+                    + "below was checked"
+            )
+        )
+        #expect(
+            declarations.count > assignments,
+            Comment(
+                rawValue: "found \(declarations.count) `var "
+                    + "onLog:` declaration(s) but \(assignments) "
+                    + "bootstrap assignment(s). Every seam that "
+                    + "is assigned must first be declared, and "
+                    + "`KiwiCore.onLog` is declared without "
+                    + "being assigned, so declarations always "
+                    + "exceed assignments — this scan lost some."
+            )
+        )
     }
 }

--- a/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
@@ -91,18 +91,20 @@ struct LogSeamDefaultTests {
             ),
             encoding: .utf8
         )
-        let body = SourceScan.stripComments(source)
-            .components(separatedBy: "static func write(")
-        #expect(
-            body.count == 2,
-            Comment(
-                rawValue: "CoreLog no longer declares `static "
-                    + "func write(` — this guard reads its body "
-                    + "and cannot find it"
-            )
+        // The **balanced** body, not "everything after the
+        // signature". `components(separatedBy:)` would run to
+        // EOF, so a sibling declaration below carrying its own
+        // `NSLog(` would satisfy this while `write` itself was
+        // gutted — the guard passing for exactly the reason it
+        // exists to catch. It passes today only because `write`
+        // happens to be the file's last declaration, which is
+        // not a property anything holds still.
+        let body = try functionBody(
+            of: "static func write",
+            in: SourceScan.stripComments(source)
         )
         #expect(
-            body.last?.contains("NSLog(") == true,
+            body?.contains("NSLog(") == true,
             Comment(
                 rawValue: "`CoreLog.write` no longer calls "
                     + "`NSLog`. Nothing else in the tree asserts "
@@ -115,7 +117,7 @@ struct LogSeamDefaultTests {
             )
         )
         #expect(
-            body.last?.contains("#if") != true,
+            body?.contains("#if") != true,
             Comment(
                 rawValue: "`CoreLog.write`'s body is "
                     + "conditionally compiled — a build where "
@@ -125,11 +127,72 @@ struct LogSeamDefaultTests {
         )
     }
 
+    /// The nearest non-blank line above `index`, or "" at the
+    /// top of the file.
+    private func previousCodeLine(
+        before index: Int,
+        in lines: [Substring]
+    ) -> Substring {
+        var cursor = index - 1
+        while cursor >= 0,
+            lines[cursor].trimmingCharacters(in: .whitespaces)
+                .isEmpty
+        {
+            cursor -= 1
+        }
+        return cursor >= 0 ? lines[cursor] : ""
+    }
+
+    /// The balanced `{ … }` run following `signature`, or nil
+    /// when the signature is not there — which the caller reds
+    /// on, rather than silently checking an empty string.
+    private func functionBody(
+        of signature: String,
+        in source: String
+    ) throws -> String? {
+        guard let range = source.range(of: signature) else {
+            Issue.record(
+                Comment(
+                    rawValue: "CoreLog no longer declares "
+                        + "`\(signature)` — this guard reads its "
+                        + "body and cannot find it"
+                )
+            )
+            return nil
+        }
+        let characters = Array(source)
+        var cursor = source.distance(
+            from: source.startIndex,
+            to: range.upperBound
+        )
+        // Step over the parameter list, then take the brace run.
+        guard
+            SourceScan.balanced(
+                characters,
+                from: &cursor,
+                open: "(",
+                close: ")"
+            ) != nil
+        else { return nil }
+        return SourceScan.balanced(
+            characters,
+            from: &cursor,
+            open: "{",
+            close: "}"
+        )
+    }
+
     @Test("Core reaches CoreLog only through a seam default")
     func theDefaultIsNeverCalledDirectly() throws {
+        // Keyed on the full path, not the basename: two files of
+        // one name under `Sources/KiwiDeskCore` would otherwise
+        // let a declaration in the first mask a real direct call
+        // at the same line number in the second. Nothing has that
+        // shape today, which is exactly when it is cheap to rule
+        // out.
         let declarationLines = Set(
             try SourceScan.logSeamDeclarations(under: coreRoot)
-                .map(\.site)
+                .map { "\($0.file.path):\($0.line)" }
         )
         var callSites: [String] = []
         for file in try SourceScan.swiftSources(under: coreRoot)
@@ -140,11 +203,24 @@ struct LogSeamDefaultTests {
             .split(separator: "\n", omittingEmptySubsequences: false)
             for index in lines.indices
             where lines[index].contains("CoreLog.") {
-                let site = "\(file.lastPathComponent):\(index + 1)"
-                guard !declarationLines.contains(site) else {
-                    continue
-                }
-                callSites.append(site)
+                guard
+                    !declarationLines.contains(
+                        "\(file.path):\(index + 1)"
+                    )
+                else { continue }
+                // A wrapped declaration puts the default on its
+                // own line, which is not a call site. Without
+                // this, that shape reds twice: once correctly
+                // ("cannot read a default from") and once telling
+                // the author to log through `onLog`, which is
+                // what they were already doing.
+                guard
+                    !previousCodeLine(before: index, in: lines)
+                        .contains("var onLog:")
+                else { continue }
+                callSites.append(
+                    "\(file.lastPathComponent):\(index + 1)"
+                )
             }
         }
         #expect(
@@ -169,14 +245,32 @@ struct LogSeamDefaultTests {
     /// this helper family — leaves the loops above asserting
     /// nothing at all.
     ///
-    /// The floor is **derived, not restated**: the seams outnumber
-    /// bootstrap's assignments, because `KiwiCore.onLog` is a
-    /// declaration that is never assigned. So a scan that lost even
-    /// one declaration reds here, and the bound moves on its own
-    /// when a seam is added. A hand-written total would instead red
-    /// on the next honest seam, and `!isEmpty` would be satisfied
-    /// by a single surviving declaration while eight went
-    /// unchecked.
+    /// Two checks, and the algebra of the first is worth being
+    /// careful about, because the obvious version reds a correct
+    /// tree.
+    ///
+    /// **Distinct receivers, and `>=` not `>`.** Every receiver
+    /// bootstrap assigns must be declared somewhere, so the
+    /// declarations cannot be fewer than the distinct receivers.
+    /// Counting raw assignments and demanding strictly more
+    /// declarations looks tighter and is wrong: it spends a
+    /// margin of exactly one, which two legitimate changes
+    /// consume — wiring two instances of one seam-owning type
+    /// (the shape `LogSeamWiringTests` documents as plausible)
+    /// and assigning one seam in a second
+    /// `KiwiCore+Bootstrap*.swift` (which its prefix match exists
+    /// to allow). Both would then red naming a scan bug that is
+    /// not there.
+    ///
+    /// **And an anchor in `App/`.** The count alone still passes
+    /// a scan narrowed to skip `App/` entirely, which drops the
+    /// bootstrap files and the sink together and so shrinks both
+    /// sides at once. Requiring the sink's own declaration pins
+    /// the one directory that failure hides in.
+    ///
+    /// Between them: a mistyped root reds, a narrowed file
+    /// predicate reds, and neither bound has to be edited when a
+    /// seam is added.
     private func assertScanReachedTheTree(
         _ declarations: [LogSeamDeclaration]
     ) throws {
@@ -186,19 +280,21 @@ struct LogSeamDefaultTests {
         .filter {
             $0.lastPathComponent.hasPrefix("KiwiCore+Bootstrap")
         }
-        var assignments = 0
+        var receivers: Set<String> = []
         for file in bootstrap {
-            assignments +=
+            receivers.formUnion(
                 SourceScan.allMatches(
                     in: SourceScan.stripComments(
                         try String(contentsOf: file, encoding: .utf8)
                     ),
-                    pattern: #"(\.onLog)\s*="#
-                ).count
+                    pattern:
+                        #"([A-Za-z_][A-Za-z0-9_.]*)\.onLog\s*="#
+                )
+            )
         }
 
         #expect(
-            assignments > 0,
+            !receivers.isEmpty,
             Comment(
                 rawValue: "no `.onLog =` assignment found in any "
                     + "KiwiCore+Bootstrap file under \(coreRoot) "
@@ -207,15 +303,23 @@ struct LogSeamDefaultTests {
             )
         )
         #expect(
-            declarations.count > assignments,
+            declarations.count >= receivers.count,
             Comment(
                 rawValue: "found \(declarations.count) `var "
-                    + "onLog:` declaration(s) but \(assignments) "
-                    + "bootstrap assignment(s). Every seam that "
-                    + "is assigned must first be declared, and "
-                    + "`KiwiCore.onLog` is declared without "
-                    + "being assigned, so declarations always "
-                    + "exceed assignments — this scan lost some."
+                    + "onLog:` declaration(s) but bootstrap "
+                    + "assigns \(receivers.count) distinct "
+                    + "receiver(s). Each of those is declared "
+                    + "somewhere, so this scan reached fewer "
+                    + "files than it should have."
+            )
+        )
+        #expect(
+            declarations.contains { $0.owner == "KiwiCore" },
+            Comment(
+                rawValue: "the scan found no `var onLog:` in "
+                    + "`KiwiCore` itself, so it did not reach "
+                    + "`App/` — where the sink and every "
+                    + "bootstrap file live"
             )
         )
     }

--- a/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
@@ -20,6 +20,10 @@ import Testing
 /// catches a seam nobody wired, this one catches a seam whose
 /// unwired state would be silent. Neither implies the other.
 ///
+/// It reads the working tree, not a snapshot, so a red naming a
+/// file can mean the tree moved under the run rather than that
+/// the file is wrong — re-run before believing it.
+///
 /// Deliberately line-scoped: it reads the default off the
 /// declaration's own line and **gaps** — reds naming what it
 /// could not read — on a declaration whose `=` is elsewhere, so a

--- a/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+/// Every `var onLog` declaration under `Sources/KiwiDeskCore`
+/// defaults to `CoreLog.emit` (#624).
+///
+/// The argument for that default is on `CoreLog` itself, where an
+/// author reaches it. What this guard adds is that the default
+/// cannot drift back one seam at a time: `{ _ in }` is the
+/// obvious thing to type when declaring a new seam, it compiles,
+/// and the subsystem it silences is the one nobody was reading
+/// yet. Six of the eight seams carried exactly that default
+/// until #624.
+///
+/// It is the **companion** to `LogSeamWiringTests`, not a
+/// duplicate of it, and the two fail on opposite mistakes: that
+/// one catches a seam nobody wired, this one catches a seam whose
+/// unwired state would be silent. Neither implies the other — a
+/// seam can be wired and still declare a no-op default (harmless
+/// today, a silent drop the moment someone forgets the wiring),
+/// and a seam can default here and never be wired (loud, but
+/// bypassing the sink a GUI console reads from).
+///
+/// Deliberately line-scoped: it reads the default off the same
+/// line as the declaration and **gaps** — reds naming what it
+/// could not read — on a declaration whose `=` is not there. A
+/// wrapped or otherwise unrecognised shape therefore fails shut
+/// with an honest message rather than as "does not default to
+/// `CoreLog.emit`", which would send the reader looking at the
+/// wrong thing.
+///
+/// It lives in the GUI test target because `SourceScan` does, as
+/// `LogSeamWiringTests` and `VisibleBoundsRoutingTests` do.
+@Suite("Log-seam defaults")
+struct LogSeamDefaultTests {
+    private var coreRoot: URL {
+        SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDeskCore")
+    }
+
+    @Test("Every onLog seam defaults to CoreLog.emit")
+    func everySeamDefaultsToTheSyslogWrite() throws {
+        let declarations = try onLogDeclarations()
+
+        // The canary over the collection this test consumes.
+        // `SourceScan.swiftSources` answers `[]` for a directory
+        // that does not exist rather than throwing, so a mistyped
+        // `coreRoot` yields no declarations and every loop below
+        // passes without asserting once. No count is pinned: the
+        // set is meant to grow, and a hand-written total would
+        // red on the next honest seam.
+        #expect(
+            !declarations.isEmpty,
+            Comment(
+                rawValue: "no `var onLog` declaration found "
+                    + "under \(coreRoot) — the scan reached "
+                    + "nothing, so nothing below was checked"
+            )
+        )
+
+        for declaration in declarations {
+            guard let defaultValue = declaration.defaultValue
+            else {
+                Issue.record(
+                    Comment(
+                        rawValue: "\(declaration.site) declares "
+                            + "`var onLog` in a shape this scan "
+                            + "cannot read a default from — it "
+                            + "expects the `=` on the "
+                            + "declaration's own line"
+                    )
+                )
+                continue
+            }
+            #expect(
+                defaultValue == "CoreLog.emit",
+                Comment(
+                    rawValue: "\(declaration.site) defaults its "
+                        + "`onLog` seam to `\(defaultValue)`. "
+                        + "Every seam defaults to `CoreLog.emit` "
+                        + "so that forgetting to wire one costs "
+                        + "a routing inconsistency rather than "
+                        + "silence — see `CoreLog`."
+                )
+            )
+        }
+    }
+
+    // MARK: - Discovery
+
+    private struct Declaration {
+        /// `File.swift:12`, for a message that can be clicked.
+        let site: String
+        /// The text right of `=`, or nil when the line has none.
+        let defaultValue: String?
+    }
+
+    /// Every `var onLog:` declaration and the default it carries.
+    ///
+    /// The colon is load-bearing exactly as it is in
+    /// `LogSeamWiringTests`: without it a future `onLogLevel`
+    /// registers as a seam and is asked for a default it has no
+    /// use for.
+    private func onLogDeclarations() throws -> [Declaration] {
+        var found: [Declaration] = []
+        for file in try SourceScan.swiftSources(under: coreRoot) {
+            let source = SourceScan.stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            let lines = source.split(
+                separator: "\n",
+                omittingEmptySubsequences: false
+            )
+            for index in lines.indices
+            where lines[index].contains("var onLog:") {
+                found.append(
+                    Declaration(
+                        site: "\(file.lastPathComponent):"
+                            + "\(index + 1)",
+                        defaultValue: defaultValue(
+                            on: lines[index]
+                        )
+                    )
+                )
+            }
+        }
+        return found
+    }
+
+    /// The trimmed text after the first `=`, or nil when the
+    /// line carries none. `(String) -> Void` holds no `=`, so
+    /// the first one is the assignment's.
+    private func defaultValue(on line: Substring) -> String? {
+        guard let equals = line.firstIndex(of: "=") else {
+            return nil
+        }
+        let value = line[line.index(after: equals)...]
+            .trimmingCharacters(in: .whitespaces)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamDefaultTests.swift
@@ -4,8 +4,8 @@ import Testing
 /// Every `var onLog:` declaration under `Sources/KiwiDeskCore`
 /// defaults to `CoreLog.write` (#624).
 ///
-/// `{ _ in }` is the
-/// obvious thing to type when declaring a new seam, it compiles,
+/// `{ _ in }` is the obvious thing to type when declaring a new
+/// seam, it compiles,
 /// and the subsystem it silences is the one nobody was reading
 /// yet — six of the eight seams carried exactly that default
 /// until #624.
@@ -68,6 +68,46 @@ struct LogSeamDefaultTests {
         }
     }
 
+    /// The canary over the collection these tests consume.
+    ///
+    /// `SourceScan.swiftSources` answers `[]` for a directory that
+    /// does not exist rather than throwing, so a mistyped root — or
+    /// a narrowed file predicate, the harm `tests.md` names for
+    /// this helper family — leaves the loops above asserting
+    /// nothing at all.
+    ///
+    /// Two checks, and the algebra of the first is worth being
+    /// careful about, because the obvious version reds a correct
+    /// tree.
+    ///
+    /// **Distinct receivers, and strictly greater.** Deduping
+    /// the receivers is what absorbs a seam assigned twice — the
+    /// duplicate that `#625` is about, and the shape a stale
+    /// auto-merge produces. Keeping `>` is what still catches a
+    /// narrowed scan: drop one subsystem from the walk and both
+    /// sides fall by one together, so `>=` would hold and the
+    /// seam would go unchecked by either guard. That is the
+    /// `tests.md` harm exactly, so the strict bound stays.
+    ///
+    /// What it is **not**: a law that declarations always exceed
+    /// receivers. A receiver is not declared — its *type* is — so
+    /// wiring N instances of one seam-owning type gives N
+    /// receivers against one declaration, and the margin here
+    /// absorbs none of them. That shape (`LogSeamWiringTests`
+    /// documents it as plausible, nothing has it today) would red
+    /// naming a scan bug that is not there. It fails shut, and
+    /// the alternative reopens a live hole.
+    ///
+    /// **And an anchor in `App/`.** The count alone still passes
+    /// a scan narrowed to skip `App/` entirely, which drops the
+    /// bootstrap files and the sink together and so shrinks both
+    /// sides at once. Anchoring on the *directory* rather than on
+    /// the sink's type name pins the same thing without a second
+    /// copy of who the sink is, and survives renaming it.
+    ///
+    /// Between them: a mistyped root reds, a narrowed file
+    /// predicate reds, and neither bound has to be edited when a
+    /// seam is added.
     private func assertScanReachedTheTree(
         _ declarations: [LogSeamDeclaration]
     ) throws {

--- a/Tests/KiwiDeskGuiTests/LogSeamSinkTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamSinkTests.swift
@@ -137,6 +137,62 @@ struct LogSeamSinkTests {
         )
     }
 
+    /// Every immediate subdirectory of `Sources/KiwiDeskCore`
+    /// contributed at least one scanned file.
+    ///
+    /// This guard needs a **wider** reach than the seam guards do,
+    /// and that difference is not obvious. `LogSeamDefaultTests`
+    /// carries the family's only floor, and it proves the walk
+    /// reached every file holding a `var onLog:` — which is enough
+    /// for a question about seams, and not enough for this one: a
+    /// direct `CoreLog.write` can sit in any Core file at all.
+    /// Narrowing the scan to skip a directory with no seam in it
+    /// leaves every suite in the family green while the call-site
+    /// ban quietly stops covering that subsystem. `Lua/` is such a
+    /// directory, and dropping it was measured to pass all four.
+    ///
+    /// Derived from the filesystem, so a new subsystem is inside
+    /// it on arrival and no list here is edited to keep it there.
+    private func assertEverySubsystemWasScanned(
+        _ scanned: [URL]
+    ) throws {
+        let reached = Set(
+            scanned.compactMap { file -> String? in
+                let parts = file.pathComponents
+                guard
+                    let root = parts.firstIndex(of: "KiwiDeskCore"),
+                    parts.index(after: root) < parts.count - 1
+                else { return nil }
+                return parts[parts.index(after: root)]
+            }
+        )
+        let directories = Set(
+            try FileManager.default.contentsOfDirectory(
+                at: coreRoot,
+                includingPropertiesForKeys: [.isDirectoryKey]
+            )
+            .filter {
+                (try? $0.resourceValues(forKeys: [.isDirectoryKey])
+                    .isDirectory) == true
+            }
+            .map(\.lastPathComponent)
+            // Assets, not code — it holds no Swift file to scan.
+            .filter { $0 != "Resources" }
+        )
+        #expect(
+            directories.subtracting(reached).isEmpty,
+            Comment(
+                rawValue: "the scan reached no Swift file under "
+                    + directories.subtracting(reached).sorted()
+                    .joined(separator: ", ")
+                    + ", so a direct `CoreLog` call there would "
+                    + "go unseen. A narrowed file predicate does "
+                    + "this, and the seam guards cannot catch it "
+                    + "when the directory holds no seam."
+            )
+        )
+    }
+
     @Test("Core reaches CoreLog only through a seam default")
     func theDefaultIsNeverCalledDirectly() throws {
         // Keyed on the full path, not the basename: two files of
@@ -155,8 +211,11 @@ struct LogSeamSinkTests {
             seams.filter { $0.defaultValue == nil }
                 .map { "\($0.file.path):\($0.line + 1)" }
         )
+        let scanned = try SourceScan.swiftSources(under: coreRoot)
+        try assertEverySubsystemWasScanned(scanned)
+
         var callSites: [String] = []
-        for file in try SourceScan.swiftSources(under: coreRoot)
+        for file in scanned
         where file.lastPathComponent != "CoreLog.swift" {
             let lines = SourceScan.stripComments(
                 try String(contentsOf: file, encoding: .utf8)

--- a/Tests/KiwiDeskGuiTests/LogSeamSinkTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamSinkTests.swift
@@ -50,17 +50,26 @@ struct LogSeamSinkTests {
         // instead, and a gutted `write` would pass. This also
         // turns a `balanced` failure into an honest red rather
         // than a nil that reports "no longer calls NSLog".
-        #expect(
+        // `guard`, not `#expect`: `#expect` does not
+        // short-circuit, so letting the body assertions run on
+        // the `nil` this returns fires a second, false red
+        // ("no longer calls `NSLog`") beside the true one.
+        guard
             stripped.components(separatedBy: "static func write")
-                .count == 2,
-            Comment(
-                rawValue: "`CoreLog` declares `static func write` "
-                    + "more than once (or not at all). This guard "
-                    + "reads the first one's body, so an overload "
-                    + "above the real default would be checked in "
-                    + "its place."
+                .count == 2
+        else {
+            Issue.record(
+                Comment(
+                    rawValue: "`CoreLog` declares `static func "
+                        + "write` more than once (or not at "
+                        + "all). This guard reads the first "
+                        + "one's body, so an overload above the "
+                        + "real default would be checked in its "
+                        + "place."
+                )
             )
-        )
+            return
+        }
         let body = try functionBody(
             of: "static func write",
             in: stripped
@@ -136,13 +145,14 @@ struct LogSeamSinkTests {
         // at the same line number in the second. Nothing has that
         // shape today, which is exactly when it is cheap to rule
         // out.
+        let seams = try SourceScan.logSeamDeclarations(
+            under: coreRoot
+        )
         let declarationLines = Set(
-            try SourceScan.logSeamDeclarations(under: coreRoot)
-                .map { "\($0.file.path):\($0.line)" }
+            seams.map { "\($0.file.path):\($0.line)" }
         )
         let continuationLines = Set(
-            try SourceScan.logSeamDeclarations(under: coreRoot)
-                .filter { $0.defaultValue == nil }
+            seams.filter { $0.defaultValue == nil }
                 .map { "\($0.file.path):\($0.line + 1)" }
         )
         var callSites: [String] = []
@@ -192,45 +202,4 @@ struct LogSeamSinkTests {
             )
         )
     }
-
-    /// The canary over the collection these tests consume.
-    ///
-    /// `SourceScan.swiftSources` answers `[]` for a directory that
-    /// does not exist rather than throwing, so a mistyped root — or
-    /// a narrowed file predicate, the harm `tests.md` names for
-    /// this helper family — leaves the loops above asserting
-    /// nothing at all.
-    ///
-    /// Two checks, and the algebra of the first is worth being
-    /// careful about, because the obvious version reds a correct
-    /// tree.
-    ///
-    /// **Distinct receivers, and strictly greater.** Deduping
-    /// the receivers is what absorbs a seam assigned twice — the
-    /// duplicate that `#625` is about, and the shape a stale
-    /// auto-merge produces. Keeping `>` is what still catches a
-    /// narrowed scan: drop one subsystem from the walk and both
-    /// sides fall by one together, so `>=` would hold and the
-    /// seam would go unchecked by either guard. That is the
-    /// `tests.md` harm exactly, so the strict bound stays.
-    ///
-    /// What it is **not**: a law that declarations always exceed
-    /// receivers. A receiver is not declared — its *type* is — so
-    /// wiring N instances of one seam-owning type gives N
-    /// receivers against one declaration, and the margin here
-    /// absorbs none of them. That shape (`LogSeamWiringTests`
-    /// documents it as plausible, nothing has it today) would red
-    /// naming a scan bug that is not there. It fails shut, and
-    /// the alternative reopens a live hole.
-    ///
-    /// **And an anchor in `App/`.** The count alone still passes
-    /// a scan narrowed to skip `App/` entirely, which drops the
-    /// bootstrap files and the sink together and so shrinks both
-    /// sides at once. Anchoring on the *directory* rather than on
-    /// the sink's type name pins the same thing without a second
-    /// copy of who the sink is, and survives renaming it.
-    ///
-    /// Between them: a mistyped root reds, a narrowed file
-    /// predicate reds, and neither bound has to be edited when a
-    /// seam is added.
 }

--- a/Tests/KiwiDeskGuiTests/LogSeamSinkTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamSinkTests.swift
@@ -1,0 +1,236 @@
+import Foundation
+import Testing
+
+/// `CoreLog.write` is a default, not a logging API (#624).
+///
+/// Two invariants, split from `LogSeamDefaultTests` — which owns
+/// "every seam names it" — because these two are about the sink
+/// itself rather than about the seams, and the combined file was
+/// closing on the 350-line ceiling.
+///
+/// 1. **Its body still writes.** Nothing else in the tree looks
+///    at what `CoreLog.write` *does*: every other seam guard
+///    assigns `core.onLog` itself, so none of them ever runs the
+///    default. Gut the `NSLog` and the tree returns to its
+///    pre-#624 behaviour with every seam still naming
+///    `CoreLog.write` and every other guard green.
+/// 2. **Core reaches it only through a seam declaration.** It is
+///    `internal`, but internal is the whole of `KiwiDeskCore`. A
+///    direct `CoreLog.write("…")` call site would put a
+///    diagnostic in syslog that `KiwiCore.onLog` never sees —
+///    the routing failure the wiring rule exists to prevent,
+///    wearing a blessed-looking spelling.
+@Suite("Log-seam sink")
+struct LogSeamSinkTests {
+    private var coreRoot: URL {
+        SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDeskCore")
+    }
+
+    @Test("CoreLog.write still writes")
+    func theDefaultStillReachesSyslog() throws {
+        let source = try String(
+            contentsOf: coreRoot.appendingPathComponent(
+                "App/CoreLog.swift"
+            ),
+            encoding: .utf8
+        )
+        // The **balanced** body, not "everything after the
+        // signature". `components(separatedBy:)` would run to
+        // EOF, so a sibling declaration below carrying its own
+        // `NSLog(` would satisfy this while `write` itself was
+        // gutted — the guard passing for exactly the reason it
+        // exists to catch. It passes today only because `write`
+        // happens to be the file's last declaration, which is
+        // not a property anything holds still.
+        let stripped = SourceScan.stripComments(source)
+        // Uniqueness first. `range(of:)` takes the FIRST match,
+        // so an overload declared above — `write(_:level:)` is
+        // the obvious future one — would have its body read
+        // instead, and a gutted `write` would pass. This also
+        // turns a `balanced` failure into an honest red rather
+        // than a nil that reports "no longer calls NSLog".
+        #expect(
+            stripped.components(separatedBy: "static func write")
+                .count == 2,
+            Comment(
+                rawValue: "`CoreLog` declares `static func write` "
+                    + "more than once (or not at all). This guard "
+                    + "reads the first one's body, so an overload "
+                    + "above the real default would be checked in "
+                    + "its place."
+            )
+        )
+        let body = try functionBody(
+            of: "static func write",
+            in: stripped
+        )
+        #expect(
+            body?.contains("NSLog(") == true,
+            Comment(
+                rawValue: "`CoreLog.write` no longer calls "
+                    + "`NSLog`. Nothing else in the tree asserts "
+                    + "what this body does, so gutting it "
+                    + "restores the pre-#624 silence with every "
+                    + "seam still naming `CoreLog.write`. If the "
+                    + "write is deliberately moving to `os_log` "
+                    + "or similar, change this guard in the same "
+                    + "commit rather than around it."
+            )
+        )
+        #expect(
+            body?.contains("#if") != true,
+            Comment(
+                rawValue: "`CoreLog.write`'s body is "
+                    + "conditionally compiled — a build where "
+                    + "the write vanishes is the failure this "
+                    + "guard exists to catch"
+            )
+        )
+    }
+
+    /// The balanced `{ … }` run following `signature`, or nil
+    /// when the signature is not there — which the caller reds
+    /// on, rather than silently checking an empty string.
+    private func functionBody(
+        of signature: String,
+        in source: String
+    ) throws -> String? {
+        guard let range = source.range(of: signature) else {
+            Issue.record(
+                Comment(
+                    rawValue: "CoreLog no longer declares "
+                        + "`\(signature)` — this guard reads its "
+                        + "body and cannot find it"
+                )
+            )
+            return nil
+        }
+        let characters = Array(source)
+        var cursor = source.distance(
+            from: source.startIndex,
+            to: range.upperBound
+        )
+        // Step over the parameter list, then take the brace run.
+        guard
+            SourceScan.balanced(
+                characters,
+                from: &cursor,
+                open: "(",
+                close: ")"
+            ) != nil
+        else { return nil }
+        return SourceScan.balanced(
+            characters,
+            from: &cursor,
+            open: "{",
+            close: "}"
+        )
+    }
+
+    @Test("Core reaches CoreLog only through a seam default")
+    func theDefaultIsNeverCalledDirectly() throws {
+        // Keyed on the full path, not the basename: two files of
+        // one name under `Sources/KiwiDeskCore` would otherwise
+        // let a declaration in the first mask a real direct call
+        // at the same line number in the second. Nothing has that
+        // shape today, which is exactly when it is cheap to rule
+        // out.
+        let declarationLines = Set(
+            try SourceScan.logSeamDeclarations(under: coreRoot)
+                .map { "\($0.file.path):\($0.line)" }
+        )
+        let continuationLines = Set(
+            try SourceScan.logSeamDeclarations(under: coreRoot)
+                .filter { $0.defaultValue == nil }
+                .map { "\($0.file.path):\($0.line + 1)" }
+        )
+        var callSites: [String] = []
+        for file in try SourceScan.swiftSources(under: coreRoot)
+        where file.lastPathComponent != "CoreLog.swift" {
+            let lines = SourceScan.stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            for index in lines.indices
+            where lines[index].contains("CoreLog.") {
+                guard
+                    !declarationLines.contains(
+                        "\(file.path):\(index + 1)"
+                    )
+                else { continue }
+                // A wrapped declaration puts its default on the
+                // following line, which is not a call site.
+                // Derived from the scan rather than by looking
+                // at the previous line's text: only a
+                // declaration whose default the scan could NOT
+                // read continues onto the next line, so a
+                // genuine call placed right after a complete
+                // declaration is still caught — inspecting the
+                // text skipped that, which is the single most
+                // likely place to put one.
+                guard
+                    !continuationLines.contains(
+                        "\(file.path):\(index + 1)"
+                    )
+                else { continue }
+                callSites.append(
+                    "\(file.lastPathComponent):\(index + 1)"
+                )
+            }
+        }
+        #expect(
+            callSites.isEmpty,
+            Comment(
+                rawValue: "\(callSites.sorted().joined(separator: ", ")) "
+                    + "names `CoreLog` outside a `var onLog:` "
+                    + "declaration. It is a default, not a "
+                    + "logging API — a direct call writes to "
+                    + "syslog without passing `KiwiCore.onLog`, "
+                    + "so nothing capturing that sink sees it. "
+                    + "Log through the subsystem's own `onLog`."
+            )
+        )
+    }
+
+    /// The canary over the collection these tests consume.
+    ///
+    /// `SourceScan.swiftSources` answers `[]` for a directory that
+    /// does not exist rather than throwing, so a mistyped root — or
+    /// a narrowed file predicate, the harm `tests.md` names for
+    /// this helper family — leaves the loops above asserting
+    /// nothing at all.
+    ///
+    /// Two checks, and the algebra of the first is worth being
+    /// careful about, because the obvious version reds a correct
+    /// tree.
+    ///
+    /// **Distinct receivers, and strictly greater.** Deduping
+    /// the receivers is what absorbs a seam assigned twice — the
+    /// duplicate that `#625` is about, and the shape a stale
+    /// auto-merge produces. Keeping `>` is what still catches a
+    /// narrowed scan: drop one subsystem from the walk and both
+    /// sides fall by one together, so `>=` would hold and the
+    /// seam would go unchecked by either guard. That is the
+    /// `tests.md` harm exactly, so the strict bound stays.
+    ///
+    /// What it is **not**: a law that declarations always exceed
+    /// receivers. A receiver is not declared — its *type* is — so
+    /// wiring N instances of one seam-owning type gives N
+    /// receivers against one declaration, and the margin here
+    /// absorbs none of them. That shape (`LogSeamWiringTests`
+    /// documents it as plausible, nothing has it today) would red
+    /// naming a scan bug that is not there. It fails shut, and
+    /// the alternative reopens a live hole.
+    ///
+    /// **And an anchor in `App/`.** The count alone still passes
+    /// a scan narrowed to skip `App/` entirely, which drops the
+    /// bootstrap files and the sink together and so shrinks both
+    /// sides at once. Anchoring on the *directory* rather than on
+    /// the sink's type name pins the same thing without a second
+    /// copy of who the sink is, and survives renaming it.
+    ///
+    /// Between them: a mistyped root reds, a narrowed file
+    /// predicate reds, and neither bound has to be edited when a
+    /// seam is added.
+}

--- a/Tests/KiwiDeskGuiTests/LogSeamSinkTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamSinkTests.swift
@@ -153,17 +153,34 @@ struct LogSeamSinkTests {
     ///
     /// Derived from the filesystem, so a new subsystem is inside
     /// it on arrival and no list here is edited to keep it there.
+    ///
+    /// **The expected set must not come from the walker under
+    /// test.** Deriving "directories holding a `.swift` file" via
+    /// `SourceScan.swiftSources` would make this tautological —
+    /// expected and actual narrow together and it is green
+    /// forever. A second hand-rolled walk is the same trap one
+    /// step out, and is the drift `tests.md` names for this
+    /// helper family. A plain directory listing against the
+    /// scan's own output is the only shape in which a narrowing
+    /// is visible at all; do not "simplify" it into agreement.
     private func assertEverySubsystemWasScanned(
         _ scanned: [URL]
     ) throws {
+        // Indexed, not searched: every scanned file descends
+        // from `coreRoot`, so its depth is exact. Searching the
+        // components for "KiwiDeskCore" would read the wrong
+        // element on a checkout path that happens to contain one
+        // higher up, and then red a correct tree.
+        let depth = coreRoot.pathComponents.count
         let reached = Set(
             scanned.compactMap { file -> String? in
                 let parts = file.pathComponents
-                guard
-                    let root = parts.firstIndex(of: "KiwiDeskCore"),
-                    parts.index(after: root) < parts.count - 1
-                else { return nil }
-                return parts[parts.index(after: root)]
+                // `depth` is the subdirectory, `depth + 1` the
+                // file inside it — so a `.swift` sitting directly
+                // in `KiwiDeskCore/` contributes no directory,
+                // which is correct.
+                guard parts.count > depth + 1 else { return nil }
+                return parts[depth]
             }
         )
         let directories = Set(
@@ -176,8 +193,20 @@ struct LogSeamSinkTests {
                     .isDirectory) == true
             }
             .map(\.lastPathComponent)
-            // Assets, not code — it holds no Swift file to scan.
+            // Assets, not code (AGENTS.md §1 owns that
+            // classification), so it contributes no Swift file.
+            // Checked both ways below, per the house rule for an
+            // exemption list.
             .filter { $0 != "Resources" }
+        )
+        #expect(
+            !reached.contains("Resources"),
+            Comment(
+                rawValue: "`Resources/` now holds Swift code, so "
+                    + "its exemption here is stale — drop it and "
+                    + "let the directory be covered like any "
+                    + "other."
+            )
         )
         #expect(
             directories.subtracting(reached).isEmpty,
@@ -186,7 +215,8 @@ struct LogSeamSinkTests {
                     + directories.subtracting(reached).sorted()
                     .joined(separator: ", ")
                     + ", so a direct `CoreLog` call there would "
-                    + "go unseen. A narrowed file predicate does "
+                    + "go unseen — or the directory holds no "
+                    + "Swift file yet. A narrowed file predicate does "
                     + "this, and the seam guards cannot catch it "
                     + "when the directory holds no seam."
             )

--- a/Tests/KiwiDeskGuiTests/LogSeamWiringTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamWiringTests.swift
@@ -20,7 +20,7 @@ import Testing
 /// function. The omission cost nothing to make and showed
 /// nowhere.
 ///
-/// Since #624 every seam defaults to `CoreLog.emit`, so an
+/// Since #624 every seam defaults to `CoreLog.write`, so an
 /// unwired one reaches syslog on its way past instead of being
 /// dropped — kept honest by `LogSeamDefaultTests`, which is what
 /// this suite's argument now rests on. That is a smaller
@@ -92,7 +92,7 @@ struct LogSeamWiringTests {
     /// instead of quietly excusing a real one.
     private let allowed: [String: String] = [
         // The sink, not a seam: what every other seam forwards
-        // *to*. It carries the same `CoreLog.emit` default they
+        // *to*. It carries the same `CoreLog.write` default they
         // do, which is where their forwarded lines end up, and
         // wiring it to itself would recurse.
         "KiwiCore": "the syslog sink every other seam feeds"
@@ -102,7 +102,10 @@ struct LogSeamWiringTests {
     func everySeamReachesTheSink() throws {
         let sources = try SourceScan.swiftSources(under: coreRoot)
         var unresolved: [String] = []
-        let owners = try seamOwners(in: sources, gaps: &unresolved)
+        let owners = try seamOwners(
+            in: SourceScan.logSeamDeclarations(under: coreRoot),
+            gaps: &unresolved
+        )
         let wired = try wiredOwners(
             properties: try storedProperties(in: sources),
             gaps: &unresolved
@@ -156,30 +159,28 @@ struct LogSeamWiringTests {
 
     // MARK: - Discovery
 
-    /// The type enclosing each `var onLog:` declaration. The
-    /// colon is load-bearing: without it a future `onLogLevel`
-    /// registers as a seam and demands a wiring it has no use
-    /// for.
+    /// The type enclosing each `var onLog:` declaration.
+    ///
+    /// The walk itself is `SourceScan.logSeamDeclarations`, shared
+    /// with `LogSeamDefaultTests` — which reads the *default* off
+    /// the same declarations this reads the *owner* off. Two
+    /// copies of one needle would let the guards drift into
+    /// disagreeing about which seams exist; that helper's doc
+    /// comment carries the argument.
     private func seamOwners(
-        in sources: [URL],
+        in declarations: [LogSeamDeclaration],
         gaps: inout [String]
     ) throws -> Set<String> {
         var owners: Set<String> = []
-        for file in sources {
-            let lines = try strippedLines(of: file)
-            let enclosing = SourceScan.enclosingTypes(of: lines)
-            for index in lines.indices
-            where lines[index].contains("var onLog:") {
-                guard let owner = enclosing[index] else {
-                    gaps.append(
-                        "the type declaring `var onLog` at "
-                            + "\(file.lastPathComponent):"
-                            + "\(index + 1)"
-                    )
-                    continue
-                }
-                owners.insert(owner)
+        for declaration in declarations {
+            guard let owner = declaration.owner else {
+                gaps.append(
+                    "the type declaring `var onLog` at "
+                        + declaration.site
+                )
+                continue
             }
+            owners.insert(owner)
         }
         return owners
     }
@@ -296,14 +297,5 @@ struct LogSeamWiringTests {
             }
         }
         return index
-    }
-
-    private func strippedLines(
-        of file: URL
-    ) throws -> [Substring] {
-        SourceScan.stripComments(
-            try String(contentsOf: file, encoding: .utf8)
-        )
-        .split(separator: "\n", omittingEmptySubsequences: false)
     }
 }

--- a/Tests/KiwiDeskGuiTests/LogSeamWiringTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamWiringTests.swift
@@ -6,10 +6,10 @@ import Testing
 /// a subsystem's diagnostics are joined to `KiwiCore.onLog`, and
 /// so to syslog.
 ///
-/// The failure this prevents is **nothing happening.** A seam
-/// whose default is a no-op, left unassigned, lets its
+/// The failure this prevents used to be **nothing happening.** A
+/// seam whose default was a no-op, left unassigned, let its
 /// subsystem compile, ship, run, and throw its diagnostics away.
-/// Nothing reds, nothing warns, and the only symptom is a log
+/// Nothing red, nothing warned, and the only symptom was a log
 /// line that was never going to appear, missed months later by
 /// whoever needed it. #599 was findable because a spring
 /// divergence was loud; #611 named the same trap — an
@@ -19,6 +19,16 @@ import Testing
 /// since it was written, six seams wired beside it in the same
 /// function. The omission cost nothing to make and showed
 /// nowhere.
+///
+/// Since #624 every seam defaults to `CoreLog.emit`, so an
+/// unwired one reaches syslog on its way past instead of being
+/// dropped — kept honest by `LogSeamDefaultTests`, which is what
+/// this suite's argument now rests on. That is a smaller
+/// failure, not the absence of one, and it is why this guard
+/// stays: an unwired seam still bypasses `KiwiCore.onLog`, and
+/// so the test capture below and the GUI console that sink's own
+/// comment anticipates. Read the two together — this suite says
+/// *wired*, that one says *would be loud if it weren't*.
 ///
 /// **The lens, not the list.** Both ends are discovered: the seam
 /// owners by scanning every Swift file in the target for
@@ -82,7 +92,8 @@ struct LogSeamWiringTests {
     /// instead of quietly excusing a real one.
     private let allowed: [String: String] = [
         // The sink, not a seam: what every other seam forwards
-        // *to*. It defaults to NSLog rather than to a no-op, and
+        // *to*. It carries the same `CoreLog.emit` default they
+        // do, which is where their forwarded lines end up, and
         // wiring it to itself would recurse.
         "KiwiCore": "the syslog sink every other seam feeds"
     ]

--- a/Tests/KiwiDeskGuiTests/LogSeamWiringTests.swift
+++ b/Tests/KiwiDeskGuiTests/LogSeamWiringTests.swift
@@ -58,6 +58,15 @@ import Testing
 ///   assignment shape, a receiver whose type is ambiguous or
 ///   undeclared, a seam whose enclosing type the walk missed.
 ///
+/// **Its completeness rests on a sibling.** This suite has no
+/// floor of its own: narrow `SourceScan.swiftSources` and it
+/// stops covering a subsystem while passing, because a seam that
+/// is never scanned is never required to be wired.
+/// `LogSeamDefaultTests` carries the floor for the seam-shaped
+/// half of the family and `LogSeamSinkTests` the per-directory
+/// one — do not delete either believing this suite is
+/// self-sufficient.
+///
 /// It lives in the GUI test target purely because `SourceScan`
 /// does — `VisibleBoundsRoutingTests` makes the same trade. It
 /// scans `Sources/KiwiDeskCore`; the GUI tree declares no seam.

--- a/Tests/KiwiDeskGuiTests/SourceScan+LogSeams.swift
+++ b/Tests/KiwiDeskGuiTests/SourceScan+LogSeams.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// One `var onLog:` declaration found in source.
+struct LogSeamDeclaration {
+    let file: URL
+    /// 1-based, so it reads like a compiler diagnostic.
+    let line: Int
+    /// The enclosing type, or nil when the walk could not resolve
+    /// one — a gap for the consumer to red on, never a silent skip.
+    let owner: String?
+    /// The trimmed text right of the first `=` on the declaration
+    /// line, or nil when the line carries none.
+    let defaultValue: String?
+
+    var site: String { "\(file.lastPathComponent):\(line)" }
+}
+
+extension SourceScan {
+    /// Every `var onLog:` declaration under `directory`, with the
+    /// type that encloses it and the default it carries.
+    ///
+    /// **One walk, two guards.** `LogSeamWiringTests` reads the
+    /// owners, `LogSeamDefaultTests` reads the defaults, and both
+    /// used to carry their own copy of this needle plus their own
+    /// copy of the reason the colon is in it. That is the drift
+    /// `tests.md` names for this helper family: teach one copy to
+    /// read a shape the other cannot — a wrapped declaration, a
+    /// `let` seam, two spaces after `var` — and the two guards
+    /// silently disagree about which seams exist, so the narrower
+    /// one stops covering a seam the other still does, with both
+    /// green.
+    ///
+    /// The colon is load-bearing: without it a future
+    /// `onLogLevel` registers as a seam, and is then asked both
+    /// for a wiring and for a default it has no use for.
+    static func logSeamDeclarations(
+        under directory: URL
+    ) throws -> [LogSeamDeclaration] {
+        var found: [LogSeamDeclaration] = []
+        for file in try swiftSources(under: directory) {
+            let lines = stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            let enclosing = enclosingTypes(of: lines)
+            for index in lines.indices
+            where lines[index].contains("var onLog:") {
+                found.append(
+                    LogSeamDeclaration(
+                        file: file,
+                        line: index + 1,
+                        owner: enclosing[index],
+                        defaultValue: defaultValue(
+                            on: lines[index]
+                        )
+                    )
+                )
+            }
+        }
+        return found
+    }
+
+    /// The trimmed text after the first `=`, or nil when the line
+    /// carries none. A seam's type — `@MainActor (String) -> Void`
+    /// — holds no `=`, so the first one is the assignment's.
+    private static func defaultValue(
+        on line: Substring
+    ) -> String? {
+        guard let equals = line.firstIndex(of: "=") else {
+            return nil
+        }
+        let value = line[line.index(after: equals)...]
+            .trimmingCharacters(in: .whitespaces)
+        return value.isEmpty ? nil : value
+    }
+}


### PR DESCRIPTION
## What

Every `var onLog` seam in Core defaults to `CoreLog.write` instead of
`{ _ in }`, and the three copies of `NSLog("KiwiDesk: %@", message)`
collapse into it.

Fixes #624.

## Why, precisely

**Not** "five silent subsystems become loud" — the issue body said that
and it was wrong, which the issue's own comment caught before any code
was written. I re-verified it independently rather than trusting either
version: all eight seams are assigned in `bootstrapCoreServices`
(`KiwiCore+Bootstrap.swift:27-33,37`), which runs unconditionally at the
end of `KiwiCore.init` (`KiwiCore.swift:327`, its only call site), and
`KiwiCore.onLog` is never assigned in `Sources/`. So the `{ _ in }`
defaults were never the operative value and **production behaviour is
unchanged by construction**.

What it buys is the cost of a *future* omission. A seam declared and
never wired — the failure `LogSeamWiringTests` exists to catch — now
degrades to a line that skips the sink rather than a line that is
dropped. Same mistake, smaller failure.

The issue body also undercounted: **six** seams defaulted to `{ _ in }`,
not five. It missed `AnimationEngine`, wired by #611. Issue body
corrected.

## Design decisions

**`CoreLog` is its own namespace, not `KiwiCore`'s default hoisted to a
static.** My first rationale for this was wrong and a reviewer caught it:
I argued leaf subsystems shouldn't name the composition root in a
property default, but this tree does that freely — `BorderManager.readWindowBounds`
defaults to `SkyLight.windowBounds`. The real reason is that `KiwiCore`
is already spread over thirty-odd `KiwiCore+*.swift` extensions, and
hanging general-purpose primitives on it is how it got that way.

**`write`, not `emit`.** `emit` already means "publish to the `EventBus`"
here (`EventBus.emit` plus eight `KiwiCore.emit*`), so a logger borrowing
it reads as an event reaching no subscriber. This deviates from the
issue's stated `CoreLog.emit`; pre-release §5 makes the rename free and
the architect ruled the issue text should yield. Issue updated.

**`internal`, not `public`.** A default-value expression is not API
surface. Public would publish the bypass — a reachable `CoreLog.write`
invites a call site that reaches syslog without passing `KiwiCore.onLog`,
which is the exact routing failure the wiring rule exists to prevent.

**`LogSink` was considered and deferred.** It would seal the default by
construction rather than guarding it (the #573/#610 precedent), but it
changes nine public property types and every test that assigns a seam,
and #625's probes showed its discovery benefit is obtainable without
that. Recorded for follow-up.

## Guards, and the mutation each was proven with

Every new or changed assertion was mutation-proven. Three of them failed
open on their first draft and were only visible by mutating:

| Guard | Mutation that reds it |
|---|---|
| `LogSeamDefaultTests` — every seam names `CoreLog.write` | revert one seam to `{ _ in }` |
| — fail-shut on an unreadable shape | wrap a declaration so its `=` moves off the line (reds **once**, honestly) |
| — scan floor | narrow the scan to one file; skip `App/` |
| `LogSeamSinkTests` — the body still writes | gut `write` to `_ = message`; wrap it in `#if DEBUG` |
| — and cannot be defeated by a sibling | gut `write`, add a `writeVerbose` below carrying the `NSLog` |
| — nor by an overload | add `write(_:level:)` **above** the real one |
| — Core never calls `CoreLog` directly | `let decoy: Void = CoreLog.write("direct")` right after a declaration |
| — every subsystem was scanned | narrow the scan to skip `/Lua/` (which passed all four suites before) |

Three defects found this way, all in guards I wrote:

1. The body check read `components(separatedBy:)`, which runs to **EOF**
   — so gutting `write` while adding any sibling function containing
   `NSLog` passed. Now bounded with `SourceScan.balanced`.
2. Its canary red a **correct** tree (the algebra assumed declarations
   always exceed bootstrap assignments, which a legitimate two-instance
   wiring breaks). Fixing that by relaxing `>` to `>=` then **reopened
   the narrowing hole** it existed for. Now deduped receivers with the
   strict bound, which gets both.
3. Skipping a directory with no seam in it left all four suites green
   while the call-site ban stopped covering it. `LogSeamSinkTests` now
   derives the subsystem list from the filesystem.

## Test-log noise

Measured, not estimated: 82 `KiwiDesk:` lines on `origin/main`, 88 here.
Six subsystems that were silent when constructed bare now write. I did
**not** silence them wholesale — that re-creates #624's silence one
fixture at a time across a hundred-plus call sites — and documented it in
`tests.md` instead, where someone meets test output.

The three `AnimationSettleWatchdogTests` fixtures producing five of the
original eleven lines now **capture and assert** instead. That is added
coverage, not silencing: each proved the watchdog *fired* and none proved
it *reported*, which is the obligation `input-and-animation.md` states.

## Verification

`swift build`, `swift test --skip ExecTests` (2223 tests / 400 suites),
`swift test --filter ExecTests` (14), `scripts/lint.sh` exit 0, and
`swift build -c release` — all green locally. CI is billing-dead, hence
the local release build.

**No device QA.** Production behaviour is provably unchanged: every seam
is overwritten at construction before anything can log, so the defaults
are never operative. There is no geometry or visual change.

## Reviewers

`code-reviewer` and `architect-reviewer` per AGENTS §3.6, four rounds.
Every finding addressed or consciously dismissed; the two dismissals
(wholesale noise silencing, `LogSink`) are argued above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
