### PR TITLE
ci(release): gate the draft on a verify job

### DIFF
--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -137,17 +137,29 @@ never met the script's (#487; branch protection cannot see tags,
 so the workflow is the only gate such a tag passes). Both copies
 are pinned to the skill by `VerifyGateParityTests`, which derives
 the command list from `SKILL.md` — extend that suite before
-shipping a further copy. (Drift in ci.yml's copy weakens a PR
-check, not a release, so it sits outside the suite's ship-grade
-scope.)
+shipping a further copy, and at a *third* ship-grade copy weigh
+one sealed verify script every copy calls over another scanner
+(the same past-two-mirrors escalation parity-tests.md applies to
+field lists). (Drift in ci.yml's copy weakens a PR check, not a
+release, so it sits outside the suite's ship-grade scope.)
 
-The `verify` job carries one named exemption, which that suite
-also encodes: no `swift build -c release`. The obligation it
-leans on — **the release job must keep a `-c release` compile
-ahead of any submission or draft**; today that is
-`build-app.sh`'s first act — is what lets the pipeline still
-refuse a tree that cannot build release without paying the same
-compile twice in sequence.
+The `verify` job carries one named exemption, which the suite
+encodes structurally — its workflow pin scrapes only the skill's
+fast-inner-loop section: no `swift build -c release`. The
+obligation it leans on — **the release job must keep a
+`-c release` compile ahead of any submission or draft**; today
+that is `build-app.sh`'s first act — is what lets the pipeline
+still refuse a tree that cannot build release without paying the
+same compile twice in sequence.
+
+**A job downstream of `verify` checks out
+`needs.verify.outputs.sha`, never a ref name.** A tag name is
+re-resolved against the remote at each job's own start, so by
+name a single-job re-run — or a tag deleted and re-pushed
+mid-run — hands the job a tree the gate never saw. The release
+job's checkout comment carries the full argument; a future
+publish job (a tap bump, a Sparkle appcast) copies its shape,
+not ci.yml's `github.ref` template.
 
 **Stamp the commit at build time; never check one in.** A commit
 cannot contain its own SHA, so a bump made while the release

--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -128,17 +128,26 @@ fails on the far side of the one irreversible step.
 
 **Its verification gate mirrors the `verify-gate` skill, and a
 change to one updates the others.** AGENTS.md §3 gives that skill
-the procedure, and it is re-stated twice: `scripts/release.sh`
-runs it with the release build made unconditional, and the
-`verify` job in `release.yml` re-runs it against the pushed tag —
-the copy that catches a tag pushed by hand, which never met the
-script's (#487; branch protection cannot see tags, so the
-workflow is the only gate such a tag passes). That job skips the
-`-c release` compile for the reason its own comment argues:
-`build-app.sh` in the job after it performs that exact compile
-before anything is drafted. These are the copies where running a
-*stale* gate ships an artifact, and nothing keeps them in step
-automatically.
+the procedure, and two ship-grade copies re-state it — the ones
+where running a *stale* gate ships an artifact:
+`scripts/release.sh` (release build made unconditional) and the
+`verify` job in `release.yml`, which re-runs the gate against a
+pushed tag — the copy that catches a tag pushed by hand, which
+never met the script's (#487; branch protection cannot see tags,
+so the workflow is the only gate such a tag passes). Both copies
+are pinned to the skill by `VerifyGateParityTests`, which derives
+the command list from `SKILL.md` — extend that suite before
+shipping a further copy. (ci.yml runs the same commands as the
+merge gate; drift there weakens a PR check, not a release, so it
+sits outside the suite's ship-grade scope.)
+
+The `verify` job carries one named exemption, which that suite
+also encodes: no `swift build -c release`. The obligation it
+leans on — **the release job must keep a `-c release` compile
+ahead of any submission or draft**; today that is
+`build-app.sh`'s first act — is what lets the pipeline still
+refuse a tree that cannot build release without paying the same
+compile twice in sequence.
 
 **Stamp the commit at build time; never check one in.** A commit
 cannot contain its own SHA, so a bump made while the release

--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -137,9 +137,9 @@ never met the script's (#487; branch protection cannot see tags,
 so the workflow is the only gate such a tag passes). Both copies
 are pinned to the skill by `VerifyGateParityTests`, which derives
 the command list from `SKILL.md` — extend that suite before
-shipping a further copy. (ci.yml runs the same commands as the
-merge gate; drift there weakens a PR check, not a release, so it
-sits outside the suite's ship-grade scope.)
+shipping a further copy. (Drift in ci.yml's copy weakens a PR
+check, not a release, so it sits outside the suite's ship-grade
+scope.)
 
 The `verify` job carries one named exemption, which that suite
 also encodes: no `swift build -c release`. The obligation it

--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -127,11 +127,18 @@ fails on the far side of the one irreversible step.
 `ScriptStampTests` holds the accepted shape.
 
 **Its verification gate mirrors the `verify-gate` skill, and a
-change to one updates the other.** AGENTS.md §3 gives that skill
-the procedure, and `scripts/release.sh` deliberately re-states it
-with the release build made unconditional — but this is the copy
-where running a *stale* gate ships an artifact, and nothing keeps
-it in step automatically.
+change to one updates the others.** AGENTS.md §3 gives that skill
+the procedure, and it is re-stated twice: `scripts/release.sh`
+runs it with the release build made unconditional, and the
+`verify` job in `release.yml` re-runs it against the pushed tag —
+the copy that catches a tag pushed by hand, which never met the
+script's (#487; branch protection cannot see tags, so the
+workflow is the only gate such a tag passes). That job skips the
+`-c release` compile for the reason its own comment argues:
+`build-app.sh` in the job after it performs that exact compile
+before anything is drafted. These are the copies where running a
+*stale* gate ships an artifact, and nothing keeps them in step
+automatically.
 
 **Stamp the commit at build time; never check one in.** A commit
 cannot contain its own SHA, so a bump made while the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,7 @@ jobs:
       - name: Test (ExecTests)
         run: swift test --filter ExecTests
 
+
   release:
     name: Build & draft release
     needs: verify
@@ -534,6 +535,15 @@ jobs:
                 esac
               fi
             done <<< "$assets"
+            # A draft outlives its tag (it mints no ref until
+            # published) and is found here by NAME — so after a
+            # delete-and-re-tag its stored target still names
+            # the old commit, and a later publish following one
+            # more tag deletion would mint the ref THERE, under
+            # this run's artifact. Re-pin it beside the upload,
+            # the same invariant the create branch sets.
+            gh release edit "$TAG" \
+              --target "$(git rev-parse HEAD)"
             gh release upload "$TAG" "$ARCHIVE" --clobber
           else
             # --target: if the tag was deleted mid-run (a human

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,52 +31,57 @@ concurrency:
   group: release-${{ github.event.inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
+# Bound once here for every job, never pasted into a `run:`
+# body. A `${{ }}` expansion is substituted BEFORE bash parses
+# the script, so a tag name carrying a quote or a newline would
+# be executed rather than read. The trust boundary is "write
+# access" — one person today — so this is hardening, not a live
+# hole; it costs nothing and removes the class.
+env:
+  TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 jobs:
-  release:
-    name: Build & draft release
+  # The gate scripts/release.sh runs before it will tag, re-run
+  # against the tag itself. That script is the intended way to
+  # cut a release — but a tag can also be pushed by hand,
+  # skipping the gate entirely, and branch protection cannot see
+  # tags. A bad merge to main is cheap to fix; a bad tag fans out
+  # to Homebrew and the direct download and cannot be unshipped
+  # (#487). Tests fail, nothing ships: the release job `needs:`
+  # this one.
+  #
+  # No `swift build -c release` here, although the local gate
+  # runs one unconditionally: build-app.sh in the release job
+  # compiles the same tree at -c release as its first act, before
+  # anything is signed, uploaded or drafted — the pipeline's
+  # shape already refuses to ship a tree that cannot build
+  # release, and the jobs run in sequence, so a second compile
+  # here would only lengthen the critical path.
+  verify:
+    name: Verify
     # macos-26 for the same reason ci.yml pins it: the tree uses
     # macOS 26 SDK symbols, and `if #available` gates execution,
     # not compilation.
     runs-on: macos-26
-    env:
-      # Bound once here, never pasted into a `run:` body. A
-      # `${{ }}` expansion is substituted BEFORE bash parses the
-      # script, so a tag name carrying a quote or a newline would
-      # be executed rather than read. The trust boundary is
-      # "write access" — one person today — so this is hardening,
-      # not a live hole; it costs nothing and removes the class.
-      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
-          # Needed for the "tag is on main" assertion below, which
-          # resolves origin/main. NOT for the release notes:
-          # `--generate-notes` is computed server-side by the API
-          # and reads nothing from this clone.
+          # Needed for the "tag is on main" assertion below,
+          # which resolves origin/main.
           fetch-depth: 0
 
-      # No `|| /Applications/Xcode.app` fallback, deliberately
-      # diverging from ci.yml. There the fallback is right: a test
-      # run on a slightly different toolchain still tells you
-      # something. Here the output is the artifact a user installs,
-      # and a runner-image bump would silently build it with an
-      # unannounced compiler while nothing on the artifact records
-      # which. A release is precisely the run to stop rather than
-      # let vary.
+      # The same strict pin as the release job below, and unlike
+      # ci.yml's fallback: a green Verify must vouch for the
+      # exact toolchain the artifact is then built with, so the
+      # two jobs must not be allowed to diverge.
       - name: Select Xcode
         run: |
           sudo xcode-select -s /Applications/Xcode_26.6.app
           swift --version
           xcodebuild -version
-
-      - name: Resolve the tag
-        id: tag
-        run: |
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       # The one guard that stops a mislabelled binary shipping.
       # The tag and KiwiDeskVersion.semantic are two hand-written
@@ -85,10 +90,12 @@ jobs:
       # silently disagree the first time someone tags by hand.
       # Failing here costs a re-tag; not failing here ships a
       # binary whose --version output names a release it is not.
+      # First in the gate, before the build: every step in this
+      # job exists to fail a bad tag fast, and this one is the
+      # cheapest.
       - name: Verify the tag matches the binary
-        env:
-          EXPECTED: ${{ steps.tag.outputs.version }}
         run: |
+          EXPECTED="${TAG#v}"
           FILE=Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
           # `head -1` matches build-app.sh's extraction. This is
           # the stricter of the two guards, so it must not be the
@@ -121,6 +128,61 @@ jobs:
             exit 1
           fi
           echo "tag and binary agree on $EXPECTED"
+
+      - name: Build
+        run: swift build
+
+      - name: Lint
+        run: ./scripts/lint.sh
+
+      # Split per AGENTS.md §5: run as one `swift test` the suite
+      # stalls for minutes at the tail, because spawned exec
+      # children hold the runner's pipe. #489 tracks the root fix.
+      - name: Test
+        run: swift test --skip ExecTests
+
+      - name: Test (ExecTests)
+        run: swift test --filter ExecTests
+
+  release:
+    name: Build & draft release
+    needs: verify
+    # macos-26 for the same reason ci.yml pins it: the tree uses
+    # macOS 26 SDK symbols, and `if #available` gates execution,
+    # not compilation.
+    runs-on: macos-26
+    permissions:
+      # The draft and its assets — the one write this workflow
+      # does. Verify above runs with read only.
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+          # Shallow is enough here: the tag-on-main assertion
+          # that needed origin/main (fetch-depth: 0) lives in
+          # Verify now, and the release notes read nothing from
+          # this clone — `--generate-notes` is computed
+          # server-side by the API.
+
+      # No `|| /Applications/Xcode.app` fallback, deliberately
+      # diverging from ci.yml. There the fallback is right: a test
+      # run on a slightly different toolchain still tells you
+      # something. Here the output is the artifact a user installs,
+      # and a runner-image bump would silently build it with an
+      # unannounced compiler while nothing on the artifact records
+      # which. A release is precisely the run to stop rather than
+      # let vary.
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.6.app
+          swift --version
+          xcodebuild -version
+
+      - name: Resolve the tag
+        id: tag
+        run: |
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       # Not a second copy of the sed in bump-version.sh — that
       # script owns the file's shape and this calls it. HEAD is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,13 @@ concurrency:
 # hole; it costs nothing and removes the class.
 env:
   TAG: ${{ github.event.inputs.tag || github.ref_name }}
+  # One copy for both jobs, read by the shell like TAG above: a
+  # green Verify vouches for the exact toolchain the artifact is
+  # then built with, so the two pins must be one string — an
+  # Xcode bump that edited one job and not the other would leave
+  # both green while the artifact is built by a compiler Verify
+  # never ran.
+  XCODE: /Applications/Xcode_26.6.app
 
 jobs:
   # The gate scripts/release.sh runs before it will tag, re-run
@@ -48,15 +55,14 @@ jobs:
   # tags. A bad merge to main is cheap to fix; a bad tag fans out
   # to Homebrew and the direct download and cannot be unshipped
   # (#487). Tests fail, nothing ships: the release job `needs:`
-  # this one.
+  # this one. VerifyGateParityTests pins this job's command list
+  # to the verify-gate skill that owns the procedure.
   #
-  # No `swift build -c release` here, although the local gate
-  # runs one unconditionally: build-app.sh in the release job
-  # compiles the same tree at -c release as its first act, before
-  # anything is signed, uploaded or drafted — the pipeline's
-  # shape already refuses to ship a tree that cannot build
-  # release, and the jobs run in sequence, so a second compile
-  # here would only lengthen the critical path.
+  # No `swift build -c release` here: the release job must keep
+  # that compile ahead of any submission or draft — today it is
+  # build-app.sh's first act — and the jobs run in sequence, so
+  # this copy would only lengthen the critical path. The full
+  # argument lives in packaging-and-release.md.
   verify:
     name: Verify
     # macos-26 for the same reason ci.yml pins it: the tree uses
@@ -65,6 +71,12 @@ jobs:
     runs-on: macos-26
     permissions:
       contents: read
+    # The commit this job vetted, for the release job to build.
+    # A tag NAME is re-resolved against the remote at each job's
+    # own checkout, so it cannot carry this assertion — see the
+    # release job's checkout for what would slip through.
+    outputs:
+      sha: ${{ steps.audit.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -73,13 +85,19 @@ jobs:
           # which resolves origin/main.
           fetch-depth: 0
 
-      # The same strict pin as the release job below, and unlike
-      # ci.yml's fallback: a green Verify must vouch for the
-      # exact toolchain the artifact is then built with, so the
-      # two jobs must not be allowed to diverge.
+      # Not `github.sha`: on a workflow_dispatch run that is the
+      # DEFAULT branch's tip, not the tag's commit — only the
+      # clone knows what the ref above resolved to.
+      - name: Record the audited commit
+        id: audit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Strict, from the one workflow-level pin — and unlike
+      # ci.yml's fallback, deliberately: see the release job's
+      # Select Xcode for the argument.
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.6.app
+          sudo xcode-select -s "$XCODE"
           swift --version
           xcodebuild -version
 
@@ -158,7 +176,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # The exact commit Verify vetted — never the tag name,
+          # which is re-resolved against the remote at THIS job's
+          # start. By name, a tag deleted and re-pushed after
+          # Verify passed (or a "Re-run failed jobs" of this job
+          # alone, to which job outputs are replayed) would build
+          # a tree that never met the gate. Everything below is
+          # tag-safe: `gh` reaches the release by $TAG through
+          # the API, and the stamp reads HEAD from this clone.
+          ref: ${{ needs.verify.outputs.sha }}
           # Shallow is enough here: the tag-on-main assertion
           # that needed origin/main (fetch-depth: 0) lives in
           # Verify now, and the release notes read nothing from
@@ -175,7 +201,7 @@ jobs:
       # let vary.
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.6.app
+          sudo xcode-select -s "$XCODE"
           swift --version
           xcodebuild -version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,15 +181,39 @@ jobs:
           # start. By name, a tag deleted and re-pushed after
           # Verify passed (or a "Re-run failed jobs" of this job
           # alone, to which job outputs are replayed) would build
-          # a tree that never met the gate. Everything below is
-          # tag-safe: `gh` reaches the release by $TAG through
-          # the API, and the stamp reads HEAD from this clone.
+          # a tree that never met the gate. Everything below
+          # reads the tag only as a NAME for the API — and the
+          # one call that could recreate the ref, `gh release
+          # create`, pins --target to this clone's HEAD.
           ref: ${{ needs.verify.outputs.sha }}
           # Shallow is enough here: the tag-on-main assertion
           # that needed origin/main (fetch-depth: 0) lives in
           # Verify now, and the release notes read nothing from
           # this clone — `--generate-notes` is computed
           # server-side by the API.
+
+      # The pin above fails OPEN if its wiring ever breaks: a
+      # renamed step id or output key evaluates to an empty
+      # string with Verify still green, and checkout treats an
+      # empty `ref` as unset — falling back to the DEFAULT
+      # branch's tip on a workflow_dispatch run, after which
+      # every later check self-agrees on the wrong tree (the
+      # stamp and the binary check both read this clone's HEAD).
+      # So prove the checkout resolved the pin, not a fallback.
+      - name: Assert the vetted commit is checked out
+        env:
+          VETTED: ${{ needs.verify.outputs.sha }}
+        run: |
+          if [ -z "$VETTED" ]; then
+            echo "::error::verify's sha output is empty — the" \
+                 "audit step's wiring broke"
+            exit 1
+          fi
+          if [ "$(git rev-parse HEAD)" != "$VETTED" ]; then
+            echo "::error::checked out $(git rev-parse HEAD)" \
+                 "but verify vetted $VETTED"
+            exit 1
+          fi
 
       # No `|| /Applications/Xcode.app` fallback, deliberately
       # diverging from ci.yml. There the fallback is right: a test
@@ -512,9 +536,17 @@ jobs:
             done <<< "$assets"
             gh release upload "$TAG" "$ARCHIVE" --clobber
           else
+            # --target: if the tag was deleted mid-run (a human
+            # aborting a bad release), this call would otherwise
+            # MINT it server-side at the default branch's
+            # current tip — an ungated, unstamped commit, with
+            # the vetted artifact attached under it. Pinned, a
+            # minted tag lands on the vetted commit; with the
+            # tag intact the flag is ignored.
             gh release create "$TAG" "$ARCHIVE" \
               --draft \
               --prerelease \
               --title "KiwiDesk $VERSION" \
+              --target "$(git rev-parse HEAD)" \
               --generate-notes
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,8 +217,9 @@ scripts.
   [packaging-and-release.md](.claude/rules/packaging-and-release.md).
 - `./scripts/release.sh <version>` cuts a release: stamps the
   version, runs the gate, commits, tags and pushes. The pushed
-  tag fires `.github/workflows/release.yml`, which builds the
-  artifact and drafts the release — same rule file.
+  tag fires `.github/workflows/release.yml`, which re-verifies
+  the tag, builds the artifact and drafts the release — same
+  rule file.
 - `./scripts/install-subagents.sh --claude` (Claude Code agents +
   workspace skills) or `--codex` (project-scoped Codex agents),
   per clone, one explicit target.

--- a/Tests/KiwiDeskCoreTests/VerifyGateParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/VerifyGateParityTests.swift
@@ -67,17 +67,16 @@ struct VerifyGateParityTests {
 
     @Test("every fast skill step runs in release.yml's verify job")
     func gateMatchesWorkflowVerifyJob() throws {
-        // `swift build -c release` is the workflow copy's one
-        // named exemption: the release job must keep that
-        // compile ahead of any submission or draft (the
-        // obligation and its argument live in
-        // packaging-and-release.md), so verify does not repeat
-        // it.
-        let steps = try skillSteps().filter {
-            !$0.contains("-c release")
-        }
-        // Guards this test's own collection: the filter above
-        // consumes the scrape, so the count is re-asserted on
+        // The fast inner loop only, by the skill's own section
+        // structure — not a command-text filter, which would
+        // silently exempt any future step that happened to
+        // mention `-c release`. The conditional release build
+        // binds release.sh alone: the release job must keep
+        // that compile ahead of any submission or draft, and
+        // packaging-and-release.md owns that obligation.
+        let steps = try skillSteps(section: "Fast inner loop")
+        // Guards this test's own collection: the section scope
+        // narrows the scrape, so the count is re-asserted on
         // what THIS test iterates, not on the sibling's input.
         #expect(
             steps.count >= 4,
@@ -109,11 +108,14 @@ struct VerifyGateParityTests {
         // the boundaries would mean the slice absorbed a job
         // that is not `verify` — its commands would satisfy the
         // assertions below while the release job no longer
-        // `needs:` them.
+        // `needs:` them. The suffix is checked trimmed:
+        // `bogus: ` with a trailing space is YAML-identical to
+        // `bogus:` and must not slip past.
         let absorbed = lines[(start + 1)..<end].filter { line in
             line.hasPrefix("  ") && !line.hasPrefix("   ")
                 && !line.hasPrefix("  #")
-                && line.hasSuffix(":")
+                && line.trimmingCharacters(in: .whitespaces)
+                    .hasSuffix(":")
         }
         #expect(
             absorbed.isEmpty,
@@ -142,11 +144,17 @@ struct VerifyGateParityTests {
 
     /// The skill's numbered commands, in document order.
     ///
-    /// Both its lists are scraped: the fast inner loop and the
-    /// conditional release build. `release.sh` runs the release
-    /// build unconditionally — its own comment argues why — so
-    /// the skill's list is a subset obligation, not an equality.
-    private func skillSteps() throws -> [String] {
+    /// Both its lists are scraped by default: the fast inner
+    /// loop and the conditional release build. `release.sh` runs
+    /// the release build unconditionally — its own comment
+    /// argues why — so the skill's list is a subset obligation,
+    /// not an equality. `section` narrows the scrape to one
+    /// `## ` heading's list, which is how the workflow pin
+    /// expresses its exemption structurally instead of by
+    /// command text.
+    private func skillSteps(
+        section: String? = nil
+    ) throws -> [String] {
         let skill = try String(
             contentsOf: Self.repoRoot
                 .appendingPathComponent(".claude")
@@ -156,8 +164,16 @@ struct VerifyGateParityTests {
             encoding: .utf8
         )
         var steps: [String] = []
+        var heading = ""
         for raw in skill.split(separator: "\n") {
             let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("## ") {
+                heading = String(line.dropFirst(3))
+                continue
+            }
+            guard section == nil || heading == section else {
+                continue
+            }
             // `1. \`swift build\`` — a numbered step whose command
             // is the first backticked span on the line.
             guard let dot = line.firstIndex(of: "."),

--- a/Tests/KiwiDeskCoreTests/VerifyGateParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/VerifyGateParityTests.swift
@@ -105,6 +105,20 @@ struct VerifyGateParityTests {
             lines[start...].firstIndex(of: "  release:"),
             "release.yml has no `release:` job after `verify:`"
         )
+        // A job key sits at exactly 2-space indent. One between
+        // the boundaries would mean the slice absorbed a job
+        // that is not `verify` — its commands would satisfy the
+        // assertions below while the release job no longer
+        // `needs:` them.
+        let absorbed = lines[(start + 1)..<end].filter { line in
+            line.hasPrefix("  ") && !line.hasPrefix("   ")
+                && !line.hasPrefix("  #")
+                && line.hasSuffix(":")
+        }
+        #expect(
+            absorbed.isEmpty,
+            "verify slice absorbed another job: \(absorbed)"
+        )
         let slice = lines[start..<end].map {
             $0.trimmingCharacters(in: .whitespaces)
         }

--- a/Tests/KiwiDeskCoreTests/VerifyGateParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/VerifyGateParityTests.swift
@@ -1,24 +1,28 @@
 import Foundation
 import Testing
 
-/// `scripts/release.sh`'s verification gate against the
-/// `verify-gate` skill that owns the procedure (#32).
+/// The ship-grade copies of the verification gate against the
+/// `verify-gate` skill that owns the procedure (#32, #487).
 ///
 /// AGENTS.md §3 gives the skill the gate — "what to run, in what
-/// order" — and `release.sh` deliberately re-states it, because
-/// CI cannot run and a release must not be cut on an unverified
-/// tree. That makes the command list a hand-mirror, and
+/// order" — and two copies deliberately re-state it:
+/// `scripts/release.sh`, because a release must not be cut on an
+/// unverified tree, and the `verify` job in
+/// `.github/workflows/release.yml`, because a tag pushed by hand
+/// never met the script's gate and branch protection cannot see
+/// tags. That makes the command list a hand-mirror, and
 /// `.claude/rules/parity-tests.md` says a shipped mirror must
 /// carry a parity test.
 ///
-/// This is the mirror where drift is worst: every other copy of
-/// the gate merely reports, while a stale copy *here* ships an
-/// artifact. Adding a step to the skill and not to `release.sh`
-/// silently narrows what a release is checked against, and
-/// nothing else notices.
+/// These are the mirrors where drift is worst: every other copy
+/// of the gate merely reports, while a stale copy in either
+/// ships an artifact. Adding a step to the skill and not to a
+/// ship-grade copy silently narrows what a release is checked
+/// against, and nothing else notices — the workflow copy cannot
+/// even be exercised before a tag is live.
 ///
 /// The expectation is **derived from the skill**, never listed
-/// here — a hand-written copy in this file would be a third
+/// here — a hand-written copy in this file would be one more
 /// place to forget, which is the failure the rule names.
 @Suite("Release gate mirrors the verify-gate skill")
 struct VerifyGateParityTests {
@@ -58,6 +62,67 @@ struct VerifyGateParityTests {
                 "release.sh drifted from the skill: no `\(step)`"
             )
             searchFrom = at + 1
+        }
+    }
+
+    @Test("every fast skill step runs in release.yml's verify job")
+    func gateMatchesWorkflowVerifyJob() throws {
+        // `swift build -c release` is the workflow copy's one
+        // named exemption: the release job must keep that
+        // compile ahead of any submission or draft (the
+        // obligation and its argument live in
+        // packaging-and-release.md), so verify does not repeat
+        // it.
+        let steps = try skillSteps().filter {
+            !$0.contains("-c release")
+        }
+        // Guards this test's own collection: the filter above
+        // consumes the scrape, so the count is re-asserted on
+        // what THIS test iterates, not on the sibling's input.
+        #expect(
+            steps.count >= 4,
+            "scraped too few steps — has SKILL.md's list changed?"
+        )
+
+        let workflow = try String(
+            contentsOf: Self.repoRoot
+                .appendingPathComponent(".github")
+                .appendingPathComponent("workflows")
+                .appendingPathComponent("release.yml"),
+            encoding: .utf8
+        )
+        let lines = workflow.split(
+            separator: "\n",
+            omittingEmptySubsequences: false
+        ).map(String.init)
+        // The job's slice, keyed on the 2-space job indentation
+        // so a `needs: verify` elsewhere cannot match.
+        let start = try #require(
+            lines.firstIndex(of: "  verify:"),
+            "release.yml has no `verify:` job"
+        )
+        let end = try #require(
+            lines[start...].firstIndex(of: "  release:"),
+            "release.yml has no `release:` job after `verify:`"
+        )
+        let slice = lines[start..<end].map {
+            $0.trimmingCharacters(in: .whitespaces)
+        }
+
+        // Presence, not order: the job runs lint before the
+        // tests (ci.yml's arrangement) while the skill lists
+        // lint last, so the obligation here is the command SET.
+        for step in steps {
+            let present = slice.contains { line in
+                line == step
+                    || line == "./\(step)"
+                    || line == "run: \(step)"
+                    || line == "run: ./\(step)"
+            }
+            #expect(
+                present,
+                "verify job drifted from the skill: no `\(step)`"
+            )
         }
     }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Cut a release: stamp the version, verify, commit, tag, push
 # (#32). Pushing the tag is what triggers .github/workflows/
-# release.yml, which builds the artifact and drafts the release.
+# release.yml, which re-verifies the tag, builds the artifact
+# and drafts the release.
 #
 # Usage: scripts/release.sh <semantic-version> [options]
 #   e.g. scripts/release.sh 0.9.0


### PR DESCRIPTION
## Summary

Builds #487's "Gate the release, not just the merge": `release.yml` gains a `verify` job — the same gate `scripts/release.sh` runs locally (tag-match + tag-on-main guard first, then build, lint, the two-command test split), re-run in CI against the pushed tag itself. The `release` job `needs: verify`, so a hand-pushed tag that never met the local gate cannot draft anything. Branch protection cannot see tags; this job is the only gate such a tag passes.

Hardening that fell out of review (two full rounds, code-reviewer + architect-reviewer, sequential re-reviews):

- **The release job builds the commit verify vetted, not the tag name.** A tag name is re-resolved per job, so a delete-and-re-push mid-run — or a "Re-run failed jobs" of the release job alone — would build a tree the gate never saw. Verify exports the audited SHA as a job output; the release job checks it out, asserts the checkout resolved it (the pin fails open to the default-branch tip on dispatch if its wiring ever breaks), and pins `gh release create --target` / re-pins via `gh release edit` so a tag deleted mid-run can never be minted at an ungated commit.
- **`VerifyGateParityTests` now pins the workflow copy too.** The suite already derived the gate's command list from the verify-gate skill and pinned `release.sh`; a second test pins `release.yml`'s verify job — scoped structurally to the skill's fast-inner-loop section (the conditional `-c release` binds release.sh alone; in the workflow the release job's `build-app.sh` performs that compile before anything is drafted). Red-proofed four ways: mutated run line, planted job key, planted trailing-space job key, planted skill step.
- **One Xcode pin** at workflow level for both jobs; per-job permissions (verify reads, release writes); the cross-job "consume the SHA, never a ref name" obligation recorded in `packaging-and-release.md` for the future tap/appcast job.

Caveat stated plainly: this workflow has still never executed (Actions is billing-dead until the repo goes public, #487) — everything here is correct by inspection and by the parity/red-proof tests only. First live run remains the first real test.

Fixes nothing standalone; part of #487.

## Test plan

- [x] `swift build`, `swift test --skip ExecTests` (2237), `swift test --filter ExecTests` (14), `scripts/lint.sh` — all green on each commit
- [x] Parity suite red-proofed against the tree it watches (four planted mutations, each caught; green after revert)
- [x] YAML parse-validated; release build skipped (no concurrency touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)