### PR TITLE
ci(release): adopt the #494 single-command gate in verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,14 +153,13 @@ jobs:
       - name: Lint
         run: ./scripts/lint.sh
 
-      # Split per AGENTS.md §5: run as one `swift test` the suite
-      # stalls for minutes at the tail, because spawned exec
-      # children hold the runner's pipe. #489 tracks the root fix.
+      # One `swift test`: the two-command split died with the
+      # #494 tail-hang fix (.claude/rules/tests.md). ci.yml
+      # keeps a two-step over ExecTests for per-partition
+      # failure attribution; this job mirrors the skill instead,
+      # and VerifyGateParityTests pins it there.
       - name: Test
-        run: swift test --skip ExecTests
-
-      - name: Test (ExecTests)
-        run: swift test --filter ExecTests
+        run: swift test
 
 
   release:

--- a/Tests/KiwiDeskCoreTests/VerifyGateParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/VerifyGateParityTests.swift
@@ -78,8 +78,10 @@ struct VerifyGateParityTests {
         // Guards this test's own collection: the section scope
         // narrows the scrape, so the count is re-asserted on
         // what THIS test iterates, not on the sibling's input.
+        // 3 = build, test, lint since #494 collapsed the test
+        // split; the sibling's canary covers the full list.
         #expect(
-            steps.count >= 4,
+            steps.count >= 3,
             "scraped too few steps — has SKILL.md's list changed?"
         )
 


### PR DESCRIPTION
## Summary

#631 and the #494 tail-hang fix merged concurrently and semantically conflicted: the verify-gate skill now names one `swift test`, while the freshly-merged verify job still ran the dead two-command split — `VerifyGateParityTests.gateMatchesWorkflowVerifyJob` went red on main the moment the two met (exactly the drift it was built to catch). This aligns the verify job with the current skill and adjusts the workflow pin's count canary to the three-step fast loop.

ci.yml deliberately keeps its two-step over ExecTests (per-partition failure attribution, argued in `.claude/rules/tests.md`) and stays outside the parity suite's ship-grade scope.

## Test plan

- [x] `VerifyGateParityTests` red on main before, green after (live drift, not a planted one)
- [x] Full gate: `swift build`, `swift test` (2260 tests, single command, ~93 s), `scripts/lint.sh` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)