### PR TITLE
refactor(site): extract shared brand tokens

### DIFF
--- a/.claude/rules/site.md
+++ b/.claude/rules/site.md
@@ -49,6 +49,10 @@ every light text/link/eyebrow role takes `--kiwi-flesh-text`, the
 50/50 midpoint of `--kiwi-flesh` and `--kiwi-ink` shared with the
 wider brand family (#635). Never put raw `--kiwi-flesh` on text.
 
+An edit to `--kiwi-flesh` or `--kiwi-ink` must include a manual
+cross-repo check against kiwicanopy.com and KiwiCV. The local guard
+can enforce the relationship but cannot see those repositories.
+
 `scripts/check-site-tokens.py` enforces all of the above: it
 rejects a brand hex written anywhere else under `site/src`,
 recomputes both the midpoint and the WCAG contrast from the tokens

--- a/.claude/rules/site.md
+++ b/.claude/rules/site.md
@@ -26,6 +26,48 @@ though:
 - Site i18n is hand-maintained (not generated from the app
   catalogs).
 
+## One brand-color layer, imported by both stylesheets
+
+`site/src/styles/brand-tokens.css` is the **only** place a brand
+hex may be written. `theme.css` (the Starlight docs, wired through
+`customCss` in `astro.config.mjs`) and `landing.css` (every
+non-Starlight surface — landing, guide, legal) must both `@import`
+it and map their own role names through `var()`.
+
+Neither may re-state a brand hex. The two reach **disjoint page
+sets**, so nothing renders both at once and nothing makes them
+agree on its own: they had each declared the same nine hexes
+independently, several under divergent names for one color
+(`--kiwi-green` vs `--kiwi-flesh`) — the vocabulary split
+[config-vocabulary.md](config-vocabulary.md) exists to prevent,
+one layer below Swift. When two names compete for one color, keep
+the one with live `var()` consumers.
+
+**The light-mode text green is derived, not chosen.** Raw
+`--kiwi-flesh` is ~2.3:1 on the light surfaces and fails AA, so
+every light text/link/eyebrow role takes `--kiwi-flesh-text`, the
+50/50 midpoint of `--kiwi-flesh` and `--kiwi-ink` shared with the
+wider brand family (#635). Never put raw `--kiwi-flesh` on text.
+
+`scripts/check-site-tokens.py` enforces all of the above: it
+rejects a brand hex written anywhere else under `site/src`,
+recomputes both the midpoint and the WCAG contrast from the tokens
+rather than restating them, and fails if a stylesheet drops the
+import. The site workflow runs it against the built artifact.
+
+Two gaps it deliberately leaves:
+
+- **Alpha variants.** `landing.css` still spells brand colors as
+  decimal `rgba()` triples wherever it needs opacity —
+  `rgba(141, 179, 84, 0.45)` is `--kiwi-flesh`. Folding those in
+  wants relative-color syntax (`rgb(from var(--kiwi-flesh) r g b /
+  0.45)`) and its own browser-support call; until then, don't add
+  new ones by hand.
+- **Values CSS cannot reach.** A `<meta name="theme-color">`
+  attribute cannot read a custom property, so the shared
+  `ThemeHead.astro` component owns that non-token browser-chrome
+  color for every standalone page.
+
 ## Build
 
 Run `npm run build` in `site/` when you touch either, after
@@ -98,33 +140,6 @@ set, so a new locale must be added there or its 404 omits itself.
 `docs/translating.md`'s add-a-locale section owns the full list and
 gives a grep for finding them rather than an enumeration to keep in
 step.
-
-## The light-mode green is derived, not chosen (#635)
-
-The accent-as-text green is the 50/50 midpoint of the brand fill
-green and the forest ink — a rule, not a hex — and it is one
-decision with two homes: `theme.css` for the Starlight docs and
-`landing.css` for every non-Starlight surface (`grep -l landing.css
-site/src` lists them). They were independently derived and one
-notch apart until #635.
-
-`scripts/check-site-tokens.py` recomputes the midpoint from the
-tree and holds both files to it, plus AA as text on the light bg —
-so it catches a drift applied to both files at once, which comparing
-them only to each other would not.
-
-It pins the *relationship*, though, and both endpoints are in-tree:
-retune the fill green and re-derive everything downstream here, and
-it passes. The same value is shared with kiwicanopy.com and KiwiCV,
-so **an edit to the fill green or the forest ink still needs the
-cross-repo check by hand** — that half is a review obligation, not
-something CI here can reach.
-
-Those two stylesheets are deliberately independent — neither
-imports the other. If a future change unifies them behind a shared
-token file, **delete that check in the same change set**: it
-requires a literal hex in each light block and would otherwise fail
-with a message that reads like a bug rather than like a fix.
 
 ## Template comments ship to visitors (#557)
 

--- a/scripts/check-site-tokens.py
+++ b/scripts/check-site-tokens.py
@@ -61,10 +61,12 @@ SRC = REPO / "site" / "src"
 TOKENS = STYLES / "brand-tokens.css"
 CONSUMERS = (STYLES / "theme.css", STYLES / "landing.css")
 HEX = re.compile(r"#[0-9a-fA-F]{6}\b")
-TOKEN_DECL = re.compile(
-    r"(--kiwi-[a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{6})\b"
-)
+TOKEN_DECL = re.compile(r"(--kiwi-[a-z0-9-]+)\s*:\s*([^;}]+)")
 SCAN_SUFFIXES = {".css", ".astro", ".ts", ".js", ".mjs"}
+LIGHT = (
+    r"[^{}]*\[\s*data-theme\s*[|~^$*]?=\s*['\"]?light['\"]?"
+    r"\s*[isIS]?\s*\][^{}]*\{"
+)
 
 def fail(msg: str) -> None:
     sys.exit(f"check-site-tokens: {msg}")
@@ -87,7 +89,15 @@ def token_map() -> dict[str, str]:
     found = TOKEN_DECL.findall(source_without_comments(TOKENS))
     if not found:
         fail(f"{TOKENS.relative_to(REPO)} declares no brand tokens")
-    tokens = {name: value.lower() for name, value in found}
+    tokens = {}
+    for name, raw in found:
+        value = raw.strip()
+        if name in tokens:
+            fail(f"{TOKENS.relative_to(REPO)} repeats {name}")
+        if not HEX.fullmatch(value):
+            fail(f"{TOKENS.relative_to(REPO)} declares {name} as "
+                 f"`{value}`, not a six-digit hex")
+        tokens[name] = value.lower()
     if len(tokens) != len(found):
         fail(f"{TOKENS.relative_to(REPO)} repeats a token name")
     return tokens
@@ -98,16 +108,38 @@ def check_token_layer(tokens: dict[str, str]) -> None:
     for path in sorted(SRC.rglob("*")):
         if path == TOKENS or path.suffix not in SCAN_SUFFIXES:
             continue
-        for hit in HEX.findall(source_without_comments(path)):
+        body = source_without_comments(path)
+        declared = TOKEN_DECL.search(body)
+        if declared:
+            fail(f"{path.relative_to(REPO)} declares {declared.group(1)}; "
+                 f"brand tokens belong in {TOKENS.relative_to(REPO)}")
+        for hit in HEX.findall(body):
             if hit.lower() in owners:
                 fail(
                     f"{path.relative_to(REPO)} repeats {owners[hit.lower()]} "
                     f"as {hit}; use var({owners[hit.lower()]})"
                 )
-    needle = f'@import "./{TOKENS.name}"'
+    needle = f'@import "./{TOKENS.name}";'
     for path in CONSUMERS:
-        if needle not in path.read_text():
-            fail(f"{path.name}: missing `{needle}`")
+        body = source_without_comments(path).lstrip()
+        if not body.startswith(needle):
+            fail(f"{path.name}: `{needle}` must be its first rule")
+
+
+def light_role(path: pathlib.Path, prop: str) -> str:
+    """Return the cascade-winning light-theme value for `prop`."""
+    values = []
+    body = source(path)
+    for match in re.finditer(LIGHT, body):
+        block = body[match.end() :].split("}", 1)[0]
+        found = re.findall(re.escape(prop) + r"\s*:\s*([^;}]+)", block)
+        if found:
+            values.append(found[-1].strip())
+    if not values:
+        fail(f"{path.name}: no light-theme {prop} declaration")
+    if any("!important" in value for value in values):
+        fail(f"{path.name}: {prop} must not use !important")
+    return values[-1]
 
 
 def midpoint(a: str, b: str) -> str:
@@ -143,6 +175,16 @@ def check_accent(tokens: dict[str, str]) -> None:
     if text != expected:
         fail(f"--kiwi-flesh-text is {text}, not the {expected} midpoint "
              f"of {fill} and {ink} (#635)")
+    expected_role = "var(--kiwi-flesh-text)"
+    roles = (
+        (STYLES / "theme.css", "--sl-color-accent"),
+        (STYLES / "landing.css", "--accent"),
+    )
+    for path, prop in roles:
+        value = light_role(path, prop)
+        if value != expected_role:
+            fail(f"{path.name}: light {prop} is `{value}`, not "
+                 f"`{expected_role}`")
     for surface in ("--kiwi-cream", "--kiwi-snow"):
         bg = tokens.get(surface)
         if not bg:

--- a/scripts/check-site-tokens.py
+++ b/scripts/check-site-tokens.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 """Guard the site's shared brand decisions (#635, #106).
 
-Three checks, all of which DERIVE what they assert from the tree
+Four checks, all of which DERIVE what they assert from the tree
 rather than restating it here — a literal in this file would just
 be one more copy to drift.
 
-1. The light-mode accent-as-text green equals the 50/50 midpoint of
-   the brand's fill green and the forest ink, in BOTH stylesheets.
-   `theme.css` serves the Starlight docs and `landing.css` every
-   other surface; neither imports the other, so the value has two
-   homes. Comparing them only to each other would miss a drift
-   applied to both at once, so the midpoint is computed and both
-   sides are checked against it.
+1. `brand-tokens.css` is the one raw brand-color layer. Its hexes
+   appear nowhere else under `site/src`, and both role-mapping
+   stylesheets import it.
+
+2. The light-mode accent-as-text green equals the 50/50 midpoint of
+   the brand's fill green and forest ink in that token layer.
 
    What this does NOT cover: it pins the *relationship*, and both
    endpoints are in-tree and mutable. Retune the fill green, then
@@ -20,11 +19,10 @@ be one more copy to drift.
    splits — which is the most likely way it actually happens. So
    **any edit to the fill green or the forest ink still needs the
    cross-repo check by hand.**
-2. That green clears WCAG AA (4.5:1) as text on the light page
-   background, also read out of the stylesheet. Agreement alone
-   would happily pass two files that both name the raw fill green,
-   which is ~2.3:1.
-3. The built 404 is the branded page. `src/pages/404.astro` and
+3. That green clears WCAG AA (4.5:1) as text on both tokenized light
+   backgrounds. Agreement alone would happily pass the raw fill
+   green, which is ~2.3:1.
+4. The built 404 is the branded page. `src/pages/404.astro` and
    `disable404Route: true` in astro.config.mjs must move together,
    and BOTH one-sided failures are silent: without the flag Astro
    only *logs* a duplicate-route collision (a log line fails no
@@ -34,16 +32,9 @@ be one more copy to drift.
    catches both, plus a rename of the page and an upstream rename
    of the option, which a config-pair check cannot.
 
-KNOWN LIMITS. This reads CSS with regexes, not a parser, so treat it
-as a net for ordinary edits rather than proof. Three adversarial
-attribute-selector spellings are known to slip past and would ship:
-`[data-theme|="light"]`, `[data-theme~="light"]` and
-`[data-theme*="light"]` in a block that also re-declares the token.
-Nothing writes those by accident, which is why they are documented
-rather than handled — but do not read a green run as "no override
-exists anywhere". `STYLES` also names two stylesheets by hand; a
-third that declared a light token (e.g. `learn.css`) would be
-invisible.
+KNOWN LIMIT. This reads CSS with regexes, not a parser, so treat it
+as a net for ordinary edits rather than proof. `CONSUMERS` names the
+two role-mapping stylesheets by hand; add any future consumer there.
 
 Usage: scripts/check-site-tokens.py --dist site/dist
 
@@ -66,147 +57,57 @@ import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 STYLES = REPO / "site" / "src" / "styles"
-
-# Any selector that targets the light theme, in any spelling that
-# ships: double or single quotes, an unquoted attribute value, a
-# tag/pseudo prefix, or CSS nesting (`:root { &[data-theme="light"]
-# { … } }`). Matching one literal spelling is a vacuous pass waiting
-# to happen — every variant here is valid CSS that lightningcss
-# emits happily, and no stylelint config normalizes them.
-LIGHT = (
-    r"[^{}]*\[\s*data-theme\s*[|~^$*]?=\s*['\"]?light['\"]?"
-    r"\s*[isIS]?\s*\][^{}]*\{"
+SRC = REPO / "site" / "src"
+TOKENS = STYLES / "brand-tokens.css"
+CONSUMERS = (STYLES / "theme.css", STYLES / "landing.css")
+HEX = re.compile(r"#[0-9a-fA-F]{6}\b")
+TOKEN_DECL = re.compile(
+    r"(--kiwi-[a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{6})\b"
 )
-
-# A bare `:root { … }` block — the un-themed token layer. Excludes
-# `:root[…]` so the light/dark blocks are not mistaken for it.
-BARE_ROOT = r":root\s*\{"
-
+SCAN_SUFFIXES = {".css", ".astro", ".ts", ".js", ".mjs"}
 
 def fail(msg: str) -> None:
     sys.exit(f"check-site-tokens: {msg}")
 
 
-def declared(block: str, prop: str) -> str | None:
-    """`prop`'s winning value in `block`, or None if not declared.
-
-    The LAST declaration, because that is the one CSS takes — and
-    re-declaring a token below the old line is the most ordinary way
-    to change one, so reading the first would be a vacuous pass on
-    the commonest edit there is.
-
-    Returns the raw value text, hex or not. Telling "not declared"
-    apart from "declared as something other than a hex" is what
-    keeps a `var()` or 3-digit override loud instead of invisible.
-    """
-    found = re.findall(re.escape(prop) + r"\s*:\s*([^;}]+)", block)
-    return found[-1].strip() if found else None
-
-
-def as_hex(value: str) -> str | None:
-    m = re.fullmatch(r"(#[0-9a-fA-F]{6})", value.split()[0] if value else "")
-    return m.group(1).lower() if m else None
-
-
 def source(path: pathlib.Path) -> str:
-    """`path` with comments stripped.
-
-    Blocks are delimited by the first `}`, so a `}` inside a comment
-    would truncate the block and hide every declaration after it —
-    falling back to an earlier block's stale value, the same vacuous
-    pass by another route. These stylesheets carry long prose
-    comments right above the tokens, so this is not hypothetical.
-    """
+    """`path` with block and JSX comments stripped."""
     return re.sub(r"/\*.*?\*/", "", path.read_text(), flags=re.S)
 
 
-def blocks(path: pathlib.Path, selector: str, label: str) -> list[str]:
-    """Every `selector` block in `path`, in source order."""
+def source_without_comments(path: pathlib.Path) -> str:
+    """Source with block, JSX, and ordinary line comments removed."""
     text = source(path)
-    found = [
-        text[m.end() :].split("}", 1)[0]
-        for m in re.finditer(selector, text)
-    ]
+    return re.sub(r"(?<!:)//[^\n]*", "", text)
+
+
+def token_map() -> dict[str, str]:
+    if not TOKENS.is_file():
+        fail(f"missing {TOKENS.relative_to(REPO)}")
+    found = TOKEN_DECL.findall(source_without_comments(TOKENS))
     if not found:
-        fail(f"{path.name}: no {label} block")
-    return found
+        fail(f"{TOKENS.relative_to(REPO)} declares no brand tokens")
+    tokens = {name: value.lower() for name, value in found}
+    if len(tokens) != len(found):
+        fail(f"{TOKENS.relative_to(REPO)} repeats a token name")
+    return tokens
 
 
-def resolve(path: pathlib.Path, prop: str, selector: str, label: str) -> str:
-    """`prop`'s cascade-winning value across every `selector` block.
-
-    Resolved per property, not per block. A stylesheet may carry more
-    than one such block: reading only the first would let an appended
-    override ship while this check kept reading the original, and
-    reading only the last would let a one-token override hide every
-    other token's real value. Both are vacuous passes.
-
-    A block that declares `prop` as anything but a 6-digit hex is a
-    hard error, not a skip — skipping it would fall back to the
-    previous block's stale value, which is the same vacuous pass by
-    another route.
-    """
-    values = []
-    for block in blocks(path, selector, label):
-        value = declared(block, prop)
-        if value is None:
+def check_token_layer(tokens: dict[str, str]) -> None:
+    owners = {value: name for name, value in tokens.items()}
+    for path in sorted(SRC.rglob("*")):
+        if path == TOKENS or path.suffix not in SCAN_SUFFIXES:
             continue
-        if "!important" in value:
-            fail(
-                f"{path.name}: a {label} block declares `{prop}` "
-                "`!important`. A token block has no legitimate use for "
-                "it, and this check models the cascade as last-wins, so "
-                "it would read the wrong winner. Drop the `!important`."
-            )
-        found = as_hex(value)
-        if found is None:
-            fail(
-                f"{path.name}: a {label} block declares `{prop}: {value}`, "
-                "which is not a 6-digit hex. This check compares hex "
-                "values, so it cannot follow that — resolve the colour "
-                "to a literal here, or update this script to understand "
-                "the new form."
-            )
-        values.append(found)
-    if not values:
-        fail(f"{path.name}: no `{prop}` declaration in any {label} block")
-    return values[-1]
-
-
-def root_hex(path: pathlib.Path, prop: str) -> str:
-    """A brand endpoint, which must be declared EXACTLY once.
-
-    Not last-wins like a themed token: `theme.css` carries more than
-    one bare `:root` block (the brand palette, then the dark-theme
-    defaults), and taking the last would let an ordinary addition to
-    the dark block silently become the derivation endpoint. The check
-    would then still fail — but by accusing the *light* accent of a
-    brand violation while naming the dark fill as the authority, when
-    nothing about the brand changed. A count check fails in terms of
-    the actual problem instead.
-    """
-    found = [
-        value
-        for block in blocks(path, BARE_ROOT, "bare `:root`")
-        if (value := declared(block, prop)) is not None
-    ]
-    if not found:
-        fail(f"{path.name}: no `{prop}` in any bare `:root` block")
-    if len(found) > 1:
-        fail(
-            f"{path.name}: `{prop}` is declared in {len(found)} bare "
-            "`:root` blocks. It is a brand endpoint this check derives "
-            "from, so which one wins must not be ambiguous — keep it in "
-            "the brand-palette block only."
-        )
-    value = as_hex(found[0])
-    if value is None:
-        fail(f"{path.name}: `{prop}` is `{found[0]}`, not a 6-digit hex")
-    return value
-
-
-def light_hex(path: pathlib.Path, prop: str) -> str:
-    return resolve(path, prop, LIGHT, "light-theme")
+        for hit in HEX.findall(source_without_comments(path)):
+            if hit.lower() in owners:
+                fail(
+                    f"{path.relative_to(REPO)} repeats {owners[hit.lower()]} "
+                    f"as {hit}; use var({owners[hit.lower()]})"
+                )
+    needle = f'@import "./{TOKENS.name}"'
+    for path in CONSUMERS:
+        if needle not in path.read_text():
+            fail(f"{path.name}: missing `{needle}`")
 
 
 def midpoint(a: str, b: str) -> str:
@@ -231,42 +132,25 @@ def contrast(fg: str, bg: str) -> float:
     return (hi + 0.05) / (lo + 0.05)
 
 
-def check_accent() -> None:
-    theme, landing = STYLES / "theme.css", STYLES / "landing.css"
-
-    # theme.css is the authority for the two endpoints: the raw
-    # brand fill green on bare :root, and the forest ink that its
-    # light block uses as strong text.
-    fill = root_hex(theme, "--kiwi-green")
-    ink = light_hex(theme, "--sl-color-white")
+def check_accent(tokens: dict[str, str]) -> None:
+    fill = tokens.get("--kiwi-flesh")
+    ink = tokens.get("--kiwi-ink")
+    text = tokens.get("--kiwi-flesh-text")
+    if not fill or not ink or not text:
+        fail("token layer needs --kiwi-flesh, --kiwi-ink, and "
+             "--kiwi-flesh-text")
     expected = midpoint(fill, ink)
-
-    docs = light_hex(theme, "--sl-color-accent")
-    rest = light_hex(landing, "--accent")
-    print(
-        f"fill {fill} + ink {ink} -> midpoint {expected}; "
-        f"theme.css {docs}, landing.css {rest}"
-    )
-
-    for name, found in (("theme.css", docs), ("landing.css", rest)):
-        if found != expected:
-            fail(
-                f"{name}'s light-mode accent is {found}, not the "
-                f"{expected} midpoint of {fill} and {ink}. This green "
-                "is one decision shared with kiwicanopy.com and "
-                "KiwiCV — re-derive it and the brand family splits "
-                "silently (#635)."
-            )
-
-    bg = light_hex(theme, "--sl-color-black")
-    ratio = contrast(expected, bg)
-    print(f"contrast {ratio:.2f}:1 on the light bg {bg}")
-    if ratio < 4.5:
-        fail(
-            f"{expected} is {ratio:.2f}:1 on {bg}, below WCAG AA "
-            "(4.5:1) for body text. The raw fill green fails this, "
-            "which is why the midpoint exists."
-        )
+    if text != expected:
+        fail(f"--kiwi-flesh-text is {text}, not the {expected} midpoint "
+             f"of {fill} and {ink} (#635)")
+    for surface in ("--kiwi-cream", "--kiwi-snow"):
+        bg = tokens.get(surface)
+        if not bg:
+            fail(f"token layer needs {surface} for the contrast check")
+        ratio = contrast(text, bg)
+        print(f"contrast {ratio:.2f}:1 on {surface} {bg}")
+        if ratio < 4.5:
+            fail(f"{text} is {ratio:.2f}:1 on {bg}, below WCAG AA")
 
 
 def check_branded_404(dist: pathlib.Path) -> None:
@@ -302,7 +186,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    check_accent()
+    tokens = token_map()
+    check_token_layer(tokens)
+    check_accent(tokens)
     check_branded_404(pathlib.Path(args.dist).resolve())
 
 

--- a/site/src/styles/brand-tokens.css
+++ b/site/src/styles/brand-tokens.css
@@ -14,14 +14,10 @@
    puts its hex under `scripts/check-site-tokens.py`, which
    fails if the literal reappears anywhere else in `site/src`.
 
-   Naming: where the two stylesheets disagreed, the name with
-   live var() consumers won over the name with none —
-   --kiwi-flesh (9 uses) over --kiwi-green (0), --kiwi-bright
-   (13) over --kiwi-green-bright (0), --kiwi-shell (1) over
-   --kiwi-brown (0). That also keeps the kiwifruit-anatomy
-   family (seed / flesh / shell) that --kiwi-seed and
-   --kiwi-cream — already spelled identically in both files —
-   were the surviving half of.
+   Naming: where the two stylesheets disagreed, keep the name
+   with live var() consumers rather than the dead synonym. That
+   also preserves the kiwifruit-anatomy family (seed / flesh /
+   shell) already used throughout the landing design system.
    ========================================================= */
 :root {
   /* ---- Darks ---- */

--- a/site/src/styles/brand-tokens.css
+++ b/site/src/styles/brand-tokens.css
@@ -1,0 +1,48 @@
+/* =========================================================
+   KiwiDesk — raw brand color layer (issue #439)
+
+   The ONE place a brand hex literal is written. `theme.css`
+   (Starlight docs) and `landing.css` (every non-Starlight
+   surface) both @import this file and map their own role names
+   through var() — they reach disjoint page sets and had each
+   re-declared these values independently, several under
+   divergent names for one color.
+
+   This layer is theme-INVARIANT: it names colors, never roles.
+   A consumer decides which theme block a token lands in, and
+   never re-states its hex. Adding a token here automatically
+   puts its hex under `scripts/check-site-tokens.py`, which
+   fails if the literal reappears anywhere else in `site/src`.
+
+   Naming: where the two stylesheets disagreed, the name with
+   live var() consumers won over the name with none —
+   --kiwi-flesh (9 uses) over --kiwi-green (0), --kiwi-bright
+   (13) over --kiwi-green-bright (0), --kiwi-shell (1) over
+   --kiwi-brown (0). That also keeps the kiwifruit-anatomy
+   family (seed / flesh / shell) that --kiwi-seed and
+   --kiwi-cream — already spelled identically in both files —
+   were the surviving half of.
+   ========================================================= */
+:root {
+  /* ---- Darks ---- */
+  --kiwi-seed: #0d1512; /* deep brand bg (darkest surface) */
+  --kiwi-ink: #12251a; /* forest ink, green-forward, no teal */
+
+  /* ---- Chromatics ---- */
+  --kiwi-shell: #8b5e3c; /* warm tertiary — fills only, sparing */
+  --kiwi-flesh: #8db354; /* deeper kiwi green — fills */
+  --kiwi-bright: #aacb5d; /* brighter kiwi green — AA on darks */
+
+  /* Text-safe flesh: the 50/50 midpoint of --kiwi-flesh and
+     --kiwi-ink, shared with the wider brand family (#635). Raw
+     --kiwi-flesh is only ~2.3:1 on the light surfaces and fails
+     AA, so this is the shade every light-mode text/link/eyebrow
+     role uses. The site-token guard recomputes the midpoint and
+     its contrast from the token layer. */
+  --kiwi-flesh-text: #506c37;
+
+  /* ---- Pales ---- */
+  --kiwi-cream: #e1eedb; /* pale kiwi mist — light deepest tint */
+  --kiwi-frost: #eaf3ee; /* green-tinted off-white — dark ink */
+  --kiwi-snow: #f7f9f5; /* near-neutral white — light page ground */
+}

--- a/site/src/styles/landing-modes.css
+++ b/site/src/styles/landing-modes.css
@@ -749,7 +749,7 @@
 /* Extra Lua/CLI syntax tokens for the code blocks. */
 .code .str { color: #d8b06a; }
 .code .num { color: #7fd0a0; }
-.code .fn { color: #aacb5d; }
+.code .fn { color: var(--kiwi-bright); }
 
 /* =========================================================
    Pull-quotes — a personal, human voice.

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -1,3 +1,4 @@
+@import "./brand-tokens.css";
 @import "./landing-modes.css";
 
 /* =========================================================
@@ -10,15 +11,6 @@
    ========================================================= */
 
 :root {
-  /* ---- Brand palette (theme-invariant, KiwiCanopy tokens —
-     see KiwiCanopy-web/src/styles/theme.css, issue #439) ---- */
-  --kiwi-flesh: #8db354; /* accent — deeper kiwi green, fills */
-  --kiwi-bright: #aacb5d; /* accent-soft — brighter kiwi green */
-  --kiwi-shell: #8b5e3c; /* warm tertiary — fills only, sparing */
-  --kiwi-cream: #e1eedb; /* pale kiwi surface-mist tint (unused ref) */
-  --kiwi-seed: #0d1512; /* deep brand bg (unused ref) */
-  --kiwi-ink: #12251a; /* forest ink, green-forward (unused ref) */
-
   /* ---- Spacing scale (8pt-ish, fluid at the edges) ---- */
   --sp-1: 0.5rem;
   --sp-2: 0.75rem;
@@ -53,7 +45,7 @@
      are derived rungs on the same ramp for the extra bands this
      page needs (deepest floor, tinted section). */
   --bg-0: #0a100d;   /* deepest (code / diagrams) */
-  --bg-1: #0d1512;   /* base — brand --bg (dark) */
+  --bg-1: var(--kiwi-seed); /* base — brand --bg (dark) */
   --bg-2: #101a16;   /* tinted band */
   --bg-3: #14201c;   /* card / raised — brand --surface (dark) */
   --border: rgba(137, 181, 137, 0.14); /* sage — no teal, #439 */
@@ -61,7 +53,7 @@
 
   /* Text — brand --ink / --text-muted (dark); --text-faint is a
      recomputed third tier, still AA on every dark surface above. */
-  --text: #eaf3ee;
+  --text: var(--kiwi-frost);
   --text-dim: #9fb3ab;
   --text-faint: #7a8c85;
 
@@ -149,8 +141,8 @@
      bg-0/bg-2 are derived rungs blending in kiwi-green tints for
      the extra bands this page needs (deepest floor, tinted
      section) — green-forward, no teal (issue #439 follow-up). */
-  --bg-0: #e1eedb;   /* deepest (code / diagrams) — kiwi mist */
-  --bg-1: #f7f9f5;   /* base — brand --bg (light) */
+  --bg-0: var(--kiwi-cream); /* deepest (code / diagrams) */
+  --bg-1: var(--kiwi-snow);  /* base — brand --bg (light) */
   --bg-2: #ecf3e9;   /* tinted band (bg-1 x bg-0 blend) */
   --bg-3: #ffffff;   /* card / raised — brand --surface (light) */
   --border: rgba(18, 37, 26, 0.12); /* forest ink, no teal */
@@ -161,7 +153,7 @@
      recomputed third tier, both re-verified AA on every new
      light surface above (incl. --bg-0, the footer/diagram floor:
      text-faint holds 4.57:1 there, text-dim 5.25:1). */
-  --text: #12251a;
+  --text: var(--kiwi-ink);
   --text-dim: #55635c;
   --text-faint: #5f6c65;     /* AA (4.5:1) on footer/tint #e1eedb */
 
@@ -176,7 +168,7 @@
      private near-neighbour here.
      Re-verified AA on every new surface above (4.93:1 min, on
      --bg-0). */
-  --accent: #506c37;         /* AA on bg + .tint bands */
+  --accent: var(--kiwi-flesh-text);
   --accent-deep: var(--kiwi-flesh);
   --glow: rgba(141, 179, 84, 0.35);
 
@@ -1268,7 +1260,7 @@ section {
   background: var(--code-dot-idle);
 }
 .code__dot:nth-child(1) {
-  background: #8b5e3c;
+  background: var(--kiwi-shell);
 }
 .code__dot:nth-child(2) {
   background: #a98a4b;

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -1,22 +1,16 @@
+@import "./brand-tokens.css";
+
 /* KiwiCanopy brand palette layered onto Starlight's theme —
    shared kiwi-green accent + a sparing warm-brown tertiary,
    matching the parent brand's token set (issue #439). */
-:root {
-  --kiwi-green: #8db354;
-  --kiwi-green-bright: #aacb5d;
-  --kiwi-brown: #8b5e3c;
-  --kiwi-cream: #e1eedb;
-  --kiwi-seed: #0d1512;
-}
-
 /* Dark theme accents (default). Accent text uses the brighter
    kiwi green (accent-soft) — it clears AA on these dark
    surfaces; the deeper green stays a fill-only color elsewhere. */
 :root {
   --sl-color-accent-low: #1a2519;
-  --sl-color-accent: #aacb5d;
+  --sl-color-accent: var(--kiwi-bright);
   --sl-color-accent-high: #c7dd9e;
-  --sl-color-white: #eaf3ee;
+  --sl-color-white: var(--kiwi-frost);
   --sl-color-gray-1: #cdd6d1;
   --sl-color-gray-2: #868e8a;
   --sl-color-gray-3: #454e4a;
@@ -24,14 +18,14 @@
   --sl-color-gray-5: #161e1b;
   --sl-color-gray-6: #0f1714;
   --sl-color-gray-7: #0e1613;
-  --sl-color-black: #0d1512;
+  --sl-color-black: var(--kiwi-seed);
 }
 
 /* Light theme accents. Accent text is a darkened variant of the
    brand's kiwi green — the raw fill green is ~2.3:1 on this bg
    and fails AA, so this role stays a purpose-built text-safe
    shade rather than the raw brand hex. Specifically the 50/50
-   midpoint of --kiwi-green and the forest ink (--sl-color-white
+   midpoint of --kiwi-flesh and the forest ink (--sl-color-white
    below), which is the one value the whole brand family uses for
    this decision — so never re-derive a private near-neighbour of
    it here. scripts/check-site-tokens.py recomputes that midpoint
@@ -42,9 +36,9 @@
    teal-tinted ink. */
 :root[data-theme="light"] {
   --sl-color-accent-low: #cce0a2;
-  --sl-color-accent: #506c37;
+  --sl-color-accent: var(--kiwi-flesh-text);
   --sl-color-accent-high: #384721;
-  --sl-color-white: #12251a;
+  --sl-color-white: var(--kiwi-ink);
   --sl-color-gray-1: #14271c;
   --sl-color-gray-2: #1d2f25;
   --sl-color-gray-3: #2b3c32;
@@ -52,7 +46,7 @@
   --sl-color-gray-5: #949d96;
   --sl-color-gray-6: #d9ddd8;
   --sl-color-gray-7: #e7eae6;
-  --sl-color-black: #f7f9f5;
+  --sl-color-black: var(--kiwi-snow);
 }
 
 /* Quiet KiwiCanopy parent-brand mention appended below the docs


### PR DESCRIPTION
## What changed

- extract the nine theme-invariant KiwiDesk brand colors into one shared CSS token layer
- map the Starlight and standalone-page roles through that layer
- preserve the shared `#506c37` light-text midpoint introduced by #635
- strengthen the site guard around ownership, consumer roles, imports, midpoint/contrast, and the branded 404 artifact
- document the token ownership and cross-repository review obligation

## Why

The Starlight and standalone stylesheets reach disjoint page sets and previously repeated the same palette under divergent names. A shared raw-color layer removes that drift path while leaving role decisions local to each stylesheet.

## Impact

This is a visual-preserving refactor. Landing, guide, legal, docs, and the branded 404 keep the same light/dark colors, while future brand edits now have one local authority and stronger failure checks.

## Validation

- `npm run build`
- `python3 ../scripts/check-site-tokens.py --dist dist`
- light/dark visual QA: landing, guide, legal, and 404
- `swift build`
- `swift test` — 2,298 tests passed
- `scripts/lint.sh`
- `swift build -c release`
- parallel code and architecture review, followed by sequential fix re-review

The token guard was red-tested against consumer-role drift, non-hex redeclaration, commented imports, and out-of-layer token declarations.
