### PR TITLE
fix(site): use custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Powerful when you reach for it, never in your way.
 
 <br>
 
-[![Documentation](https://img.shields.io/badge/📖_Documentation-8DB354?style=for-the-badge)](https://kiwidesk.pages.dev/docs/)
-[![Quick Start](https://img.shields.io/badge/🚀_Quick_Start-627D3A?style=for-the-badge)](https://kiwidesk.pages.dev/docs/user-guide/)
-[![Recipes](https://img.shields.io/badge/🧩_Recipes-AACB5D?style=for-the-badge)](https://kiwidesk.pages.dev/docs/recipes/)
+[![Documentation](https://img.shields.io/badge/📖_Documentation-8DB354?style=for-the-badge)](https://kiwidesk.kiwicanopy.com/docs/)
+[![Quick Start](https://img.shields.io/badge/🚀_Quick_Start-627D3A?style=for-the-badge)](https://kiwidesk.kiwicanopy.com/docs/user-guide/)
+[![Recipes](https://img.shields.io/badge/🧩_Recipes-AACB5D?style=for-the-badge)](https://kiwidesk.kiwicanopy.com/docs/recipes/)
 [![Support on Ko-fi](https://img.shields.io/badge/Support-FF5E5B?style=for-the-badge&logo=kofi&logoColor=white)](https://ko-fi.com/kiwicanopy)
 
 </div>
@@ -43,10 +43,10 @@ Powerful when you reach for it, never in your way.
 > current via `brew upgrade`; a signed, notarized `.dmg` follows
 > once the app can update itself, so that a direct download is
 > never a dead end — see
-> [No distribution channel without an update path](https://kiwidesk.pages.dev/docs/design-decisions/#no-distribution-channel-without-an-update-path).
+> [No distribution channel without an update path](https://kiwidesk.kiwicanopy.com/docs/design-decisions/#no-distribution-channel-without-an-update-path).
 > KiwiDesk is
 > distributed directly and **not** through the Mac App Store —
-> see [Distribution](https://kiwidesk.pages.dev/docs/design-decisions/#distribution-direct-download-not-the-mac-app-store)
+> see [Distribution](https://kiwidesk.kiwicanopy.com/docs/design-decisions/#distribution-direct-download-not-the-mac-app-store)
 > for why.
 
 KiwiDesk is a modular, high-performance tiling window manager for
@@ -177,7 +177,7 @@ end)
 
 ## Documentation
 
-Full docs live at **[kiwidesk.pages.dev](https://kiwidesk.pages.dev)**
+Full docs live at **[kiwidesk.kiwicanopy.com](https://kiwidesk.kiwicanopy.com)**
 (searchable, light/dark). The same pages are readable here on
 GitHub:
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,9 +6,10 @@ import mermaid from "astro-mermaid";
 import { remarkDocsLinks } from "./remark-docs-links.mjs";
 
 // The public site URL. Override with SITE_URL at build time
-// (Cloudflare Pages sets it per environment); the default is
-// the free pages.dev subdomain until a custom domain lands.
-const site = process.env.SITE_URL ?? "https://kiwidesk.pages.dev";
+// for a one-off local build; production uses the committed
+// custom-domain default (#106).
+const site =
+  process.env.SITE_URL ?? "https://kiwidesk.kiwicanopy.com";
 
 export default defineConfig({
   site,


### PR DESCRIPTION
## Description

Use `https://kiwidesk.kiwicanopy.com` as Astro’s committed
production site URL and repoint the README documentation links
from the temporary `pages.dev` hostname.

This makes generated canonical, Open Graph, alternate-language,
and sitemap URLs use the attached custom domain.

## Related Issue(s)

Closes #106

## Checklist

- [x] Commits follow Conventional Commits format
- [x] No contradictions between code and documentation
- [x] `swift build`, `swift test`, and `scripts/lint.sh` pass
- [x] Release build passes
- [x] PR is focused

## How I verified

- Built the site using Node 24.
- Confirmed generated canonical and sitemap URLs use
  `kiwidesk.kiwicanopy.com`.
- Confirmed no generated URLs still reference `pages.dev`.
- Confirmed the custom domain responds over TLS with HTTP 200.
- Ran `swift build`, all 2,298 tests, `scripts/lint.sh`, and
  `swift build -c release`.

## Notes for Reviewer

Cloudflare Pages ignores dashboard `SITE_URL` when the committed
Wrangler configuration is used. The production hostname therefore
needs to be committed as Astro’s default site URL.