### PR TITLE
ci: prepare workflows for public runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     # is unchanged, so the binary still runs on older macOS.
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select Xcode
         run: |
@@ -70,7 +70,7 @@ jobs:
     # build silently accepts. #532.
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select Xcode
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
     outputs:
       sha: ${{ steps.audit.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
           # Needed for the "tag is on main" assertion below,
@@ -174,7 +174,7 @@ jobs:
       # does. Verify above runs with read only.
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # The exact commit Verify vetted — never the tag name,
           # which is re-resolved against the remote at THIS job's

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -33,9 +33,9 @@ jobs:
       run:
         working-directory: site
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # Read from site/.nvmrc so CI and a local `nvm use`
           # cannot drift apart — a literal here would silently

--- a/Tests/KiwiDeskCoreTests/PerSpaceResizeTests.swift
+++ b/Tests/KiwiDeskCoreTests/PerSpaceResizeTests.swift
@@ -10,18 +10,26 @@ import Testing
 @Suite("Per-space resize (#17)", .serialized)
 @MainActor
 struct PerSpaceResizeTests {
+    /// The display these ratio clamps resize against (#531).
+    /// Pin it so a narrow headless runner cannot lower the cap.
+    private static let display = CGRect(
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1080
+    )
+
     private func makeCore() -> KiwiCore {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "kiwidesk-tests-\(UUID().uuidString)"
             )
-        return makeTestCore(configDirectory: dir)
+        let core = makeTestCore(configDirectory: dir)
+        core.tiler.visibleBounds = { _ in Self.display }
+        #expect(core.tiler.settings.minWindowSize == 300)
+        return core
     }
 
-    // NOTE: the grow assertions below assume the host (or
-    // headless-fallback 1920) screen is wide enough that the
-    // #44 interactive cap sits above the tested bases — true
-    // for any visible width > 1000 pt.
     private func stackSpace(_ core: KiwiCore) {
         core.execute(
             "set_mode",


### PR DESCRIPTION
## Description

Make CI deterministic on GitHub's public macOS runners and remove the
Node.js 20 action-runtime warning:

- pin the resize test fixture to an injected 1920x1080 display
- assert the fixture's minimum window size assumption
- upgrade `actions/checkout` and `actions/setup-node` to v6

## Related Issue(s)

None.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build green — CI's `Release Build` job (read it
  before merging; it reports, it does not block), or locally
  for concurrency / `@Sendable` changes
- [x] PR is focused; refactors separated from features

## How I verified

- `swift test --filter PerSpaceResizeTests`: 5 tests passed
- `swift build`: passed
- `swift test`: 2,298 tests passed
- `./scripts/lint.sh`: passed
- `swift build -c release`: passed
- parsed all three edited workflows as YAML
- checked the diff with `git diff --check`

No product behavior changes; the test now uses the display-bound injection
required by the repository's geometry-fixture convention.

## Notes for Reviewer

The public runner exposed a narrower host screen, lowering the interactive
ratio cap from the fixture's assumed value. The production resize behavior
was correct; only the test was coupled to the host display.

The v6 action upgrades use Node.js 24 directly instead of relying on
GitHub's compatibility override for Node.js 20 actions.
