### PR TITLE
test: eliminate compiler warnings

### DIFF
--- a/Tests/KiwiDeskCoreTests/DragTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragTests.swift
@@ -14,6 +14,15 @@ import Testing
 /// slows a passing run — it only bounds a genuine hang.
 private let dragSettleHangGuard: Duration = .seconds(30)
 
+@MainActor
+private final class MouseButtonState {
+    var isPressed: Bool
+
+    init(isPressed: Bool) {
+        self.isPressed = isPressed
+    }
+}
+
 @Suite("DragCoordinator", .serialized)
 @MainActor
 struct DragCoordinatorTests {
@@ -21,8 +30,8 @@ struct DragCoordinatorTests {
     func debounce() async throws {
         let drag = DragCoordinator()
         drag.settleDelay = 0.05
-        var pressed = true
-        drag.isMousePressed = { pressed }
+        let mouse = MouseButtonState(isPressed: true)
+        drag.isMousePressed = { mouse.isPressed }
         var ended: [(WindowID, CGRect, CGRect)] = []
         drag.onDragEnd = { id, start, frame in
             ended.append((id, start, frame))
@@ -39,7 +48,7 @@ struct DragCoordinatorTests {
                 )
             )
         }
-        pressed = false
+        mouse.isPressed = false
         // Poll instead of a fixed sleep: under full-suite
         // load the settle task can get main-actor time late.
         let deadline = ContinuousClock.now + dragSettleHangGuard
@@ -102,8 +111,8 @@ struct DragCoordinatorTests {
     func trailingMovesJoinGesture() async throws {
         let drag = DragCoordinator()
         drag.settleDelay = 0.05
-        var pressed = true
-        drag.isMousePressed = { pressed }
+        let mouse = MouseButtonState(isPressed: true)
+        drag.isMousePressed = { mouse.isPressed }
         var ended: [(start: CGRect, end: CGRect)] = []
         drag.onDragEnd = { _, start, end in
             ended.append((start, end))
@@ -112,7 +121,7 @@ struct DragCoordinatorTests {
         drag.windowMoved(WindowID(1), frame: first)
         // The last AX event of a fast drag lags the release;
         // it must still update the gesture's end frame.
-        pressed = false
+        mouse.isPressed = false
         let trailing = CGRect(x: 400, y: 0, width: 10, height: 10)
         drag.windowMoved(WindowID(1), frame: trailing)
         let deadline = ContinuousClock.now + dragSettleHangGuard
@@ -140,12 +149,12 @@ struct DragCoordinatorTests {
     func cancelPending() async throws {
         let drag = DragCoordinator()
         drag.settleDelay = 0.05
-        var pressed = true
-        drag.isMousePressed = { pressed }
+        let mouse = MouseButtonState(isPressed: true)
+        drag.isMousePressed = { mouse.isPressed }
         var ended = 0
         drag.onDragEnd = { _, _, _ in ended += 1 }
         drag.windowMoved(WindowID(1), frame: .zero)
-        pressed = false
+        mouse.isPressed = false
         drag.cancel(WindowID(1))
         try await Task.sleep(nanoseconds: 150_000_000)
         #expect(ended == 0)
@@ -154,8 +163,8 @@ struct DragCoordinatorTests {
     @Test("Moves with the button down fire live drag moves")
     func liveMoves() throws {
         let drag = DragCoordinator()
-        var pressed = true
-        drag.isMousePressed = { pressed }
+        let mouse = MouseButtonState(isPressed: true)
+        drag.isMousePressed = { mouse.isPressed }
         var moves: [CGRect] = []
         drag.onDragMove = { _, _, frame in
             moves.append(frame)
@@ -164,7 +173,7 @@ struct DragCoordinatorTests {
         drag.windowMoved(WindowID(1), frame: frame)
         #expect(moves == [frame])
         // Trailing AX events after the release: no feedback.
-        pressed = false
+        mouse.isPressed = false
         drag.windowMoved(WindowID(1), frame: .zero)
         #expect(moves == [frame])
     }
@@ -185,8 +194,8 @@ struct DragCoordinatorTests {
         let drag = DragCoordinator()
         drag.settleDelay = 0.05
         drag.releasePollDelay = 0.02
-        var pressed = true
-        drag.isMousePressed = { pressed }
+        let mouse = MouseButtonState(isPressed: true)
+        drag.isMousePressed = { mouse.isPressed }
         var ended: [CGRect] = []
         drag.onDragEnd = { _, _, frame in
             ended.append(frame)
@@ -196,7 +205,7 @@ struct DragCoordinatorTests {
         // Standing still with the button down is not a drop.
         try await Task.sleep(nanoseconds: 150_000_000)
         #expect(ended.isEmpty)
-        pressed = false
+        mouse.isPressed = false
         let deadline = ContinuousClock.now + dragSettleHangGuard
         while ended.isEmpty, ContinuousClock.now < deadline {
             try await Task.sleep(nanoseconds: 20_000_000)

--- a/Tests/KiwiDeskCoreTests/SleepWakeManagerTests.swift
+++ b/Tests/KiwiDeskCoreTests/SleepWakeManagerTests.swift
@@ -4,6 +4,15 @@ import Testing
 
 @testable import KiwiDeskCore
 
+@MainActor
+private final class DisplayFingerprintState {
+    var values: [String]
+
+    init(_ values: [String]) {
+        self.values = values
+    }
+}
+
 /// The wake/unlock preserve-and-replay cycle, and its display
 /// topology gate (#633). The rest/return pair is driven
 /// directly — never through the real workspace notification
@@ -65,13 +74,13 @@ struct SleepWakeManagerTests {
         var logged: [String] = []
         manager.onLog = { logged.append($0) }
         manager.captureState = { self.sample() }
-        var current = ["main", "side"]
-        manager.displayFingerprints = { current }
+        let displays = DisplayFingerprintState(["main", "side"])
+        manager.displayFingerprints = { displays.values }
         var restored = false
         manager.restoreState = { _ in restored = true }
         manager.systemWillRest()
         // The side monitor was unplugged while asleep.
-        current = ["main"]
+        displays.values = ["main"]
         manager.systemDidReturn()
         await pollUntil {
             logged.contains { $0.contains("topology") }
@@ -90,12 +99,12 @@ struct SleepWakeManagerTests {
         manager.onLog = { _ in }
         manager.restoreDelayMS = 0
         manager.captureState = { self.sample() }
-        var current = ["main", "side"]
-        manager.displayFingerprints = { current }
+        let displays = DisplayFingerprintState(["main", "side"])
+        manager.displayFingerprints = { displays.values }
         var restored = false
         manager.restoreState = { _ in restored = true }
         manager.systemWillRest()
-        current = ["side", "main"]
+        displays.values = ["side", "main"]
         manager.systemDidReturn()
         await pollUntil { restored }
         #expect(restored)
@@ -111,12 +120,12 @@ struct SleepWakeManagerTests {
         var logged: [String] = []
         manager.onLog = { logged.append($0) }
         manager.captureState = { self.sample() }
-        var current = ["twin", "twin"]
-        manager.displayFingerprints = { current }
+        let displays = DisplayFingerprintState(["twin", "twin"])
+        manager.displayFingerprints = { displays.values }
         var restored = false
         manager.restoreState = { _ in restored = true }
         manager.systemWillRest()
-        current = ["twin"]
+        displays.values = ["twin"]
         manager.systemDidReturn()
         await pollUntil {
             logged.contains { $0.contains("topology") }

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropMoveTests.swift
@@ -108,7 +108,9 @@ struct SpaceBarDropMoveTests {
         // calls this closure). Eager membership: the window moves
         // into the target NOW, so the live drag can preview and the
         // drop places it precisely.
-        core.spaceBarDrop.spring(SpaceID("2"), WindowID(1))
+        #expect(
+            core.spaceBarDrop.spring(SpaceID("2"), WindowID(1))
+        )
 
         #expect(core.state.workspaces.activeSpace == SpaceID("2"))
         #expect(


### PR DESCRIPTION
## Description

- Replace mutable locals captured by main-actor test seams with
  main-actor fixture state.
- Assert the Space Bar spring seam's success result.

This removes all nine actionable compiler-warning sites from the clean
CI inventory without changing product behavior. The separately documented
`activateIgnoringOtherApps` warning remains intentionally unchanged because
its source comment requires a two-monitor focus A/B before removal.

## Related Issue(s)

None.

## Checklist

- [x] I understand what this change does; it is test-only and has no app
  behavior to exercise.
- [x] Commits follow Conventional Commits format.
- [x] Existing affected behavior remains tested.
- [x] User-facing documentation is not applicable.
- [x] No contradictions between code and docs.
- [x] `swift build`, `swift test`, and `scripts/lint.sh` pass.
- [x] Local release build is green.
- [x] PR is focused; refactors are separate from features.

## How I verified

- Focused run: 18 tests across the three affected suites passed.
- Full gate: debug build passed; 2,298 tests passed; lint passed; optimized
  release build passed.
- The changed test files compiled without the prior capture or unused-result
  warnings.

## Notes for Reviewer

The state holders are `@MainActor`, matching the seams and suites. This avoids
introducing locks or `@unchecked Sendable` solely for test fixtures.
