### PR TITLE
ci(release): publish Homebrew cask

### DIFF
--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -191,6 +191,15 @@ change that step to publish without changing that entry first —
 restating its argument here is how the two copies came to
 disagree about a draft's reach on the day they were written.
 
+**Advance Homebrew only after publication.**
+`.github/workflows/homebrew.yml` owns the tap update: the
+`release.published` event is the distribution boundary, never the
+tag push or draft creation. It must verify the release's one ZIP
+against GitHub's SHA-256 digest before changing the cask, and its
+write credential stays scoped to `KiwiCanopy/homebrew-tap`. A
+manual dispatch is a retry of that same published asset, not an
+alternate way to build or publish one.
+
 ## Never `Bundle.module` in code that runs from the `.app` (#89)
 
 Go through `ResourceBundle.locate` (`Bundle.kiwiDeskCore` /

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,150 @@
+name: Update Homebrew Cask
+
+# The release workflow deliberately stops at a draft. Only the owner's
+# publication action makes the asset a real distribution channel, so that is
+# the event allowed to advance the cask. A manual dispatch retries an existing
+# published release without rebuilding or retagging it.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Published release tag to retry (e.g. v0.9.0)'
+        required: true
+
+permissions:
+  contents: read
+
+# Two releases must never race to write the tap's one version pointer. Queue
+# every pending update: GitHub otherwise retains only the newest pending run,
+# so a manual retry could displace a newer release. Do not cancel a running
+# update either; cancellation can stop between commit and push.
+concurrency:
+  group: homebrew-cask
+  queue: max
+  cancel-in-progress: false
+
+env:
+  TAG: ${{ github.event.release.tag_name || inputs.tag }}
+
+jobs:
+  update:
+    name: Update cask
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # This supplies the updater, not release bytes. Use today's
+          # protected main so a manual retry can repair an older release.
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Verify the published release asset
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::tag must be vMAJOR.MINOR.PATCH: $TAG"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          EXPECTED="KiwiDesk-$VERSION.zip"
+          RELEASE="$(gh api \
+            "repos/$GITHUB_REPOSITORY/releases/tags/$TAG")"
+
+          if [ "$(jq -r '.draft' <<< "$RELEASE")" != false ]; then
+            echo "::error::$TAG is still a draft"
+            exit 1
+          fi
+          COUNT="$(jq '.assets | length' <<< "$RELEASE")"
+          if [ "$COUNT" -ne 1 ]; then
+            echo "::error::$TAG must have exactly one asset, found $COUNT"
+            exit 1
+          fi
+
+          NAME="$(jq -r '.assets[0].name' <<< "$RELEASE")"
+          STATE="$(jq -r '.assets[0].state' <<< "$RELEASE")"
+          TYPE="$(jq -r '.assets[0].content_type' <<< "$RELEASE")"
+          DIGEST="$(jq -r '.assets[0].digest' <<< "$RELEASE")"
+          if [ "$NAME" != "$EXPECTED" ]; then
+            echo "::error::expected $EXPECTED, found $NAME"
+            exit 1
+          fi
+          if [ "$STATE" != uploaded ] || [ "$TYPE" != application/zip ]; then
+            echo "::error::$NAME is not an uploaded ZIP ($STATE, $TYPE)"
+            exit 1
+          fi
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::$NAME has no valid GitHub SHA-256 digest"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "asset=$NAME" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST#sha256:}" >> "$GITHUB_OUTPUT"
+
+      - name: Download and verify the archive bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSET: ${{ steps.release.outputs.asset }}
+          DIGEST: ${{ steps.release.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir "$RUNNER_TEMP/release"
+          gh release download "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$ASSET" \
+            --dir "$RUNNER_TEMP/release"
+          ACTUAL="$(sha256sum "$RUNNER_TEMP/release/$ASSET")"
+          ACTUAL="${ACTUAL%% *}"
+          if [ "$ACTUAL" != "$DIGEST" ]; then
+            echo "::error::$ASSET digest is $ACTUAL, expected $DIGEST"
+            exit 1
+          fi
+
+      - name: Require the tap deploy key
+        env:
+          DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+        run: |
+          if [ -z "$DEPLOY_KEY" ]; then
+            echo "::error::HOMEBREW_TAP_DEPLOY_KEY is not configured"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          repository: KiwiCanopy/homebrew-tap
+          ref: main
+          path: homebrew-tap
+          ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+
+      - name: Update and validate the cask
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          DIGEST: ${{ steps.release.outputs.digest }}
+        run: |
+          set -euo pipefail
+          scripts/update-homebrew-cask.py \
+            "$VERSION" "$DIGEST" \
+            --cask homebrew-tap/Casks/kiwidesk.rb
+          ruby -c homebrew-tap/Casks/kiwidesk.rb
+          git -C homebrew-tap diff --check
+
+      - name: Commit and push the cask
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git -C homebrew-tap diff --quiet -- Casks/kiwidesk.rb; then
+            echo "Homebrew cask already points to $TAG"
+            exit 0
+          fi
+          git -C homebrew-tap config user.name github-actions\[bot\]
+          git -C homebrew-tap config \
+            user.email 41898282+github-actions\[bot\]@users.noreply.github.com
+          git -C homebrew-tap add Casks/kiwidesk.rb
+          git -C homebrew-tap commit \
+            -m "chore: update kiwidesk to $VERSION"
+          git -C homebrew-tap push origin HEAD:main

--- a/Tests/KiwiDeskCoreTests/HomebrewCaskUpdateTests.swift
+++ b/Tests/KiwiDeskCoreTests/HomebrewCaskUpdateTests.swift
@@ -34,6 +34,22 @@ struct HomebrewCaskUpdateTests {
         #expect(try fixture.source() == once)
     }
 
+    @Test("same version with different bytes fails closed")
+    func sameVersionDifferentDigestFailsClosed() throws {
+        let fixture = try CaskFixture()
+        defer { fixture.cleanup() }
+        let original = try fixture.source()
+
+        let run = try fixture.update(
+            "0.9.0",
+            String(repeating: "b", count: 64)
+        )
+
+        #expect(run.status != 0)
+        #expect(run.stderr.contains("refusing to replace digest"))
+        #expect(try fixture.source() == original)
+    }
+
     @Test("malformed inputs fail without changing the cask")
     func malformedInputsFailClosed() throws {
         let fixture = try CaskFixture()

--- a/Tests/KiwiDeskCoreTests/HomebrewCaskUpdateTests.swift
+++ b/Tests/KiwiDeskCoreTests/HomebrewCaskUpdateTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+
+@Suite("Homebrew cask updater")
+struct HomebrewCaskUpdateTests {
+    @Test("updates only the version and digest")
+    func updatesVersionAndDigest() throws {
+        let fixture = try CaskFixture()
+        defer { fixture.cleanup() }
+        let digest = String(repeating: "b", count: 64)
+
+        let run = try fixture.update("1.2.3", digest)
+
+        #expect(run.status == 0, "stderr: \(run.stderr)")
+        let source = try fixture.source()
+        #expect(source.contains("  version \"1.2.3\""))
+        #expect(source.contains("  sha256 \"\(digest)\""))
+        #expect(source.contains("releases/download/v#{version}"))
+        #expect(source.contains("app \"KiwiDesk.app\""))
+    }
+
+    @Test("same release is an idempotent no-op")
+    func sameReleaseNoOp() throws {
+        let fixture = try CaskFixture()
+        defer { fixture.cleanup() }
+        let digest = String(repeating: "c", count: 64)
+        #expect(try fixture.update("1.2.3", digest).status == 0)
+        let once = try fixture.source()
+
+        let twice = try fixture.update("1.2.3", digest)
+
+        #expect(twice.status == 0, "stderr: \(twice.stderr)")
+        #expect(twice.stdout.contains("already at 1.2.3"))
+        #expect(try fixture.source() == once)
+    }
+
+    @Test("malformed inputs fail without changing the cask")
+    func malformedInputsFailClosed() throws {
+        let fixture = try CaskFixture()
+        defer { fixture.cleanup() }
+        let original = try fixture.source()
+
+        let version = try fixture.update(
+            "1.2.3-rc1",
+            String(repeating: "d", count: 64)
+        )
+        #expect(version.status != 0)
+        #expect(try fixture.source() == original)
+
+        let digest = try fixture.update("1.2.3", "not-a-digest")
+        #expect(digest.status != 0)
+        #expect(try fixture.source() == original)
+    }
+
+    @Test("an older release cannot roll the tap back")
+    func olderReleaseFailsClosed() throws {
+        let fixture = try CaskFixture()
+        defer { fixture.cleanup() }
+        let original = try fixture.source()
+
+        let run = try fixture.update(
+            "0.8.9",
+            String(repeating: "f", count: 64)
+        )
+
+        #expect(run.status != 0)
+        #expect(run.stderr.contains("refusing to downgrade"))
+        #expect(try fixture.source() == original)
+    }
+
+    @Test("a drifted cask fails instead of partially updating")
+    func driftedCaskFailsClosed() throws {
+        let fixture = try CaskFixture()
+        defer { fixture.cleanup() }
+        try fixture.rewrite { source in
+            source.replacingOccurrences(
+                of: "  sha256 \"",
+                with: "  sha256 :no_check # \""
+            )
+        }
+        let original = try fixture.source()
+
+        let run = try fixture.update(
+            "1.2.3",
+            String(repeating: "e", count: 64)
+        )
+
+        #expect(run.status != 0)
+        #expect(run.stderr.contains("sha256"))
+        #expect(try fixture.source() == original)
+    }
+
+    @Test("workflow advances only published verified releases")
+    func workflowGuardsDistributionBoundary() throws {
+        let workflow = try String(
+            contentsOf: CaskFixture.repoRoot
+                .appendingPathComponent(".github")
+                .appendingPathComponent("workflows")
+                .appendingPathComponent("homebrew.yml"),
+            encoding: .utf8
+        )
+
+        #expect(workflow.contains("types: [published]"))
+        #expect(workflow.contains("workflow_dispatch:"))
+        #expect(workflow.contains("queue: max"))
+        #expect(workflow.contains("cancel-in-progress: false"))
+        #expect(workflow.contains("HOMEBREW_TAP_DEPLOY_KEY"))
+        #expect(workflow.contains("assets | length"))
+        #expect(workflow.contains("sha256sum"))
+        #expect(workflow.contains("update-homebrew-cask.py"))
+    }
+}
+
+private struct CaskFixture {
+    let root: URL
+    let cask: URL
+
+    static var repoRoot: URL { scriptFixtureRepoRoot() }
+
+    static var updater: URL {
+        repoRoot
+            .appendingPathComponent("scripts")
+            .appendingPathComponent("update-homebrew-cask.py")
+    }
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cask-\(UUID().uuidString)")
+        cask = root.appendingPathComponent("kiwidesk.rb")
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        try Self.initial.write(
+            to: cask,
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func source() throws -> String {
+        try String(contentsOf: cask, encoding: .utf8)
+    }
+
+    func update(_ version: String, _ digest: String) throws -> ScriptRun {
+        try runPythonScript(
+            at: Self.updater,
+            arguments: [version, digest, "--cask", cask.path]
+        )
+    }
+
+    func rewrite(_ transform: (String) -> String) throws {
+        let before = try source()
+        let after = transform(before)
+        #expect(after != before, "fixture rewrite matched nothing")
+        try after.write(to: cask, atomically: true, encoding: .utf8)
+    }
+
+    private static var initial: String {
+        let digest = String(repeating: "a", count: 64)
+        let url =
+            "https://github.com/KiwiCanopy/KiwiDesk/releases/"
+            + "download/v#{version}/KiwiDesk-#{version}.zip"
+        return """
+            cask "kiwidesk" do
+              version "0.9.0"
+              sha256 "\(digest)"
+
+              url "\(url)"
+              name "KiwiDesk"
+              desc "Tiling window manager with layouts, profiles, and Lua"
+              homepage "https://kiwidesk.kiwicanopy.com/"
+
+              app "KiwiDesk.app"
+            end
+            """
+    }
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -219,32 +219,32 @@ publishing rather than on remembering to fix it afterwards.
 
 **Homebrew is the deliberate exception, and it is conditional.**
 `brew upgrade` is a real update path, so a Sparkle-less build
-may ship as a cask. That holds only while the release workflow
-actually bumps the tap — if the cask goes stale the exception
-lapses and the cask users are the stranded ones. It is an
-obligation on the cask
+may ship as a cask. The cask's public GitHub Release ZIP is its
+backing artifact, not a standalone channel KiwiDesk promotes:
+until Sparkle lands, do not link that ZIP from the product site
+or advertise it as a direct download. Someone who deliberately
+installs from the repository instead of Homebrew has chosen a
+manual update path.
+
+The Release must be published before Homebrew can fetch its ZIP,
+so publication and the tap update cannot be atomic. The accepted
+failure model is a short, visible stale-cask window: the release
+is not operationally complete until the `Update Homebrew Cask`
+workflow is green. That workflow queues every publication,
+verifies the published bytes, and permits a retry only when the
+same version still has the same digest. On failure, retry the
+workflow or publish a newer version; never replace an existing
+version's bytes.
+
+This exception holds only while the release workflow actually
+bumps the tap — if the cask goes stale the exception lapses and
+the cask users are the stranded ones. It is an obligation on the cask
 ([#105](https://github.com/KiwiCanopy/KiwiDesk/issues/105)), not
 a property that exists for free.
 
-Until Sparkle lands, the two together mean: cask yes, `.dmg`
-and Release assets no.
-
-**Where the cask's bytes live is the part this does not settle,
-and [#105](https://github.com/KiwiCanopy/KiwiDesk/issues/105)
-has to.** A cask installs from a URL, so blessing the cask while
-shutting every host it could read from leaves it with no legal
-source. The distinction that resolves it is the one this entry
-already rests on: the rule governs who can *reach* a build, not
-where the file is stored. So the question is which host lets
-`brew` fetch the archive without that same URL becoming the
-browse-and-download channel a stranded user arrives through —
-and answering it is a precondition of shipping the cask, not a
-detail of it. Until then the release workflow drafts rather than
-publishes: a draft has no public URL and is visible only to
-people who already have repository access, so it proves the
-pipeline end to end without opening a channel a stranger can
-install from. Not "reachable by nobody" — collaborators can
-fetch it, and the distinction is the whole point of the rule.
+Until Sparkle lands, the two together mean: a Homebrew cask
+backed by one public Release ZIP yes; a promoted standalone ZIP
+or `.dmg` download no.
 
 Trade-off: the first release reaches fewer people. Accepted, and
 it buys something back — Sparkle's update path is first

--- a/scripts/update-homebrew-cask.py
+++ b/scripts/update-homebrew-cask.py
@@ -18,7 +18,7 @@ VERSION_LINE = re.compile(
     r'^(?P<indent>\s*)version "(?P<value>[^"]+)"$', re.MULTILINE
 )
 SHA_LINE = re.compile(
-    r'^(?P<indent>\s*)sha256 "[^"]+"$', re.MULTILINE
+    r'^(?P<indent>\s*)sha256 "(?P<value>[^"]+)"$', re.MULTILINE
 )
 
 
@@ -102,12 +102,27 @@ def main() -> int:
     current = current_versions[0].group("value")
     if VERSION.fullmatch(current) is None:
         raise SystemExit(f"error: current cask version is invalid: {current}")
+    current_digests = list(SHA_LINE.finditer(source))
+    if len(current_digests) != 1:
+        raise SystemExit(
+            "error: expected exactly one sha256 line, "
+            f"found {len(current_digests)}"
+        )
+    current_digest = current_digests[0].group("value")
     requested_parts = tuple(map(int, arguments.version.split(".")))
     current_parts = tuple(map(int, current.split(".")))
     if requested_parts < current_parts:
         raise SystemExit(
             f"error: refusing to downgrade {current} to {arguments.version}"
         )
+    if requested_parts == current_parts:
+        if arguments.sha256 != current_digest:
+            raise SystemExit(
+                "error: refusing to replace digest for existing version "
+                f"{current}"
+            )
+        print(f"kiwidesk cask is already at {arguments.version}")
+        return 0
 
     try:
         updated = replace_one(
@@ -118,10 +133,6 @@ def main() -> int:
         )
     except ValueError as error:
         raise SystemExit(f"error: {error}") from error
-
-    if updated == source:
-        print(f"kiwidesk cask is already at {arguments.version}")
-        return 0
 
     try:
         write_atomically(path, updated)

--- a/scripts/update-homebrew-cask.py
+++ b/scripts/update-homebrew-cask.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Update KiwiDesk's Homebrew cask version and archive digest."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import re
+import stat
+import tempfile
+
+
+VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+SHA256 = re.compile(r"[0-9a-f]{64}")
+CASK = re.compile(r'^cask "kiwidesk" do$', re.MULTILINE)
+VERSION_LINE = re.compile(
+    r'^(?P<indent>\s*)version "(?P<value>[^"]+)"$', re.MULTILINE
+)
+SHA_LINE = re.compile(
+    r'^(?P<indent>\s*)sha256 "[^"]+"$', re.MULTILINE
+)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Update Casks/kiwidesk.rb without rewriting it."
+    )
+    result.add_argument("version", help="three-part release version")
+    result.add_argument("sha256", help="lowercase SHA-256 digest")
+    result.add_argument(
+        "--cask",
+        type=Path,
+        default=Path("Casks/kiwidesk.rb"),
+        help="cask file to update",
+    )
+    return result
+
+
+def replace_one(
+    source: str,
+    pattern: re.Pattern[str],
+    value: str,
+    label: str,
+) -> str:
+    matches = list(pattern.finditer(source))
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one {label} line, found {len(matches)}"
+        )
+    return pattern.sub(
+        lambda match: f'{match.group("indent")}{label} "{value}"',
+        source,
+        count=1,
+    )
+
+
+def write_atomically(path: Path, contents: str) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as handle:
+            handle.write(contents)
+            temporary = Path(handle.name)
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    if VERSION.fullmatch(arguments.version) is None:
+        raise SystemExit("error: version must be MAJOR.MINOR.PATCH")
+    if SHA256.fullmatch(arguments.sha256) is None:
+        raise SystemExit("error: sha256 must be 64 lowercase hex digits")
+
+    path: Path = arguments.cask
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise SystemExit(f"error: cannot read {path}: {error}") from error
+
+    if len(CASK.findall(source)) != 1:
+        raise SystemExit(
+            'error: expected exactly one `cask "kiwidesk" do` declaration'
+        )
+
+    current_versions = list(VERSION_LINE.finditer(source))
+    if len(current_versions) != 1:
+        raise SystemExit(
+            "error: expected exactly one version line, "
+            f"found {len(current_versions)}"
+        )
+    current = current_versions[0].group("value")
+    if VERSION.fullmatch(current) is None:
+        raise SystemExit(f"error: current cask version is invalid: {current}")
+    requested_parts = tuple(map(int, arguments.version.split(".")))
+    current_parts = tuple(map(int, current.split(".")))
+    if requested_parts < current_parts:
+        raise SystemExit(
+            f"error: refusing to downgrade {current} to {arguments.version}"
+        )
+
+    try:
+        updated = replace_one(
+            source, VERSION_LINE, arguments.version, "version"
+        )
+        updated = replace_one(
+            updated, SHA_LINE, arguments.sha256, "sha256"
+        )
+    except ValueError as error:
+        raise SystemExit(f"error: {error}") from error
+
+    if updated == source:
+        print(f"kiwidesk cask is already at {arguments.version}")
+        return 0
+
+    try:
+        write_atomically(path, updated)
+    except OSError as error:
+        raise SystemExit(f"error: cannot write {path}: {error}") from error
+    print(f"updated kiwidesk cask to {arguments.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- update the public Homebrew tap when a GitHub Release is published
- verify the sole ZIP against GitHub’s SHA-256 digest before changing the cask
- serialize every pending release and reject changed bytes for an existing version
- document the accepted public-ZIP/Homebrew distribution boundary

## Validation

- `swift build`
- `swift test` — 2,304 tests
- `swift test --filter HomebrewCaskUpdateTests` — 7 tests
- `scripts/lint.sh`
- `swift build -c release`
- code-reviewer and architect-reviewer passes

Closes #648