### PR TITLE
docs(site): un-hide top kofi button and mark direct download as coming soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Powerful when you reach for it, never in your way.
 [![CI](https://github.com/KiwiCanopy/KiwiDesk/actions/workflows/ci.yml/badge.svg)](https://github.com/KiwiCanopy/KiwiDesk/actions/workflows/ci.yml)
 ![License MIT](https://img.shields.io/badge/License-MIT-8DB354)
 ![Public beta](https://img.shields.io/badge/Public_beta-Homebrew-8DB354)
-![Direct download — with in-app updates](https://img.shields.io/badge/Direct_download-with_in--app_updates-8B5E3C)
+![Direct download — coming soon](https://img.shields.io/badge/Direct_download-coming_soon-inactive)
 
 <br>
 

--- a/site/src/components/Landing.astro
+++ b/site/src/components/Landing.astro
@@ -397,8 +397,8 @@ const jsonLd = [
                and compact. Reads as LESS obtrusive than a worded
                link: a small, recognizable control sitting quietly
                among the toggles. aria-label carries the meaning. */}
-          <a class="nav__support dev-only" href={kofi} target="_blank"
-            rel="noopener" aria-label={t.nav_support_aria}>
+          <a class="nav__support" href={kofi} target="_blank"
+            rel="noopener" aria-label={t.nav_support_aria} title={t.nav_support_aria}>
             <img class="kofi-icon" src={kofiIcon.src} alt=""
               aria-hidden="true" width="20" height="16" />
           </a>
@@ -863,7 +863,7 @@ KiwiDesk.bind(<span class="str">"cmd+alt+left"</span>, <span class="fn">function
               </svg>
               {t.hero_dev_cta_github}
             </a>
-            <a class="btn btn--ghost dev-only" href={kofi}
+            <a class="btn btn--ghost" href={kofi}
               target="_blank" rel="noopener">
               <img class="kofi-icon" src={kofiIcon.src} alt=""
                 aria-hidden="true" width="20" height="16" />


### PR DESCRIPTION
## Description

1. Un-hides the Ko-fi support button in the top navigation bar of `Landing.astro` so it is visible in both Simple and Nerd modes.
2. Un-hides the Ko-fi support button in the final `#cta` section of `Landing.astro` so it appears in Simple mode beside the primary CTA button.
3. Updates the `README.md` direct download badge to "Direct download — coming soon" (`inactive` badge) to clarify that Homebrew is the active public beta installation method.

## Related Issue(s)

N/A

## Checklist

- [x] I understand what this change does and have run it in the app to confirm it works as intended
- [x] Commits follow Conventional Commits format
- [x] User-facing changes are documented
- [x] No contradictions between code and docs
- [x] `npm run build` and `python3 scripts/check-site-tokens.py --dist site/dist` pass
- [x] PR is focused; refactors separated from features

## How I verified

1. Built the site using `npm run build` in `site/`.
2. Verified contrast tokens and 404 page with `python3 scripts/check-site-tokens.py --dist site/dist`.
3. Ran `./scripts/lint.sh`.

## Notes for Reviewer

- Top navbar Ko-fi button now renders consistently across both modes matching `Guide.astro`.