### PR TITLE
fix(gui): disable miniaturize on settings window and bump version to 0.9.2

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsWindowController.swift
+++ b/Sources/KiwiDesk/Settings/SettingsWindowController.swift
@@ -99,7 +99,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
                 height: 620
             ),
             styleMask: [
-                .titled, .closable, .miniaturizable,
+                .titled, .closable,
                 .resizable, .fullSizeContentView,
             ],
             backing: .buffered,

--- a/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
+++ b/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
@@ -25,7 +25,7 @@
 /// guard against the real file.
 public enum KiwiDeskVersion {
     /// Semantic version, bumped per release.
-    public static let semantic = "0.9.1"
+    public static let semantic = "0.9.2"
 
     /// Short commit SHA of the build, stamped by the release
     /// workflow; `"unknown"` in every other build.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -998,6 +998,19 @@ frames across monitors before. (#445)
 
 ## Settings GUI & UX
 
+### Settings window non-miniaturizable
+
+**[Rationale]**
+
+**The Settings window disables the miniaturize button (`.miniaturizable`
+removed).** Minimizing the Settings window leaves KiwiDesk in an
+active-but-invisible foreground state (`.regular`), causing macOS focus
+handoff ambiguity where foreground PID checks (`focusedCommandDenial`)
+fail and focus commands get blocked. Removing `.miniaturizable` ensures the
+Settings window is only ever closed, which cleanly triggers the
+`windowWillClose` teardown path and returns focus to the active managed
+workspace window.
+
 ### Open at login
 
 **[Principle]**


### PR DESCRIPTION
## Summary
- Disables the yellow miniaturize/minimize button on the Settings window by removing `.miniaturizable` from the style mask.
- Bumps semantic version to `0.9.2`.

## Rationale
Minimizing the Settings window left KiwiDesk in an active-but-invisible foreground state, causing focus handoff ambiguity. Disabling the miniaturize button ensures Settings is only ever closed, which triggers the clean `windowWillClose` teardown path and returns focus cleanly to the active managed workspace window.