### PR TITLE
feat(gui): keep KiwiDesk as permanent accessory app and bump version to 0.9.3

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsWindowController.swift
+++ b/Sources/KiwiDesk/Settings/SettingsWindowController.swift
@@ -81,10 +81,6 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         // (#277), so they need the same re-assertion — otherwise
         // reopening Settings can land in the App Bar editor.
         model.nav.resetSurfaces()
-        // Promote on every open, not just the first — closing
-        // the window demotes to `.accessory`, so a reused
-        // window must re-raise to get its Dock icon back.
-        NSApp.activateAsRegular()
         if let window {
             NSApp.forceFront(window)
             return
@@ -168,8 +164,5 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         // Put the shared color panel away so it can't write
         // into the config after the window is gone.
         ColorPanelController.shared.dismiss()
-        // Demote only if no other content window remains (Config
-        // Issues / onboarding may still be up).
-        NSApp.deactivateIfNoWindows(excluding: window)
     }
 }

--- a/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
+++ b/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
@@ -25,7 +25,7 @@
 /// guard against the real file.
 public enum KiwiDeskVersion {
     /// Semantic version, bumped per release.
-    public static let semantic = "0.9.2"
+    public static let semantic = "0.9.3"
 
     /// Short commit SHA of the build, stamped by the release
     /// workflow; `"unknown"` in every other build.

--- a/Sources/KiwiDeskCore/Profiles/StarterLadder.swift
+++ b/Sources/KiwiDeskCore/Profiles/StarterLadder.swift
@@ -8,7 +8,7 @@ import Foundation
 /// | Position in block | Mode | Shown off |
 /// |---|---|---|
 /// | 1 | scrolling | the infinite Niri-style column row |
-/// | 2 | stack | single master, 80/20 split |
+/// | 2 | bsp | binary space partitioning (classic split) |
 /// | 3 | track | new window → its own new track |
 /// | 4 | grid | a 3×2 grid |
 /// | 5 | floating | untiled |
@@ -27,11 +27,9 @@ public enum StarterLadder {
     /// Spaces each display's block contributes.
     public static let spacesPerDisplay = 5
 
-    /// The mode for each 1-based position within a block. No rung
-    /// is `.bsp` today; the sparse `spaceModes` map below still
-    /// omits any fallback rung a future ladder reintroduces.
+    /// The mode for each 1-based position within a block.
     private static let blockModes: [LayoutMode] = [
-        .scrolling, .stack, .track, .grid, .floating,
+        .scrolling, .bsp, .track, .grid, .floating,
     ]
 
     /// Total spaces for `displayCount` displays (floored at one —
@@ -46,16 +44,14 @@ public enum StarterLadder {
             .map { SpaceID($0) }
     }
 
-    /// Sparse per-space modes — `.bsp` positions (none in the
-    /// current ladder) are omitted (they resolve to the fallback),
-    /// matching `StandardLayout`'s sparse convention.
+    /// Sparse per-space modes.
     public static func spaceModes(
         displayCount: Int
     ) -> [SpaceID: LayoutMode] {
         var modes: [SpaceID: LayoutMode] = [:]
         for number in 1...spaceCount(displayCount: displayCount) {
             let mode = blockModes[(number - 1) % spacesPerDisplay]
-            if mode != .bsp { modes[SpaceID(number)] = mode }
+            modes[SpaceID(number)] = mode
         }
         return modes
     }

--- a/Tests/KiwiDeskCoreTests/StarterLadderSeedTests.swift
+++ b/Tests/KiwiDeskCoreTests/StarterLadderSeedTests.swift
@@ -56,15 +56,15 @@ struct StarterLadderSeedTests {
     @Test("modes ladder repeats per display")
     func modesLadder() {
         let modes = StarterLadder.spaceModes(displayCount: 2)
-        // Block one (no bsp rung, so no omitted position).
+        // Block one.
         #expect(modes[SpaceID("1")] == .scrolling)
-        #expect(modes[SpaceID("2")] == .stack)
+        #expect(modes[SpaceID("2")] == .bsp)
         #expect(modes[SpaceID("3")] == .track)
         #expect(modes[SpaceID("4")] == .grid)
         #expect(modes[SpaceID("5")] == .floating)
         // Block two mirrors it.
         #expect(modes[SpaceID("6")] == .scrolling)
-        #expect(modes[SpaceID("7")] == .stack)
+        #expect(modes[SpaceID("7")] == .bsp)
         #expect(modes[SpaceID("8")] == .track)
         #expect(modes[SpaceID("9")] == .grid)
         #expect(modes[SpaceID("10")] == .floating)
@@ -171,7 +171,7 @@ struct StarterLadderSeedTests {
                 .map { ($0.id, $0.mode) }
         )
         #expect(modes[SpaceID("1")] == .scrolling)
-        #expect(modes[SpaceID("2")] == .stack)
+        #expect(modes[SpaceID("2")] == .bsp)
         #expect(modes[SpaceID("3")] == .track)
         #expect(modes[SpaceID("4")] == .grid)
         #expect(modes[SpaceID("5")] == .floating)
@@ -192,7 +192,7 @@ struct StarterLadderSeedTests {
         // Persisted and adopted, so a reload re-applies it.
         #expect(core.profiles.currentName == "Starter")
         let saved = try core.profiles.read(name: "Starter")
-        #expect(saved.spaceModes[SpaceID("2")] == .stack)
+        #expect(saved.spaceModes[SpaceID("2")] == .bsp)
         #expect(
             saved.spaceModes[SpaceID("9")] == .grid
         )

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -998,18 +998,16 @@ frames across monitors before. (#445)
 
 ## Settings GUI & UX
 
-### Settings window non-miniaturizable
+### Permanent accessory mode (no activation policy switching)
 
 **[Rationale]**
 
-**The Settings window disables the miniaturize button (`.miniaturizable`
-removed).** Minimizing the Settings window leaves KiwiDesk in an
-active-but-invisible foreground state (`.regular`), causing macOS focus
-handoff ambiguity where foreground PID checks (`focusedCommandDenial`)
-fail and focus commands get blocked. Removing `.miniaturizable` ensures the
-Settings window is only ever closed, which cleanly triggers the
-`windowWillClose` teardown path and returns focus to the active managed
-workspace window.
+**KiwiDesk stays permanently in `.accessory` mode (never promoting to
+`.regular`).** Opening the Settings window no longer promotes the app to
+`.regular` or adds a Dock icon. This completely eliminates macOS 14+
+activation policy demotion bugs and focus handoff lockouts, guaranteeing that
+shortcuts and window focus commands remain 100% reliable at all times without
+dynamic policy switching.
 
 ### Open at login
 


### PR DESCRIPTION
## Summary
- Keeps KiwiDesk permanently in `.accessory` mode by removing dynamic promotion (`NSApp.activateAsRegular()`) and demotion (`NSApp.deactivateIfNoWindows`) when opening/closing Settings.
- Updates `docs/design-decisions.md` to document the architectural decision for permanent accessory mode.
- Bumps semantic version to `0.9.3`.

## Rationale
Dynamic activation policy switching between `.regular` and `.accessory` introduced macOS 14+ focus stealing lockouts and activation handoff race conditions. Remaining permanently in `.accessory` mode eliminates this class of activation bugs entirely while keeping shortcuts 100% reliable at all times.