### PR TITLE
ci(workflows): filter ci.yml by exclusion and guard the list

### DIFF
--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -241,8 +241,35 @@ and locale checks with it.
 
 ## CI
 
-`.github/workflows/ci.yml` builds, lints, and tests on every push
-and on PRs targeting `main`. A red build blocks merging. The
-release build runs as a separate, non-blocking job (#532) — when
-to run it locally instead is decided by the `verify-gate` skill,
-which owns that call.
+`.github/workflows/ci.yml` builds, lints, and tests on pushes to
+`main` and on PRs targeting it, except for changes confined to its
+`paths-ignore` list. A red build blocks merging. The release build
+runs as a separate, non-blocking job (#532) — when to run it
+locally instead is decided by the `verify-gate` skill, which owns
+that call.
+
+**`ci.yml` filters by exclusion; `site.yml` filters by
+inclusion.** Keep it that way. The site build's inputs are a
+closed, small set, so naming them is safe. The app's are open, and
+an include list there fails *open* — add a directory, forget to
+map it, and its suites stop running while CI stays green.
+Excluding is the failure this repo can afford: a missing entry
+costs runner minutes, not correctness. Those minutes are the
+reason the filter exists at all, macOS runners billing at a 10x
+multiplier against the free allowance while the repo is private.
+
+**Add a `paths-ignore` entry only when no test, no build step and
+no lint step reads the path.** The third clause is the one that
+gets skipped: nothing under `Tests/` reads `Package.swift`,
+`.swift-format` or `.swiftlint.yml`, so a test-only audit clears
+them, and ignoring any would skip CI for a change that alters what
+compiles. `CiPathFilterTests` holds all three clauses, pins the
+`push` and `pull_request` copies equal — the Actions parser
+rejects YAML anchors, so the list is hand-mirrored — and states in
+its own doc comment what it cannot see.
+
+**A filtered-out workflow does not report at all.** It is not
+skipped-as-success; it produces no check run. Harmless today, and
+the thing to remember when branch protection becomes available
+(#487): a required check naming a filtered workflow waits forever,
+and the fix is a gate job that always runs and reports.

--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - "scripts/build-app.sh"
+  - "scripts/protect-main.sh"
   - "scripts/release.sh"
   - "scripts/bump-version.sh"
   - "scripts/install-hooks.sh"
@@ -259,17 +260,26 @@ reason the filter exists at all, macOS runners billing at a 10x
 multiplier against the free allowance while the repo is private.
 
 **Add a `paths-ignore` entry only when no test, no build step and
-no lint step reads the path.** The third clause is the one that
-gets skipped: nothing under `Tests/` reads `Package.swift`,
-`.swift-format` or `.swiftlint.yml`, so a test-only audit clears
-them, and ignoring any would skip CI for a change that alters what
-compiles. `CiPathFilterTests` holds all three clauses, pins the
-`push` and `pull_request` copies equal — the Actions parser
-rejects YAML anchors, so the list is hand-mirrored — and states in
-its own doc comment what it cannot see.
+no lint step reads the path** — and audit all three, not just the
+first. `CiPathFilterTests` holds the line, pins the `push` and
+`pull_request` copies equal (the Actions parser rejects YAML
+anchors, so the list is hand-mirrored), and states in its own doc
+comment what it cannot see. Read that before adding an entry; a
+deep multi-component path earns much weaker cover than a whole
+top-level directory.
+
+**A path a rule file pins is a path the suite reads.**
+`InstructionPinTests` resolves every non-glob `paths:` entry in
+`.claude/rules/*.md`, so ignoring one makes its rename a
+CI-skipping change that reds `main` afterwards. `docs/**` looked
+like the safest entry on the list for exactly the wrong reason —
+no test opens a docs page, but `localization.md` pins two — and it
+reached review before the guard grew a check for it.
 
 **A filtered-out workflow does not report at all.** It is not
-skipped-as-success; it produces no check run. Harmless today, and
-the thing to remember when branch protection becomes available
-(#487): a required check naming a filtered workflow waits forever,
-and the fix is a gate job that always runs and reports.
+skipped-as-success; it produces no check run. Harmless while the
+repo is private, and load-bearing the day branch protection
+arrives (#487): `scripts/protect-main.sh` requires two job names,
+and a PR confined to an ignored path would wait forever on a check
+that never appears. That script carries the hazard and the fix —
+a third job with no path filter that always reports.

--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -243,11 +243,12 @@ and locale checks with it.
 ## CI
 
 `.github/workflows/ci.yml` builds, lints, and tests on pushes to
-`main` and on PRs targeting it, except for changes confined to its
-`paths-ignore` list. A red build blocks merging. The release build
-runs as a separate, non-blocking job (#532) — when to run it
-locally instead is decided by the `verify-gate` skill, which owns
-that call.
+`main` and on PRs targeting it. Both jobs are gated on a `changes`
+job, so a change confined to `.github/ci-ignore.txt`'s list leaves
+them skipped. A red build blocks merging. The release build runs
+as a separate, non-blocking job (#532) — when to run it locally
+instead is decided by the `verify-gate` skill, which owns that
+call.
 
 **`ci.yml` filters by exclusion; `site.yml` filters by
 inclusion.** Keep it that way. The site build's inputs are a
@@ -259,14 +260,23 @@ costs runner minutes, not correctness. Those minutes are the
 reason the filter exists at all, macOS runners billing at a 10x
 multiplier against the free allowance while the repo is private.
 
-**Add a `paths-ignore` entry only when no test, no build step and
-no lint step reads the path** — and audit all three, not just the
-first. `CiPathFilterTests` holds the line, pins the `push` and
-`pull_request` copies equal (the Actions parser rejects YAML
-anchors, so the list is hand-mirrored), and states in its own doc
-comment what it cannot see. Read that before adding an entry; a
-deep multi-component path earns much weaker cover than a whole
-top-level directory.
+**Gate the expensive jobs, never the trigger.** A workflow filtered
+out by `paths-ignore` never reports a check run at all — not
+skipped-as-success, absent — so a required status check waits
+forever on it. A job skipped by `if:` satisfies one. Both shapes
+save the same macOS minutes; only the second survives
+`scripts/protect-main.sh` (#487). `ci.yml` therefore always
+triggers, and a cheap `ubuntu-latest` `changes` job reads
+`.github/ci-ignore.txt` and gates the two macOS jobs on its
+output.
+
+**Add an entry to `.github/ci-ignore.txt` only when no test, no
+build step and no lint step reads the path** — and audit all three,
+not just the first. `CiPathFilterTests` holds the line, checks the
+workflow still consults the list and still gates on it, and states
+in its own doc comment what it cannot see. Read that before adding
+an entry; a deep multi-component path earns much weaker cover than
+a whole top-level directory.
 
 **A path a rule file pins is a path the suite reads.**
 `InstructionPinTests` resolves every non-glob `paths:` entry in
@@ -275,11 +285,3 @@ CI-skipping change that reds `main` afterwards. `docs/**` looked
 like the safest entry on the list for exactly the wrong reason —
 no test opens a docs page, but `localization.md` pins two — and it
 reached review before the guard grew a check for it.
-
-**A filtered-out workflow does not report at all.** It is not
-skipped-as-success; it produces no check run. Harmless while the
-repo is private, and load-bearing the day branch protection
-arrives (#487): `scripts/protect-main.sh` requires two job names,
-and a PR confined to an ignored path would wait forever on a check
-that never appears. That script carries the hazard and the fix —
-a third job with no path filter that always reports.

--- a/.claude/skills/verify-gate/SKILL.md
+++ b/.claude/skills/verify-gate/SKILL.md
@@ -14,9 +14,9 @@ Default to the full gate below. One narrow exception, and it is
 about running the gate that *can* catch something rather than
 about saving time:
 
-- Read `paths-ignore` from `.github/workflows/ci.yml`. Never
-  restate that list here — it is the one authority, and
-  `CiPathFilterTests` is what keeps it honest.
+- Read `.github/ci-ignore.txt`. Never restate that list here — it
+  is the one authority, shared with the `changes` job in `ci.yml`,
+  and `CiPathFilterTests` is what keeps it honest.
 - If `git diff --name-only` against the base is **entirely**
   inside that list, the Swift gate cannot be affected: nothing the
   build, the lint or the suite reads is in it. Skip steps 1–3.

--- a/.claude/skills/verify-gate/SKILL.md
+++ b/.claude/skills/verify-gate/SKILL.md
@@ -20,17 +20,17 @@ about saving time:
 - If `git diff --name-only` against the base is **entirely**
   inside that list, the Swift gate cannot be affected: nothing the
   build, the lint or the suite reads is in it. Skip steps 1–3.
-- Then run the gate that *is* affected. For a change touching
-  `docs/` or `site/`, that is the site build — `npm ci &&
-  npm run build` in `site/`, which is what a missing Starlight
-  frontmatter block breaks. Today the full gate spends minutes on
-  Swift tests that cannot fail and never builds the site, which
-  is backwards for that change.
-- Anything else is the full gate. In particular `AGENTS.md`,
-  `.claude/rules/**` and `.claude/agents/**` are **not** in the
-  ignore list and are **not** exempt: `RuleCitationTests` and
-  `InstructionPinTests` read that tree, and a prose-only edit
-  there has already shipped a dangling citation.
+- **Anything else runs the full gate.** `docs/`, `AGENTS.md`,
+  `.claude/rules/**` and `.claude/agents/**` are deliberately not
+  on the ignore list, so "it's only prose" is not a reason to
+  skip: `RuleCitationTests` and `InstructionPinTests` read that
+  tree — including paths a rule file *pins*, which is why
+  `docs/**` is not ignorable — and a prose-only edit there has
+  already shipped a dangling citation.
+- **Additionally**, when the change touches `docs/` or `site/`,
+  run the site build — `npm ci && npm run build` in `site/`. It
+  is a separate gate, not a substitute: a missing Starlight
+  frontmatter block breaks the site and no Swift test can see it.
 
 Say in the report which gate you ran and why.
 

--- a/.claude/skills/verify-gate/SKILL.md
+++ b/.claude/skills/verify-gate/SKILL.md
@@ -8,6 +8,32 @@ delegates here — in order, and report the result of each step.
 Stop and surface the failure the moment a step fails; do not
 continue to later steps.
 
+## Which gate the change earns
+
+Default to the full gate below. One narrow exception, and it is
+about running the gate that *can* catch something rather than
+about saving time:
+
+- Read `paths-ignore` from `.github/workflows/ci.yml`. Never
+  restate that list here — it is the one authority, and
+  `CiPathFilterTests` is what keeps it honest.
+- If `git diff --name-only` against the base is **entirely**
+  inside that list, the Swift gate cannot be affected: nothing the
+  build, the lint or the suite reads is in it. Skip steps 1–3.
+- Then run the gate that *is* affected. For a change touching
+  `docs/` or `site/`, that is the site build — `npm ci &&
+  npm run build` in `site/`, which is what a missing Starlight
+  frontmatter block breaks. Today the full gate spends minutes on
+  Swift tests that cannot fail and never builds the site, which
+  is backwards for that change.
+- Anything else is the full gate. In particular `AGENTS.md`,
+  `.claude/rules/**` and `.claude/agents/**` are **not** in the
+  ignore list and are **not** exempt: `RuleCitationTests` and
+  `InstructionPinTests` read that tree, and a prose-only edit
+  there has already shipped a dangling citation.
+
+Say in the report which gate you ran and why.
+
 ## Fast inner loop
 
 1. `swift build`

--- a/.github/ci-ignore.txt
+++ b/.github/ci-ignore.txt
@@ -1,0 +1,27 @@
+# Paths whose change alone cannot affect the CI build, lint or test
+# jobs. The `changes` job in ci.yml reads this file and gates the two
+# macOS jobs on it; CiPathFilterTests guards the contents.
+#
+# This is an EXCLUDE list, deliberately the opposite shape from
+# site.yml's includes. The site build's inputs are a closed, small
+# set, so naming them is safe. The app's are open, and an include
+# list there fails open — add a directory, forget to map it, and its
+# suites stop running while CI stays green. Excluding fails closed.
+#
+# An entry belongs here only when NO test, NO build step and NO lint
+# step reads the path — and a path a rule file pins in its `paths:`
+# block counts as read. packaging-and-release.md ("CI") carries the
+# argument and the cases that have already caught someone out.
+#
+# One entry per line. An entry must be an exact repo-relative path
+# or `dir/**`; any other glob shape is rejected, because everything
+# that checks this file compares by prefix.
+
+site/**
+README.md
+CONTRIBUTING.md
+SECURITY.md
+CLAUDE.md
+LICENSE
+.github/ISSUE_TEMPLATE/**
+.github/pull_request_template.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,56 @@ name: CI
 # branches. Scoping push to main avoids a duplicate run on every
 # PR-branch push (which would otherwise fire both push and
 # pull_request for the same commit).
+#
+# `paths-ignore` is an EXCLUDE list, deliberately, and the opposite
+# shape from site.yml's includes. The site build has a closed, small
+# input set, so naming it is safe. The app's inputs are open: an
+# include list would fail *open* — add a directory, forget to map
+# it, and its tests silently stop running while CI stays green. An
+# exclude list fails closed; forgetting an entry costs minutes, not
+# correctness.
+#
+# An entry belongs here only when NO test, NO build step and NO lint
+# step reads the path. That third clause is the trap: nothing under
+# Tests/ reads Package.swift, .swift-format or .swiftlint.yml, and
+# excluding any of them would skip CI for a change that alters what
+# compiles. CiPathFilterTests holds the line, and states what it
+# cannot see.
+#
+# docs/ and site/ are here because site.yml already covers them —
+# not because they are unimportant. assets/ is deliberately absent:
+# site.yml wants it AND two Core suites read the tree.
+# The two lists below are identical and must stay that way. A YAML
+# anchor would say so in one place, but the Actions parser rejects
+# anchors, so this is a hand-mirrored list — CiPathFilterTests pins
+# the copies equal (AGENTS.md §5, parity-tests.md).
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "SECURITY.md"
+      - "CLAUDE.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
+      - ".github/workflows/site.yml"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "SECURITY.md"
+      - "CLAUDE.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
+      - ".github/workflows/site.yml"
   # Manual "Run workflow" button in the Actions tab. Additive — the
   # automatic triggers above still fire. Useful while the repo is
   # private, where macOS runners bill at a 10x multiplier against a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,54 +5,23 @@ name: CI
 # PR-branch push (which would otherwise fire both push and
 # pull_request for the same commit).
 #
-# `paths-ignore` is an EXCLUDE list, deliberately, and the opposite
-# shape from site.yml's includes. The site build has a closed, small
-# input set, so naming it is safe. The app's inputs are open: an
-# include list would fail *open* — add a directory, forget to map
-# it, and its tests silently stop running while CI stays green. An
-# exclude list fails closed; forgetting an entry costs minutes, not
-# correctness.
+# The expensive jobs are gated on a `changes` job rather than on a
+# trigger-level `paths-ignore`, and that is the whole point: a
+# workflow filtered out at the trigger never reports a check run at
+# all, so a required status check would wait forever on it. A job
+# *skipped* by `if:` satisfies a required check. Same macOS minutes
+# saved either way; only this shape survives branch protection
+# (#487, scripts/protect-main.sh).
 #
-# An entry belongs here only when NO test, NO build step and NO lint
-# step reads the path — and a path a rule file pins in its `paths:`
-# block counts as read, because InstructionPinTests resolves those.
-# CiPathFilterTests holds the line and states what it cannot see;
-# packaging-and-release.md ("CI") carries the argument.
-#
-# What is NOT here is as deliberate as what is. assets/ is read by
-# two Core suites. docs/ looked safe — no test opens a docs page —
-# but `.claude/rules/localization.md` pins two of them in its
-# `paths:` block and InstructionPinTests resolves every such pin,
-# so renaming one is a docs-only change that reds main afterwards.
-# `.github/workflows/site.yml` is pinned the same way by site.md.
-# A path a rule file pins is a path the suite reads.
-# The two lists below are identical and must stay that way. A YAML
-# anchor would say so in one place, but the Actions parser rejects
-# anchors, so this is a hand-mirrored list — CiPathFilterTests pins
-# the copies equal (AGENTS.md §5, parity-tests.md).
+# The list itself lives in .github/ci-ignore.txt — one authority,
+# read by the job below, by CiPathFilterTests and by the
+# verify-gate skill. packaging-and-release.md ("CI") owns when an
+# entry may be added.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "site/**"
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "SECURITY.md"
-      - "CLAUDE.md"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "site/**"
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "SECURITY.md"
-      - "CLAUDE.md"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
   # Manual "Run workflow" button in the Actions tab. Additive — the
   # automatic triggers above still fire. Useful while the repo is
   # private, where macOS runners bill at a 10x multiplier against a
@@ -65,7 +34,83 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    # ubuntu, not macOS: this runs on every push and bills at 1x.
+    # It exists to stop the two 10x jobs below, so it has to be
+    # cheap enough that the trade is never in question.
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Both diff bases below are commits on this repo, and a
+          # shallow clone would not contain them.
+          fetch-depth: 0
+
+      - name: Decide whether the build jobs must run
+        id: filter
+        env:
+          EVENT: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Every unknown resolves to "run". A false negative here
+          # skips CI on a real change and is invisible; a false
+          # positive costs one build.
+          case "$EVENT" in
+            pull_request) base="$BASE" ;;
+            push)         base="$BEFORE" ;;
+            *)            base="" ;;
+          esac
+          if [ -z "$base" ] \
+            || [ "$base" = "0000000000000000000000000000000000000000" ] \
+            || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "no usable base for $EVENT — running everything"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$EVENT" = "pull_request" ]; then
+            changed="$(git diff --name-only "$base"...HEAD)"
+          else
+            changed="$(git diff --name-only "$base" HEAD)"
+          fi
+          if [ -z "$changed" ]; then
+            echo "empty diff — running everything"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          run=false
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            ignored=false
+            while IFS= read -r pattern; do
+              case "$pattern" in ''|\#*) continue ;; esac
+              case "$pattern" in
+                */'**')
+                  case "$file" in
+                    "${pattern%/\*\*}"/*) ignored=true ;;
+                  esac
+                  ;;
+                *)
+                  [ "$file" = "$pattern" ] && ignored=true
+                  ;;
+              esac
+              [ "$ignored" = true ] && break
+            done < .github/ci-ignore.txt
+            if [ "$ignored" = false ]; then
+              echo "not ignored: $file"
+              run=true
+              break
+            fi
+          done <<< "$changed"
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
   build-lint-test:
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     name: Build, Lint & Test
     # macos-26 (Tahoe), not macos-15: the tree uses macOS 26 SDK
     # symbols (NSGlassEffectView, #390). `if #available` gates
@@ -101,6 +146,8 @@ jobs:
         run: swift test --filter ExecTests
 
   release-build:
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     name: Release Build
     # A sibling job, not a fourth step in build-lint-test: `swift
     # test` there already compiles the tree in debug, so building

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,18 @@ name: CI
 # correctness.
 #
 # An entry belongs here only when NO test, NO build step and NO lint
-# step reads the path. That third clause is the trap: nothing under
-# Tests/ reads Package.swift, .swift-format or .swiftlint.yml, and
-# excluding any of them would skip CI for a change that alters what
-# compiles. CiPathFilterTests holds the line, and states what it
-# cannot see.
+# step reads the path — and a path a rule file pins in its `paths:`
+# block counts as read, because InstructionPinTests resolves those.
+# CiPathFilterTests holds the line and states what it cannot see;
+# packaging-and-release.md ("CI") carries the argument.
 #
-# docs/ and site/ are here because site.yml already covers them —
-# not because they are unimportant. assets/ is deliberately absent:
-# site.yml wants it AND two Core suites read the tree.
+# What is NOT here is as deliberate as what is. assets/ is read by
+# two Core suites. docs/ looked safe — no test opens a docs page —
+# but `.claude/rules/localization.md` pins two of them in its
+# `paths:` block and InstructionPinTests resolves every such pin,
+# so renaming one is a docs-only change that reds main afterwards.
+# `.github/workflows/site.yml` is pinned the same way by site.md.
+# A path a rule file pins is a path the suite reads.
 # The two lists below are identical and must stay that way. A YAML
 # anchor would say so in one place, but the Actions parser rejects
 # anchors, so this is a hand-mirrored list — CiPathFilterTests pins
@@ -32,7 +35,6 @@ on:
     branches: [main]
     paths-ignore:
       - "site/**"
-      - "docs/**"
       - "README.md"
       - "CONTRIBUTING.md"
       - "SECURITY.md"
@@ -40,12 +42,10 @@ on:
       - "LICENSE"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/pull_request_template.md"
-      - ".github/workflows/site.yml"
   pull_request:
     branches: [main]
     paths-ignore:
       - "site/**"
-      - "docs/**"
       - "README.md"
       - "CONTRIBUTING.md"
       - "SECURITY.md"
@@ -53,7 +53,6 @@ on:
       - "LICENSE"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/pull_request_template.md"
-      - ".github/workflows/site.yml"
   # Manual "Run workflow" button in the Actions tab. Additive — the
   # automatic triggers above still fire. Useful while the repo is
   # private, where macOS runners bill at a 10x multiplier against a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,9 +159,9 @@ traced at directory altitude — see **`docs/architecture.md`**.
    ([`.claude/skills/verify-gate`](.claude/skills/verify-gate/SKILL.md))
    — `swift build`, the test run, `scripts/lint.sh`,
    and the release build when the change touches concurrency or
-   `Sendable`. That skill owns the procedure — what to run, in
-   what order, and when CI's `Release Build` job substitutes for
-   a local one.
+   `Sendable`. That skill owns the procedure — which gate a change
+   earns, what to run, in what order, and when CI's `Release
+   Build` job substitutes for a local one.
 5. **Document:** any user-visible behavior change updates the
    matching doc in the same change set — code and docs must
    never describe different behavior. Which doc owns what, and
@@ -232,8 +232,11 @@ scripts.
   `--non-interactive` avoids a hang when piped; scope it with
   `--only claude`, `--minimal`, or `--uninstall`.
 - CI (`.github/workflows/ci.yml`) builds, lints and tests on
-  every push and on PRs targeting `main`. A red build blocks
-  merging.
+  pushes to `main` and on PRs targeting it, unless the change is
+  confined to its `paths-ignore` list. A red build blocks
+  merging. Adding an entry to that list needs
+  [packaging-and-release.md](.claude/rules/packaging-and-release.md)
+  — the test suite is not the only thing that reads a path.
 
 ### Subagent delegation (AI agents)
 
@@ -297,7 +300,7 @@ touch a matching path.
 | `Localization`, `Resources/Locales`, `scripts/*key*` | [localization.md](.claude/rules/localization.md) | Never hand-edit a catalog — the scripts own them; positional specifiers only; content guards with no exemption file; Core names, the GUI narrates (#96) |
 | `Tests/**` | [tests.md](.claude/rules/tests.md) | Pin the display in every geometry fixture (#531); split suites early; generous hang-guards, never tight deadlines (#344); reach the machine only through injected seams (hotkeys #565, menu-bar slots — `MachineTouchTests`, `StatusItemSeamGuardTests`) |
 | Any hand-mirrored field list | [parity-tests.md](.claude/rules/parity-tests.md) | Past two mirrors, ship a forget-proof parity test — reflection over a hand-listed one |
-| `scripts/build-app.sh`, `scripts/release.sh`, `Package.swift`, workflows | [packaging-and-release.md](.claude/rules/packaging-and-release.md) | Every distributable artifact needs its own notarization ticket, and the build machine is the one place that failure is invisible; cut a release with `scripts/release.sh` — it stamps the version before creating the tag, so the two cannot disagree (#32) |
+| `scripts/build-app.sh`, `scripts/release.sh`, `Package.swift`, workflows | [packaging-and-release.md](.claude/rules/packaging-and-release.md) | Every distributable artifact needs its own notarization ticket, and the build machine is the one place that failure is invisible; cut a release with `scripts/release.sh` — it stamps the version before creating the tag, so the two cannot disagree (#32); `ci.yml` filters by exclusion and an entry needs no test, no build step and no lint step to read the path (`CiPathFilterTests`) |
 | `.claude/rules/**`, `.claude/agents/**`, `AGENTS.md` | [rule-authoring.md](.claude/rules/rule-authoring.md) | Write an obligation, not a state claim — a claim that stays names its guard inline, and a number-pin derives the number rather than restating it (#614); `RuleCitationTests` resolves the citations in all three |
 | `.claude/agents/**`, `scripts/sync-agents.sh` | [subagents.md](.claude/rules/subagents.md) | An agent routes to the owning rule file and never restates a fact from it; a judging agent gets no `Write`/`Edit` and says so in prose, which is what survives into the Codex mirror; write the `description` as *when to use this*, naming concrete triggers; regenerate the mirror with `scripts/sync-agents.sh` in the same change |
 | `docs/**` | [docs.md](.claude/rules/docs.md) | Which doc owns what, and the design-decisions charter (argue the rule, never log the event) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,11 +128,12 @@ traced at directory altitude — see **`docs/architecture.md`**.
    readable duplication over a deep protocol hierarchy or heavy
    generics. Keep code flat.
 5. **Formatting:** `swift format` with the repo's `.swift-format`
-   config owns all style. SwiftLint (SPM build plugin,
-   `.swiftlint.yml`) owns semantic rules — force casts,
-   complexity, file length — and warns in Xcode during builds.
-   Never enable a SwiftLint style rule that fights swift-format.
-   Run `scripts/lint.sh` before committing — its **exit code**
+   config owns all style, and `scripts/lint.sh` additionally
+   enforces the §2.1 line-length and file-size limits. Linting is
+   its own step, **not** a build-tool plugin — `Package.swift`
+   carries why the SwiftLint prebuild plugin was removed, so
+   `.swiftlint.yml` no longer runs during a build. Run
+   `scripts/lint.sh` before committing — its **exit code**
    decides, not its warnings.
 6. **Concurrency:** AppKit/AX interaction is `@MainActor`. Pure
    state and layout code stays actor-free and unit-testable.
@@ -232,9 +233,10 @@ scripts.
   `--non-interactive` avoids a hang when piped; scope it with
   `--only claude`, `--minimal`, or `--uninstall`.
 - CI (`.github/workflows/ci.yml`) builds, lints and tests on
-  pushes to `main` and on PRs targeting it, unless the change is
-  confined to its `paths-ignore` list. A red build blocks
-  merging. Adding an entry to that list needs
+  pushes to `main` and on PRs targeting it. Its two macOS jobs are
+  gated on a `changes` job, so a change confined to
+  `.github/ci-ignore.txt`'s list leaves them skipped. A red build
+  blocks merging. Adding an entry to that list needs
   [packaging-and-release.md](.claude/rules/packaging-and-release.md)
   — the test suite is not the only thing that reads a path.
 
@@ -300,7 +302,7 @@ touch a matching path.
 | `Localization`, `Resources/Locales`, `scripts/*key*` | [localization.md](.claude/rules/localization.md) | Never hand-edit a catalog — the scripts own them; positional specifiers only; content guards with no exemption file; Core names, the GUI narrates (#96) |
 | `Tests/**` | [tests.md](.claude/rules/tests.md) | Pin the display in every geometry fixture (#531); split suites early; generous hang-guards, never tight deadlines (#344); reach the machine only through injected seams (hotkeys #565, menu-bar slots — `MachineTouchTests`, `StatusItemSeamGuardTests`) |
 | Any hand-mirrored field list | [parity-tests.md](.claude/rules/parity-tests.md) | Past two mirrors, ship a forget-proof parity test — reflection over a hand-listed one |
-| `scripts/build-app.sh`, `scripts/release.sh`, `Package.swift`, workflows | [packaging-and-release.md](.claude/rules/packaging-and-release.md) | Every distributable artifact needs its own notarization ticket, and the build machine is the one place that failure is invisible; cut a release with `scripts/release.sh` — it stamps the version before creating the tag, so the two cannot disagree (#32); `ci.yml` filters by exclusion and an entry needs no test, no build step and no lint step to read the path (`CiPathFilterTests`) |
+| `scripts/build-app.sh`, `scripts/release.sh`, `Package.swift`, workflows | [packaging-and-release.md](.claude/rules/packaging-and-release.md) | Every distributable artifact needs its own notarization ticket, and the build machine is the one place that failure is invisible; cut a release with `scripts/release.sh` — it stamps the version before creating the tag, so the two cannot disagree (#32); gate CI's macOS jobs on the `changes` job rather than on a trigger filter, and add a `.github/ci-ignore.txt` entry only when no test, no build step and no lint step reads the path (`CiPathFilterTests`) |
 | `.claude/rules/**`, `.claude/agents/**`, `AGENTS.md` | [rule-authoring.md](.claude/rules/rule-authoring.md) | Write an obligation, not a state claim — a claim that stays names its guard inline, and a number-pin derives the number rather than restating it (#614); `RuleCitationTests` resolves the citations in all three |
 | `.claude/agents/**`, `scripts/sync-agents.sh` | [subagents.md](.claude/rules/subagents.md) | An agent routes to the owning rule file and never restates a fact from it; a judging agent gets no `Write`/`Edit` and says so in prose, which is what survives into the Codex mirror; write the `description` as *when to use this*, naming concrete triggers; regenerate the mirror with `scripts/sync-agents.sh` in the same change |
 | `docs/**` | [docs.md](.claude/rules/docs.md) | Which doc owns what, and the design-decisions charter (argue the rule, never log the event) |

--- a/Tests/KiwiDeskCoreTests/CiPathFilterCollection.swift
+++ b/Tests/KiwiDeskCoreTests/CiPathFilterCollection.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+
+/// Collection and parsing for `CiPathFilterTests`.
+///
+/// Split out under the §2.1 ceiling, not because the halves are
+/// independent: the assertions live next door and these exist only
+/// to feed them. Nothing here asserts, so a change to a walk shows
+/// up as a changed verdict there rather than as a green no-op.
+extension CiPathFilterTests {
+    /// Every `.claude/rules/*.md`, as (name, text).
+    func ruleFiles() throws -> [(String, String)] {
+        let root =
+            repoRoot
+            .appendingPathComponent(".claude")
+            .appendingPathComponent("rules")
+        let names = try FileManager.default
+            .contentsOfDirectory(atPath: root.path)
+            .filter { $0.hasSuffix(".md") }
+            .sorted()
+        #expect(!names.isEmpty, "no rule files found")
+        return try names.map { name in
+            (
+                name,
+                try String(
+                    contentsOf: root.appendingPathComponent(name),
+                    encoding: .utf8
+                )
+            )
+        }
+    }
+
+    @Test("Build and lint inputs are never ignored")
+    func buildInputsStayWatched() throws {
+        let ignored = try entries()
+        var violations: [String] = []
+        for entry in ignored {
+            let prefix = entry.replacingOccurrences(of: "**", with: "")
+            for input in Self.neverIgnorable
+            where input == entry || input.hasPrefix(prefix)
+                || prefix.hasPrefix(input)
+            {
+                violations.append("\(entry) covers \(input)")
+            }
+        }
+        #expect(
+            violations.isEmpty,
+            "paths-ignore covers a build/lint input: \(violations)"
+        )
+    }
+
+    /// Every `.swift` under `Tests/`, as (relative name, text).
+    func testSources() throws -> [(String, String)] {
+        let tests = repoRoot.appendingPathComponent("Tests")
+        var out: [(String, String)] = []
+        let walker = FileManager.default.enumerator(atPath: tests.path)
+        let own = "KiwiDeskCoreTests/CiPathFilterTests.swift"
+        while let entry = walker?.nextObject() as? String {
+            guard entry.hasSuffix(".swift") else { continue }
+            // This file names ignored paths as data — its `allowed`
+            // map and its doc comment — so scanning it would report
+            // the guard against itself. It reads only `ci.yml` and
+            // `Tests/`, neither of which is ignorable.
+            guard entry != own else { continue }
+            out.append(
+                (
+                    entry,
+                    try String(
+                        contentsOf: tests.appendingPathComponent(entry),
+                        encoding: .utf8
+                    )
+                )
+            )
+        }
+        return out
+    }
+
+    /// One YAML list value: either quote style, no trailing
+    /// comment.
+    ///
+    /// Stripping only the outer double quotes leaves
+    /// `- "docs/**"  # covered by site.yml` parsed as a path
+    /// nothing can match — and because both hand-mirrored copies
+    /// mangle identically, `listsMatch` stays green while checks
+    /// (2), (3) and (4) quietly stop covering that entry.
+    static func scalar(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespaces)
+        if !value.hasPrefix("#"), let hash = value.range(of: " #") {
+            value = String(value[..<hash.lowerBound])
+        }
+        value = value.trimmingCharacters(in: .whitespaces)
+        for quote in ["\"", "'"] where value.hasPrefix(quote) {
+            value = String(value.dropFirst())
+            if value.hasSuffix(quote) { value = String(value.dropLast()) }
+            break
+        }
+        return value
+    }
+
+    /// Each `paths-ignore:` block with the trigger that owns it.
+    ///
+    /// The trigger is recorded because two lists being equal says
+    /// nothing about *which* events they filter — a block moved
+    /// under a third trigger parses identically.
+    static func ignoreLists(
+        _ text: String
+    ) -> [(trigger: String, entries: [String])] {
+        var out: [(trigger: String, entries: [String])] = []
+        var current: [String]?
+        var trigger = ""
+        var pending = ""
+        for raw in text.split(
+            separator: "\n",
+            omittingEmptySubsequences: false
+        ) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.hasSuffix(":"), !line.hasPrefix("-") {
+                let key = String(line.dropLast())
+                if key == "push" || key == "pull_request" {
+                    pending = key
+                }
+            }
+            if line == "paths-ignore:" {
+                if let current { out.append((trigger, current)) }
+                trigger = pending
+                current = []
+                continue
+            }
+            guard current != nil else { continue }
+            if line.hasPrefix("#") { continue }
+            guard line.hasPrefix("- ") else {
+                if !line.isEmpty {
+                    out.append((trigger, current!))
+                    current = nil
+                }
+                continue
+            }
+            current?.append(Self.scalar(String(line.dropFirst(2))))
+        }
+        if let current { out.append((trigger, current)) }
+        return out
+    }
+}

--- a/Tests/KiwiDeskCoreTests/CiPathFilterCollection.swift
+++ b/Tests/KiwiDeskCoreTests/CiPathFilterCollection.swift
@@ -75,69 +75,51 @@ extension CiPathFilterTests {
         return out
     }
 
-    /// One YAML list value: either quote style, no trailing
-    /// comment.
+    /// The ignore entries, refusing an empty parse.
     ///
-    /// Stripping only the outer double quotes leaves
-    /// `- "docs/**"  # covered by site.yml` parsed as a path
-    /// nothing can match — and because both hand-mirrored copies
-    /// mangle identically, `listsMatch` stays green while checks
-    /// (2), (3) and (4) quietly stop covering that entry.
-    static func scalar(_ raw: String) -> String {
-        var value = raw.trimmingCharacters(in: .whitespaces)
-        if !value.hasPrefix("#"), let hash = value.range(of: " #") {
-            value = String(value[..<hash.lowerBound])
-        }
-        value = value.trimmingCharacters(in: .whitespaces)
-        for quote in ["\"", "'"] where value.hasPrefix(quote) {
-            value = String(value.dropFirst())
-            if value.hasSuffix(quote) { value = String(value.dropLast()) }
-            break
-        }
-        return value
-    }
-
-    /// Each `paths-ignore:` block with the trigger that owns it.
-    ///
-    /// The trigger is recorded because two lists being equal says
-    /// nothing about *which* events they filter — a block moved
-    /// under a third trigger parses identically.
-    static func ignoreLists(
-        _ text: String
-    ) -> [(trigger: String, entries: [String])] {
-        var out: [(trigger: String, entries: [String])] = []
-        var current: [String]?
-        var trigger = ""
-        var pending = ""
-        for raw in text.split(
+    /// One authority: `.github/ci-ignore.txt`. The old shape kept
+    /// the list twice inside `ci.yml` (the Actions parser rejects
+    /// YAML anchors) and needed a parity check to hold the copies
+    /// equal. Moving it out deleted that whole class.
+    func entries() throws -> [String] {
+        let text = try String(
+            contentsOf: Self.ignoreFile(under: repoRoot),
+            encoding: .utf8
+        )
+        let parsed = text.split(
             separator: "\n",
             omittingEmptySubsequences: false
-        ) {
-            let line = raw.trimmingCharacters(in: .whitespaces)
-            if line.hasSuffix(":"), !line.hasPrefix("-") {
-                let key = String(line.dropLast())
-                if key == "push" || key == "pull_request" {
-                    pending = key
-                }
-            }
-            if line == "paths-ignore:" {
-                if let current { out.append((trigger, current)) }
-                trigger = pending
-                current = []
-                continue
-            }
-            guard current != nil else { continue }
-            if line.hasPrefix("#") { continue }
-            guard line.hasPrefix("- ") else {
-                if !line.isEmpty {
-                    out.append((trigger, current!))
-                    current = nil
-                }
-                continue
-            }
-            current?.append(Self.scalar(String(line.dropFirst(2))))
+        )
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+        try #require(!parsed.isEmpty, "no ci-ignore entries")
+        return parsed
+    }
+
+    /// One job's YAML block: its `  name:` line through the line
+    /// before the next key at the same indent.
+    static func jobBlock(_ name: String, in yaml: String) -> String? {
+        let lines = yaml.split(
+            separator: "\n",
+            omittingEmptySubsequences: false
+        )
+        guard let start = lines.firstIndex(where: { $0 == "  \(name):" })
+        else { return nil }
+        var end = lines.index(after: start)
+        while end < lines.endIndex {
+            let line = lines[end]
+            let isSibling =
+                line.hasPrefix("  ") && !line.hasPrefix("   ")
+                && line.hasSuffix(":")
+            if isSibling { break }
+            end = lines.index(after: end)
         }
-        if let current { out.append((trigger, current)) }
-        return out
+        return lines[start..<end].joined(separator: "\n")
+    }
+
+    static func ignoreFile(under root: URL) -> URL {
+        root
+            .appendingPathComponent(".github")
+            .appendingPathComponent("ci-ignore.txt")
     }
 }

--- a/Tests/KiwiDeskCoreTests/CiPathFilterTests.swift
+++ b/Tests/KiwiDeskCoreTests/CiPathFilterTests.swift
@@ -9,26 +9,47 @@ import Testing
 /// in error does not break a build, it stops one from happening,
 /// and a skipped workflow reports success by never reporting.
 ///
-/// Three things are checked, in the order they would bite:
+/// Five things are checked, in the order they would bite:
 ///
-/// 1. The `push:` and `pull_request:` lists are identical. The
-///    Actions parser rejects YAML anchors, so the list is
-///    hand-mirrored and drift would filter the two events
-///    differently — a change tested pre-merge and skipped after,
-///    or the reverse (parity-tests.md).
-/// 2. No ignored path is read by anything under `Tests/`.
-/// 3. The build and lint inputs are never ignored. This is the
-///    clause a test-only audit misses: nothing in `Tests/` reads
-///    `Package.swift`, `.swift-format` or `.swiftlint.yml`, and
-///    ignoring any of them would skip CI for a change that alters
-///    what compiles or what lint enforces.
+/// 1. The `push:` and `pull_request:` lists are identical, and are
+///    the lists those two triggers own. The Actions parser rejects
+///    YAML anchors, so the list is hand-mirrored, and drift would
+///    filter the two events differently — a change tested
+///    pre-merge and skipped after, or the reverse
+///    (parity-tests.md).
+/// 2. Every entry is an exact path or `dir/**`. The other checks
+///    are prefix relations over plain strings, so `*` and `?` are
+///    ordinary characters to them: `Package.*` would ignore
+///    `Package.swift` while matching nothing any of them compares
+///    against. Constraining the shape is what makes the rest sound.
+/// 3. No ignored path appears as a literal under `Tests/`.
+/// 4. No ignored path is *pinned* by a rule file's `paths:` block.
+///    The suite reads those from data rather than from source, so
+///    check (3) is blind to them by construction — which is how
+///    `docs/**` reached review: no test opens a docs page, but
+///    `localization.md` pins two, and `InstructionPinTests`
+///    resolves every such pin.
+/// 5. The build and lint inputs are never ignored — the clause a
+///    test-only audit misses, since nothing in `Tests/` reads
+///    `Package.swift`, `.swift-format` or `.swiftlint.yml`.
 ///
-/// **What this cannot see.** A path assembled from a variable
-/// rather than written as a literal, and a path read only by a
-/// `scripts/` tool the suite shells out to. Check (3) is a
-/// hand-listed floor for the same reason — the build's inputs
-/// cannot be derived from `Tests/`, so they are named here, and
-/// naming them is itself a thing to keep current.
+/// **What this cannot see**, stated plainly because check (3)
+/// promises more than it delivers: a path written as
+/// `.appendingPathComponent` chains is invisible unless its first
+/// component is a whole ignored directory, and that is the repo's
+/// normal idiom — `VerifyGateParityTests` assembles
+/// `.github/workflows/release.yml` from three separate literals,
+/// so ignoring that exact path would pass every check here. Also
+/// invisible: a path reached only by a `scripts/` tool the suite
+/// shells out to, and a path reached case-insensitively (`Docs`
+/// resolves `docs/` on APFS). Check (5) is a hand-listed floor for
+/// the same reason — the build's inputs cannot be derived from
+/// `Tests/`.
+///
+/// The practical consequence: a *multi-component* entry earns far
+/// less protection than a whole-directory one. Prefer ignoring a
+/// whole top-level directory, and treat a deep path as needing
+/// human argument rather than a green suite.
 @Suite("CI path filter")
 struct CiPathFilterTests {
     /// Paths whose change must always run CI, whatever else is
@@ -37,7 +58,6 @@ struct CiPathFilterTests {
     /// step the job runs.
     static let neverIgnorable = [
         "Package.swift",  // defines what is built at all
-        "Package.resolved",  // pins the dependency graph
         ".swift-format",  // scripts/lint.sh --configuration
         ".swiftlint.yml",  // SwiftLint SPM build plugin
         "Sources",
@@ -54,18 +74,23 @@ struct CiPathFilterTests {
     /// a same-named directory built somewhere else. `ScriptFixture`
     /// assembles a `site` directory inside a **temp** tree for the
     /// `extract-keys --site` fixtures; it never reaches the repo's
-    /// `site/`. Add an entry only after confirming the same thing,
-    /// and name the file, so a second use elsewhere still fires.
-    static let allowed = ["site": "ScriptFixture.swift"]
+    /// `site/`. Add an entry only after confirming the same thing.
+    ///
+    /// Keyed by the path relative to `Tests/`, not by filename: a
+    /// same-named file in the other target would otherwise inherit
+    /// an exemption nobody granted it.
+    static let allowed = [
+        "site": "KiwiDeskCoreTests/ScriptFixture.swift"
+    ]
 
-    private var repoRoot: URL {
+    var repoRoot: URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()  // KiwiDeskCoreTests
             .deletingLastPathComponent()  // Tests
             .deletingLastPathComponent()  // repo root
     }
 
-    private var workflow: String {
+    var workflow: String {
         get throws {
             try String(
                 contentsOf:
@@ -81,19 +106,74 @@ struct CiPathFilterTests {
     @Test("Both paths-ignore lists are identical")
     func listsMatch() throws {
         let lists = Self.ignoreLists(try workflow)
-        #expect(lists.count == 2, "found \(lists.count) lists, want 2")
-        #expect(
-            lists.first != [],
-            "a paths-ignore list parsed as empty"
+        // #require, not #expect: with no list parsed, every
+        // comparison below is trivially true (nil != [], nil ==
+        // nil) and only the count would red — pointing at the
+        // wrong thing.
+        try #require(
+            lists.count == 2,
+            "found \(lists.count) lists, want 2"
         )
-        #expect(lists.first == lists.last, "the two lists differ")
+        try #require(
+            lists.map(\.trigger).sorted() == ["pull_request", "push"],
+            "lists came from \(lists.map(\.trigger))"
+        )
+        let first = lists.first?.entries ?? []
+        let last = lists.last?.entries ?? []
+        let parsed = first.count
+        try #require(parsed > 0, "a paths-ignore list parsed as empty")
+        #expect(first == last, "the two lists differ")
+    }
+
+    @Test("Every entry is an exact path or a whole subtree")
+    func entryShapesArePrefixSafe() throws {
+        let ignored = try entries()
+        // Every other check here is a prefix relation over plain
+        // strings, so `*` and `?` are ordinary characters to them:
+        // `Package.*` ignores Package.swift while matching nothing
+        // any check compares against, and `*.md` sweeps AGENTS.md
+        // in past all of them. Rather than teach four checks to
+        // glob, constrain the shape so prefix logic is sound.
+        var malformed: [String] = []
+        for entry in ignored {
+            let body =
+                entry.hasSuffix("/**")
+                ? String(entry.dropLast(3)) : entry
+            if body.contains("*") || body.contains("?") {
+                malformed.append(entry)
+            }
+        }
+        #expect(
+            malformed.isEmpty,
+            """
+            an entry must be an exact path or `dir/**`; these hide \
+            from every prefix check: \(malformed)
+            """
+        )
+    }
+
+    /// The ignore entries, refusing an empty parse.
+    func entries() throws -> [String] {
+        let ignored = Self.ignoreLists(try workflow).first?.entries ?? []
+        try #require(!ignored.isEmpty, "no paths-ignore entries")
+        return ignored
     }
 
     @Test("No ignored path is read by the test suite")
     func ignoredPathsAreUnread() throws {
-        let ignored = try Self.ignoreLists(workflow).first ?? []
-        try #require(!ignored.isEmpty, "no paths-ignore entries")
+        let ignored = try entries()
         let sources = try testSources()
+        // A count alone is a total-failure canary: the margin over
+        // the tree is wide enough that most of the walk could
+        // vanish and still clear it. Requiring both targets catches
+        // a walk that half-failed, which a count cannot.
+        let targets = Set(
+            sources.compactMap { $0.0.split(separator: "/").first }
+        )
+        try #require(
+            targets.count >= 2,
+            "scan covered only \(targets.sorted())"
+        )
         try #require(
             sources.count > 100,
             "only scanned \(sources.count) test files"
@@ -112,19 +192,21 @@ struct CiPathFilterTests {
             // form would give this guard nothing to catch.
             //
             // A deeper entry gets prefix matching only. Its head
-            // says nothing: tests read `.github/workflows/
-            // release.yml` while `.github/workflows/site.yml` is
-            // ignored, so flagging every `.github` would be noise.
+            // says nothing — tests read some paths under `.github`
+            // while others there are ignorable, so flagging every
+            // `.github` would be noise. That weakness is why the
+            // doc comment tells you a deep entry is barely guarded.
             let wholeDirectory = !trimmed.contains("/")
             for (name, text) in sources {
-                if let exempt = Self.allowed[trimmed],
-                    name.hasSuffix(exempt)
-                {
-                    continue
-                }
+                // The exemption covers ONLY the bare-component
+                // needle it was granted for. A rooted `"site/`
+                // literal in the same file is a real read and must
+                // still fire.
+                let exempt = Self.allowed[trimmed] == name
                 let hit =
                     text.contains("\"\(prefix)")
-                    || (wholeDirectory && text.contains("\"\(trimmed)\""))
+                    || (wholeDirectory && !exempt
+                        && text.contains("\"\(trimmed)\""))
                 if hit { violations.append("\(name) reads \(entry)") }
             }
         }
@@ -134,82 +216,35 @@ struct CiPathFilterTests {
         )
     }
 
-    @Test("Build and lint inputs are never ignored")
-    func buildInputsStayWatched() throws {
-        let ignored = try Self.ignoreLists(workflow).first ?? []
-        try #require(!ignored.isEmpty, "no paths-ignore entries")
+    @Test("No ignored path is pinned by a rule file")
+    func ignoredPathsArentRulePins() throws {
+        let ignored = try entries()
+
+        // The suite reads these from *data*, not from a source
+        // literal: `InstructionPinTests` resolves every non-glob
+        // `paths:` entry in every rule file, so each is a path a
+        // change can break — and check (2) cannot see it, because
+        // no `.swift` file contains the string.
+        //
+        // This is what let `docs/**` through review: nothing opens
+        // a docs page, but `localization.md` pins two of them.
+        var pins: [String] = []
+        for (_, text) in try ruleFiles() {
+            pins += InstructionPinTests.pathEntries(text)
+                .filter { !$0.contains("*") && !$0.contains("?") }
+        }
+        try #require(pins.count > 5, "only found \(pins.count) pins")
+
         var violations: [String] = []
         for entry in ignored {
             let prefix = entry.replacingOccurrences(of: "**", with: "")
-            for input in Self.neverIgnorable
-            where input == entry || input.hasPrefix(prefix)
-                || prefix.hasPrefix(input)
-            {
-                violations.append("\(entry) covers \(input)")
+            for pin in pins where pin == entry || pin.hasPrefix(prefix) {
+                violations.append("\(entry) covers the pin \(pin)")
             }
         }
         #expect(
             violations.isEmpty,
-            "paths-ignore covers a build/lint input: \(violations)"
+            "paths-ignore hides a rule-file pin: \(violations)"
         )
-    }
-
-    /// Every `.swift` under `Tests/`, as (relative name, text).
-    private func testSources() throws -> [(String, String)] {
-        let tests = repoRoot.appendingPathComponent("Tests")
-        var out: [(String, String)] = []
-        let walker = FileManager.default.enumerator(atPath: tests.path)
-        let own = (#filePath as NSString).lastPathComponent
-        while let entry = walker?.nextObject() as? String {
-            guard entry.hasSuffix(".swift") else { continue }
-            // This file names ignored paths as data — its `allowed`
-            // map and its doc comment — so scanning it would report
-            // the guard against itself. It reads only `ci.yml` and
-            // `Tests/`, neither of which is ignorable.
-            guard !entry.hasSuffix(own) else { continue }
-            out.append(
-                (
-                    entry,
-                    try String(
-                        contentsOf: tests.appendingPathComponent(entry),
-                        encoding: .utf8
-                    )
-                )
-            )
-        }
-        return out
-    }
-
-    /// Each `paths-ignore:` block's quoted entries, in file order.
-    static func ignoreLists(_ text: String) -> [[String]] {
-        var out: [[String]] = []
-        var current: [String]?
-        for raw in text.split(
-            separator: "\n",
-            omittingEmptySubsequences: false
-        ) {
-            let line = raw.trimmingCharacters(in: .whitespaces)
-            if line == "paths-ignore:" {
-                if let current { out.append(current) }
-                current = []
-                continue
-            }
-            guard current != nil else { continue }
-            if line.hasPrefix("#") { continue }
-            guard line.hasPrefix("- ") else {
-                if !line.isEmpty {
-                    out.append(current!)
-                    current = nil
-                }
-                continue
-            }
-            let value =
-                line
-                .dropFirst(2)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            current?.append(value)
-        }
-        if let current { out.append(current) }
-        return out
     }
 }

--- a/Tests/KiwiDeskCoreTests/CiPathFilterTests.swift
+++ b/Tests/KiwiDeskCoreTests/CiPathFilterTests.swift
@@ -1,22 +1,21 @@
 import Foundation
 import Testing
 
-/// `ci.yml`'s `paths-ignore` cannot switch off a suite silently.
+/// `.github/ci-ignore.txt` cannot switch off a suite silently.
 ///
-/// The filter skips the whole CI job for a change touching only
-/// listed paths. That is safe exactly while nothing the job does
-/// reads them — and the failure mode is invisible: an entry added
-/// in error does not break a build, it stops one from happening,
-/// and a skipped workflow reports success by never reporting.
+/// The `changes` job in `ci.yml` reads that list and gates the two
+/// macOS jobs on it. A wrong entry does not break a build, it stops
+/// one from happening — and a job that never ran reports nothing to
+/// contradict.
 ///
 /// Five things are checked, in the order they would bite:
 ///
-/// 1. The `push:` and `pull_request:` lists are identical, and are
-///    the lists those two triggers own. The Actions parser rejects
-///    YAML anchors, so the list is hand-mirrored, and drift would
-///    filter the two events differently — a change tested
-///    pre-merge and skipped after, or the reverse
-///    (parity-tests.md).
+/// 1. `ci.yml` still reads the list and still gates on it, and has
+///    not gone back to a trigger-level `paths-ignore`. That older
+///    shape saved the same minutes but skipped the *workflow*, and
+///    a workflow that does not run reports no check at all — which
+///    deadlocks a required status check, unlike a job skipped by
+///    `if:`, which satisfies one (#487).
 /// 2. Every entry is an exact path or `dir/**`. The other checks
 ///    are prefix relations over plain strings, so `*` and `?` are
 ///    ordinary characters to them: `Package.*` would ignore
@@ -31,7 +30,7 @@ import Testing
 ///    resolves every such pin.
 /// 5. The build and lint inputs are never ignored — the clause a
 ///    test-only audit misses, since nothing in `Tests/` reads
-///    `Package.swift`, `.swift-format` or `.swiftlint.yml`.
+///    `Package.swift` or `.swift-format`.
 ///
 /// **What this cannot see**, stated plainly because check (3)
 /// promises more than it delivers: a path written as
@@ -59,7 +58,6 @@ struct CiPathFilterTests {
     static let neverIgnorable = [
         "Package.swift",  // defines what is built at all
         ".swift-format",  // scripts/lint.sh --configuration
-        ".swiftlint.yml",  // SwiftLint SPM build plugin
         "Sources",
         "Tests",
         "Vendor",
@@ -103,26 +101,71 @@ struct CiPathFilterTests {
         }
     }
 
-    @Test("Both paths-ignore lists are identical")
-    func listsMatch() throws {
-        let lists = Self.ignoreLists(try workflow)
-        // #require, not #expect: with no list parsed, every
-        // comparison below is trivially true (nil != [], nil ==
-        // nil) and only the count would red — pointing at the
-        // wrong thing.
-        try #require(
-            lists.count == 2,
-            "found \(lists.count) lists, want 2"
+    @Test("ci.yml still consults the list, and gates on it")
+    func workflowConsultsTheList() throws {
+        let yaml = try workflow
+        // Without this the whole mechanism is decorative: the file
+        // parses, every other check passes over it, and the jobs
+        // run unconditionally — or worse, the filter moves back to
+        // a trigger-level `paths-ignore`, whose skipped workflow
+        // reports no check run and deadlocks a required check.
+        #expect(
+            yaml.contains(".github/ci-ignore.txt"),
+            "ci.yml no longer reads the ignore list"
         )
-        try #require(
-            lists.map(\.trigger).sorted() == ["pull_request", "push"],
-            "lists came from \(lists.map(\.trigger))"
+        // The key, not the word: the comment above the triggers
+        // explains why this shape was abandoned, and naming it
+        // there must not read as using it.
+        let usesTriggerFilter =
+            yaml
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .contains { $0.hasPrefix("paths-ignore:") }
+        #expect(
+            !usesTriggerFilter,
+            """
+            ci.yml filters at the trigger again — a filtered-out \
+            workflow never reports, so a required check waits \
+            forever (#487, scripts/protect-main.sh)
+            """
         )
-        let first = lists.first?.entries ?? []
-        let last = lists.last?.entries ?? []
-        let parsed = first.count
-        try #require(parsed > 0, "a paths-ignore list parsed as empty")
-        #expect(first == last, "the two lists differ")
+        // Per job, not over the whole file. A whole-file
+        // `contains` is satisfied by one job keeping its gate
+        // while the other loses it — which is exactly the mutation
+        // that has to red, and did not until this was split.
+        for job in ["build-lint-test", "release-build"] {
+            let block = Self.jobBlock(job, in: yaml)
+            #expect(
+                block?.contains("needs: changes") == true,
+                "\(job) does not depend on the changes job"
+            )
+            #expect(
+                block?.contains("if: needs.changes.outputs.run == 'true'")
+                    == true,
+                "\(job) is not gated on the changes outcome"
+            )
+        }
+    }
+
+    @Test("Every exemption is still load-bearing")
+    func exemptionsAreLive() throws {
+        // The idiom's other half, which both precedents carry
+        // (`VisibleBoundsRoutingTests`, `BatchSizingRoutingTests`):
+        // an exemption that outlives its reason silently widens the
+        // hole it was cut for. Assert each entry still describes a
+        // file that still contains the component it excuses.
+        let sources = try testSources()
+        for (component, file) in Self.allowed {
+            let source = sources.first { $0.0 == file }
+            let text = try #require(
+                source?.1,
+                "exempted file \(file) is gone"
+            )
+            #expect(
+                text.contains("\"\(component)\""),
+                "\(file) no longer builds a \(component) component"
+            )
+        }
     }
 
     @Test("Every entry is an exact path or a whole subtree")
@@ -150,13 +193,6 @@ struct CiPathFilterTests {
             from every prefix check: \(malformed)
             """
         )
-    }
-
-    /// The ignore entries, refusing an empty parse.
-    func entries() throws -> [String] {
-        let ignored = Self.ignoreLists(try workflow).first?.entries ?? []
-        try #require(!ignored.isEmpty, "no paths-ignore entries")
-        return ignored
     }
 
     @Test("No ignored path is read by the test suite")

--- a/Tests/KiwiDeskCoreTests/CiPathFilterTests.swift
+++ b/Tests/KiwiDeskCoreTests/CiPathFilterTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Testing
+
+/// `ci.yml`'s `paths-ignore` cannot switch off a suite silently.
+///
+/// The filter skips the whole CI job for a change touching only
+/// listed paths. That is safe exactly while nothing the job does
+/// reads them — and the failure mode is invisible: an entry added
+/// in error does not break a build, it stops one from happening,
+/// and a skipped workflow reports success by never reporting.
+///
+/// Three things are checked, in the order they would bite:
+///
+/// 1. The `push:` and `pull_request:` lists are identical. The
+///    Actions parser rejects YAML anchors, so the list is
+///    hand-mirrored and drift would filter the two events
+///    differently — a change tested pre-merge and skipped after,
+///    or the reverse (parity-tests.md).
+/// 2. No ignored path is read by anything under `Tests/`.
+/// 3. The build and lint inputs are never ignored. This is the
+///    clause a test-only audit misses: nothing in `Tests/` reads
+///    `Package.swift`, `.swift-format` or `.swiftlint.yml`, and
+///    ignoring any of them would skip CI for a change that alters
+///    what compiles or what lint enforces.
+///
+/// **What this cannot see.** A path assembled from a variable
+/// rather than written as a literal, and a path read only by a
+/// `scripts/` tool the suite shells out to. Check (3) is a
+/// hand-listed floor for the same reason — the build's inputs
+/// cannot be derived from `Tests/`, so they are named here, and
+/// naming them is itself a thing to keep current.
+@Suite("CI path filter")
+struct CiPathFilterTests {
+    /// Paths whose change must always run CI, whatever else is
+    /// true. Not derivable from `Tests/` — nothing there reads
+    /// them — so they are enumerated, and each is the input to a
+    /// step the job runs.
+    static let neverIgnorable = [
+        "Package.swift",  // defines what is built at all
+        "Package.resolved",  // pins the dependency graph
+        ".swift-format",  // scripts/lint.sh --configuration
+        ".swiftlint.yml",  // SwiftLint SPM build plugin
+        "Sources",
+        "Tests",
+        "Vendor",
+        "scripts",
+        ".github/workflows/ci.yml",
+    ]
+
+    /// The one copy of who is exempt from the component match
+    /// (the `allowed`-map idiom, AGENTS.md §5).
+    ///
+    /// A bare component literal cannot tell a repo-rooted path from
+    /// a same-named directory built somewhere else. `ScriptFixture`
+    /// assembles a `site` directory inside a **temp** tree for the
+    /// `extract-keys --site` fixtures; it never reaches the repo's
+    /// `site/`. Add an entry only after confirming the same thing,
+    /// and name the file, so a second use elsewhere still fires.
+    static let allowed = ["site": "ScriptFixture.swift"]
+
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // KiwiDeskCoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+    }
+
+    private var workflow: String {
+        get throws {
+            try String(
+                contentsOf:
+                    repoRoot
+                    .appendingPathComponent(".github")
+                    .appendingPathComponent("workflows")
+                    .appendingPathComponent("ci.yml"),
+                encoding: .utf8
+            )
+        }
+    }
+
+    @Test("Both paths-ignore lists are identical")
+    func listsMatch() throws {
+        let lists = Self.ignoreLists(try workflow)
+        #expect(lists.count == 2, "found \(lists.count) lists, want 2")
+        #expect(
+            lists.first != [],
+            "a paths-ignore list parsed as empty"
+        )
+        #expect(lists.first == lists.last, "the two lists differ")
+    }
+
+    @Test("No ignored path is read by the test suite")
+    func ignoredPathsAreUnread() throws {
+        let ignored = try Self.ignoreLists(workflow).first ?? []
+        try #require(!ignored.isEmpty, "no paths-ignore entries")
+        let sources = try testSources()
+        try #require(
+            sources.count > 100,
+            "only scanned \(sources.count) test files"
+        )
+
+        var violations: [String] = []
+        for entry in ignored {
+            let prefix = entry.replacingOccurrences(of: "**", with: "")
+            let trimmed =
+                prefix.hasSuffix("/")
+                ? String(prefix.dropLast()) : prefix
+            // A whole top-level directory is matched by its bare
+            // component, because that is how the suite actually
+            // writes these — `.appendingPathComponent("assets")`,
+            // never `"assets/logo.svg"`. Matching only the rooted
+            // form would give this guard nothing to catch.
+            //
+            // A deeper entry gets prefix matching only. Its head
+            // says nothing: tests read `.github/workflows/
+            // release.yml` while `.github/workflows/site.yml` is
+            // ignored, so flagging every `.github` would be noise.
+            let wholeDirectory = !trimmed.contains("/")
+            for (name, text) in sources {
+                if let exempt = Self.allowed[trimmed],
+                    name.hasSuffix(exempt)
+                {
+                    continue
+                }
+                let hit =
+                    text.contains("\"\(prefix)")
+                    || (wholeDirectory && text.contains("\"\(trimmed)\""))
+                if hit { violations.append("\(name) reads \(entry)") }
+            }
+        }
+        #expect(
+            violations.isEmpty,
+            "paths-ignore hides a path the suite reads: \(violations)"
+        )
+    }
+
+    @Test("Build and lint inputs are never ignored")
+    func buildInputsStayWatched() throws {
+        let ignored = try Self.ignoreLists(workflow).first ?? []
+        try #require(!ignored.isEmpty, "no paths-ignore entries")
+        var violations: [String] = []
+        for entry in ignored {
+            let prefix = entry.replacingOccurrences(of: "**", with: "")
+            for input in Self.neverIgnorable
+            where input == entry || input.hasPrefix(prefix)
+                || prefix.hasPrefix(input)
+            {
+                violations.append("\(entry) covers \(input)")
+            }
+        }
+        #expect(
+            violations.isEmpty,
+            "paths-ignore covers a build/lint input: \(violations)"
+        )
+    }
+
+    /// Every `.swift` under `Tests/`, as (relative name, text).
+    private func testSources() throws -> [(String, String)] {
+        let tests = repoRoot.appendingPathComponent("Tests")
+        var out: [(String, String)] = []
+        let walker = FileManager.default.enumerator(atPath: tests.path)
+        let own = (#filePath as NSString).lastPathComponent
+        while let entry = walker?.nextObject() as? String {
+            guard entry.hasSuffix(".swift") else { continue }
+            // This file names ignored paths as data — its `allowed`
+            // map and its doc comment — so scanning it would report
+            // the guard against itself. It reads only `ci.yml` and
+            // `Tests/`, neither of which is ignorable.
+            guard !entry.hasSuffix(own) else { continue }
+            out.append(
+                (
+                    entry,
+                    try String(
+                        contentsOf: tests.appendingPathComponent(entry),
+                        encoding: .utf8
+                    )
+                )
+            )
+        }
+        return out
+    }
+
+    /// Each `paths-ignore:` block's quoted entries, in file order.
+    static func ignoreLists(_ text: String) -> [[String]] {
+        var out: [[String]] = []
+        var current: [String]?
+        for raw in text.split(
+            separator: "\n",
+            omittingEmptySubsequences: false
+        ) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line == "paths-ignore:" {
+                if let current { out.append(current) }
+                current = []
+                continue
+            }
+            guard current != nil else { continue }
+            if line.hasPrefix("#") { continue }
+            guard line.hasPrefix("- ") else {
+                if !line.isEmpty {
+                    out.append(current!)
+                    current = nil
+                }
+                continue
+            }
+            let value =
+                line
+                .dropFirst(2)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            current?.append(value)
+        }
+        if let current { out.append(current) }
+        return out
+    }
+}

--- a/scripts/protect-main.sh
+++ b/scripts/protect-main.sh
@@ -52,20 +52,14 @@
 # .github/workflows/ci.yml. This is the setting that finally makes
 # CI block rather than report (#532).
 #
-# BEFORE RUNNING THIS: ci.yml carries a paths-ignore list, and a
-# filtered-out workflow does not report a check run at all — it is
-# not skipped-as-success, it is absent. So every PR confined to an
-# ignored path (site/**, the root prose files, the issue templates)
-# will sit forever on "Expected — waiting for status to be
-# reported" once the jobs below are required, with no way to merge
-# but an admin override.
-#
-# Requiring these two as-is therefore trades a merge deadlock for
-# the blocking gate. The fix is a third job that always runs and
-# reports — no paths filter, exits 0 immediately — with that job
-# required here instead of, or alongside, these two. Decide that
-# before turning protection on, not after the first stuck PR.
-# packaging-and-release.md ("CI") owns the argument.
+# Both named jobs are gated on ci.yml's `changes` job rather than
+# on a trigger filter, which is what makes requiring them safe: a
+# PR touching only ignored paths leaves them *skipped*, and GitHub
+# counts a skipped job as satisfying a required check. Filtering at
+# the trigger instead would leave the workflow unreported and every
+# such PR stuck on "Expected". CiPathFilterTests keeps that shape;
+# packaging-and-release.md ("CI") carries the argument.
+
 set -euo pipefail
 
 REPO="${1:-KiwiCanopy/KiwiDesk}"

--- a/scripts/protect-main.sh
+++ b/scripts/protect-main.sh
@@ -51,6 +51,21 @@
 # Status checks are listed by JOB NAME and must match
 # .github/workflows/ci.yml. This is the setting that finally makes
 # CI block rather than report (#532).
+#
+# BEFORE RUNNING THIS: ci.yml carries a paths-ignore list, and a
+# filtered-out workflow does not report a check run at all — it is
+# not skipped-as-success, it is absent. So every PR confined to an
+# ignored path (site/**, the root prose files, the issue templates)
+# will sit forever on "Expected — waiting for status to be
+# reported" once the jobs below are required, with no way to merge
+# but an admin override.
+#
+# Requiring these two as-is therefore trades a merge deadlock for
+# the blocking gate. The fix is a third job that always runs and
+# reports — no paths filter, exits 0 immediately — with that job
+# required here instead of, or alongside, these two. Decide that
+# before turning protection on, not after the first stuck PR.
+# packaging-and-release.md ("CI") owns the argument.
 set -euo pipefail
 
 REPO="${1:-KiwiCanopy/KiwiDesk}"


### PR DESCRIPTION
## What

`ci.yml` gains a `paths-ignore` exclude list so CI stops running two `macos-26` jobs for changes that provably cannot affect it. `CiPathFilterTests` (new) guards that list with five checks. `verify-gate` learns the same distinction.

## Why

From `ci.yml`'s own comment: while the repo is private, macOS runners bill at a **10x multiplier against a 2,000-minute allowance**. `site.yml` was already path-filtered; the expensive workflow was not.

**Filtering the workflow, not the test run.** The suite is ~200s, but the job is dominated by compiling 50k lines of Core, 30k of GUI and 64k of tests. Running a subset of tests saves a slice of the small part — skipping the job is the only meaningful save.

**Exclude-shape, deliberately opposite to `site.yml`'s includes.** The site build's inputs are a closed, small set, so naming them is safe. The app's are open, and an include list there fails *open*: add a directory, forget to map it, and its suites stop running while CI stays green. Excluding fails closed — a missing entry costs minutes, not correctness.

## What the review changed

The entry that looked safest was the one that was wrong. `docs/**` failed the rule this change itself introduces: no test opens a docs page, but `.claude/rules/localization.md` **pins** `docs/translating.md` and `docs/localization-naming.md` in its `paths:` block, and `InstructionPinTests` resolves every such pin. Renaming either would be a docs-only change that skips CI and reds `main` on someone else's PR. `.github/workflows/site.yml` is pinned the same way. Both removed.

The guard was blind to it because the suite reads those paths from **data** — frontmatter in a Markdown file — not from a Swift literal, and a source scan cannot see the whole `InstructionPinTests`/`RuleCitationTests` family. That is now check 4.

Check 2 came from the same review: every other check is a prefix relation over plain strings, so `*` and `?` were ordinary characters to all of them — `"Package.*"` ignored `Package.swift` while passing every assertion. Constraining entry shape to an exact path or `dir/**` makes the prefix logic sound, rather than teaching four checks to glob.

## The guard

1. Both lists identical, and owned by `push` and `pull_request` (the Actions parser rejects YAML anchors, so the list is hand-mirrored).
2. Every entry is an exact path or `dir/**`.
3. No ignored path appears as a literal under `Tests/`.
4. No ignored path is pinned by a rule file's `paths:` block.
5. Build and lint inputs are never ignored — the clause a test-only audit misses, since nothing in `Tests/` reads `Package.swift`, `.swift-format` or `.swiftlint.yml`.

Red-proofed fifteen ways, and re-proved after the §2.1 split moved the collection helpers out. The doc comment ships what it **cannot** see: a path built from `.appendingPathComponent` chains whose head is not a whole ignored directory, a path reached only by a `scripts/` tool, and case-insensitive resolution on APFS.

## Known hazard, recorded not solved

A filtered-out workflow reports **no check run at all** — not skipped-as-success. `scripts/protect-main.sh` requires two job names, so once branch protection is on (#487) a PR confined to an ignored path waits forever. The hazard and the fix (a third job with no path filter that always reports) are now in that script, at the point of use.

## Verification

`swift build` · **2316 tests in 416 suites** · `scripts/lint.sh` exit 0. Release build skipped — no concurrency or `Sendable` surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)