### PR TITLE
feat(gui): show hover help sooner than AppKit's default

### DIFF
--- a/Sources/KiwiDesk/AppDelegate.swift
+++ b/Sources/KiwiDesk/AppDelegate.swift
@@ -50,6 +50,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
     private var localeObserver: AnyCancellable?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Shorten the hover-help delay before any window opens
+        // (`ToolTipDelay` carries why).
+        ToolTipDelay.install()
+
         // Inject the persisted language pick before any view
         // reads `L(_:_:)` (issue #9). Read directly from
         // UserDefaults, NOT via `loadGuiConfig()` — a language

--- a/Sources/KiwiDesk/ToolTipDelay.swift
+++ b/Sources/KiwiDesk/ToolTipDelay.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// How long the pointer must rest before hover help appears.
+///
+/// AppKit's own default is around two seconds (measured on
+/// device, macOS 15, 2026-08-03) — long enough that a greyed
+/// control's `GreyOut(help:)` sentence reads as *absent* rather
+/// than as slow. That is the whole reason hover is a fallback
+/// and not the #94 affordance: a channel nobody waits for
+/// explains nothing. Shortening it does not promote hover to
+/// the primary explanation, it just stops the fallback from
+/// being a dead letter.
+///
+/// Not shorter than this: below roughly half a second, tooltips
+/// fire while the pointer merely *crosses* a row on its way
+/// somewhere else, which is worse than late help.
+///
+/// `register`, never `set` — a user who has already chosen an
+/// `NSInitialToolTipDelay` (globally or for this app) keeps
+/// their value, since `register` only supplies a fallback.
+enum ToolTipDelay {
+    /// AppKit reads this in milliseconds.
+    static let key = "NSInitialToolTipDelay"
+    static let milliseconds = 700
+
+    static func install(into defaults: UserDefaults = .standard) {
+        defaults.register(defaults: [key: milliseconds])
+    }
+}

--- a/Sources/KiwiDesk/ToolTipDelay.swift
+++ b/Sources/KiwiDesk/ToolTipDelay.swift
@@ -1,23 +1,21 @@
 import Foundation
 
-/// How long the pointer must rest before hover help appears.
+/// How long the pointer must rest before hover help appears —
+/// shorter than AppKit's own default, which is long enough that
+/// a greyed control's `GreyOut(help:)` sentence reads as absent
+/// rather than as slow.
 ///
-/// AppKit's own default is around two seconds (measured on
-/// device, macOS 15, 2026-08-03) — long enough that a greyed
-/// control's `GreyOut(help:)` sentence reads as *absent* rather
-/// than as slow. That is the whole reason hover is a fallback
-/// and not the #94 affordance: a channel nobody waits for
-/// explains nothing. Shortening it does not promote hover to
-/// the primary explanation, it just stops the fallback from
-/// being a dead letter.
-///
-/// Not shorter than this: below roughly half a second, tooltips
-/// fire while the pointer merely *crosses* a row on its way
-/// somewhere else, which is worse than late help.
+/// Why that trade, why this value, and why not shorter, are
+/// argued once in `docs/design-decisions.md` ▸ "Hover help
+/// appears sooner than AppKit's default". The band this value
+/// must stay inside is asserted by `ToolTipDelayTests`.
 ///
 /// `register`, never `set` — a user who has already chosen an
 /// `NSInitialToolTipDelay` (globally or for this app) keeps
 /// their value, since `register` only supplies a fallback.
+/// `ToolTipDelayTests` holds that too: it is the one line here
+/// whose failure mode is silent, overwriting a preference the
+/// user set deliberately.
 enum ToolTipDelay {
     /// AppKit reads this in milliseconds.
     static let key = "NSInitialToolTipDelay"

--- a/Tests/KiwiDeskGuiTests/ToolTipDelayTests.swift
+++ b/Tests/KiwiDeskGuiTests/ToolTipDelayTests.swift
@@ -39,6 +39,19 @@ struct ToolTipDelayTests {
         #expect((500...1000).contains(ToolTipDelay.milliseconds))
     }
 
+    /// **`register` writes to `NSRegistrationDomain`, which is
+    /// process-global** — not to the suite it is called on. So a
+    /// freshly-created scratch suite can already read the value
+    /// another test in this file registered, and
+    /// `removePersistentDomain` does not clear it. Asserting the
+    /// key is absent beforehand is therefore unsatisfiable by
+    /// construction; it passed locally on a lucky order and red
+    /// on CI, which parallelises differently.
+    ///
+    /// What is deterministic is *where the value lands*: read the
+    /// registration domain directly, so this asserts `install`
+    /// registered rather than merely that something, somewhere,
+    /// answers for the key.
     @Test("installs the shortened delay")
     func installsDelay() {
         let defaults = scratchDefaults("install")
@@ -47,8 +60,12 @@ struct ToolTipDelayTests {
                 forName: "kiwidesk.tests.tooltip.install"
             )
         }
-        #expect(defaults.object(forKey: ToolTipDelay.key) == nil)
         ToolTipDelay.install(into: defaults)
+        let registered =
+            defaults.volatileDomain(
+                forName: UserDefaults.registrationDomain
+            )[ToolTipDelay.key] as? Int
+        #expect(registered == ToolTipDelay.milliseconds)
         #expect(
             defaults.integer(forKey: ToolTipDelay.key)
                 == ToolTipDelay.milliseconds

--- a/Tests/KiwiDeskGuiTests/ToolTipDelayTests.swift
+++ b/Tests/KiwiDeskGuiTests/ToolTipDelayTests.swift
@@ -27,10 +27,13 @@ struct ToolTipDelayTests {
         #expect(ToolTipDelay.key == "NSInitialToolTipDelay")
     }
 
-    /// The band `ToolTipDelay` itself argues for: fast enough that
-    /// a reader who pauses is not left concluding there is nothing
-    /// to read, slow enough that a pointer merely crossing a row
-    /// doesn't fire it. Prose nothing guards is prose that drifts.
+    /// The band argued for in `docs/design-decisions.md` ▸ "Hover
+    /// help appears sooner than AppKit's default": fast enough
+    /// that a reader who pauses isn't left concluding there is
+    /// nothing to read, slow enough that a pointer merely
+    /// crossing a row doesn't fire it. Prose nothing guards is
+    /// prose that drifts, and both edges of that argument are
+    /// reachable here.
     @Test("the delay stays in its defended band")
     func delayInBand() {
         #expect((500...1000).contains(ToolTipDelay.milliseconds))

--- a/Tests/KiwiDeskGuiTests/ToolTipDelayTests.swift
+++ b/Tests/KiwiDeskGuiTests/ToolTipDelayTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// Hover help is useless if it arrives after the pointer has
+/// left, so the shortened `NSInitialToolTipDelay` is load-bearing
+/// for every `GreyOut(help:)` sentence in Settings. Two halves,
+/// because each fails on its own: the value and its *fallback*
+/// semantics, and the fact that launch actually installs it.
+@Suite("Tooltip delay")
+struct ToolTipDelayTests {
+    private func scratchDefaults(_ name: String) -> UserDefaults {
+        let suite = "kiwidesk.tests.tooltip.\(name)"
+        UserDefaults().removePersistentDomain(forName: suite)
+        return UserDefaults(suiteName: suite)!
+    }
+
+    @Test("installs the shortened delay")
+    func installsDelay() {
+        let defaults = scratchDefaults("install")
+        defer {
+            UserDefaults().removePersistentDomain(
+                forName: "kiwidesk.tests.tooltip.install"
+            )
+        }
+        #expect(defaults.object(forKey: ToolTipDelay.key) == nil)
+        ToolTipDelay.install(into: defaults)
+        #expect(
+            defaults.integer(forKey: ToolTipDelay.key)
+                == ToolTipDelay.milliseconds
+        )
+    }
+
+    /// Registering only supplies a fallback, so a user who has
+    /// picked their own delay keeps it. `set` here would silently
+    /// overwrite a system-wide preference.
+    @Test("a user's own delay wins")
+    func userValueWins() {
+        let defaults = scratchDefaults("user")
+        defer {
+            UserDefaults().removePersistentDomain(
+                forName: "kiwidesk.tests.tooltip.user"
+            )
+        }
+        defaults.set(1234, forKey: ToolTipDelay.key)
+        ToolTipDelay.install(into: defaults)
+        #expect(defaults.integer(forKey: ToolTipDelay.key) == 1234)
+    }
+
+    /// The value is inert unless launch installs it, and nothing
+    /// about `ToolTipDelay` compiling proves that it does.
+    @Test("launch installs it")
+    func launchInstallsIt() throws {
+        let root = SourceScan.repoRoot(from: #filePath)
+        let delegate = root.appendingPathComponent(
+            "Sources/KiwiDesk/AppDelegate.swift"
+        )
+        let source = try String(contentsOf: delegate, encoding: .utf8)
+        // A guard over source that read nothing would pass for
+        // having found no violations (.claude/rules/tests.md).
+        #expect(source.contains("applicationDidFinishLaunching"))
+        #expect(source.occurrences(of: "ToolTipDelay.install(") == 1)
+    }
+}

--- a/Tests/KiwiDeskGuiTests/ToolTipDelayTests.swift
+++ b/Tests/KiwiDeskGuiTests/ToolTipDelayTests.swift
@@ -16,6 +16,26 @@ struct ToolTipDelayTests {
         return UserDefaults(suiteName: suite)!
     }
 
+    /// Both sides of an `install`-then-read assertion derive from
+    /// the same two symbols, so on its own it pins neither. The
+    /// key is an **AppKit** contract — restating the literal is
+    /// the derivation, the authority being AppKit and not a
+    /// second copy in this repo — and a typo there ships a
+    /// permanently ~2s delay with everything else green.
+    @Test("the key is the one AppKit reads")
+    func keyMatchesAppKit() {
+        #expect(ToolTipDelay.key == "NSInitialToolTipDelay")
+    }
+
+    /// The band `ToolTipDelay` itself argues for: fast enough that
+    /// a reader who pauses is not left concluding there is nothing
+    /// to read, slow enough that a pointer merely crossing a row
+    /// doesn't fire it. Prose nothing guards is prose that drifts.
+    @Test("the delay stays in its defended band")
+    func delayInBand() {
+        #expect((500...1000).contains(ToolTipDelay.milliseconds))
+    }
+
     @Test("installs the shortened delay")
     func installsDelay() {
         let defaults = scratchDefaults("install")
@@ -50,6 +70,11 @@ struct ToolTipDelayTests {
 
     /// The value is inert unless launch installs it, and nothing
     /// about `ToolTipDelay` compiling proves that it does.
+    ///
+    /// Scoped to the launch method's **body**, not the file: a
+    /// count over the whole file is satisfied by the call sitting
+    /// in `applicationWillTerminate` (proven), where it would run
+    /// after every window has already closed.
     @Test("launch installs it")
     func launchInstallsIt() throws {
         let root = SourceScan.repoRoot(from: #filePath)
@@ -57,9 +82,35 @@ struct ToolTipDelayTests {
             "Sources/KiwiDesk/AppDelegate.swift"
         )
         let source = try String(contentsOf: delegate, encoding: .utf8)
+        let head = "func applicationDidFinishLaunching"
+        let range = try #require(
+            source.range(of: head),
+            "launch method not found — repoint this guard"
+        )
+        let characters = Array(source)
+        var cursor = source.distance(
+            from: source.startIndex,
+            to: range.upperBound
+        )
+        // Step over the parameter list, then take the body.
+        _ = SourceScan.balanced(
+            characters,
+            from: &cursor,
+            open: "(",
+            close: ")"
+        )
+        let body = try #require(
+            SourceScan.balanced(
+                characters,
+                from: &cursor,
+                open: "{",
+                close: "}"
+            ),
+            "could not read the launch method's body"
+        )
         // A guard over source that read nothing would pass for
         // having found no violations (.claude/rules/tests.md).
-        #expect(source.contains("applicationDidFinishLaunching"))
-        #expect(source.occurrences(of: "ToolTipDelay.install(") == 1)
+        #expect(!body.isEmpty)
+        #expect(body.occurrences(of: "ToolTipDelay.install(") == 1)
     }
 }

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1167,6 +1167,39 @@ non-standard *controls*, which is the half that stays bound.
 (Owner ruling 2026-08-02, in chat; first applied in the Phase 2
 Bars area.)
 
+### Hover help appears sooner than AppKit's default
+
+**[Trade-off]**
+
+**KiwiDesk registers a shorter `NSInitialToolTipDelay` (700 ms)
+than AppKit's default of roughly two seconds.** Registered as a
+fallback, never set: a user who has chosen their own delay keeps
+it.
+
+This is a deliberate deviation from "standard controls work the
+standard way", taken because the default makes a specific
+explanation channel unreadable. A greyed control's "why can't I
+touch this" sentence is a hover string; at two seconds, a user
+who moves the pointer onto a dimmed stepper and pauses to read
+sees nothing, concludes there is nothing to see, and leaves. The
+sentence was written, translated into eleven locales, and
+delivered to nobody. Shortening the delay is what makes the
+fallback a fallback rather than dead copy.
+
+It does not promote hover to the primary affordance. A block
+gate still explains itself through a live `?` outside the gated
+subtree, and a control-scoped gate still leans first on the
+gating control sitting directly above it (#527) — hover remains
+the last of the three, and a surface that needs hover to be
+understood is mis-designed.
+
+The floor matters as much as the ceiling: below roughly half a
+second, tooltips fire while the pointer merely *crosses* a row on
+its way elsewhere, and Settings becomes a field of popping
+yellow. Late help is better than that. 700 ms is chosen to be
+clearly faster than a pause-and-give-up while still requiring
+the pointer to actually rest.
+
 ### Permanent accessory mode (no activation policy switching)
 
 **[Principle]**


### PR DESCRIPTION
## What

Registers `NSInitialToolTipDelay = 700` at launch, so a greyed
control's `GreyOut(help:)` sentence appears while the pointer is
still resting on it.

`register`, never `set` — a user who has chosen their own delay
keeps it.

## Why

Investigated as a suspected `GreyOut` bug: the `help:` string was
reported as never reaching the user, app-wide.

That diagnosis was wrong, and it is worth recording why.
`.disabled()` does **not** suppress `.help()` — verified in a probe
app on the exact shipping shape (`.disabled(true).opacity(0.5)
.help(…)`) across Text, Stepper and Toggle, and then in the running
app. SwiftUI's `.help()` registers zero AppKit tooltips (confirmed
by swizzling `addToolTipRect:owner:userData:` / `setToolTip:` /
`removeAllToolTips`), so an empty view-tree dump proves nothing
either way.

The real cause of every "no tooltip" observation was AppKit's
initial tooltip delay, which defaults to about two seconds. A user
who moves onto a dimmed row and pauses to read sees nothing,
concludes there is nothing to see, and leaves — so the sentence was
authored, translated into eleven locales, and delivered to nobody.

The floor matters as much as the ceiling: below roughly half a
second, tooltips fire while the pointer merely *crosses* a row on
its way elsewhere.

This does not promote hover to the primary affordance. A block gate
still explains itself through a live `?` outside the gated subtree,
and a control-scoped gate still leans on the gating control
directly above it (#527). Hover stays the last of the three.

## Why this is not cosmetic, post-#701

#701 gave `AutoGatedGroup` a `gatedHelp:` parameter, and two Layout
Defaults call sites now pass real reasons through it — Grid's
Auto-size dimensions and Track's auto limit. Those were plumbed to
nothing before. At the default delay they are effectively invisible
from the day they shipped, in all eleven locales. This change is
what makes them readable for the first time.

## Relationship to #710

Disjoint and complementary. #710 is docs-only: it corrects the
`GreyOut` docstring, which currently tells the next author the
hover "was not observed to render" and points at `.disabled()`.
This PR is the behavior. Merging #710 first is the cleaner order;
the two touch no common file.

## Tests

`ToolTipDelayTests`, 5 tests. All five red-proofed by `guard-prover`
after two shipped weaker than their names: the value assertion was
a tautology (both sides derived from `install()`'s own symbols, so a
typo'd key stayed green), and the call-site scan counted over the
whole file, which a call in `applicationWillTerminate` satisfied.
Now the key is pinned against the AppKit literal, the value against
the band its design-decisions entry defends, and the scan is scoped
to `applicationDidFinishLaunching`'s body.

One residual limit, proven rather than assumed: a commented-out
`ToolTipDelay.install()` inside that body would satisfy the scan.
Closing it needs a parser, which this invariant does not earn.

## Verification

Rebased onto `main` (post-#701) and re-run there:

- `swift build` PASS
- `swift test` PASS (2581 tests, 468 suites)
- `scripts/lint.sh` PASS (exit 0)
- `swift build -c release` PASS
- site build PASS (27 pages) — `docs/` touched

Reviewers and on-device eye-confirm waived by the owner. The 700 ms
value has been run on device from this branch's binary but not
signed off; only the 200 ms probe was eyeballed side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)