### PR TITLE
docs(gui): correct the GreyOut hover note — it was the tooltip delay

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Common/AutoGatedGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/AutoGatedGroup.swift
@@ -79,19 +79,17 @@ struct AutoGatedGroup<Gated: View>: View {
 /// adjacency already answers "why", the way the toggle above an
 /// `AutoGatedGroup` does.
 ///
-/// **That fallback was not observed to render** (device check
-/// 2026-08-03, the greyed Columns/Rows steppers under Grid's
-/// Auto-size toggle: the string reached this modifier and no
-/// tooltip appeared). The likely cause is that SwiftUI stops
-/// delivering hover to what `.disabled()` disables, but that has
-/// not been confirmed and no workaround has been tested — so
-/// treat the hover as unavailable rather than as diagnosed.
-/// The adjacency above is therefore not a nicety: it is the
-/// whole explanation a control-scoped gate ships today, and a
-/// gate whose reason is NOT answered by an adjacent control
-/// needs a live `?` outside the gated subtree rather than a
-/// `help:` here. The strings that exist are kept for the day the
-/// hover works, not relied on now.
+/// **A "no tooltip" report is AppKit's tooltip delay until
+/// proven otherwise** (2026-08-03): the greyed Columns/Rows
+/// steppers under Grid's Auto-size toggle read as having no
+/// hover string at all, and the cause was the default delay,
+/// not the gate. `.disabled()` does NOT suppress `.help()`.
+/// Hover long enough and the sentence appears.
+///
+/// That is worth a line here because the wrong reading is the
+/// tempting one — the string is on a disabled control, so the
+/// control looks like the culprit — and it sent one change down
+/// a workaround that fixed nothing. Reach for the delay first.
 ///
 /// **Dims once, however deeply it nests.** Opacity multiplies,
 /// so a row inside an already-dimmed block used to land at


### PR DESCRIPTION
## Description

A correction to a note I added in #701.

`GreyOut`'s docstring claimed its `help:` string "was not observed to render", and guessed the cause was SwiftUI not delivering hover to a `.disabled()` view. **That guess is wrong.** `.disabled()` does not suppress `.help()` — the greyed Columns/Rows steppers under Grid's Auto-size toggle have a live tooltip sitting behind AppKit's default delay, which is long enough to read as no tooltip at all.

Independently confirmed by the session working on `claude/quizzical-archimedes-66a3ac`, which is shipping a shorter `ToolTipDelay` for exactly this.

## Related Issue(s)

Follow-up to #701.

## Checklist

- [x] I understand what this change does and have run it in the app to confirm it works as intended — comment-only; the underlying behaviour was verified by the session that diagnosed it
- [x] Commits follow Conventional Commits format (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code required) — n/a, no behaviour change
- [x] User-facing changes are documented in `docs/` — n/a
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes — 2576 green
- [x] Release build green — no code change; CI reports it
- [x] PR is focused; refactors separated from features

## How I verified

`swift build`, `swift test` (2576), `scripts/lint.sh` — all green. Comment-only diff.

## Notes for Reviewer

Worth correcting rather than leaving to rot because these docstrings load as **instructions**, which is the #614 failure mode: the next author reasons from an unconfirmed diagnosis without rechecking it. That already happened once here — a workaround was written against the wrong cause and fixed nothing.

`claude/quizzical-archimedes-66a3ac` branches from `20945498`, before #701, and never touches `AutoGatedGroup`, so it will not correct this on its way in. If that branch is rebased onto `main` after this lands it may conflict on this docstring; take this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)