### PR TITLE
docs(review): skip the reviewer pair on a logic-free diff

### DIFF
--- a/.claude/skills/review-change/SKILL.md
+++ b/.claude/skills/review-change/SKILL.md
@@ -18,6 +18,20 @@ merge base with `main`.
 
 ## 2. First round — parallel
 
+**A logic-free diff skips the pair.** Before spawning anything,
+gate on what the diff *can be wrong about*. When its entire content
+is string edits, catalog JSON, or doc prose — **no Swift logic
+changed** — the `code-reviewer` / `architect-reviewer` pair has
+nothing to bite on: `scripts/lint.sh` already owns style and line
+length, and the only real failure mode is wrong *content*. Do not
+spawn the pair. Run the specialist lane the diff earns and stop —
+`localization-auditor` (a drafter, then a **separate** read-only
+audit) for strings and catalogs, `docs-steward` for prose — that
+lane **is** the review, not a supplement to it. `guard-prover`
+still runs if the diff adds or edits a test (the table below). The
+moment any Swift logic changes, the pair is back, exactly as
+follows.
+
 Spawn `code-reviewer` and `architect-reviewer` on the diff **in
 parallel** (one message, one Agent call each): the diff is finished
 and the perspectives are independent, so serializing only costs


### PR DESCRIPTION
## Description

`review-change` §2 mandated `code-reviewer` + `architect-reviewer` on **every** round-1 review. This adds a gate: when a diff's entire content is string edits, catalog JSON, or doc prose — **no Swift logic changed** — the pair has nothing to bite on (`scripts/lint.sh` owns style and line length; the only real failure mode is wrong *content*). Such a diff is reviewed by its specialist lane alone — `localization-auditor` (drafter + a **separate** read-only audit) or `docs-steward` — with `guard-prover` still run if a test's assertions moved. Any Swift logic change → the pair is back, unchanged.

Skill-owned by design: AGENTS.md §3.6 delegates "which lanes a diff earns" to this skill, so the gate lives here and AGENTS.md is untouched.

## Related Issue(s)

Prompted by #717 / PR #721 — a one-line English fix plus a catalog retranslation drew the full pair, which surfaced nothing the localization audit had not.

## Checklist

- [ ] I understand what this change does and have run it in the app — N/A, instruction prose, no runtime surface
- [x] Commits follow Conventional Commits format
- [ ] New behavior is tested — N/A (prose); the `.claude/` tree is exercised by `RuleCitationTests` / `InstructionPinTests`, which pass
- [x] User-facing changes are documented — this IS the doc change
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes (2656 tests)
- [ ] Release build green — CI's `Release Build` job (reports, does not block); skipped locally, no concurrency change
- [x] PR is focused

## How I verified

Logic-free prose edit. Verified: full gate green (build, 2656 tests including the `.claude`-tree citation/instruction guards, lint exit 0); clause phrased as an obligation per `rule-authoring.md`; every reference (`scripts/lint.sh`, the three agents, the §2 table) resolves.

## Notes for Reviewer

Per the rule it introduces, this logic-free diff took no reviewer pair — self-verified.