### PR TITLE
feat(gui): render Gaps & Borders from the census (#678 Phase 3)

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -130,15 +130,14 @@ never views.
 `Settings/Census/` records every setting's redesign placement,
 tier, gate and text keys, and the redesigned GUI renders from
 it. **Bars, Colours & Motion, Advanced Colours, Shortcuts,
-Layout Defaults and App Rules render from it now** (#678 Phases
-2-3):
-`BarsRowOrder` / `ColorsRowOrder` / `ShortcutsRowOrder` /
-`LayoutDefaultsRowOrder`
-hold the display order and `BarsCensusRenderTests` /
-`ColorsCensusRenderTests` / `ShortcutsCensusRenderTests` /
-`LayoutDefaultsCensusRenderTests` pin
-them to the census, so a row in
-those areas moves by editing the census.
+Layout Defaults, App Rules, General and Gaps & Borders render
+from it now** (#678 Phases 2-3): each carries its own order list
+and a census-render suite pinning that order to the census
+(`GapsBordersRowOrder` / `GapsAndBordersCensusRenderTests` is the
+newest pair), so a row in a `ForEach`-rendered container moves by
+editing the census — with the bespoke edge below. This bold list is itself a hand-kept claim with no guard,
+so an added area joins it here in the same change that ships its
+`*RowOrder` (General was silently dropped from it once).
 
 That promise has a stated edge in Shortcuts, and reading it as
 unqualified will waste your afternoon: three containers there
@@ -150,6 +149,13 @@ MEMBERSHIP, but editing one moves nothing on screen. Which
 three is data — `ShortcutsRowOrder.bespokeContainers`, asserted
 by `ShortcutsCensusRenderTests` — so a fourth going bespoke has
 to edit that set; check it before assuming an edit will show up.
+
+General and Gaps & Borders push that edge wider: EVERY container
+in them is bespoke (`GeneralRowOrder.bespokeContainers` /
+`GapsBordersRowOrder.bespokeContainers`, each the whole set,
+asserted by `bespokeMeansNoForEach` in each area's render suite),
+so their order lists are membership-and-search only and editing
+one moves nothing on screen.
 
 **The census's unit is a SETTING, and one setting may draw many
 rows.** A keybinding family is the worked case: `focusDir` is
@@ -188,17 +194,25 @@ The rule that needs no guessing:
   the gap stays deliberate and a new gate landing in neither
   set reds.
 
-The resolvers still take different shapes — one keys on
-`SettingsContainer.gate` over `TilingSettings`, another on
-`SettingRuntimeGate` over `GuiConfig`, a third
-(`LayoutDefaultsGates`) on a row's own `SettingKey` over
-`TilingSettings`. **Converge them before a fourth shape
-appears**; the split is why one legitimate gate is "resolved
-elsewhere" today. Layout Defaults did not force the
-convergence and does not discharge it: it answers only ROW
-gates, so it had nothing to converge *with* — **give this area
-a container gate or a `.runtime` one and converge the
-resolvers rather than teaching this one a second shape.**
+The resolvers still take different shapes — `BarsGateContext`
+keys on `SettingsContainer.gate` over `TilingSettings`,
+`ShortcutsRuntimeGate` on `SettingRuntimeGate` over `GuiConfig`,
+and the reason-case family (`LayoutDefaultsGates`, `GeneralGates`,
+`GapsBordersGates`) on a row's own `SettingKey`. **Converge the
+first two onto that reason-case shape before a fourth shape
+appears.** The "it had nothing to converge with" excuse is now
+spent: `GapsBordersGates` answers a container gate
+(`containerReason(for:)`, held by `GapsAndBordersGateTests`'
+`containerGateIsResolved`) AND a saved-config `.runtime` gate
+(the gap masters) on the SAME `SettingKey`-keyed struct — so the
+shared shape demonstrably carries all three gate flavours. Folding
+`BarsGateContext` and `ShortcutsRuntimeGate` onto it is
+**consciously deferred** (owner ruling 2026-08-03, the Gaps &
+Borders lane kept low-risk) and stays an obligation on the next
+author who touches those two resolvers.
+`ShortcutsRuntimeGate.resolvedElsewhere` sits elsewhere because
+its one gate (`.luaImportAvailable`) is a live-state predicate the
+saved config cannot answer — not because of the shape split.
 `LayoutDefaultsGateTests`' `everyGatedRowIsResolved` holds both
 halves: it reds when a ROW gate this resolver does not answer
 appears, and it pins that no container in the area declares a

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/DragVisualsEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/DragVisualsEditor.swift
@@ -15,6 +15,10 @@ import SwiftUI
 struct DragVisualsEditor: View {
     @ObservedObject var model: SettingsModel
 
+    private var gates: GapsBordersGates {
+        GapsBordersGates(settings: model.config.settings)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             SettingsSection(
@@ -40,7 +44,13 @@ struct DragVisualsEditor: View {
                         "Marks the position your window is "
                             + "dragged from."
                     ),
-                    visual: $model.config.settings.dragGhost
+                    visual: $model.config.settings.dragGhost,
+                    enabledReason: gates.inertReason(
+                        for: .borders(.dragGhostBorder)
+                    ),
+                    borderReason: gates.inertReason(
+                        for: .borders(.dragGhostBorderWidth)
+                    )
                 )
                 column(
                     control: SettingsCatalog.gapsAndBorders
@@ -50,7 +60,13 @@ struct DragVisualsEditor: View {
                         "Marks the position your window will "
                             + "snap into when dropped."
                     ),
-                    visual: $model.config.settings.dragDropZone
+                    visual: $model.config.settings.dragDropZone,
+                    enabledReason: gates.inertReason(
+                        for: .borders(.dragDropZoneBorder)
+                    ),
+                    borderReason: gates.inertReason(
+                        for: .borders(.dragDropZoneBorderWidth)
+                    )
                 )
             }
         }
@@ -62,7 +78,9 @@ struct DragVisualsEditor: View {
     private func column(
         control: SettingsControl,
         caption: String,
-        visual: Binding<DragVisual>
+        visual: Binding<DragVisual>,
+        enabledReason: GapsBordersGates.InertReason?,
+        borderReason: GapsBordersGates.InertReason?
     ) -> some View {
         // The header `?` is the gate's live anchor (#527): with
         // the visual off the column below the Enabled toggle is
@@ -71,19 +89,18 @@ struct DragVisualsEditor: View {
             control,
             caption: caption,
             subsection: true,
-            help: visual.wrappedValue.enabled
-                ? nil
-                : L(
-                    "drag.disabled.help",
-                    "Turn on Enabled to edit this visual."
-                )
+            help: enabledReason.map(GapsBordersGateHelp.sentence)
         ) {
             DragVisualPreview(
                 visual: visual.wrappedValue,
                 cornerRadius: model.config.settings
                     .dragCornerRadius
             )
-            DragVisualControls(visual: visual)
+            DragVisualControls(
+                visual: visual,
+                enabledReason: enabledReason,
+                borderReason: borderReason
+            )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .environment(
@@ -103,6 +120,8 @@ struct DragVisualsEditor: View {
 /// with is Advanced Colours'.
 struct DragVisualControls: View {
     @Binding var visual: DragVisual
+    let enabledReason: GapsBordersGates.InertReason?
+    let borderReason: GapsBordersGates.InertReason?
 
     /// Two gates the column already implies and none of it
     /// enforced (#520): with the visual off nothing it draws
@@ -141,8 +160,10 @@ struct DragVisualControls: View {
             }
             .modifier(
                 GreyOut(
-                    active: !visual.border,
-                    help: borderOffHelp
+                    active: borderReason != nil,
+                    help:
+                        borderReason
+                        .map(GapsBordersGateHelp.sentence) ?? ""
                 )
             )
             Divider()
@@ -150,20 +171,11 @@ struct DragVisualControls: View {
         }
         .modifier(
             GreyOut(
-                active: !visual.enabled,
-                help: L(
-                    "drag.disabled.help",
-                    "Turn on Enabled to edit this visual."
-                )
+                active: enabledReason != nil,
+                help:
+                    enabledReason
+                    .map(GapsBordersGateHelp.sentence) ?? ""
             )
-        )
-    }
-
-    private var borderOffHelp: String {
-        L(
-            "drag.border.off_help",
-            "Turn on Border to edit its width and "
-                + "alignment."
         )
     }
 

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FocusBorderEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FocusBorderEditor.swift
@@ -18,6 +18,27 @@ struct FocusBorderEditor: View {
         $model.config.settings.borderStyle
     }
 
+    private var gates: GapsBordersGates {
+        GapsBordersGates(settings: model.config.settings)
+    }
+
+    /// The block gate: the whole card is inert while the ring is
+    /// off. Resolved once at the container so its grey and its
+    /// sentence stay one decision (#678).
+    private var blockReason: GapsBordersGates.InertReason? {
+        gates.containerReason(for: .focusBorder)
+    }
+
+    private var blockHelp: String {
+        blockReason.map(GapsBordersGateHelp.sentence) ?? ""
+    }
+
+    /// The glow-size row's gate, inside a live block: greyed while
+    /// the glow effect is off.
+    private var glowSizeReason: GapsBordersGates.InertReason? {
+        gates.inertReason(for: .borders(.borderGlowSize))
+    }
+
     var body: some View {
         // The header `?` is the gate's live anchor (#527): every
         // help affordance inside the greyed block is dead, so the
@@ -29,7 +50,7 @@ struct FocusBorderEditor: View {
                 "Outlines the focused window so it stands out "
                     + "in a gapped layout."
             ),
-            help: style.wrappedValue.enabled ? nil : offHelp
+            help: blockReason.map(GapsBordersGateHelp.sentence)
         ) {
             Toggle(
                 L("border.enabled", "Show focus border"),
@@ -37,20 +58,9 @@ struct FocusBorderEditor: View {
             )
             FocusBorderPreview(style: style.wrappedValue)
             controls.modifier(
-                GreyOut(
-                    active: !style.wrappedValue.enabled,
-                    help: offHelp
-                )
+                GreyOut(active: blockReason != nil, help: blockHelp)
             )
         }
-    }
-
-    private var offHelp: String {
-        L(
-            "border.controls.disabled",
-            "Turn on Show focus border to edit "
-                + "these settings."
-        )
     }
 
     @ViewBuilder private var controls: some View {
@@ -114,7 +124,14 @@ struct FocusBorderEditor: View {
                 restore: BorderStyle.glowBlur(
                     for: style.wrappedValue.clampedWidth
                 ).rounded()
-            )
+            ),
+            // Glow off greys the group (resolver reason); with
+            // glow on, `nil` hands greying back to the auto
+            // sentinel, so auto-size still dims its own slider.
+            gatedIsInert: glowSizeReason != nil ? true : nil,
+            gatedHelp:
+                glowSizeReason
+                .map(GapsBordersGateHelp.sentence) ?? ""
         ) {
             PtSlider(
                 label: L("border.glow_size", "Glow size"),
@@ -123,16 +140,6 @@ struct FocusBorderEditor: View {
                 autoAtZero: true
             )
         }
-        .modifier(
-            GreyOut(
-                active: style.wrappedValue.enabled
-                    && !style.wrappedValue.glow,
-                help: L(
-                    "border.glow_size.disabled",
-                    "Turn on Glow effect to adjust its size."
-                )
-            )
-        )
         Divider()
         FitGapsAction(model: model)
     }

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGateHelp.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGateHelp.swift
@@ -1,0 +1,48 @@
+import KiwiDeskCore
+
+/// The inline sentence each `GapsBordersGates.InertReason`
+/// renders — the "why you can't edit this" a greyed row or block
+/// shows on hover. Split from the resolver so the resolver stays
+/// assertable off the main actor; the reason and its sentence are
+/// one decision, never two that can disagree (#678, gui.md).
+///
+/// Every key here is reused from the hand-wired gate this
+/// conversion replaced, so the English is unchanged and no
+/// translation is dropped.
+@MainActor
+enum GapsBordersGateHelp {
+    static func sentence(
+        for reason: GapsBordersGates.InertReason
+    ) -> String {
+        switch reason {
+        case .borderOff:
+            return L(
+                "border.controls.disabled",
+                "Turn on Show focus border to edit "
+                    + "these settings."
+            )
+        case .glowOff:
+            return L(
+                "border.glow_size.disabled",
+                "Turn on Glow effect to adjust its size."
+            )
+        case .visualOff:
+            return L(
+                "drag.disabled.help",
+                "Turn on Enabled to edit this visual."
+            )
+        case .visualBorderOff:
+            return L(
+                "drag.border.off_help",
+                "Turn on Border to edit its width and "
+                    + "alignment."
+            )
+        case .gapsDiffer:
+            return L(
+                "gaps.mixed.help",
+                "Edges differ — edit them "
+                    + "individually below."
+            )
+        }
+    }
+}

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGates.swift
@@ -1,0 +1,142 @@
+import KiwiDeskCore
+
+/// The Gaps & Borders area's greying, resolved from the census
+/// (#678 Phase 3). Keyed on a row's own `SettingKey` over
+/// `TilingSettings`, returning a REASON case rather than a Bool
+/// — the shape General and Layout Defaults already share, so
+/// this area adds no new resolver signature (owner ruling
+/// 2026-08-03: converge Bars/Shortcuts onto it in a later PR,
+/// not here).
+///
+/// Unlike Layout Defaults this area carries all three gate
+/// flavours, so the resolver answers two questions:
+///
+/// - `containerReason(for:)` — the Focus-border block gate. Every
+///   row in `.focusBorder` is inert while the ring is off, except
+///   the enable toggle that owns the gate (`exemptFromContainer\
+///   Gate`). The block draws one grey with one sentence, so the
+///   gate resolves once at the container, not per row.
+/// - `inertReason(for:)` — the row and runtime gates inside a
+///   live block: the glow-size row (glow off), the drag columns
+///   (visual or its border off), and the two gap masters (their
+///   edges / axes differ, the `.runtime(.perEdgeValuesDiffer)`
+///   gate).
+///
+/// Returning the reason rather than a Bool keeps the grey and its
+/// inline sentence from being two decisions that can disagree
+/// (`GapsBordersGateHelp` renders it). The reason cases keep the
+/// whole resolver assertable off the main actor.
+struct GapsBordersGates {
+    let settings: TilingSettings
+
+    /// Why a row (or the Focus-border block) is inert. One case
+    /// per predicate; the sentence lives in `GapsBordersGateHelp`.
+    enum InertReason: Hashable {
+        case borderOff
+        case glowOff
+        case visualOff
+        case visualBorderOff
+        case gapsDiffer
+    }
+
+    /// The one container gate in this area: the Focus-border block
+    /// is inert while the ring is off. Other containers gate
+    /// nothing.
+    func containerReason(
+        for container: SettingsContainer
+    ) -> InertReason? {
+        switch container {
+        case .focusBorder:
+            return settings.borderStyle.enabled ? nil : .borderOff
+        default:
+            return nil
+        }
+    }
+
+    /// The row / runtime gate for a row inside a LIVE block. The
+    /// container gate is the block's job, so a Focus-border row's
+    /// reason here never repeats `.borderOff` — it guards on the
+    /// ring being enabled first.
+    func inertReason(for key: SettingKey) -> InertReason? {
+        guard key.placement.gate != nil else { return nil }
+        switch key {
+        case .gaps(.outer):
+            return outerGapsDiffer ? .gapsDiffer : nil
+        case .gaps(.inner):
+            return innerGapsDiffer ? .gapsDiffer : nil
+        case .borders(.borderGlowSize):
+            guard settings.borderStyle.enabled else { return nil }
+            return settings.borderStyle.glow ? nil : .glowOff
+        case .borders(.dragGhostBorder),
+            .borders(.dragGhostFill):
+            return settings.dragGhost.enabled ? nil : .visualOff
+        case .borders(.dragGhostBorderWidth),
+            .borders(.dragGhostBorderAlignment):
+            if !settings.dragGhost.enabled { return .visualOff }
+            return settings.dragGhost.border
+                ? nil : .visualBorderOff
+        case .borders(.dragDropZoneBorder),
+            .borders(.dragDropZoneFill):
+            return settings.dragDropZone.enabled
+                ? nil : .visualOff
+        case .borders(.dragDropZoneBorderWidth),
+            .borders(.dragDropZoneBorderAlignment):
+            if !settings.dragDropZone.enabled {
+                return .visualOff
+            }
+            return settings.dragDropZone.border
+                ? nil : .visualBorderOff
+        default:
+            // A gated key with no arm here is a bug: the census
+            // declared a gate this resolver cannot answer. Fail
+            // loud in debug, fail-open in release so a shipped
+            // Settings window never locks a row it can't reason
+            // about (mirrors `LayoutDefaultsGates`).
+            assertionFailure(
+                "unhandled Gaps & Borders gate: \(key.id)"
+            )
+            return nil
+        }
+    }
+
+    /// The gated rows this resolver answers (data, so
+    /// `everyGatedRowIsResolved` reds when a new census gate lands
+    /// in neither set). The Focus-border CONTAINER gate is held
+    /// separately by `containerGateIsResolved`.
+    static let resolved: Set<SettingKey> = [
+        .gaps(.outer),
+        .gaps(.inner),
+        .borders(.borderGlowSize),
+        .borders(.dragGhostBorder),
+        .borders(.dragGhostFill),
+        .borders(.dragGhostBorderWidth),
+        .borders(.dragGhostBorderAlignment),
+        .borders(.dragDropZoneBorder),
+        .borders(.dragDropZoneFill),
+        .borders(.dragDropZoneBorderWidth),
+        .borders(.dragDropZoneBorderAlignment),
+    ]
+
+    /// Declared-but-answered-elsewhere. Empty and kept so a new
+    /// gate this resolver cannot answer must land here on purpose
+    /// rather than pass silently.
+    static let resolvedElsewhere: Set<SettingKey> = []
+
+    // MARK: - Predicates
+
+    /// The outer master is inert while its four edges disagree —
+    /// there is no single value for it to show or write.
+    private var outerGapsDiffer: Bool {
+        let o = settings.gapsGlobal.outer
+        return
+            !(o.top == o.bottom
+            && o.top == o.left
+            && o.top == o.right)
+    }
+
+    /// The inner master is inert while its two axes disagree.
+    private var innerGapsDiffer: Bool {
+        let i = settings.gapsGlobal.inner
+        return i.horizontal != i.vertical
+    }
+}

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersRowOrder.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersRowOrder.swift
@@ -1,0 +1,92 @@
+/// Display order for the Gaps & Borders area's rows (#678
+/// Phase 3). Geometry only — every colour this feature draws
+/// moved to Advanced Colours, so no colour row appears here.
+///
+/// The area's four containers each own one decision:
+///
+/// - `.gaps` — the outer and inner master sliders, each with a
+///   per-edge / per-axis drawer beneath it.
+/// - `.focusBorder` — the ring: its width, corner, unfocused
+///   twin, glow, and the fit-layout-gaps action. The enable
+///   toggle owns the container gate.
+/// - `.stickyWindows` — the one on-window sticky mark toggle.
+/// - `.dragAndDrop` — the shared corner radius plus the ghost
+///   and drop-zone visual columns.
+///
+/// `GapsAndBordersCensusRenderTests` pins each list against the
+/// census, so a row moves by editing the census rather than a
+/// view.
+enum GapsBordersRowOrder {
+    /// Outer master then its four edges, inner master then its
+    /// two axes — the order the editor stacks them.
+    static let gaps: [SettingKey] = [
+        .gaps(.outer),
+        .gaps(.outerTop),
+        .gaps(.outerBottom),
+        .gaps(.outerLeft),
+        .gaps(.outerRight),
+        .gaps(.inner),
+        .gaps(.innerHorizontal),
+        .gaps(.innerVertical),
+    ]
+
+    /// The enable toggle first (it owns the container gate),
+    /// then the ring's shape, its glow, and the fit-gaps action.
+    static let focusBorder: [SettingKey] = [
+        .borders(.borderEnabled),
+        .borders(.borderUnfocusedEnabled),
+        .borders(.borderWidth),
+        .borders(.borderCorner),
+        .borders(.borderGlow),
+        .borders(.borderGlowSizeAuto),
+        .borders(.borderGlowSize),
+        .borders(.borderFitGapsExtraSpacing),
+        .borders(.borderFitGaps),
+    ]
+
+    static let stickyWindows: [SettingKey] = [
+        .borders(.stickyMark)
+    ]
+
+    /// The shared corner radius, then the ghost column, then the
+    /// drop-zone column — each column's enable, border and fill.
+    static let dragAndDrop: [SettingKey] = [
+        .borders(.dragCornerRadius),
+        .borders(.dragGhostEnabled),
+        .borders(.dragGhostBorder),
+        .borders(.dragGhostBorderWidth),
+        .borders(.dragGhostBorderAlignment),
+        .borders(.dragGhostFill),
+        .borders(.dragDropZoneEnabled),
+        .borders(.dragDropZoneBorder),
+        .borders(.dragDropZoneBorderWidth),
+        .borders(.dragDropZoneBorderAlignment),
+        .borders(.dragDropZoneFill),
+    ]
+
+    /// Every row this area draws, by container.
+    static let byContainer: [SettingsContainer: [SettingKey]] = [
+        .gaps: gaps,
+        .focusBorder: focusBorder,
+        .stickyWindows: stickyWindows,
+        .dragAndDrop: dragAndDrop,
+    ]
+
+    /// Containers drawn as BESPOKE views rather than a `ForEach`
+    /// over the list above.
+    ///
+    /// All four are: the gaps drawers, the ring preview and its
+    /// auto-gated glow group, the single sticky toggle, and the
+    /// two-column drag layout are hand-built, not list-walked. So
+    /// the lists exist to record membership for the placement
+    /// table and search — and the guard holds that membership —
+    /// but editing one moves nothing on screen (the edge `gui.md`
+    /// warns about). A container that becomes a real `ForEach`
+    /// leaves this set in the same change.
+    static let bespokeContainers: Set<SettingsContainer> = [
+        .gaps,
+        .focusBorder,
+        .stickyWindows,
+        .dragAndDrop,
+    ]
+}

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsEditor.swift
@@ -25,6 +25,10 @@ struct GapsEditor: View {
         SettingsCatalog.gapsAndBorders.gapsPerAxis
     }
 
+    private var gates: GapsBordersGates {
+        GapsBordersGates(settings: model.config.settings)
+    }
+
     var body: some View {
         SettingsSection(SettingsCatalog.gapsAndBorders.gapsCard) {
             GapsDiagram(outer: outer, inner: inner)
@@ -130,11 +134,7 @@ struct GapsEditor: View {
             .minimumScaleFactor(0.75)
             .help(
                 mixed
-                    ? L(
-                        "gaps.mixed.help",
-                        "Edges differ — edit them "
-                            + "individually below."
-                    )
+                    ? GapsBordersGateHelp.sentence(for: .gapsDiffer)
                     : ""
             )
         }
@@ -150,14 +150,16 @@ struct GapsEditor: View {
         model.config.settings.gapsGlobal.inner
     }
 
+    // The master slider is inert while its edges / axes differ.
+    // The predicate is the census's, resolved once in
+    // `GapsBordersGates`, so the view never re-derives "differ"
+    // beside the gate that declares it (#678, gui.md).
     private var outerMixed: Bool {
-        !(outer.top == outer.bottom
-            && outer.top == outer.left
-            && outer.top == outer.right)
+        gates.inertReason(for: .gaps(.outer)) != nil
     }
 
     private var innerMixed: Bool {
-        inner.horizontal != inner.vertical
+        gates.inertReason(for: .gaps(.inner)) != nil
     }
 
     /// The master slider: reads the shared value, writes every

--- a/Tests/KiwiDeskGuiTests/GapsAndBordersCensusRenderTests.swift
+++ b/Tests/KiwiDeskGuiTests/GapsAndBordersCensusRenderTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// The Gaps & Borders area against the census (#678 Phase 3).
+///
+/// As in General the promise is the WEAKER one: all four
+/// containers are bespoke views (the gap drawers, the ring
+/// preview and its auto-gated glow, the sticky toggle, the two
+/// drag columns), so the order lists record membership for the
+/// placement table and search without driving anything on screen.
+/// What is guarded is that the lists and the census agree, and
+/// that the bespoke declaration stays true of the tree.
+@Suite("Gaps & Borders render ↔ census parity")
+struct GapsAndBordersCensusRenderTests {
+    /// Rows the census places in this area's container, at a tier
+    /// this area draws (`.atRest` / `.showMore`). Lua-only and
+    /// internal rows carry no container and are excluded already,
+    /// but the tier filter says so rather than relying on it.
+    private func censusRows(
+        _ container: SettingsContainer
+    ) -> Set<SettingKey> {
+        Set(
+            SettingKey.allCases.filter {
+                $0.placement.area == .gapsAndBorders
+                    && $0.placement.container == container
+                    && [.atRest, .showMore]
+                        .contains($0.placement.tier)
+            }
+        )
+    }
+
+    @Test("each container renders exactly its census rows")
+    func listsMatchCensus() {
+        for (container, order)
+            in GapsBordersRowOrder.byContainer
+        {
+            #expect(
+                Set(order) == censusRows(container),
+                Comment(
+                    rawValue:
+                        "\(container) drifted from the census — "
+                        + "a row moves by editing the census, "
+                        + "and the order list follows"
+                )
+            )
+            #expect(
+                order.count == Set(order).count,
+                "\(container) lists a row twice"
+            )
+        }
+    }
+
+    /// The area draws no container it does not list, and lists
+    /// none it cannot draw.
+    @Test("the area holds only the containers it renders")
+    func containersMatch() {
+        let declared = Set(
+            SettingKey.allCases
+                .filter { $0.placement.area == .gapsAndBorders }
+                .filter {
+                    [.atRest, .showMore]
+                        .contains($0.placement.tier)
+                }
+                .compactMap { $0.placement.container }
+        )
+        #expect(
+            declared == Set(GapsBordersRowOrder.byContainer.keys)
+        )
+    }
+
+    /// The bespoke claim, read off the TREE rather than restated
+    /// against another literal: a container is bespoke exactly
+    /// when nothing `ForEach`es its order list.
+    @Test("the bespoke containers really have no ForEach")
+    func bespokeMeansNoForEach() throws {
+        #expect(
+            GapsBordersRowOrder.bespokeContainers
+                == Set(GapsBordersRowOrder.byContainer.keys)
+        )
+        let root = SourceScan.repoRoot(from: #filePath)
+        var files = try SourceScan.swiftSources(
+            under: root.appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Components/"
+                    + "GapsAndBorders"
+            )
+        )
+        files += try SourceScan.swiftSources(
+            under: root.appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Sections"
+            )
+        ).filter {
+            $0.lastPathComponent.hasPrefix("GapsAndBordersSection")
+        }
+        // Assert the scan found its input before asserting about
+        // it: an enumerator over a renamed directory yields [] and
+        // every check below would pass for having looked at
+        // nothing.
+        #expect(files.count >= 6)
+        for file in files {
+            let source = SourceScan.blankingCommentsAndLiterals(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            let squashed = source.split(
+                whereSeparator: \.isWhitespace
+            ).joined()
+            #expect(
+                !squashed.contains(
+                    "ForEach(GapsBordersRowOrder."
+                ),
+                Comment(
+                    rawValue:
+                        "\(file.lastPathComponent) walks an order "
+                        + "list — that container is no longer "
+                        + "bespoke, and bespokeContainers must "
+                        + "say so"
+                )
+            )
+        }
+    }
+}

--- a/Tests/KiwiDeskGuiTests/GapsAndBordersGateTests.swift
+++ b/Tests/KiwiDeskGuiTests/GapsAndBordersGateTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import KiwiDeskCore
+import Testing
+
+@testable import KiwiDesk
+
+/// Gaps & Borders' gate resolver (#678 Phase 3). The area carries
+/// all three gate flavours, so this pins each: the Focus-border
+/// CONTAINER gate, the row gates (glow size, drag sub-rows), and
+/// the two `.runtime` gap-master gates.
+@Suite("Gaps & Borders gates")
+struct GapsAndBordersGateTests {
+    private func settings(
+        border: Bool = true,
+        glow: Bool = true,
+        ghost: Bool = true,
+        ghostBorder: Bool = true,
+        dropZone: Bool = true,
+        dropZoneBorder: Bool = true,
+        outerEdgesDiffer: Bool = false,
+        innerAxesDiffer: Bool = false
+    ) -> TilingSettings {
+        var s = TilingSettings()
+        s.borderStyle.enabled = border
+        s.borderStyle.glow = glow
+        s.dragGhost.enabled = ghost
+        s.dragGhost.border = ghostBorder
+        s.dragDropZone.enabled = dropZone
+        s.dragDropZone.border = dropZoneBorder
+        s.gapsGlobal.outer = Gaps.Outer(
+            top: 10,
+            bottom: outerEdgesDiffer ? 4 : 10,
+            left: 10,
+            right: 10
+        )
+        s.gapsGlobal.inner = Gaps.Inner(
+            horizontal: 10,
+            vertical: innerAxesDiffer ? 4 : 10
+        )
+        return s
+    }
+
+    private func gates(
+        _ overrides: (inout TilingSettings) -> Void = { _ in }
+    ) -> GapsBordersGates {
+        var s = settings()
+        overrides(&s)
+        return GapsBordersGates(settings: s)
+    }
+
+    /// The declared-vs-answered split, read off the census: a new
+    /// gated ROW in this area that lands in neither set reds here
+    /// rather than failing open at runtime.
+    @Test("every gated row is resolved somewhere")
+    func everyGatedRowIsResolved() {
+        let gated = Set(
+            SettingKey.allCases.filter {
+                $0.placement.area == .gapsAndBorders
+                    && $0.placement.gate != nil
+            }
+        )
+        #expect(
+            gated
+                == GapsBordersGates.resolved
+                .union(GapsBordersGates.resolvedElsewhere)
+        )
+        #expect(
+            GapsBordersGates.resolved.isDisjoint(
+                with: GapsBordersGates.resolvedElsewhere
+            )
+        )
+    }
+
+    /// The one CONTAINER gate this area carries — Layout Defaults
+    /// has none, so this net does not exist there. `.focusBorder`
+    /// is the only container with a gate, and the resolver answers
+    /// it both ways.
+    @Test("the focus-border block gate is resolved")
+    func containerGateIsResolved() {
+        let gatedContainers = Set(
+            SettingKey.allCases
+                .filter { $0.placement.area == .gapsAndBorders }
+                .compactMap { $0.placement.container }
+                .filter { $0.gate != nil }
+        )
+        #expect(gatedContainers == [.focusBorder])
+        #expect(
+            gates { $0.borderStyle.enabled = false }
+                .containerReason(for: .focusBorder) == .borderOff
+        )
+        #expect(
+            gates { $0.borderStyle.enabled = true }
+                .containerReason(for: .focusBorder) == nil
+        )
+        // No other container greys: a stray reason would dim a
+        // whole card with nothing declaring it.
+        for container in GapsBordersRowOrder.byContainer.keys
+        where container != .focusBorder {
+            #expect(
+                gates().containerReason(for: container) == nil
+            )
+        }
+    }
+
+    /// An ungated row is never inert — the resolver's first guard,
+    /// and what keeps its `default:` arm unreachable rather than
+    /// merely believed to be. Runs with everything OFF, the state
+    /// most likely to trip a stray predicate.
+    @Test("ungated rows stay live")
+    func ungatedRowsStayLive() {
+        let g = GapsBordersGates(
+            settings: settings(
+                border: false,
+                glow: false,
+                ghost: false,
+                ghostBorder: false,
+                dropZone: false,
+                dropZoneBorder: false
+            )
+        )
+        for key in SettingKey.allCases
+        where key.placement.area == .gapsAndBorders
+            && key.placement.gate == nil
+        {
+            #expect(g.inertReason(for: key) == nil)
+        }
+    }
+
+    @Test("glow size greys with the glow effect off")
+    func glowSizeNeedsGlow() {
+        // Border on, glow off → the row is inert.
+        #expect(
+            gates { $0.borderStyle.glow = false }
+                .inertReason(for: .borders(.borderGlowSize))
+                == .glowOff
+        )
+        // Glow on → live (the auto sentinel greys it separately).
+        #expect(
+            gates { $0.borderStyle.glow = true }
+                .inertReason(for: .borders(.borderGlowSize)) == nil
+        )
+        // Border off → the block owns the grey; the row reason
+        // stands down so its hover cannot shadow the block's.
+        #expect(
+            gates {
+                $0.borderStyle.enabled = false
+                $0.borderStyle.glow = false
+            }
+            .inertReason(for: .borders(.borderGlowSize)) == nil
+        )
+    }
+
+    @Test("the ghost column gates on enabled then border")
+    func ghostColumnLayers() {
+        // Ghost off → border toggle, fill and the width row all
+        // read `.visualOff`.
+        let off = gates { $0.dragGhost.enabled = false }
+        #expect(
+            off.inertReason(for: .borders(.dragGhostBorder))
+                == .visualOff
+        )
+        #expect(
+            off.inertReason(for: .borders(.dragGhostFill))
+                == .visualOff
+        )
+        #expect(
+            off.inertReason(for: .borders(.dragGhostBorderWidth))
+                == .visualOff
+        )
+        // Ghost on, its border off → width is `.visualBorderOff`,
+        // the border toggle itself stays live.
+        let noBorder = gates { $0.dragGhost.border = false }
+        #expect(
+            noBorder.inertReason(
+                for: .borders(.dragGhostBorderWidth)
+            ) == .visualBorderOff
+        )
+        #expect(
+            noBorder.inertReason(
+                for: .borders(.dragGhostBorder)
+            ) == nil
+        )
+        // All on → live.
+        #expect(
+            gates().inertReason(
+                for: .borders(.dragGhostBorderWidth)
+            ) == nil
+        )
+    }
+
+    @Test("the drop-zone column gates on enabled then border")
+    func dropZoneColumnLayers() {
+        let off = gates { $0.dragDropZone.enabled = false }
+        #expect(
+            off.inertReason(for: .borders(.dragDropZoneBorder))
+                == .visualOff
+        )
+        #expect(
+            off.inertReason(for: .borders(.dragDropZoneFill))
+                == .visualOff
+        )
+        #expect(
+            off.inertReason(
+                for: .borders(.dragDropZoneBorderWidth)
+            ) == .visualOff
+        )
+        let noBorder = gates { $0.dragDropZone.border = false }
+        #expect(
+            noBorder.inertReason(
+                for: .borders(.dragDropZoneBorderWidth)
+            ) == .visualBorderOff
+        )
+        #expect(
+            noBorder.inertReason(
+                for: .borders(.dragDropZoneBorder)
+            ) == nil
+        )
+    }
+
+    @Test("a gap master greys while its edges or axes differ")
+    func gapMastersGateOnDiffer() {
+        #expect(
+            GapsBordersGates(
+                settings: settings(outerEdgesDiffer: true)
+            ).inertReason(for: .gaps(.outer)) == .gapsDiffer
+        )
+        #expect(
+            gates().inertReason(for: .gaps(.outer)) == nil
+        )
+        #expect(
+            GapsBordersGates(
+                settings: settings(innerAxesDiffer: true)
+            ).inertReason(for: .gaps(.inner)) == .gapsDiffer
+        )
+        #expect(
+            gates().inertReason(for: .gaps(.inner)) == nil
+        )
+    }
+
+    /// Every reason renders a distinct, non-empty sentence: a
+    /// collapsed pair would send the reader to the wrong fix.
+    @MainActor
+    @Test("each inert reason renders its own sentence")
+    func eachReasonHasItsOwnSentence() {
+        let all: [GapsBordersGates.InertReason] = [
+            .borderOff, .glowOff, .visualOff, .visualBorderOff,
+            .gapsDiffer,
+        ]
+        let sentences = all.map(GapsBordersGateHelp.sentence)
+        for sentence in sentences {
+            #expect(!sentence.isEmpty)
+        }
+        #expect(Set(sentences).count == all.count)
+    }
+}

--- a/Tests/KiwiDeskGuiTests/GapsAndBordersGateWiringTests.swift
+++ b/Tests/KiwiDeskGuiTests/GapsAndBordersGateWiringTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// The Gaps & Borders editors are wired to the gate resolver
+/// (#678 Phase 3), split from the behaviour suite so neither file
+/// crosses the size ceiling.
+///
+/// General shipped a round-1 cut whose resolver was built only in
+/// tests while the views re-derived each predicate and re-authored
+/// each sentence inline; the census gate and the on-screen grey
+/// could then drift with every gate test still green. This is the
+/// wiring half — the behaviour half is `GapsAndBordersGateTests`.
+@Suite("Gaps & Borders gate wiring")
+struct GapsAndBordersGateWiringTests {
+    private var dir: URL {
+        SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Components/"
+                    + "GapsAndBorders"
+            )
+    }
+
+    private func read(_ name: String) throws -> String {
+        try String(
+            contentsOf: dir.appendingPathComponent(name),
+            encoding: .utf8
+        )
+    }
+
+    /// EACH gate's own resolver call, not a file-level "touches
+    /// the resolver somewhere". A file with two gates (Focus
+    /// border's block + glow) would satisfy a file check while one
+    /// gate quietly went hand-rolled — the very drift this guard
+    /// exists to catch, and the hole the first cut of it left
+    /// (caught by guard-prover before this PR). Sticky is
+    /// deliberately ungated, so it is not a consumer.
+    @Test("each gate is wired to the resolver, not a copy")
+    func rowsConsultTheResolver() throws {
+        // Whitespace-free source, so a needle survives the
+        // formatter wrapping a `gates.inertReason(for:)` call
+        // across lines.
+        func squashed(_ name: String) throws -> String {
+            SourceScan.stripComments(try read(name))
+                .split(whereSeparator: \.isWhitespace)
+                .joined()
+        }
+        let consults: [String: [String]] = [
+            "GapsEditor.swift": [
+                "gates.inertReason(for:.gaps(.outer))",
+                "gates.inertReason(for:.gaps(.inner))",
+            ],
+            "FocusBorderEditor.swift": [
+                "gates.containerReason(for:.focusBorder)",
+                "gates.inertReason(for:.borders(.borderGlowSize))",
+            ],
+            "DragVisualsEditor.swift": [
+                "gates.inertReason(for:.borders(.dragGhostBorder))",
+                "gates.inertReason("
+                    + "for:.borders(.dragGhostBorderWidth))",
+                "gates.inertReason("
+                    + "for:.borders(.dragDropZoneBorder))",
+                "gates.inertReason("
+                    + "for:.borders(.dragDropZoneBorderWidth))",
+            ],
+        ]
+        for (name, needles) in consults {
+            let source = try squashed(name)
+            for needle in needles {
+                #expect(
+                    source.contains(needle),
+                    Comment(
+                        rawValue:
+                            "\(name) no longer wires `\(needle)` to "
+                            + "the gate resolver — that gate went "
+                            + "hand-rolled"
+                    )
+                )
+            }
+            #expect(
+                source.contains("GapsBordersGateHelp.sentence"),
+                Comment(
+                    rawValue:
+                        "\(name) does not read GapsBordersGateHelp "
+                        + "for its inert caption"
+                )
+            )
+        }
+        // Every gate sentence is authored ONCE, in the help enum;
+        // a row that re-authors one is the duplication that let
+        // General describe one status two ways.
+        let help = try read("GapsBordersGateHelp.swift")
+        let allEditors =
+            Array(consults.keys) + ["StickyMarkEditor.swift"]
+        for key in [
+            "border.controls.disabled",
+            "border.glow_size.disabled",
+            "drag.disabled.help",
+            "drag.border.off_help",
+            "gaps.mixed.help",
+        ] {
+            #expect(
+                help.contains(key),
+                Comment(rawValue: "GapsBordersGateHelp lost \(key)")
+            )
+            for name in allEditors {
+                #expect(
+                    !(try read(name)).contains(key),
+                    Comment(
+                        rawValue:
+                            "\(name) re-authors \(key) — it must "
+                            + "come from GapsBordersGateHelp"
+                    )
+                )
+            }
+        }
+    }
+}

--- a/Tests/KiwiDeskGuiTests/GreyOutAnchorTests.swift
+++ b/Tests/KiwiDeskGuiTests/GreyOutAnchorTests.swift
@@ -27,9 +27,12 @@ struct GreyOutAnchorTests {
     /// gaining an occurrence is a conscious edit, so it updates
     /// the count.
     private let anchors: [(file: String, anchor: String, count: Int)] = [
+        // The header `?` anchor now reads the resolver's reason
+        // (#678 Phase 3): nil while the ring is on, the block
+        // sentence while it is off — outside the greyed block.
         (
             "FocusBorderEditor.swift",
-            "help: style.wrappedValue.enabled ? nil : offHelp",
+            "help: blockReason.map(GapsBordersGateHelp.sentence)",
             1
         ),
         (
@@ -65,9 +68,12 @@ struct GreyOutAnchorTests {
             "HelpButton(explanation: help, subject: title)",
             1
         ),
+        // The column header `?` anchor reads the resolver's
+        // enabled reason (#678 Phase 3): one call site, both
+        // columns route through it.
         (
             "DragVisualsEditor.swift",
-            "help: visual.wrappedValue.enabled",
+            "help: enabledReason.map(GapsBordersGateHelp.sentence)",
             1
         ),
         (

--- a/Tests/KiwiDeskGuiTests/GreyOutParityTests.swift
+++ b/Tests/KiwiDeskGuiTests/GreyOutParityTests.swift
@@ -56,9 +56,12 @@ struct GreyOutParityTests {
     /// left the suite green while the swatch stayed editable
     /// with nothing to tint (#678 Phase 3).
     private let gatedEditors: [(file: String, gate: String, count: Int)] = [
+        // The block gate now resolves through `GapsBordersGates`
+        // (#678 Phase 3): the needle is the resolver-driven wrap
+        // on the controls block, not the old inline predicate.
         (
             "FocusBorderEditor.swift",
-            "active: !style.wrappedValue.enabled",
+            "GreyOut(active: blockReason != nil",
             1
         ),
         // The two census-rendered bar cards (#678 Phase 2)
@@ -75,7 +78,14 @@ struct GreyOutParityTests {
             "active: !allows",
             1
         ),
-        ("DragVisualsEditor.swift", "active: !visual.enabled", 1),
+        // Each drag column's outer gate resolves through
+        // `GapsBordersGates` (#678 Phase 3) — the enabled reason
+        // wraps border, width, alignment and fill.
+        (
+            "DragVisualsEditor.swift",
+            "active: enabledReason != nil",
+            1
+        ),
         // `StickyMarkEditor` is deliberately absent: its coverage
         // guard was dropped in #678 Phase 3, the mark being what
         // survives the Space Bar rather than what depends on it.


### PR DESCRIPTION
## Description

Converts the **Gaps & Borders** Settings area to census rendering — the last area the "every area renders from the census" sweep was missing (#678 Phase 3).

- **`GapsBordersRowOrder`** records each container's rows for the placement table and search. All four containers are bespoke (gap drawers, ring preview + auto-gated glow, the sticky toggle, the two drag columns), so the lists hold membership, not on-screen order — `GapsAndBordersCensusRenderTests` pins that (`bespokeMeansNoForEach`).
- **`GapsBordersGates`** resolves the area's greying on the reason-case shape General + Layout Defaults already share (keyed on `SettingKey` over `TilingSettings`, returns `InertReason?`) — **no new resolver signature**. It answers all three gate flavours this area carries: the Focus-border **container** gate (`containerReason`), the **row** gates (glow size, drag sub-rows), and the two **`.runtime`** gap-master gates.
- The four editors now **consult the resolver** instead of re-deriving each predicate, and read `GapsBordersGateHelp` for the inert caption. `GapsAndBordersGateWiringTests.rowsConsultTheResolver` holds that wiring **per gate** (not per file), so a single gate going hand-rolled reds — the dead-resolver trap turn 14b hit.
- Every gate sentence keeps its existing `L()` key, moved once into `GapsBordersGateHelp`, so **en.json is unchanged** and no translation is dropped.

Behavior is preserved exactly — every old greying predicate is reproduced (confirmed by code-reviewer). The `GreyOut` parity/anchor guards' needles for the three rewired editors move to the resolver-driven expressions; the invariants are unchanged.

Per **owner ruling 2026-08-03 (Option A)** this builds on the shared shape and **defers** converging `BarsGateContext` / `ShortcutsRuntimeGate` onto one signature to a follow-up (tracked in the plan; gui.md now records the deferral as a standing obligation).

## Related Issue(s)

Part of #678 (Settings redesign, Phase 3).

## Checklist

- [ ] I understand what this change does and have run it in the app — **not device-verified** (owner eye-confirm of the Gaps & Borders greying + `?` anchors owed before/after merge as preferred)
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested — 3 new suites (census parity, gate behaviour, gate wiring); every new/changed assertion `guard-prover`-red-proofed (11/11), incl. the strengthened per-gate wiring guard
- [x] User-facing changes are documented — no behavior change; `gui.md` census + convergence sections corrected in the same change (rule accuracy)
- [x] No contradictions between code and docs — docs-steward confirmed `user-guide.md` / `ui-patterns.md` parity holds; no `design-decisions.md` entry owed
- [x] `swift build && swift test && ./scripts/lint.sh` passes (2668 tests)
- [ ] Release build green — CI's `Release Build` job (reports, does not block); skipped locally, no concurrency change
- [x] PR is focused

## How I verified

Not device-verified. Verified against code + tests: full gate green (build, 2668 tests, lint, `extract-keys --check` 887 keys). Reviewed by code-reviewer (0 blockers, behavior-preserving), architect-reviewer (0 blockers; container arm on the shared shape, not a new signature) and docs-steward (0 blockers; parity + rule fixes). guard-prover proved every new/changed guard reds against its sub-diff mutation, and closed one blind spot it found (the wiring guard was file-granular; now gate-granular and re-proven).

## Notes for Reviewer

- **Deferred work:** folding `BarsGateContext` + `ShortcutsRuntimeGate` onto the shared reason-case shape is a conscious follow-up (owner Option A), recorded in `gui.md`'s convergence obligation and the plan. Not in this diff.
- `gui.md` edits also clear a pre-existing miss (General was absent from the census-rendered area list) and correct the "resolved elsewhere" attribution — both flagged by docs-steward, folded in since they share the sentences I was already editing.