### PR TITLE
feat(gui): resolve Spaces & Layouts greying from the census (#678 Phase 3, chunk 1)

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -130,11 +130,11 @@ never views.
 `Settings/Census/` records every setting's redesign placement,
 tier, gate and text keys, and the redesigned GUI renders from
 it. **Bars, Colours & Motion, Advanced Colours, Shortcuts,
-Layout Defaults, App Rules, General and Gaps & Borders render
-from it now** (#678 Phases 2-3): each carries its own order list
-and a census-render suite pinning that order to the census
-(`GapsBordersRowOrder` / `GapsAndBordersCensusRenderTests` is the
-newest pair), so a row in a `ForEach`-rendered container moves by
+Layout Defaults, App Rules, General, Gaps & Borders and Spaces &
+Layouts render from it now** (#678 Phases 2-3): each carries its
+own order list and a census-render suite pinning that order to the
+census (`SpacesRowOrder` / `SpacesCensusRenderTests` is the newest
+pair), so a row in a `ForEach`-rendered container moves by
 editing the census — with the bespoke edge below. This bold list is itself a hand-kept claim with no guard,
 so an added area joins it here in the same change that ships its
 `*RowOrder` (General was silently dropped from it once).
@@ -150,12 +150,14 @@ three is data — `ShortcutsRowOrder.bespokeContainers`, asserted
 by `ShortcutsCensusRenderTests` — so a fourth going bespoke has
 to edit that set; check it before assuming an edit will show up.
 
-General and Gaps & Borders push that edge wider: EVERY container
-in them is bespoke (`GeneralRowOrder.bespokeContainers` /
-`GapsBordersRowOrder.bespokeContainers`, each the whole set,
-asserted by `bespokeMeansNoForEach` in each area's render suite),
-so their order lists are membership-and-search only and editing
-one moves nothing on screen.
+General, Gaps & Borders and Spaces & Layouts push that edge
+wider: EVERY container in them is bespoke
+(`GeneralRowOrder.bespokeContainers` /
+`GapsBordersRowOrder.bespokeContainers` /
+`SpacesRowOrder.bespokeContainers`, each the whole set, asserted
+by `bespokeMeansNoForEach` in each area's render suite), so their
+order lists are membership-and-search only and editing one moves
+nothing on screen.
 
 **The census's unit is a SETTING, and one setting may draw many
 rows.** A keybinding family is the worked case: `focusDir` is

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows+Footer.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows+Footer.swift
@@ -96,7 +96,14 @@ extension SpaceOverrideRows {
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
-        .disabled(g.overrideFieldCount(mode, for: space) == 0)
+        .disabled(
+            gates.inertReason(for: .spaces(.spaceOverrideResetActive))
+                != nil
+        )
+        .help(
+            gates.inertReason(for: .spaces(.spaceOverrideResetActive))
+                .map(SpacesGateHelp.sentence) ?? ""
+        )
 
         if !dormantLayouts.isEmpty {
             Button(

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows+ModeRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows+ModeRows.swift
@@ -34,12 +34,12 @@ extension SpaceOverrideRows {
         )
         .modifier(
             GreyOut(
-                active: g.resolvedGrid(for: space).type == .rigid,
-                help: L(
-                    "scroll_grid.fill_empty_space.rigid_only",
-                    "A rigid grid keeps every cell, so there is "
-                        + "no empty space to fill."
-                )
+                active: gates.inertReason(
+                    for: .layout(.gridOverrideFillEmptySpace)
+                ) != nil,
+                help: gates.inertReason(
+                    for: .layout(.gridOverrideFillEmptySpace)
+                ).map(SpacesGateHelp.sentence) ?? ""
             )
         )
         // "Arrange: Columns first / Rows first" (#217) — GUI
@@ -88,14 +88,20 @@ extension SpaceOverrideRows {
                 range: 1...10
             )
         }
+        // One grey over both steppers (they share the auto-size
+        // predicate), but each gate is consulted by name so the
+        // wiring guard sees both.
         .modifier(
             GreyOut(
-                active: g.resolvedGrid(for: space).autoSize,
-                help: L(
-                    "scroll_grid.auto_size.gates",
-                    "Auto-size grid is on for this space, so the "
-                        + "screen decides the columns and rows."
-                )
+                active: gates.inertReason(
+                    for: .layout(.gridOverrideColumns)
+                ) != nil
+                    || gates.inertReason(
+                        for: .layout(.gridOverrideRows)
+                    ) != nil,
+                help: gates.inertReason(
+                    for: .layout(.gridOverrideColumns)
+                ).map(SpacesGateHelp.sentence) ?? ""
             )
         )
     }
@@ -159,12 +165,12 @@ extension SpaceOverrideRows {
         )
         .modifier(
             GreyOut(
-                active: g.resolvedTrack(for: space).autoTracks,
-                help: L(
-                    "track.auto_tracks.gates",
-                    "Auto track limit is on for this space, so "
-                        + "the screen decides how many open."
-                )
+                active: gates.inertReason(
+                    for: .layout(.trackOverrideLimit)
+                ) != nil,
+                help: gates.inertReason(
+                    for: .layout(.trackOverrideLimit)
+                ).map(SpacesGateHelp.sentence) ?? ""
             )
         )
         OverridePickerRow(

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows+StackRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows+StackRows.swift
@@ -123,7 +123,18 @@ extension SpaceOverrideRows {
         )
         // Greyed at a resolved master count of 1, like the
         // Layout Defaults picker (§2.7 grey-don't-hide) — this
-        // space's own override decides, not the global.
-        .disabled(g.resolvedStack(for: space).masterCount <= 1)
+        // space's own override decides, not the global. The
+        // predicate is the census's, resolved once in `SpacesGates`
+        // so the row never re-derives it beside the gate.
+        .disabled(
+            gates.inertReason(
+                for: .layout(.stackOverrideMasterOrientation)
+            ) != nil
+        )
+        .help(
+            gates.inertReason(
+                for: .layout(.stackOverrideMasterOrientation)
+            ).map(SpacesGateHelp.sentence) ?? ""
+        )
     }
 }

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows.swift
@@ -63,6 +63,16 @@ struct SpaceOverrideRows: View {
     /// each file under the line ceiling, can read it.
     var g: TilingSettings { model.config.settings }
 
+    /// The census-resolved greying for this space's override rows
+    /// and reset action (#678 Phase 3). One per-instance resolver,
+    /// keyed on the space and its active layout, so a row never
+    /// re-derives "is this space rigid / auto-sized" beside the
+    /// gate that declares it. Internal so the mode-row and footer
+    /// extensions consult the same instance.
+    var gates: SpacesGates {
+        SpacesGates(settings: g, space: space, mode: mode)
+    }
+
     private func placeholder(_ text: String) -> some View {
         Text(text)
             .font(.caption)

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesGates.swift
@@ -1,0 +1,152 @@
+import KiwiDeskCore
+import SwiftUI
+
+/// The Spaces & Layouts area's greying, resolved from the census
+/// (#678 Phase 3, turn 8). Keyed on a row's own `SettingKey` and
+/// returning a REASON case rather than a Bool — the shape General,
+/// Layout Defaults and Gaps & Borders already share, so this area
+/// adds no new resolver signature.
+///
+/// Unlike those areas the resolver is PER INSTANCE: every gate
+/// here asks about one space (its resolved layout params, its
+/// override count), so the context carries the space and its
+/// active layout alongside the settings. It answers only ROW
+/// gates — no container in this area carries a
+/// `SettingsContainer.gate` — and it takes no `SettingsMode`
+/// input: the mode never changes what runs (8c), it only decides
+/// what is offered, so an override that exists greys the same way
+/// in Simple and Nerd.
+///
+/// The five override-row predicates ask the RESOLVED value for the
+/// space (#406/#520): a control the global would silence is still
+/// live for a space that overrides it, so the per-space editor
+/// reads `resolvedStack(for:)`/`resolvedGrid(for:)`/
+/// `resolvedTrack(for:)`, the same values the Layout Defaults twin
+/// resolves — two surfaces answering "is this space rigid"
+/// differently is the drift the resolver exists to prevent.
+///
+/// Returning the reason rather than a Bool keeps the grey and its
+/// inline sentence from being two decisions that can disagree
+/// (`SpacesGateHelp` renders it), and keeps the whole resolver
+/// assertable off the main actor.
+struct SpacesGates {
+    let settings: TilingSettings
+    let space: SpaceID
+    /// The space's active layout — the one the reset action
+    /// counts overrides for. The five layout-override predicates
+    /// read the space's resolved params directly and do not
+    /// consult it.
+    let mode: LayoutMode
+
+    /// Why a row is inert. One case per predicate; the sentence
+    /// lives in `SpacesGateHelp`.
+    enum InertReason: Hashable {
+        case noOverrides
+        case oneMaster
+        case rigidGrid
+        case autoSizedGrid
+        case autoTracks
+    }
+
+    /// Why `key`'s row is inert for this space right now, or nil
+    /// while it is live. Fail-OPEN on a gate this type does not own
+    /// — loud in debug, live in release — matching the other area
+    /// resolvers: a missing case must not lock a shipped Settings
+    /// row, and of the two silent readings a live row the user can
+    /// ignore beats a dead one they cannot explain.
+    /// `everyGatedRowIsResolved` keeps that arm unreachable rather
+    /// than merely believed to be.
+    func inertReason(for key: SettingKey) -> InertReason? {
+        guard key.placement.gate != nil else { return nil }
+        switch key {
+        case .spaces(.spaceOverrideResetActive):
+            return settings.overrideFieldCount(mode, for: space) == 0
+                ? .noOverrides : nil
+        case .layout(.stackOverrideMasterOrientation):
+            return settings.resolvedStack(for: space).masterCount <= 1
+                ? .oneMaster : nil
+        case .layout(.gridOverrideFillEmptySpace):
+            return settings.resolvedGrid(for: space).type == .rigid
+                ? .rigidGrid : nil
+        case .layout(.gridOverrideColumns),
+            .layout(.gridOverrideRows):
+            return settings.resolvedGrid(for: space).autoSize
+                ? .autoSizedGrid : nil
+        case .layout(.trackOverrideLimit):
+            return settings.resolvedTrack(for: space).autoTracks
+                ? .autoTracks : nil
+        default:
+            assertionFailure(
+                "unhandled Spaces & Layouts gate: \(key.id)"
+            )
+            return nil
+        }
+    }
+
+    /// The gated rows this resolver answers. Data, so
+    /// `everyGatedRowIsResolved` reds when a new census gate in
+    /// this area lands in neither set instead of hitting the
+    /// fail-open default at run time.
+    static let resolved: Set<SettingKey> = [
+        .spaces(.spaceOverrideResetActive),
+        .layout(.stackOverrideMasterOrientation),
+        .layout(.gridOverrideFillEmptySpace),
+        .layout(.gridOverrideColumns),
+        .layout(.gridOverrideRows),
+        .layout(.trackOverrideLimit),
+    ]
+
+    /// Declared-but-answered-elsewhere. Empty and kept so a new
+    /// gate this resolver cannot answer must land here on purpose
+    /// rather than pass silently.
+    static let resolvedElsewhere: Set<SettingKey> = []
+}
+
+/// The inline sentence each `SpacesGates.InertReason` renders —
+/// the "why you can't edit this" a greyed row shows on hover.
+/// Split from the resolver so the resolver stays assertable off
+/// the main actor; the reason and its sentence are one decision,
+/// never two that can disagree (#678, gui.md).
+///
+/// Every key here is reused verbatim from the hand-wired gate this
+/// conversion replaced (or, for the reset action that greyed with
+/// no sentence, from the Layout Defaults twin's), so the English
+/// is unchanged and no translation is dropped.
+@MainActor
+enum SpacesGateHelp {
+    static func sentence(
+        for reason: SpacesGates.InertReason
+    ) -> String {
+        switch reason {
+        case .noOverrides:
+            return L(
+                "space_override.reset_active.none",
+                "There are no overrides to reset."
+            )
+        case .oneMaster:
+            return L(
+                "layout_params.master_orientation.one_master",
+                "Orientation only changes anything with more than "
+                    + "one master window."
+            )
+        case .rigidGrid:
+            return L(
+                "scroll_grid.fill_empty_space.rigid_only",
+                "A rigid grid keeps every cell, so there is "
+                    + "no empty space to fill."
+            )
+        case .autoSizedGrid:
+            return L(
+                "scroll_grid.auto_size.gates",
+                "Auto-size grid is on for this space, so the "
+                    + "screen decides the columns and rows."
+            )
+        case .autoTracks:
+            return L(
+                "track.auto_tracks.gates",
+                "Auto track limit is on for this space, so "
+                    + "the screen decides how many open."
+            )
+        }
+    }
+}

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesRowOrder.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesRowOrder.swift
@@ -1,0 +1,78 @@
+/// Display order for the Spaces & Layouts area's rows (#678
+/// Phase 3, turn 8). Two containers, both hand-built:
+///
+/// - `.spaceList` — the space rows themselves (icon, name, layout
+///   mode, delete) plus the Show-more fallback space. The list is
+///   the screen: one row per space, drawn by `SpacesSection`, not
+///   walked from this list.
+/// - `.perSpaceOverrides` — the per-space layout override rows
+///   (the fields a space's active layout can override) and the two
+///   reset actions. Drawn by `SpaceOverrideRows`.
+///
+/// Both are bespoke: neither container `ForEach`es its order list,
+/// so the lists record membership for the placement table and
+/// search while `SpacesCensusRenderTests` holds them equal to the
+/// census. A row moves by editing the census; the order list
+/// follows.
+enum SpacesRowOrder {
+    /// A space's own controls first (icon, the list itself, name,
+    /// layout mode, delete), then the Show-more fallback space.
+    static let spaceList: [SettingKey] = [
+        .spaces(.spaceIcon),
+        .spaces(.spaceList),
+        .spaces(.spacesName),
+        .spaces(.spaceModes),
+        .spaces(.spacesDelete),
+        .spaces(.fallbackSpace),
+    ]
+
+    /// The override rows grouped by layout mode — the order each
+    /// mode's editor stacks them — then the two reset actions the
+    /// footer draws below.
+    static let perSpaceOverrides: [SettingKey] = [
+        .layout(.bspOverrideStrategy),
+        .layout(.bspOverrideSplitRatioH),
+        .layout(.bspOverrideSplitRatioV),
+        .layout(.stackOverrideMasterCount),
+        .layout(.stackOverrideMasterRatio),
+        .layout(.stackOverrideOverflowStyle),
+        .layout(.stackOverrideStackPosition),
+        .layout(.stackOverrideMasterOrientation),
+        .layout(.scrollingOverrideOrientation),
+        .layout(.scrollingOverrideAnchor),
+        .layout(.scrollingOverrideSlotSize),
+        .layout(.gridOverrideType),
+        .layout(.gridOverrideFillEmptySpace),
+        .layout(.gridOverrideSplitDirection),
+        .layout(.gridOverrideColumns),
+        .layout(.gridOverrideRows),
+        .layout(.monocleOverrideOrientation),
+        .layout(.trackOverrideAxis),
+        .layout(.trackOverrideLimit),
+        .layout(.trackOverrideOverflowStyle),
+        .spaces(.spaceOverrideResetActive),
+        .spaces(.spaceOverrideResetAll),
+    ]
+
+    /// Every row this area draws, by container.
+    static let byContainer: [SettingsContainer: [SettingKey]] = [
+        .spaceList: spaceList,
+        .perSpaceOverrides: perSpaceOverrides,
+    ]
+
+    /// Containers drawn as BESPOKE views rather than a `ForEach`
+    /// over the list above.
+    ///
+    /// Both are: the space list is one row per space (drag handle,
+    /// icon well, inline rename, layout menu, override cell,
+    /// delete), and the override editor switches on the active
+    /// layout to a hand-built row set. So the lists exist to record
+    /// membership for the placement table and search — the guard
+    /// holds that membership — but editing one moves nothing on
+    /// screen. A container that becomes a real `ForEach` leaves
+    /// this set in the same change.
+    static let bespokeContainers: Set<SettingsContainer> = [
+        .spaceList,
+        .perSpaceOverrides,
+    ]
+}

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -819,6 +819,7 @@
   "space_override.dormant.label": "Saved for other layouts (%1$d)",
   "space_override.floating.none": "Floating has no per-space overrides.",
   "space_override.reset_active": "Reset %1$@ Overrides",
+  "space_override.reset_active.none": "There are no overrides to reset.",
   "space_override.reset_all": "Reset All Layout Overrides",
   "space_override.reset_all_confirm.action": "Reset All",
   "space_override.reset_all_confirm.message": "This clears every layout's saved overrides for this space, not just the current one. This can't be undone.",

--- a/Tests/KiwiDeskGuiTests/GreyOutParityTests.swift
+++ b/Tests/KiwiDeskGuiTests/GreyOutParityTests.swift
@@ -108,10 +108,18 @@ struct GreyOutParityTests {
             "GreyOut(active: gatedOff",
             1
         ),
+        // The per-space grid and track override greys now resolve
+        // through `SpacesGates` (#678 Phase 3, turn 8): all three
+        // GreyOut blocks (fill-empty, the Columns/Rows pair, the
+        // track limit) wrap on a resolver call rather than an
+        // inline `resolvedGrid`/`resolvedTrack` predicate. The
+        // count pins that every one still greys — dropping any
+        // one would leave a control live with nothing to act on.
+        // `SpacesGateWiringTests` holds WHICH gate each consults.
         (
             "SpaceOverrideRows+ModeRows.swift",
-            "active: g.resolvedGrid(for: space).autoSize",
-            1
+            "active: gates.inertReason(",
+            3
         ),
         // Advanced Colours (#678 Phase 3), which replaced the
         // interim colour cards.

--- a/Tests/KiwiDeskGuiTests/SpacesCensusRenderTests.swift
+++ b/Tests/KiwiDeskGuiTests/SpacesCensusRenderTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// The Spaces & Layouts area against the census (#678 Phase 3,
+/// turn 8).
+///
+/// As in General and Gaps & Borders the promise is the WEAKER one:
+/// both containers are bespoke views (the space list is one
+/// hand-built row per space; the override editor switches on the
+/// active layout to a hand-built row set), so the order lists
+/// record membership for the placement table and search without
+/// driving anything on screen. What is guarded is that the lists
+/// and the census agree, and that the bespoke declaration stays
+/// true of the tree.
+@Suite("Spaces & Layouts render ↔ census parity")
+struct SpacesCensusRenderTests {
+    /// Rows the census places in this area's container, at a tier
+    /// this area draws (`.atRest` / `.showMore`). Lua-only and
+    /// internal rows carry no container and are excluded already,
+    /// but the tier filter says so rather than relying on it.
+    private func censusRows(
+        _ container: SettingsContainer
+    ) -> Set<SettingKey> {
+        Set(
+            SettingKey.allCases.filter {
+                $0.placement.area == .spacesAndLayouts
+                    && $0.placement.container == container
+                    && [.atRest, .showMore]
+                        .contains($0.placement.tier)
+            }
+        )
+    }
+
+    @Test("each container renders exactly its census rows")
+    func listsMatchCensus() {
+        for (container, order) in SpacesRowOrder.byContainer {
+            #expect(
+                Set(order) == censusRows(container),
+                Comment(
+                    rawValue:
+                        "\(container) drifted from the census — "
+                        + "a row moves by editing the census, "
+                        + "and the order list follows"
+                )
+            )
+            #expect(
+                order.count == Set(order).count,
+                "\(container) lists a row twice"
+            )
+        }
+    }
+
+    /// The area draws no container it does not list, and lists
+    /// none it cannot draw.
+    @Test("the area holds only the containers it renders")
+    func containersMatch() {
+        let declared = Set(
+            SettingKey.allCases
+                .filter { $0.placement.area == .spacesAndLayouts }
+                .filter {
+                    [.atRest, .showMore]
+                        .contains($0.placement.tier)
+                }
+                .compactMap { $0.placement.container }
+        )
+        #expect(
+            declared == Set(SpacesRowOrder.byContainer.keys)
+        )
+    }
+
+    /// The bespoke claim, read off the TREE rather than restated
+    /// against another literal: a container is bespoke exactly when
+    /// nothing `ForEach`es its order list. The space list is drawn
+    /// by `SpacesSection`, the overrides by `SpaceOverrideRows`, so
+    /// both trees are scanned.
+    @Test("the bespoke containers really have no ForEach")
+    func bespokeMeansNoForEach() throws {
+        #expect(
+            SpacesRowOrder.bespokeContainers
+                == Set(SpacesRowOrder.byContainer.keys)
+        )
+        let root = SourceScan.repoRoot(from: #filePath)
+        var files = try SourceScan.swiftSources(
+            under: root.appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Components/"
+                    + "SpaceOverrides"
+            )
+        )
+        files += try SourceScan.swiftSources(
+            under: root.appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Sections"
+            )
+        ).filter {
+            $0.lastPathComponent.hasPrefix("SpacesSection")
+        }
+        // Assert the scan found its input before asserting about
+        // it: an enumerator over a renamed directory yields [] and
+        // every check below would pass for having looked at
+        // nothing.
+        #expect(files.count >= 10)
+        for file in files {
+            let source = SourceScan.blankingCommentsAndLiterals(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            let squashed = source.split(
+                whereSeparator: \.isWhitespace
+            ).joined()
+            #expect(
+                !squashed.contains("ForEach(SpacesRowOrder."),
+                Comment(
+                    rawValue:
+                        "\(file.lastPathComponent) walks an order "
+                        + "list — that container is no longer "
+                        + "bespoke, and bespokeContainers must "
+                        + "say so"
+                )
+            )
+        }
+    }
+}

--- a/Tests/KiwiDeskGuiTests/SpacesGateTests.swift
+++ b/Tests/KiwiDeskGuiTests/SpacesGateTests.swift
@@ -1,0 +1,243 @@
+import KiwiDeskCore
+import Testing
+
+@testable import KiwiDesk
+
+/// The Spaces & Layouts gate resolver (#678 Phase 3, turn 8).
+///
+/// A census `gate:` is answered by the resolver and never
+/// re-implemented beside its row: a renderer whose predicate
+/// drifts from the declaration greys the wrong row, and the
+/// census's stated owner quietly stops being the owner. These pin
+/// each declared gate against a config that satisfies it and one
+/// that does not — and pin that the declared set and the resolved
+/// set are the same set, so a new gated row cannot land in
+/// neither.
+///
+/// Unlike the other area resolvers this one is PER INSTANCE (one
+/// space, its active layout), so every case is built for a
+/// specific space and the override predicates read that space's
+/// resolved params (#406/#520): a control the global would silence
+/// is still live for a space that overrides it.
+@Suite("Spaces & Layouts gates")
+struct SpacesGateTests {
+    private let space = SpaceID("1")
+
+    private func gates(
+        mode: LayoutMode = .stack,
+        _ mutate: (inout TilingSettings) -> Void = { _ in }
+    ) -> SpacesGates {
+        var settings = TilingSettings()
+        mutate(&settings)
+        return SpacesGates(
+            settings: settings,
+            space: space,
+            mode: mode
+        )
+    }
+
+    /// The declared-vs-answered split, read off the census: a new
+    /// gated ROW in this area that lands in neither set reds here
+    /// rather than failing open at run time.
+    @Test("every gated row in the area is accounted for")
+    func everyGatedRowIsResolved() {
+        let declared = Set(
+            SettingKey.allCases.filter {
+                $0.placement.area == .spacesAndLayouts
+                    && $0.placement.gate != nil
+            }
+        )
+        #expect(
+            declared
+                == SpacesGates.resolved.union(
+                    SpacesGates.resolvedElsewhere
+                )
+        )
+        // Both halves pinned, not just their union — an entry
+        // parked in `resolvedElsewhere` that the resolver actually
+        // answers would claim the opposite of what it does.
+        // Trivially true while `resolvedElsewhere` is empty: a slot
+        // armed for its first entry, not a live net.
+        #expect(
+            SpacesGates.resolved
+                .intersection(SpacesGates.resolvedElsewhere)
+                .isEmpty
+        )
+    }
+
+    /// No container in this area carries a gate, so the resolver
+    /// answers only ROW gates — a CONTAINER gate here would grey a
+    /// whole card with nothing to resolve it. Data, so it reds the
+    /// day one is added rather than at a reviewer's discretion.
+    @Test("the area carries no container gate")
+    func noContainerGate() {
+        let gatedContainers = Set(
+            SettingKey.allCases
+                .filter { $0.placement.area == .spacesAndLayouts }
+                .compactMap { $0.placement.container }
+                .filter { $0.gate != nil }
+        )
+        #expect(gatedContainers.isEmpty)
+    }
+
+    /// An ungated row is never inert — the guard above says the
+    /// resolver knows every gate, and this says it invents none.
+    /// Keeps the `default:` arm unreachable rather than merely
+    /// believed to be.
+    @Test("ungated rows stay live")
+    func ungatedRowsStayLive() {
+        let context = gates()
+        for key in SettingKey.allCases
+        where key.placement.area == .spacesAndLayouts
+            && key.placement.gate == nil
+        {
+            #expect(context.inertReason(for: key) == nil)
+        }
+    }
+
+    /// The reset action greys once the active layout has no set
+    /// override fields for the space.
+    @Test("reset greys while the active layout has no overrides")
+    func resetGreysWithoutOverrides() {
+        let key = SettingKey.spaces(.spaceOverrideResetActive)
+        #expect(
+            gates(mode: .stack).inertReason(for: key)
+                == .noOverrides
+        )
+        #expect(
+            gates(mode: .stack) {
+                var override = StackOverride()
+                override.masterCount = 2
+                $0.stack.override[space] = override
+            }
+            .inertReason(for: key) == nil
+        )
+        // Counts the ACTIVE layout only: an override on another
+        // layout leaves this action dead.
+        #expect(
+            gates(mode: .grid) {
+                var override = StackOverride()
+                override.masterCount = 2
+                $0.stack.override[space] = override
+            }
+            .inertReason(for: key) == .noOverrides
+        )
+    }
+
+    /// Master orientation asks the RESOLVED master count (#406): a
+    /// space running several masters reads it whatever the global
+    /// says, so greying it there would lock the only editor for a
+    /// value something uses.
+    @Test("master orientation follows the resolved master count")
+    func masterOrientation() {
+        let key = SettingKey.layout(.stackOverrideMasterOrientation)
+        #expect(
+            gates { $0.stack.masterCount = 1 }
+                .inertReason(for: key) == .oneMaster
+        )
+        #expect(
+            gates { $0.stack.masterCount = 2 }
+                .inertReason(for: key) == nil
+        )
+        #expect(
+            gates {
+                $0.stack.masterCount = 1
+                var override = StackOverride()
+                override.masterCount = 3
+                $0.stack.override[space] = override
+            }
+            .inertReason(for: key) == nil
+        )
+    }
+
+    /// Fill-empty asks the RESOLVED grid type: a rigid global is
+    /// silenced, unless the space overrides back to dynamic.
+    @Test("fill empty space asks the resolved grid type")
+    func fillEmptySpace() {
+        let key = SettingKey.layout(.gridOverrideFillEmptySpace)
+        #expect(
+            gates { $0.grid.type = .dynamic }
+                .inertReason(for: key) == nil
+        )
+        #expect(
+            gates { $0.grid.type = .rigid }
+                .inertReason(for: key) == .rigidGrid
+        )
+        #expect(
+            gates {
+                $0.grid.type = .rigid
+                var override = GridOverride()
+                override.type = .dynamic
+                $0.grid.override[space] = override
+            }
+            .inertReason(for: key) == nil
+        )
+    }
+
+    /// The Columns/Rows steppers ask the RESOLVED auto-size: on for
+    /// the space silences both, unless the space overrides it off.
+    @Test("grid dimensions ask the resolved auto-size")
+    func gridDimensions() {
+        for key in [
+            SettingKey.layout(.gridOverrideColumns),
+            SettingKey.layout(.gridOverrideRows),
+        ] {
+            #expect(
+                gates { $0.grid.autoSize = false }
+                    .inertReason(for: key) == nil
+            )
+            #expect(
+                gates { $0.grid.autoSize = true }
+                    .inertReason(for: key) == .autoSizedGrid
+            )
+            #expect(
+                gates {
+                    $0.grid.autoSize = true
+                    var override = GridOverride()
+                    override.autoSize = false
+                    $0.grid.override[space] = override
+                }
+                .inertReason(for: key) == nil
+            )
+        }
+    }
+
+    /// The track limit follows the RESOLVED auto-tracks toggle.
+    @Test("the track limit follows the resolved auto-tracks")
+    func trackLimit() {
+        let key = SettingKey.layout(.trackOverrideLimit)
+        #expect(
+            gates { $0.track.autoTracks = true }
+                .inertReason(for: key) == .autoTracks
+        )
+        #expect(
+            gates { $0.track.autoTracks = false }
+                .inertReason(for: key) == nil
+        )
+        #expect(
+            gates {
+                $0.track.autoTracks = true
+                var override = TrackOverride()
+                override.autoTracks = false
+                $0.track.override[space] = override
+            }
+            .inertReason(for: key) == nil
+        )
+    }
+
+    /// Every reason renders a distinct, non-empty sentence: a
+    /// collapsed pair would send the reader to the wrong fix.
+    @MainActor
+    @Test("each inert reason renders its own sentence")
+    func eachReasonHasItsOwnSentence() {
+        let all: [SpacesGates.InertReason] = [
+            .noOverrides, .oneMaster, .rigidGrid, .autoSizedGrid,
+            .autoTracks,
+        ]
+        let sentences = all.map(SpacesGateHelp.sentence)
+        for sentence in sentences {
+            #expect(!sentence.isEmpty)
+        }
+        #expect(Set(sentences).count == all.count)
+    }
+}

--- a/Tests/KiwiDeskGuiTests/SpacesGateWiringTests.swift
+++ b/Tests/KiwiDeskGuiTests/SpacesGateWiringTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// The per-space override editors are wired to the gate resolver
+/// (#678 Phase 3, turn 8), split from the behaviour suite so
+/// neither file crosses the size ceiling.
+///
+/// General shipped a round-1 cut whose resolver was built only in
+/// tests while the views re-derived each predicate and re-authored
+/// each sentence inline; the census gate and the on-screen grey
+/// could then drift with every gate test still green. This is the
+/// wiring half — the behaviour half is `SpacesGateTests`.
+///
+/// SCOPE: this scans `Settings/Components/SpaceOverrides/` because
+/// every gated row `SpacesGates` answers renders there today — all
+/// six sit in the `.perSpaceOverrides` container. The area's other
+/// container, `.spaceList` (drawn by `Settings/Sections/
+/// SpacesSection*`), carries NO gated row, so it has nothing to
+/// consult and is deliberately unscanned. A future gated
+/// `.spaceList` row would be forced into `SpacesGates.resolved` by
+/// `everyGatedRowIsResolved`, yet nothing here would force
+/// `SpacesSection` to consult the resolver — the dead-resolver
+/// trap, reopened in the uncovered container. Such a row owes both
+/// its resolver consult AND a `consults` entry naming the
+/// `SpacesSection*` file that draws it (widen `dir`/`read` to reach
+/// it), in the same change.
+@Suite("Spaces & Layouts gate wiring")
+struct SpacesGateWiringTests {
+    private var dir: URL {
+        SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Components/"
+                    + "SpaceOverrides"
+            )
+    }
+
+    private func read(_ name: String) throws -> String {
+        try String(
+            contentsOf: dir.appendingPathComponent(name),
+            encoding: .utf8
+        )
+    }
+
+    /// EACH gate's own resolver call, not a file-level "touches the
+    /// resolver somewhere". `SpaceOverrideRows+ModeRows` carries
+    /// four gates across grid and track; a file check would pass
+    /// while one quietly went hand-rolled — the very drift this
+    /// guard exists to catch.
+    @Test("each gate is wired to the resolver, not a copy")
+    func rowsConsultTheResolver() throws {
+        // Whitespace-free source, so a needle survives the
+        // formatter wrapping a `gates.inertReason(for:)` call
+        // across lines.
+        func squashed(_ name: String) throws -> String {
+            SourceScan.stripComments(try read(name))
+                .split(whereSeparator: \.isWhitespace)
+                .joined()
+        }
+        let consults: [String: [String]] = [
+            "SpaceOverrideRows+Footer.swift": [
+                "gates.inertReason("
+                    + "for:.spaces(.spaceOverrideResetActive))"
+            ],
+            "SpaceOverrideRows+StackRows.swift": [
+                "gates.inertReason("
+                    + "for:.layout(.stackOverrideMasterOrientation))"
+            ],
+            "SpaceOverrideRows+ModeRows.swift": [
+                "gates.inertReason("
+                    + "for:.layout(.gridOverrideFillEmptySpace))",
+                "gates.inertReason("
+                    + "for:.layout(.gridOverrideColumns))",
+                "gates.inertReason("
+                    + "for:.layout(.gridOverrideRows))",
+                "gates.inertReason("
+                    + "for:.layout(.trackOverrideLimit))",
+            ],
+        ]
+        for (name, needles) in consults {
+            let source = try squashed(name)
+            for needle in needles {
+                #expect(
+                    source.contains(needle),
+                    Comment(
+                        rawValue:
+                            "\(name) no longer wires `\(needle)` to "
+                            + "the gate resolver — that gate went "
+                            + "hand-rolled"
+                    )
+                )
+            }
+            #expect(
+                source.contains("SpacesGateHelp.sentence"),
+                Comment(
+                    rawValue:
+                        "\(name) does not read SpacesGateHelp for "
+                        + "its inert caption"
+                )
+            )
+        }
+        // Every gate sentence is authored ONCE, in the help enum; a
+        // row that re-authors one is the duplication that let
+        // General describe one status two ways.
+        let help = try read("SpacesGates.swift")
+        let nonAuthors =
+            Array(consults.keys) + [
+                "SpaceOverrideRows.swift",
+                "OverrideSlotSizeRow.swift",
+            ]
+        for key in [
+            "space_override.reset_active.none",
+            "layout_params.master_orientation.one_master",
+            "scroll_grid.fill_empty_space.rigid_only",
+            "scroll_grid.auto_size.gates",
+            "track.auto_tracks.gates",
+        ] {
+            #expect(
+                help.contains(key),
+                Comment(rawValue: "SpacesGateHelp lost \(key)")
+            )
+            for name in nonAuthors {
+                #expect(
+                    !(try read(name)).contains(key),
+                    Comment(
+                        rawValue:
+                            "\(name) re-authors \(key) — it must "
+                            + "come from SpacesGateHelp"
+                    )
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Chunk 1 of the #678 Phase 3 **Spaces & Layouts** lane: the census/resolver foundation. No UI redesign yet — that is chunk 2 (the 8a space-list screen + 8b overrides sub-view).

Builds the area's gate resolver on the shared reason-case shape (the fifth, after Gaps & Borders / General / Layout Defaults / the converged Bars+Shortcuts):

- **`SpacesGates` + `SpacesGateHelp`** — a *per-instance* `{settings, space, mode}` resolver answering all **six** gated rows the `.spacesAndLayouts` area declares: the reset-active runtime gate plus the five per-space layout-override greys (master-orientation, fill-empty, grid columns/rows, track limit). Each override gate asks the space's **resolved** value (`resolvedStack/Grid/Track(for:)`, #406/#520), byte-identical to the inline predicates it replaces. No `SettingsMode` input — the mode never changes what runs (8c).
- **`SpacesRowOrder`** — `.spaceList` (6) + `.perSpaceOverrides` (22) membership, both bespoke; pinned to the census by `SpacesCensusRenderTests`.
- **Wiring** — the per-space override editors (`SpaceOverrideRows+Footer/+StackRows/+ModeRows`) now route their greys and their inline help through the resolver; `SpacesGateWiringTests` holds each gate gate-granular (a resolver can ship dead).
- One new string `space_override.reset_active.none` (the greyed reset button gains a hover reason); `Spaces & Layouts` added to gui.md's census bold list; `GreyOutParityTests`' ModeRows needle repointed to the resolver wraps.

## Verify

- `swift build` + full `swift test` (2701 tests) green; `scripts/lint.sh` OK; `extract-keys --check` OK (888 keys).
- **guard-prover: 13/13 assertions red-proofed, 0 inert.**
- Reviews: code-reviewer, architect-reviewer, docs-steward, localization-auditor — 0 blockers, 0 major, 2 minors (both addressed: guard-prover run done; wiring-scan scope documented).

## Notes

- No `docs/user-guide.md` change owed — the user-guide already documents the reset as "greyed when it has none"; this only surfaces that reason on hover.
- Non-`en` locales fall back to English for the one new key until a translation round (non-gate-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)