### PR TITLE
feat(state): return focus to the previously focused window on close

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Events.swift
@@ -222,6 +222,10 @@ extension KiwiCore {
             state.windows[next]?.isFullscreen != true
         {
             focusWindow(next, warp: true)
+            armCloseReturnRestack(
+                to: next,
+                fromRemovedSlot: effects.removedWindow?.tiledSlot
+            )
         }
         // A structural change in a track space (spawn, close) can
         // push a window into an overflow cascade; fix the pile's
@@ -232,6 +236,45 @@ extension KiwiCore {
         // minimize).
         if willRetile {
             scheduleTrackZOrderRestoreIfOverflowing()
+        }
+    }
+
+    /// #674, the close path: a close-return pick can cross
+    /// several scrolling slots, and `focusWindow`'s own jump arm
+    /// cannot see it — the destroy fold already wrote the pick
+    /// into `space.focused`, so the anchor the jump test
+    /// classifies from IS the target (distance zero), and the
+    /// closed window has left the row besides. Re-derive the
+    /// distance from the REMOVED slot instead: the old focus sat
+    /// there, and the successor pick inherits it, which is why
+    /// the close path never jumped before close-return existed.
+    /// The same anchor blindness means the #143 backward-pan
+    /// deferral can never defer this raise; that stays the
+    /// close-handoff's documented immediate-raise behavior
+    /// (`focusWindow`'s own comment), a pop being cheaper than a
+    /// spurious deferral on every close. Self-gated downstream on
+    /// scrolling + actual overflow; a nil slot (the closed window
+    /// was a float or fullscreen member) or a candidate outside
+    /// the tiled row is no evidence of a jump — same asymmetry
+    /// as `scrollFocusJumpsSlots`. Internal, not private: the
+    /// call site above sits behind `eventLoop.isListed` (live
+    /// AX — the `TransientOverlayFocusTests` gate note), so
+    /// `ZOrderCloseReturnArmTests` proves the arm directly.
+    func armCloseReturnRestack(
+        to target: WindowID,
+        fromRemovedSlot slot: Int?
+    ) {
+        guard let slot, let space = activeSpace else { return }
+        let tiled = state.effectiveTiledMembers(
+            of: space,
+            activeSpace: space.id
+        )
+        guard !tiled.isEmpty,
+            let targetIndex = tiled.firstIndex(of: target)
+        else { return }
+        let from = min(slot, tiled.count - 1)
+        if abs(targetIndex - from) > 1 {
+            scheduleScrollingZOrderRestoreIfOverflowing()
         }
     }
 }

--- a/Sources/KiwiDeskCore/State/AppliedEffects.swift
+++ b/Sources/KiwiDeskCore/State/AppliedEffects.swift
@@ -44,5 +44,12 @@ public struct AppliedEffects: Sendable {
         let bundleID: String?
         let space: SpaceID?
         let focusLost: Bool
+        /// The gone window's index among its space's effective
+        /// tiled members, pre-removal; nil for a float or
+        /// fullscreen member. The close handler re-derives the
+        /// close-return jump distance from it, because after
+        /// the fold the anchor `focusWindow` classifies from
+        /// IS the pick (#674's arm sees distance zero).
+        let tiledSlot: Int?
     }
 }

--- a/Sources/KiwiDeskCore/State/AppliedEffects.swift
+++ b/Sources/KiwiDeskCore/State/AppliedEffects.swift
@@ -50,6 +50,12 @@ public struct AppliedEffects: Sendable {
         /// close-return jump distance from it, because after
         /// the fold the anchor `focusWindow` classifies from
         /// IS the pick (#674's arm sees distance zero).
+        /// Scoped to the `focusLost` path: the index is framed
+        /// with the home space as active (sticky-traveler
+        /// injection follows focus), which matches reality
+        /// only there — `focusLost` implies home == active. A
+        /// consumer on a background-space removal inherits a
+        /// counterfactual frame; re-derive instead.
         let tiledSlot: Int?
     }
 }

--- a/Sources/KiwiDeskCore/State/StateCoordinator+Support.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+Support.swift
@@ -11,11 +11,19 @@ extension StateCoordinator {
         let focused =
             workspaces.activeSpace
             .flatMap { workspaces[$0]?.focused }
+        let home = workspaces.space(of: id)
+        let tiledSlot = home.flatMap { space in
+            workspaces[space].flatMap {
+                effectiveTiledMembers(of: $0, activeSpace: space)
+                    .firstIndex(of: id)
+            }
+        }
         return AppliedEffects.RemovedWindow(
             app: windows[id]?.appName,
             bundleID: windows[id]?.appBundleID,
-            space: workspaces.space(of: id),
-            focusLost: focused == id
+            space: home,
+            focusLost: focused == id,
+            tiledSlot: tiledSlot
         )
     }
 

--- a/Sources/KiwiDeskCore/State/StateCoordinator+WindowDestroyed.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+WindowDestroyed.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// The `.windowDestroyed` fold — the minimize/space memory, the
+/// removal, and the two focus picks that follow it (close-return
+/// and the #670 fullscreen re-pick). Split from
+/// `StateCoordinator.apply` for the file ceiling (§2.1), like
+/// `+WindowCreated`.
+extension StateCoordinator {
+    mutating func applyWindowDestroyed(
+        _ id: WindowID,
+        wasMinimized: Bool,
+        effects: inout AppliedEffects
+    ) {
+        effects.removedWindow = removalFacts(id)
+        if wasMinimized {
+            rememberedSpaces[id] = nil
+            // Before `windows.remove(id)` below: the record
+            // needs the snapshot's pid and bundle id (#673).
+            rememberMinimized(id)
+        } else if let space = workspaces.space(of: id) {
+            rememberedSpaces[id] = space
+        }
+        // Float intent is remembered even for minimized
+        // windows: deminiaturize re-tracks from detection
+        // and would lose a manual override too (#160).
+        if let window = windows[id] {
+            rememberFloatOverride(of: window)
+            rememberStickyIntent(of: window)
+        }
+        let home = workspaces.space(of: id)
+        let heldFocus =
+            home.map { workspaces[$0]?.focused == id }
+            ?? false
+        let slot = home.flatMap {
+            workspaces[$0]?.windows.firstIndex(of: id)
+        }
+        windows.remove(id)
+        workspaces.remove(id)
+        // Close-return: when THIS close moved the focus,
+        // hand it back to the window the user was in just
+        // before — one visible step of history, not the
+        // spatial successor. Only when the candidate is
+        // still a surfaceable member of the SAME space at
+        // close time: alive (a dead or minimized candidate
+        // is simply absent from state), still in `home`
+        // (never a cross-space yank), not native-fullscreen
+        // (#670 — the raise would switch Spaces), and not a
+        // transient overlay (#671 — no resurrecting a focus
+        // nobody granted). An invalid candidate falls
+        // through to the successor-slot pick `Space.remove`
+        // already made. This is a single step back, NOT the
+        // repeat-press MRU cycling #637 rejected — the
+        // argument lives in `docs/design-decisions.md`
+        // ▸ Close-return focus.
+        if heldFocus, let home,
+            let candidate = workspaces.previousFocused,
+            workspaces.space(of: candidate) == home,
+            windows[candidate]?.isFullscreen == false,
+            windows[candidate]?.isTransientOverlay == false
+        {
+            workspaces.withSpace(home) {
+                $0.focused = candidate
+            }
+        }
+        // The slot-neighbor fallback can land on a
+        // fullscreen member (#670 review): the close
+        // handler's raise would then switch the user to
+        // its Space. Only when THIS close moved the focus
+        // (a fullscreen slot held before the close stays
+        // held), re-pick the nearest surfaceable member —
+        // forward from the removed slot first, matching
+        // `Space.remove`'s own direction, then backward;
+        // never the array head (the #11 yank).
+        if heldFocus, let home,
+            let picked = workspaces[home]?.focused,
+            windows[picked]?.isFullscreen == true,
+            let members = workspaces[home]?.windows
+        {
+            let start = min(
+                slot ?? members.count,
+                members.count
+            )
+            let next =
+                members[start...].first {
+                    windows[$0]?.isFullscreen == false
+                }
+                ?? members[..<start].reversed().first {
+                    windows[$0]?.isFullscreen == false
+                }
+            workspaces.withSpace(home) { $0.focused = next }
+        }
+    }
+}

--- a/Sources/KiwiDeskCore/State/StateCoordinator+WindowDestroyed.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+WindowDestroyed.swift
@@ -53,7 +53,7 @@ extension StateCoordinator {
         // argument lives in `docs/design-decisions.md`
         // ▸ Close-return focus.
         if heldFocus, let home,
-            let candidate = workspaces.previousFocused,
+            let candidate = workspaces.focusReturnCandidate,
             workspaces.space(of: candidate) == home,
             windows[candidate]?.isFullscreen == false,
             windows[candidate]?.isTransientOverlay == false

--- a/Sources/KiwiDeskCore/State/StateCoordinator.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator.swift
@@ -218,58 +218,11 @@ public struct StateCoordinator: Sendable {
             applyWindowCreated(window, effects: &effects)
 
         case .windowDestroyed(let id, let wasMinimized):
-            effects.removedWindow = removalFacts(id)
-            if wasMinimized {
-                rememberedSpaces[id] = nil
-                // Before `windows.remove(id)` below: the record
-                // needs the snapshot's pid and bundle id (#673).
-                rememberMinimized(id)
-            } else if let space = workspaces.space(of: id) {
-                rememberedSpaces[id] = space
-            }
-            // Float intent is remembered even for minimized
-            // windows: deminiaturize re-tracks from detection
-            // and would lose a manual override too (#160).
-            if let window = windows[id] {
-                rememberFloatOverride(of: window)
-                rememberStickyIntent(of: window)
-            }
-            let home = workspaces.space(of: id)
-            let heldFocus =
-                home.map { workspaces[$0]?.focused == id }
-                ?? false
-            let slot = home.flatMap {
-                workspaces[$0]?.windows.firstIndex(of: id)
-            }
-            windows.remove(id)
-            workspaces.remove(id)
-            // The slot-neighbor fallback can land on a
-            // fullscreen member (#670 review): the close
-            // handler's raise would then switch the user to
-            // its Space. Only when THIS close moved the focus
-            // (a fullscreen slot held before the close stays
-            // held), re-pick the nearest surfaceable member —
-            // forward from the removed slot first, matching
-            // `Space.remove`'s own direction, then backward;
-            // never the array head (the #11 yank).
-            if heldFocus, let home,
-                let picked = workspaces[home]?.focused,
-                windows[picked]?.isFullscreen == true,
-                let members = workspaces[home]?.windows
-            {
-                let start = min(
-                    slot ?? members.count,
-                    members.count
-                )
-                let next =
-                    members[start...].first {
-                        windows[$0]?.isFullscreen == false
-                    }
-                    ?? members[..<start].reversed().first {
-                        windows[$0]?.isFullscreen == false
-                    }
-                workspaces.withSpace(home) { $0.focused = next }
-            }
+            applyWindowDestroyed(
+                id,
+                wasMinimized: wasMinimized,
+                effects: &effects
+            )
 
         case .windowMoved(let id, let frame):
             windows.updateFrame(id, frame: frame)

--- a/Sources/KiwiDeskCore/State/WorkspaceManager+Displays.swift
+++ b/Sources/KiwiDeskCore/State/WorkspaceManager+Displays.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Display bookkeeping — which display a space is assigned to
+/// and what each display shows. Split from `WorkspaceManager`
+/// for the file ceiling (§2.1); the backing maps (`order`,
+/// `displays`, `spaceDisplay`, `secondaryShown`) stay declared
+/// there and are internal for exactly this file's sake.
+extension WorkspaceManager {
+    public var allDisplays: [Display] {
+        Array(displays.values)
+    }
+
+    public mutating func upsertDisplay(_ display: Display) {
+        displays[display.id] = display
+    }
+
+    @discardableResult
+    public mutating func removeDisplay(
+        _ id: DisplayID
+    ) -> Display? {
+        for (space, display) in spaceDisplay where display == id {
+            spaceDisplay[space] = nil
+        }
+        secondaryShown[id] = nil
+        return displays.removeValue(forKey: id)
+    }
+
+    public mutating func assign(
+        _ space: SpaceID,
+        to display: DisplayID
+    ) {
+        ensureSpace(space)
+        spaceDisplay[space] = display
+        // Reassigning a space can strand a `secondaryShown` entry
+        // that still points at it on its OLD display; drop any
+        // entry no longer matching its display so stale picks
+        // never accumulate (the read path also ignores them).
+        secondaryShown = secondaryShown.filter { display, space in
+            spaceDisplay[space] == display
+        }
+    }
+
+    public func display(of space: SpaceID) -> DisplayID? {
+        spaceDisplay[space]
+    }
+
+    /// Spaces assigned to one display, in creation order.
+    public func spaces(on display: DisplayID) -> [SpaceID] {
+        order.filter { spaceDisplay[$0] == display }
+    }
+
+    /// The space a display currently shows. Alias of
+    /// `activeSpace(on:)`; kept for the bar/overlay call sites
+    /// that predate the per-display active model.
+    public func currentSpace(on display: DisplayID) -> SpaceID? {
+        activeSpace(on: display)
+    }
+}

--- a/Sources/KiwiDeskCore/State/WorkspaceManager.swift
+++ b/Sources/KiwiDeskCore/State/WorkspaceManager.swift
@@ -10,6 +10,9 @@ public struct WorkspaceManager: Sendable {
     /// Creation order, used for deterministic iteration.
     /// Internal (not private) with the three display maps
     /// below: the `+Displays` split reads them cross-file.
+    /// Writes stay inside the two `WorkspaceManager*` files —
+    /// `WorkspaceMapSealTests` pins the two scannable names
+    /// and states why these two are not.
     var order: [SpaceID] = []
     var displays: [DisplayID: Display] = [:]
     var spaceDisplay: [SpaceID: DisplayID] = [:]
@@ -50,7 +53,7 @@ public struct WorkspaceManager: Sendable {
     /// what the repeat-press-cycling ruling rejected, and one
     /// visible step back is the whole close-return promise
     /// (`docs/design-decisions.md` ▸ Close-return focus).
-    public private(set) var previousFocused: WindowID?
+    public private(set) var focusReturnCandidate: WindowID?
 
     public init() {}
 
@@ -275,7 +278,7 @@ public struct WorkspaceManager: Sendable {
     /// Removes a window from whatever space contains it.
     public mutating func remove(_ window: WindowID) {
         if lastFocused == window { lastFocused = nil }
-        if previousFocused == window { previousFocused = nil }
+        if focusReturnCandidate == window { focusReturnCandidate = nil }
         guard let id = space(of: window) else { return }
         spaces[id]?.remove(window)
     }
@@ -287,7 +290,7 @@ public struct WorkspaceManager: Sendable {
         // The close-return candidate must follow a native-tab
         // rekey like `lastFocused` does, or every tab switch
         // silently kills it.
-        if previousFocused == old { previousFocused = new }
+        if focusReturnCandidate == old { focusReturnCandidate = new }
         guard let id = space(of: old) else { return }
         spaces[id]?.rekey(old, to: new)
     }
@@ -302,7 +305,7 @@ public struct WorkspaceManager: Sendable {
         // A re-focus of the already-focused window must not
         // collapse the history to itself.
         if lastFocused != window {
-            previousFocused = lastFocused
+            focusReturnCandidate = lastFocused
         }
         spaces[id]?.focused = window
         lastFocused = window

--- a/Sources/KiwiDeskCore/State/WorkspaceManager.swift
+++ b/Sources/KiwiDeskCore/State/WorkspaceManager.swift
@@ -8,9 +8,11 @@ import Foundation
 public struct WorkspaceManager: Sendable {
     private var spaces: [SpaceID: Space] = [:]
     /// Creation order, used for deterministic iteration.
-    private var order: [SpaceID] = []
-    private var displays: [DisplayID: Display] = [:]
-    private var spaceDisplay: [SpaceID: DisplayID] = [:]
+    /// Internal (not private) with the three display maps
+    /// below: the `+Displays` split reads them cross-file.
+    var order: [SpaceID] = []
+    var displays: [DisplayID: Display] = [:]
+    var spaceDisplay: [SpaceID: DisplayID] = [:]
     /// The space shown on the FOCUSED display — the one the user
     /// is currently acting on. Every command that means "the
     /// current space" reads this. On a single monitor it is the
@@ -28,7 +30,8 @@ public struct WorkspaceManager: Sendable {
     /// needs no explicit seeding — only an explicit switch away
     /// from that default records an entry. Every non-focused
     /// display's shown space is thus `activeSpace(on:)`.
-    private var secondaryShown: [DisplayID: SpaceID] = [:]
+    /// Internal like `order`: the `+Displays` split writes it.
+    var secondaryShown: [DisplayID: SpaceID] = [:]
 
     /// The window holding the SYSTEM focus, across spaces —
     /// every focus write lands here (`focus(_:in:)` is the one
@@ -38,6 +41,16 @@ public struct WorkspaceManager: Sendable {
     /// the two disagree, and surfaces that accent "the focused
     /// window" (the Space Bar) must follow this one.
     public private(set) var lastFocused: WindowID?
+
+    /// The window focused immediately BEFORE `lastFocused` — a
+    /// one-deep history, not a stack. Read by the destroy fold's
+    /// close-return pick (validated there against current state:
+    /// alive, same space, surfaceable); deliberately never a
+    /// deeper walk-back — invisible, self-reordering history is
+    /// what the repeat-press-cycling ruling rejected, and one
+    /// visible step back is the whole close-return promise
+    /// (`docs/design-decisions.md` ▸ Close-return focus).
+    public private(set) var previousFocused: WindowID?
 
     public init() {}
 
@@ -262,6 +275,7 @@ public struct WorkspaceManager: Sendable {
     /// Removes a window from whatever space contains it.
     public mutating func remove(_ window: WindowID) {
         if lastFocused == window { lastFocused = nil }
+        if previousFocused == window { previousFocused = nil }
         guard let id = space(of: window) else { return }
         spaces[id]?.remove(window)
     }
@@ -270,6 +284,10 @@ public struct WorkspaceManager: Sendable {
     /// (#308). No-op if `old` is in no space.
     public mutating func rekey(_ old: WindowID, to new: WindowID) {
         if lastFocused == old { lastFocused = new }
+        // The close-return candidate must follow a native-tab
+        // rekey like `lastFocused` does, or every tab switch
+        // silently kills it.
+        if previousFocused == old { previousFocused = new }
         guard let id = space(of: old) else { return }
         spaces[id]?.rekey(old, to: new)
     }
@@ -280,6 +298,11 @@ public struct WorkspaceManager: Sendable {
     ) {
         guard spaces[id]?.windows.contains(window) == true else {
             return
+        }
+        // A re-focus of the already-focused window must not
+        // collapse the history to itself.
+        if lastFocused != window {
+            previousFocused = lastFocused
         }
         spaces[id]?.focused = window
         lastFocused = window
@@ -295,55 +318,4 @@ public struct WorkspaceManager: Sendable {
         spaces[id] = space
     }
 
-    // MARK: - Displays
-
-    public var allDisplays: [Display] {
-        Array(displays.values)
-    }
-
-    public mutating func upsertDisplay(_ display: Display) {
-        displays[display.id] = display
-    }
-
-    @discardableResult
-    public mutating func removeDisplay(
-        _ id: DisplayID
-    ) -> Display? {
-        for (space, display) in spaceDisplay where display == id {
-            spaceDisplay[space] = nil
-        }
-        secondaryShown[id] = nil
-        return displays.removeValue(forKey: id)
-    }
-
-    public mutating func assign(
-        _ space: SpaceID,
-        to display: DisplayID
-    ) {
-        ensureSpace(space)
-        spaceDisplay[space] = display
-        // Reassigning a space can strand a `secondaryShown` entry
-        // that still points at it on its OLD display; drop any
-        // entry no longer matching its display so stale picks
-        // never accumulate (the read path also ignores them).
-        secondaryShown = secondaryShown.filter { display, space in
-            spaceDisplay[space] == display
-        }
-    }
-
-    public func display(of space: SpaceID) -> DisplayID? {
-        spaceDisplay[space]
-    }
-
-    /// Spaces assigned to one display, in creation order.
-    public func spaces(on display: DisplayID) -> [SpaceID] {
-        order.filter { spaceDisplay[$0] == display }
-    }
-
-    /// The space a display currently shows. Alias of
-    /// `activeSpace(on:)`; kept for the bar/overlay call sites
-    /// that predate the per-display active model.
-    public func currentSpace(on display: DisplayID) -> SpaceID? {
-        activeSpace(on: display)
-    }
 }

--- a/Tests/KiwiDeskCoreTests/CloseFocusReturnTests.swift
+++ b/Tests/KiwiDeskCoreTests/CloseFocusReturnTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+// Close-return focus: closing the focused window hands focus
+// back to the previously focused window (one-deep history,
+// same space only), falling through to the successor-slot pick
+// when the candidate is gone or unsurfaceable. The argument —
+// and why this is not the repeat-press MRU cycling #637
+// rejected — lives in `docs/design-decisions.md`
+// ▸ Close-return focus.
+
+private let a = WindowID(1)
+private let b = WindowID(2)
+private let c = WindowID(3)
+
+private func makeWindow(
+    _ id: WindowID,
+    isTransientOverlay: Bool = false
+) -> ManagedWindow {
+    ManagedWindow(
+        id: id,
+        pid: pid_t(id.raw),
+        appName: "App\(id.raw)",
+        isTransientOverlay: isTransientOverlay
+    )
+}
+
+/// Pure state fixture: three windows in one space, focused in
+/// creation order (the spawn grant routes through
+/// `WorkspaceManager.focus`, so creates feed the history too).
+private func makeState() -> StateCoordinator {
+    var state = StateCoordinator()
+    state.apply(.windowCreated(makeWindow(a)))
+    state.apply(.windowCreated(makeWindow(b)))
+    state.apply(.windowCreated(makeWindow(c)))
+    return state
+}
+
+@Suite("Close-return focus")
+struct CloseFocusReturnTests {
+    @Test("Closing the focused window returns to the previous one")
+    func closeReturnsToPrevious() {
+        var state = makeState()
+        state.apply(.windowFocused(a))
+        state.apply(.windowFocused(c))
+        // Successor of c's slot would be b (`windows.last`);
+        // the history says a.
+        state.apply(.windowDestroyed(c, wasMinimized: false))
+        let home = state.workspaces.space(of: a)!
+        #expect(state.workspaces[home]?.focused == a)
+    }
+
+    @Test("A dead candidate falls through to the successor slot")
+    func deadCandidateFallsToSuccessor() {
+        var state = makeState()
+        state.apply(.windowFocused(a))
+        state.apply(.windowFocused(b))
+        // The candidate (a) dies first; closing b must then take
+        // the forward successor (c), never index-minus-one.
+        state.apply(.windowDestroyed(a, wasMinimized: false))
+        state.apply(.windowDestroyed(b, wasMinimized: false))
+        let home = state.workspaces.space(of: c)!
+        #expect(state.workspaces[home]?.focused == c)
+    }
+
+    @Test("A minimized candidate falls through to the successor")
+    func minimizedCandidateFallsToSuccessor() {
+        var state = makeState()
+        state.apply(.windowFocused(a))
+        state.apply(.windowFocused(b))
+        // A minimize surfaces as a destroy with the flag: the
+        // candidate leaves state, and the close-return must not
+        // un-park it (#673).
+        state.apply(.windowDestroyed(a, wasMinimized: true))
+        state.apply(.windowDestroyed(b, wasMinimized: false))
+        let home = state.workspaces.space(of: c)!
+        #expect(state.workspaces[home]?.focused == c)
+    }
+
+    @Test("A candidate in another space is never returned to")
+    func crossSpaceCandidateIgnored() {
+        var state = makeState()
+        // A sticky-style focus into a foreign space (#414) can
+        // put a foreign member into the history: s lives in
+        // space 2, focused from there, then b in the home
+        // space. Closing b must not yank across spaces.
+        let s = WindowID(9)
+        let homeOfA = state.workspaces.space(of: a)!
+        state.workspaces.ensureSpace(SpaceID(2))
+        state.workspaces.activate(SpaceID(2))
+        state.apply(.windowCreated(makeWindow(s)))
+        state.workspaces.activate(homeOfA)
+        state.apply(.windowFocused(s))
+        state.apply(.windowFocused(b))
+        state.apply(.windowDestroyed(b, wasMinimized: false))
+        #expect(state.workspaces[homeOfA]?.focused == c)
+    }
+
+    @Test("A transient-overlay candidate falls to the successor")
+    func transientOverlayCandidateIgnored() {
+        var state = StateCoordinator()
+        let o = WindowID(7)
+        state.apply(
+            .windowCreated(makeWindow(o, isTransientOverlay: true))
+        )
+        state.apply(.windowCreated(makeWindow(b)))
+        state.apply(.windowCreated(makeWindow(c)))
+        // The overlay never got the spawn grant (#671), but a
+        // genuine focus report can still put it in the history.
+        state.apply(.windowFocused(o))
+        state.apply(.windowFocused(b))
+        state.apply(.windowDestroyed(b, wasMinimized: false))
+        let home = state.workspaces.space(of: c)!
+        #expect(state.workspaces[home]?.focused == c)
+    }
+
+    @Test("A fullscreen candidate falls to the successor")
+    func fullscreenCandidateIgnored() {
+        var state = makeState()
+        state.apply(.windowFocused(a))
+        state.apply(
+            .windowFullscreenChanged(a, isFullscreen: true)
+        )
+        state.apply(.windowFocused(b))
+        // Two nets share this outcome: the close-return refuses
+        // the fullscreen candidate, and the #670 re-pick would
+        // correct such a pick to the same successor — so this
+        // pins the behavior, not which net caught it.
+        state.apply(.windowDestroyed(b, wasMinimized: false))
+        let home = state.workspaces.space(of: c)!
+        #expect(state.workspaces[home]?.focused == c)
+    }
+
+    @Test("Closing the first window with no history stays first")
+    func firstWindowNoHistoryStaysFirst() {
+        var state = makeState()
+        state.apply(.windowFocused(a))
+        // Kill the candidate (c) so no history remains, then
+        // close the head: the new head (b) takes focus — the
+        // successor rule, no special case.
+        state.apply(.windowDestroyed(c, wasMinimized: false))
+        state.apply(.windowDestroyed(a, wasMinimized: false))
+        let home = state.workspaces.space(of: b)!
+        #expect(state.workspaces[home]?.focused == b)
+    }
+
+    @Test("Closing an unfocused window moves no focus")
+    func unfocusedCloseKeepsFocus() {
+        var state = makeState()
+        state.apply(.windowDestroyed(a, wasMinimized: false))
+        let home = state.workspaces.space(of: c)!
+        #expect(state.workspaces[home]?.focused == c)
+        #expect(state.workspaces.previousFocused == b)
+    }
+
+    @Test("A re-focus of the same window keeps the history")
+    func reFocusDoesNotCollapseHistory() {
+        var state = makeState()
+        state.apply(.windowFocused(a))
+        state.apply(.windowFocused(c))
+        state.apply(.windowFocused(c))
+        state.apply(.windowDestroyed(c, wasMinimized: false))
+        let home = state.workspaces.space(of: a)!
+        #expect(state.workspaces[home]?.focused == a)
+    }
+
+    @Test("A native-tab rekey retargets the candidate (#308)")
+    func rekeyRetargetsCandidate() {
+        var state = makeState()
+        state.apply(.windowFocused(a))
+        state.apply(.windowFocused(c))
+        let a2 = WindowID(12)
+        state.apply(.windowRekeyed(a, a2))
+        state.apply(.windowDestroyed(c, wasMinimized: false))
+        let home = state.workspaces.space(of: a2)!
+        #expect(state.workspaces[home]?.focused == a2)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/CloseFocusReturnTests.swift
+++ b/Tests/KiwiDeskCoreTests/CloseFocusReturnTests.swift
@@ -47,9 +47,14 @@ struct CloseFocusReturnTests {
         state.apply(.windowFocused(c))
         // Successor of c's slot would be b (`windows.last`);
         // the history says a.
-        state.apply(.windowDestroyed(c, wasMinimized: false))
+        let effects = state.apply(
+            .windowDestroyed(c, wasMinimized: false)
+        )
         let home = state.workspaces.space(of: a)!
         #expect(state.workspaces[home]?.focused == a)
+        // The erased fact the close handler re-derives the
+        // restack jump from (#674): c sat at tiled index 2.
+        #expect(effects.removedWindow?.tiledSlot == 2)
     }
 
     @Test("A dead candidate falls through to the successor slot")
@@ -64,7 +69,7 @@ struct CloseFocusReturnTests {
         // of the nets refusing a dead (or recycled-id) window;
         // close-time validation is the second. Pinned directly
         // because the fall-through below cannot tell them apart.
-        #expect(state.workspaces.previousFocused == nil)
+        #expect(state.workspaces.focusReturnCandidate == nil)
         state.apply(.windowDestroyed(b, wasMinimized: false))
         let home = state.workspaces.space(of: c)!
         #expect(state.workspaces[home]?.focused == c)
@@ -157,7 +162,7 @@ struct CloseFocusReturnTests {
         state.apply(.windowDestroyed(a, wasMinimized: false))
         let home = state.workspaces.space(of: c)!
         #expect(state.workspaces[home]?.focused == c)
-        #expect(state.workspaces.previousFocused == b)
+        #expect(state.workspaces.focusReturnCandidate == b)
     }
 
     @Test("A re-focus of the same window keeps the history")

--- a/Tests/KiwiDeskCoreTests/CloseFocusReturnTests.swift
+++ b/Tests/KiwiDeskCoreTests/CloseFocusReturnTests.swift
@@ -60,6 +60,11 @@ struct CloseFocusReturnTests {
         // The candidate (a) dies first; closing b must then take
         // the forward successor (c), never index-minus-one.
         state.apply(.windowDestroyed(a, wasMinimized: false))
+        // The destroy clears the candidate outright — the first
+        // of the nets refusing a dead (or recycled-id) window;
+        // close-time validation is the second. Pinned directly
+        // because the fall-through below cannot tell them apart.
+        #expect(state.workspaces.previousFocused == nil)
         state.apply(.windowDestroyed(b, wasMinimized: false))
         let home = state.workspaces.space(of: c)!
         #expect(state.workspaces[home]?.focused == c)

--- a/Tests/KiwiDeskCoreTests/ScrollingDeferredRaiseTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingDeferredRaiseTests.swift
@@ -275,12 +275,22 @@ struct ScrollingDeferredRaiseTests {
     @Test("Closing the focused window focuses the neighbor")
     func closeFocusedFocusesNeighbor() {
         let core = makeCore()
-        makeScrollingSpace(core, windows: 5, focus: WindowID(3))
+        let space = makeScrollingSpace(
+            core,
+            windows: 5,
+            focus: WindowID(3)
+        )
+        // Pin the close-return history at the neighbor: which
+        // window the close picks is `CloseFocusReturnTests`'
+        // subject; this suite pins the raise mechanics of the
+        // handoff.
+        core.state.workspaces.focus(WindowID(4), in: space)
+        core.state.workspaces.focus(WindowID(3), in: space)
         guard startDummyPan(core) else { return }
         // Close the focused middle window: focus lands on the
-        // window that slid into its slot (#158), not `windows.last`
-        // — no yank to the far end of the row — and the handoff
-        // raises immediately (previous == target), nothing pends.
+        // close-return pick — never `windows.last` (no yank to
+        // the far end of the row) — and the handoff raises
+        // immediately (previous == target), nothing pends.
         core.eventLoop.onEvent(
             .windowDestroyed(WindowID(3), wasMinimized: false)
         )

--- a/Tests/KiwiDeskCoreTests/ZOrderCloseReturnArmTests.swift
+++ b/Tests/KiwiDeskCoreTests/ZOrderCloseReturnArmTests.swift
@@ -1,0 +1,134 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// #674, the close path: the close-return pick can cross several
+/// scrolling slots, and `focusWindow`'s own jump arm cannot see
+/// it — the destroy fold already wrote the pick into
+/// `space.focused`, so the anchor the jump test reads IS the
+/// target. `armCloseReturnRestack` re-derives the distance from
+/// the removed slot; this suite proves the arm directly because
+/// its call site sits behind `eventLoop.isListed` (live AX —
+/// the `TransientOverlayFocusTests` gate note). The fold's
+/// `tiledSlot` fact is `CloseFocusReturnTests`' half.
+///
+/// Companion to `ZOrderFocusJumpTests`, split per the
+/// early-split convention. Same suite shape: `.enabled(if:)` so
+/// a screenless runner reports SKIP, `.serialized` for the
+/// shared animation engine the dummy pan holds mid-flight.
+@Suite(
+    "Z-order restore on close-return jumps (#674)",
+    .serialized,
+    .enabled(if: NSScreen.main != nil)
+)
+@MainActor
+struct ZOrderCloseReturnArmTests {
+
+    private func makeCore() -> KiwiCore {
+        let core = makeTestCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-close-arm-\(UUID().uuidString)"
+                )
+        )
+        // Pin the display the overflow verdict is read from
+        // (tests.md / #531).
+        core.tiler.visibleBounds = { _ in
+            CGRect(x: 0, y: 25, width: 1440, height: 875)
+        }
+        return core
+    }
+
+    /// `count` windows in one scrolling space, focus on `focused`.
+    private func makeSpace(
+        _ core: KiwiCore,
+        windows count: Int,
+        focused: UInt32
+    ) -> SpaceID {
+        for id in 1...count {
+            core.state.apply(
+                .windowCreated(
+                    ManagedWindow(
+                        id: WindowID(UInt32(id)),
+                        pid: pid_t(id),
+                        appName: "App\(id)"
+                    )
+                )
+            )
+        }
+        let space = core.state.workspaces.space(of: WindowID(1))!
+        _ = core.execute(
+            "set_mode",
+            args: [.string(space.raw), .string("scrolling")]
+        )
+        core.state.workspaces.focus(WindowID(focused), in: space)
+        return space
+    }
+
+    /// Holds the animation engine mid-flight so a scheduled
+    /// restore stays pending instead of firing at once.
+    private func startDummyPan(_ core: KiwiCore) -> Bool {
+        guard let screen = NSScreen.main else { return false }
+        core.tiler.animation.animate(
+            window: WindowID(999),
+            on: screen,
+            from: CGRect(x: 0, y: 0, width: 100, height: 100),
+            to: CGRect(x: 800, y: 0, width: 100, height: 100)
+        )
+        return core.tiler.animation.activeCount > 0
+    }
+
+    @Test("A multi-slot close-return arms a restore")
+    func closeReturnJumpArmsRestore() {
+        let core = makeCore()
+        // Six auto-width slots overflow 1440 pt. The closed
+        // window sat at tiled slot 4; the close-return pick is
+        // window 1 (slot 0) — a four-slot jump.
+        _ = makeSpace(core, windows: 6, focused: 1)
+        guard startDummyPan(core) else { return }
+        #expect(!core.pendingZOrderRestore)
+        core.armCloseReturnRestack(
+            to: WindowID(1),
+            fromRemovedSlot: 4
+        )
+        #expect(core.pendingZOrderRestore)
+        core.tiler.animation.cancelAll(snapToTargets: false)
+        #expect(!core.pendingZOrderRestore)
+    }
+
+    @Test("An adjacent pick arms nothing")
+    func adjacentPickArmsNothing() {
+        let core = makeCore()
+        _ = makeSpace(core, windows: 6, focused: 4)
+        guard startDummyPan(core) else { return }
+        // The successor pick: the neighbor inherits the removed
+        // slot, a ±1 move — the raise is the whole change.
+        core.armCloseReturnRestack(
+            to: WindowID(4),
+            fromRemovedSlot: 4
+        )
+        #expect(!core.pendingZOrderRestore)
+        core.tiler.animation.cancelAll(snapToTargets: false)
+    }
+
+    @Test("A nil removed slot arms nothing")
+    func nilSlotArmsNothing() {
+        let core = makeCore()
+        // A closed float or fullscreen member has no tiled slot:
+        // no evidence of a jump, same asymmetry as
+        // `scrollFocusJumpsSlots` — a spurious restack costs N
+        // blocking raises and buries the float layer.
+        _ = makeSpace(core, windows: 6, focused: 1)
+        guard startDummyPan(core) else { return }
+        core.armCloseReturnRestack(
+            to: WindowID(1),
+            fromRemovedSlot: nil
+        )
+        #expect(!core.pendingZOrderRestore)
+        core.tiler.animation.cancelAll(snapToTargets: false)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ZOrderCloseReturnArmTests.swift
+++ b/Tests/KiwiDeskCoreTests/ZOrderCloseReturnArmTests.swift
@@ -121,11 +121,13 @@ struct ZOrderCloseReturnArmTests {
         // A closed float or fullscreen member has no tiled slot:
         // no evidence of a jump, same asymmetry as
         // `scrollFocusJumpsSlots` — a spurious restack costs N
-        // blocking raises and buries the float layer.
-        _ = makeSpace(core, windows: 6, focused: 1)
+        // blocking raises and buries the float layer. The target
+        // sits at the far end (slot 5), so a mutation that
+        // defaults a nil slot to 0 would read a jump here.
+        _ = makeSpace(core, windows: 6, focused: 6)
         guard startDummyPan(core) else { return }
         core.armCloseReturnRestack(
-            to: WindowID(1),
+            to: WindowID(6),
             fromRemovedSlot: nil
         )
         #expect(!core.pendingZOrderRestore)

--- a/Tests/KiwiDeskCoreTests/ZOrderCloseReturnArmTests.swift
+++ b/Tests/KiwiDeskCoreTests/ZOrderCloseReturnArmTests.swift
@@ -100,6 +100,22 @@ struct ZOrderCloseReturnArmTests {
         #expect(!core.pendingZOrderRestore)
     }
 
+    @Test("A distance-2 pick — the minimal jump — arms")
+    func minimalJumpArms() {
+        let core = makeCore()
+        // The boundary pin for the `> 1` threshold: distance 2
+        // is the smallest jump that must arm, so a widened
+        // trigger (`> 2`) reds here and nowhere else.
+        _ = makeSpace(core, windows: 6, focused: 4)
+        guard startDummyPan(core) else { return }
+        core.armCloseReturnRestack(
+            to: WindowID(4),
+            fromRemovedSlot: 1
+        )
+        #expect(core.pendingZOrderRestore)
+        core.tiler.animation.cancelAll(snapToTargets: false)
+    }
+
     @Test("An adjacent pick arms nothing")
     func adjacentPickArmsNothing() {
         let core = makeCore()

--- a/Tests/KiwiDeskGuiTests/WorkspaceMapSealTests.swift
+++ b/Tests/KiwiDeskGuiTests/WorkspaceMapSealTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+/// `WorkspaceManager`'s backing maps went `private` → internal
+/// so the `+Displays` split (§2.1 file ceiling) could read them
+/// cross-file — which also lets any `KiwiDeskCore` file compile
+/// a direct write. The write invariants live in the methods, not
+/// the maps: every `spaceDisplay` write must run `ensureSpace`
+/// plus the stale-`secondaryShown` filter (`assign(_:to:)`), and
+/// a stray `secondaryShown` write strands exactly the entries
+/// that filter exists to drop. This pins the maps' names to the
+/// two `WorkspaceManager*` files, so a third toucher must add
+/// itself here and say why.
+///
+/// **This map is the exemption list** — the property comments in
+/// `WorkspaceManager` point here rather than restating it.
+///
+/// Limits, stated so the next author knows where the net ends:
+/// the other two widened stores, `order` and `displays`, are
+/// UNGUARDED by this scan — both names collide across the module
+/// (z-order, `KiwiCore.displays`, locals), so a name scan would
+/// either drown in exemptions or need needles this repo's
+/// formatter can wrap apart (the `VisibleBoundsRoutingTests`
+/// fail-open lesson). Their write risk is also lower: their
+/// writers are single-statement upserts with no paired-step
+/// invariant. A future seam that gives them one owes this suite
+/// a needle or the maps a re-privatization.
+@Suite("Workspace map seal")
+struct WorkspaceMapSealTests {
+    private var coreRoot: URL {
+        SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDeskCore")
+    }
+
+    /// Per needle: every file allowed to name it, by path under
+    /// `Sources/KiwiDeskCore`, with today's exact count (comments
+    /// stripped). Keyed by path so same-named files never pool.
+    private let allowed: [String: [String: Int]] = [
+        "spaceDisplay": [
+            "State/WorkspaceManager.swift": 6,
+            "State/WorkspaceManager+Displays.swift": 6,
+        ],
+        "secondaryShown": [
+            "State/WorkspaceManager.swift": 6,
+            "State/WorkspaceManager+Displays.swift": 3,
+        ],
+    ]
+
+    @Test("The display maps are named only where declared")
+    func mapNamesStayInsideTheAllowlist() throws {
+        let root = coreRoot
+        let prefix = root.path + "/"
+        var counts: [String: [String: Int]] = [:]
+        for file in try SourceScan.swiftSources(under: root) {
+            let source = SourceScan.stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            let key =
+                file.path.hasPrefix(prefix)
+                ? String(file.path.dropFirst(prefix.count))
+                : file.path
+            for needle in allowed.keys {
+                let hits = source.occurrences(of: needle)
+                guard hits > 0 else { continue }
+                counts[needle, default: [:]][key] = hits
+            }
+        }
+        for (needle, files) in counts {
+            for (file, count) in files.sorted(
+                by: { $0.key < $1.key }
+            ) {
+                let stray =
+                    "\(file) names \(needle) \(count) time(s); "
+                    + "route through the WorkspaceManager API "
+                    + "(assign/removeDisplay), or justify and "
+                    + "pin the count here"
+                #expect(
+                    allowed[needle]?[file] == count,
+                    Comment(rawValue: stray)
+                )
+            }
+        }
+        // The inverse: a pinned count that vanished means the
+        // entry is unfalsifiable — and a mistyped root reds here
+        // instead of passing vacuously.
+        for (needle, files) in allowed {
+            for (file, expected) in files {
+                let vanished =
+                    "\(file) no longer names \(needle) "
+                    + "\(expected) time(s) — drop or re-pin "
+                    + "its entry"
+                #expect(
+                    counts[needle]?[file] == expected,
+                    Comment(rawValue: vanished)
+                )
+            }
+        }
+    }
+}

--- a/Tests/KiwiDeskGuiTests/ZOrderSequenceWiringTests.swift
+++ b/Tests/KiwiDeskGuiTests/ZOrderSequenceWiringTests.swift
@@ -194,6 +194,24 @@ struct ZOrderSequenceWiringTests {
         #expect(source.contains("raiseFloor("))
     }
 
+    /// The close path's #674 arm is the same unreachable-wiring
+    /// class: the destroy-raise block gates on
+    /// `eventLoop.isListed`, unconditionally false under
+    /// `makeTestCore`, so the full suite stayed green with the
+    /// call deleted (guard-prover, 2026-08-04). The arm's
+    /// arithmetic is pinned by `ZOrderCloseReturnArmTests`; this
+    /// pins that the destroy handler still calls it — the one
+    /// line free to regress.
+    @Test("The destroy handler arms the close-return restack")
+    func destroyHandlerArmsCloseReturnRestack() throws {
+        let source = try body(
+            of: "handle",
+            in: "KiwiCore+Events.swift",
+            under: "App"
+        )
+        #expect(source.contains("armCloseReturnRestack("))
+    }
+
     /// The teardown restack is the one raise sequence that cannot
     /// self-heal — nothing runs after it — so it is also the one
     /// where reverting to a bare `AXHelper.raiseQuietly` loop

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -2287,25 +2287,26 @@ cycle. (#673)
 
 **Close-return focus: closing the focused window returns focus
 to the previously focused window, same space only — and this is
-not the MRU the cycling ruling rejected.** The #637 argument
-against MRU is about a *repeating* gesture: a self-reordering
-ring makes the third press unpredictable. A close-return is a
-single step back to the window the user just left — one-deep,
-and the history it reads is the user's own last action, so the
-target is exactly as visible as ⌘W's native behavior (macOS
-itself hands focus down the z-order, which is the most recent
-survivor). Reading #637 as banning this trades the predictable
-outcome for a spatial successor the user may never have
-visited. The candidate is one `WindowID?`, never a stack: a
-deeper walk-back only fires when the one candidate is already
-dead — where the successor-slot pick is already good — and each
-step further back is more of the invisible history #637
-rejected. Validation happens at close time against current
-state, and the candidate must be alive (a minimized one left
-state, so #673's never-un-park holds by construction), in the
-*same space* (never a cross-space yank; a sticky focused from a
-foreign space, #414, is how a foreign member enters the
-history), not native-fullscreen (#670), and not a transient
+not the MRU the cycling ruling rejected.** [Rationale] The
+#637 argument against MRU is about a *repeating* gesture: a
+self-reordering ring makes the third press unpredictable. A
+close-return is a single step back to the window the user just
+left — one-deep, and the history it reads is the user's own
+last action, so the target is exactly as visible as ⌘W's
+native behavior (macOS itself hands focus down the z-order,
+which is the most recent survivor). Reading #637 as banning
+this trades the predictable outcome for a spatial successor
+the user may never have visited. The candidate is one
+`WindowID?`, never a stack: a deeper walk-back only fires when
+the one candidate is already dead — where the successor-slot
+pick is already good — and each step further back is more of
+the invisible history #637 rejected. Validation happens at
+close time against current state, and the candidate must be
+alive (a minimized one left state, so #673's never-un-park
+holds by construction), in the *same space* (never a
+cross-space yank; a sticky focused from a foreign space, #414,
+is how a foreign member enters the history), not
+native-fullscreen (#670), and not a transient
 overlay (#671). A candidate failing any of these falls through
 to the successor-slot pick `Space.remove` already makes —
 spatial stability is the right tiebreak once recency has run

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -2285,6 +2285,37 @@ into the layout. If demand for reaching minimized windows ever
 materializes it belongs in a Lua-only verb, never in the default
 cycle. (#673)
 
+**Close-return focus: closing the focused window returns focus
+to the previously focused window, same space only — and this is
+not the MRU the cycling ruling rejected.** The #637 argument
+against MRU is about a *repeating* gesture: a self-reordering
+ring makes the third press unpredictable. A close-return is a
+single step back to the window the user just left — one-deep,
+and the history it reads is the user's own last action, so the
+target is exactly as visible as ⌘W's native behavior (macOS
+itself hands focus down the z-order, which is the most recent
+survivor). Reading #637 as banning this trades the predictable
+outcome for a spatial successor the user may never have
+visited. The candidate is one `WindowID?`, never a stack: a
+deeper walk-back only fires when the one candidate is already
+dead — where the successor-slot pick is already good — and each
+step further back is more of the invisible history #637
+rejected. Validation happens at close time against current
+state, and the candidate must be alive (a minimized one left
+state, so #673's never-un-park holds by construction), in the
+*same space* (never a cross-space yank; a sticky focused from a
+foreign space, #414, is how a foreign member enters the
+history), not native-fullscreen (#670), and not a transient
+overlay (#671). A candidate failing any of these falls through
+to the successor-slot pick `Space.remove` already makes —
+spatial stability is the right tiebreak once recency has run
+out, because the forward neighbor inherits the closed slot and
+focus lands where the user's eyes already are; an
+index-minus-one pick would move focus against the direction
+everything just slid. Fixed behavior, no setting: no peer WM
+ships a knob here, and if demand materializes it becomes a
+Lua-only setting later. `CloseFocusReturnTests` pins all of it.
+
 ### Overrides & appearance
 
 **[Principle]**


### PR DESCRIPTION
## Description

Closing the focused window now returns focus to the previously
focused window instead of always the layout successor. One-deep
history (`WorkspaceManager.focusReturnCandidate`), validated at
close time in the destroy fold: alive, same space, not
native-fullscreen (#670), not a transient overlay (#671); a
minimized candidate left state, so #673's never-un-park holds by
construction. An invalid candidate falls through to the existing
forward successor-slot pick. Fixed behavior, no setting
(ui-designer ruling; the argument — and why this is not the
repeat-press MRU cycling #637 rejected — is a new
design-decisions entry).

Review fixes shipped with it: a multi-slot close-return in a
scrolling space arms the #674 edge-pile restack (the fold writes
the pick before `focusWindow` reads its anchor, so the existing
jump arm sees distance zero — the arm re-derives distance from
the removed slot via a new `RemovedWindow.tiledSlot` fact);
`WorkspaceMapSealTests` seals the maps the `+Displays` file
split widened; the wiring needle in `ZOrderSequenceWiringTests`
pins the one unit-unreachable call (behind live-AX `isListed`).

## Related Issue(s)

None filed — direct owner request.

## Checklist

- [x] I understand what this change does (device eye-confirm
  still owed — noted below)
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested (10-test state suite + 4-test arm
  suite + wiring needle + map seal, all guard-proved red)
- [x] User-facing changes are documented in `docs/`
  (design-decisions ▸ Close-return focus; user guide never
  documented the close fallback)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
  (2785 tests, 511 suites)
- [ ] Release build green — read CI's `Release Build` job
  before merging (no concurrency change; not run locally)
- [x] PR is focused

## How I verified

Full gate locally (build, 2785 tests, lint, site build for the
docs edit). Two guard-prover rounds: every new assertion
red-proved by mutating what it watches, including the
distance-2 threshold boundary and the wiring needle
(red-proved by deleting the call). Known honest blind spots,
documented in the suites: the fullscreen validation clause is
belt-masked by the #670 re-pick (same successor either way),
and the arm call site is unit-unreachable behind live-AX
`isListed` — the wiring needle is its net. **On-device
eye-confirm owed**: same-app close (open second Anki window,
close it → focus returns to the first) and a scrolling
multi-slot close-return (focus far window, close → pan back,
edge piles restack).

## Notes for Reviewer

Round-1 pair + docs-steward, sequential re-review (code, then
architect) all run; every finding fixed or consciously kept
(docs entry placement stays beside #637 — adjacency to the
ruling it distinguishes itself from). Dead-MRU fallback is the
FORWARD successor deliberately: recency already lost when the
candidate died; spatial stability wins, and index−1 would move
against the slide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)