### PR TITLE
fix(gui): withhold the space-override offer until it is earned

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideOffer.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideOffer.swift
@@ -1,0 +1,62 @@
+import KiwiDeskCore
+
+/// Whether the per-space override affordance is *offered* — the
+/// #678 8c capability unlock, for the Spaces list.
+///
+/// > Easy withholds only the *offer* to create an override, and
+/// > the offer unlocks itself per list the moment the profile has
+/// > one … collapsing away when the last override is cleared.
+///
+/// The Spaces list was reaching past its own mode boundary
+/// without this: `Customize…` rendered on every row in both
+/// modes, and the editor behind it exposes exactly the per-layout
+/// parameters (master count/ratio/orientation, split strategy,
+/// stack position, overflow, grid rows × columns) that the
+/// `.powerUser`-only Layout Defaults area withholds from Simple.
+/// So the mode boundary was stated in `SettingPlacement` and
+/// contradicted one screen over.
+///
+/// **Three properties, and the cheap implementation breaks two of
+/// them** (`ShortcutsCapabilityUnlockTests` names the same trap
+/// for the shortcut column):
+///
+///  - *the whole list.* One override anywhere unlocks the
+///    affordance on EVERY space row, not just the overridden
+///    one. A user who has overridden one space is a user who
+///    overrides spaces; making them re-discover the affordance
+///    per row is the thing this forbids. Hence a list-wide
+///    predicate rather than the per-row `count > 0` the button
+///    already had in hand.
+///  - *the list, not the app.* A space override must not turn a
+///    deeper surface on anywhere else — the failure mode is "the
+///    mode becomes something users lose by accident".
+///  - *the mode never changes what runs.* This gates the OFFER
+///    only. Overrides already saved keep resolving in Simple,
+///    untouched and unreachable-from-here — which is why the
+///    unlock has to consult the saved state rather than the mode
+///    alone, or a Simple user with overrides could neither see
+///    nor clear them.
+///
+/// Hidden rather than greyed when withheld (owner ruling
+/// 2026-08-04), against the standing "grey, don't hide" default:
+/// mode-withheld surface is *absent* everywhere else in this
+/// window — a `.powerUser` area has no Home card in Simple, it is
+/// not a dimmed one — because the mode adds surface rather than
+/// expanding it. A permanently dead button on every space row is
+/// the clutter the mode split exists to remove.
+enum SpaceOverrideOffer {
+    /// `spaces` is the profile's whole list, so that clearing the
+    /// last override anywhere collapses the affordance
+    /// everywhere — the "collapsing away" half of 8c, which a
+    /// per-row test cannot express.
+    static func isOffered(
+        mode: SettingsMode,
+        settings: TilingSettings,
+        spaces: [SpaceID]
+    ) -> Bool {
+        if mode == .powerUser { return true }
+        return spaces.contains {
+            settings.overrideFieldCount(for: $0) > 0
+        }
+    }
+}

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+Customize.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+Customize.swift
@@ -52,7 +52,28 @@ extension SpacesSection {
     ///   OTHER layouts, not this one) that still opens the editor
     ///   so they stay reachable — "grey, don't hide", §2.7;
     /// - Floating, N==0 → "—", disabled: genuinely no destination.
-    func customizeButton(_ space: SpaceID) -> some View {
+    /// Withheld entirely while the offer is locked (#678 8c) —
+    /// see `SpaceOverrideOffer`, which owns that predicate and
+    /// the argument for hiding rather than dimming. Gated HERE,
+    /// at the one render site, rather than at the row: the row
+    /// would then hold a second copy of the rule, which is the
+    /// hand-negated-copy drift `HomeCardOrder.isOffered` exists
+    /// to prevent one level up.
+    @ViewBuilder func customizeButton(
+        _ space: SpaceID
+    ) -> some View {
+        if SpaceOverrideOffer.isOffered(
+            mode: model.settingsMode,
+            settings: model.config.settings,
+            spaces: model.config.spaces
+        ) {
+            offeredCustomizeButton(space)
+        }
+    }
+
+    private func offeredCustomizeButton(
+        _ space: SpaceID
+    ) -> some View {
         let count = model.config.settings.overrideFieldCount(
             for: space
         )

--- a/Tests/KiwiDeskGuiTests/SpaceOverrideUnlockTests.swift
+++ b/Tests/KiwiDeskGuiTests/SpaceOverrideUnlockTests.swift
@@ -1,0 +1,160 @@
+import KiwiDeskCore
+import Testing
+
+@testable import KiwiDesk
+
+/// The Spaces half of the #678 8c capability unlock — the twin of
+/// `ShortcutsCapabilityUnlockTests`, which pins the same rules for
+/// the shortcut override column.
+///
+/// The defect this closes: `Customize…` rendered on every space
+/// row in BOTH modes, and the editor behind it exposes the
+/// per-layout parameters that the `.powerUser`-only Layout
+/// Defaults area withholds from Simple — so Simple reached the
+/// Advanced surface through a side door.
+///
+/// The trap, stated by the shortcuts suite and equally live here:
+/// the cheapest implementation is to gate on the MODE alone. That
+/// passes any test that only ever checks Simple-with-nothing and
+/// Power-User-with-nothing, and it silently strands a Simple user
+/// who already has overrides — they could neither see nor clear
+/// them. Every test below therefore names which of the three
+/// properties it is holding.
+///
+/// Two properties are deliberately NOT tested here, because a
+/// test of either would assert what the type system already says
+/// (tests.md, "Not owed"): that the gate cannot alter what runs —
+/// `isOffered` returns `Bool` and touches nothing — and that a
+/// space override cannot unlock a deeper surface elsewhere —
+/// `HomeCardOrder.isOffered` takes no `TilingSettings`, so the
+/// override is not in its reach at all. Both were drafted, both
+/// passed by construction rather than by observation, and a test
+/// that cannot fail is worse than none (#406).
+@MainActor
+@Suite("Space override unlock (#678 8c)")
+struct SpaceOverrideUnlockTests {
+    /// Three spaces, so "the whole list" has peers to be wrong
+    /// about — a single-space fixture would pass this suite while
+    /// a per-row gate shipped.
+    private let spaces = [
+        SpaceID("1"), SpaceID("2"), SpaceID("3"),
+    ]
+
+    /// Settings carrying one BSP master-count override on
+    /// `space`, and nothing else.
+    private func settings(
+        overriding space: SpaceID?
+    ) -> TilingSettings {
+        var settings = TilingSettings()
+        if let space {
+            var bsp = BspOverride()
+            bsp.splitRatioH = 0.6
+            settings.bsp.override[space] = bsp
+        }
+        return settings
+    }
+
+    // MARK: - The offer is withheld until it is earned
+
+    @Test("Simple with no override anywhere withholds the offer")
+    func simpleWithoutOverridesIsLocked() {
+        #expect(
+            !SpaceOverrideOffer.isOffered(
+                mode: .simple,
+                settings: settings(overriding: nil),
+                spaces: spaces
+            )
+        )
+    }
+
+    @Test("Power User always offers it, overrides or not")
+    func powerUserIsAlwaysOffered() {
+        #expect(
+            SpaceOverrideOffer.isOffered(
+                mode: .powerUser,
+                settings: settings(overriding: nil),
+                spaces: spaces
+            )
+        )
+    }
+
+    // MARK: - The whole list, not the overridden row
+
+    /// The property a per-row gate breaks: one override unlocks
+    /// EVERY row, including the two spaces that carry nothing.
+    ///
+    /// Asserted by asking the predicate about the whole list
+    /// while only the middle space is overridden — a gate written
+    /// as `count(for: thisRow) > 0` answers false for spaces 1
+    /// and 3 and would fail here.
+    @Test("one override unlocks the offer for every space")
+    func oneOverrideUnlocksTheWholeList() {
+        let settings = settings(overriding: spaces[1])
+        #expect(
+            SpaceOverrideOffer.isOffered(
+                mode: .simple,
+                settings: settings,
+                spaces: spaces
+            ),
+            "an override on space 2 must unlock rows 1 and 3 too"
+        )
+        // And it is the LIST that is consulted, not the space:
+        // asking with only an unoverridden space present is the
+        // locked answer, so the true above came from the list
+        // rather than from the mode leaking through.
+        #expect(
+            !SpaceOverrideOffer.isOffered(
+                mode: .simple,
+                settings: settings,
+                spaces: [spaces[0]]
+            ),
+            "a list with no overridden space stays locked"
+        )
+    }
+
+    /// The "collapsing away when the last override is cleared"
+    /// half — a state a per-row gate cannot express at all.
+    @Test("clearing the last override re-locks the offer")
+    func clearingTheLastOverrideRelocks() {
+        var live = settings(overriding: spaces[1])
+        #expect(
+            SpaceOverrideOffer.isOffered(
+                mode: .simple,
+                settings: live,
+                spaces: spaces
+            )
+        )
+        live.bsp.override[spaces[1]] = nil
+        #expect(
+            !SpaceOverrideOffer.isOffered(
+                mode: .simple,
+                settings: live,
+                spaces: spaces
+            ),
+            "the offer must collapse with the last override"
+        )
+    }
+
+    // MARK: - The mode never changes what runs
+
+    /// A Simple user who already has overrides must still reach
+    /// them — this is the arm the mode-only gate strands, and the
+    /// reason the predicate consults saved state rather than the
+    /// mode alone.
+    @Test("saved overrides stay reachable in Simple")
+    func savedOverridesStayReachableInSimple() {
+        let settings = settings(overriding: spaces[0])
+        #expect(
+            SpaceOverrideOffer.isOffered(
+                mode: .simple,
+                settings: settings,
+                spaces: spaces
+            ),
+            "a Simple user with overrides must still reach them"
+        )
+        // The values themselves are untouched by the mode: the
+        // offer is chrome, the override is state.
+        #expect(settings.overrideFieldCount(for: spaces[0]) == 1)
+    }
+
+}


### PR DESCRIPTION
Fixes #739.

## The defect

Simple mode reached Layout Defaults' parameters through a side door.

`Customize…` rendered on **every space row in both modes**, and the editor
behind it exposes exactly the per-layout parameters — master
count/ratio/orientation, split strategy, stack position, overflow, grid
rows × columns — that the `.powerUser`-only Layout Defaults area withholds
from Simple. So the mode boundary was stated in `SettingPlacement` and
contradicted one screen over.

## The fix

`SpaceOverrideOffer` is the #678 8c capability unlock for the Spaces list:

> Easy withholds only the *offer* to create an override, and the offer
> unlocks itself per list the moment the profile has one … collapsing away
> when the last override is cleared.

Power User always offers it; Simple offers it once the profile carries any
space override; it collapses when the last one is cleared.

**Hidden, not dimmed**, when withheld (owner ruling) — against the standing
"grey, don't hide" default, because mode-withheld surface is *absent*
everywhere else in this window: a `.powerUser` area has no Home card in
Simple, not a greyed one, since the mode adds surface rather than expanding
it. A permanently dead button on every space row is the clutter the mode
split exists to remove.

**List-wide, not per-row.** `count(for: thisRow) > 0` is the obvious
reading and is wrong twice: it makes a user who has overridden one space
re-discover the affordance on every other row, and it cannot express the
collapse at all.

## Tests

`SpaceOverrideUnlockTests` pins the three properties, with a three-space
fixture so "the whole list" has peers to be wrong about.

The cheap wrong implementation was run against it. Gating on the mode alone
— which `ShortcutsCapabilityUnlockTests` names as the trap for the other
half of this same sentence — reds three of the five, including the arm
that strands a Simple user who already has overrides: they could neither
see nor clear them.

Two further tests were drafted and **dropped rather than shipped**: one
asserted that the gate cannot alter what runs (`isOffered` returns `Bool`),
the other that a space override cannot unlock a deeper surface elsewhere
(`HomeCardOrder.isOffered` takes no `TilingSettings`, so the override is
not in its reach). Both passed by construction rather than by observation.
The reasoning is kept in the suite's docstring so the next author does not
re-add them.

## Scope

This is the Spaces half of 8c. The other half — the second key column on
every shortcut row — stays Phase 4, and will need its own predicate over
its own data rather than a generalisation of this one.

## Verification

`swift build`, `swift test` (**2886 passed, 0 failures** — 2881 plus the 5
new), `scripts/lint.sh` clean.

Refs #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
