### PR TITLE
fix(gui): a monitor picture fits the canvas it was given

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorArrangement.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorArrangement.swift
@@ -125,10 +125,28 @@ enum MonitorArrangement {
     /// rather than one on some other display, because a fallback
     /// here would be a second derivation of which display is main
     /// (`MonitorTray.fold` argues it).
+    ///
+    /// `hostsChips` is false for a picture that is only LOOKED
+    /// at — the Home card's thumbnail, which is read-only and
+    /// hit-test-transparent. It governs the two concessions this
+    /// layout makes to being droppable on, and they are one
+    /// decision rather than two: the follows-main tray's reserved
+    /// band, and the minimum-card floor that keeps a card big
+    /// enough to hold a chip. Both exist so a chip has somewhere
+    /// to land; a thumbnail has no chips.
+    ///
+    /// Applied unconditionally they are a bug on any small
+    /// canvas, and the Home card is one. The band (62 pt) exceeds
+    /// its 56 pt height, so the subtraction clamped to a 1 pt
+    /// canvas; and the floor then beat the fit outright, so the
+    /// displays were drawn at chip-holding size regardless. That
+    /// shipped as a display rectangle drawn outside its own card,
+    /// across the subtitle below it.
     static func layout(
         displays: [Display],
         mainID: DisplayID?,
-        canvas: CGSize
+        canvas: CGSize,
+        hostsChips: Bool = true
     ) -> Layout {
         let drawable = displays.filter {
             $0.frame.width > 0 && $0.frame.height > 0
@@ -140,6 +158,7 @@ enum MonitorArrangement {
         let scale = self.scale(
             for: capped.map(\.rect.size),
             bounds: bounds.size,
+            floored: hostsChips,
             // The tray is added AFTER scaling, so the canvas the
             // displays are fitted into is the canvas minus the
             // band it will occupy. Fitting the displays alone
@@ -150,10 +169,12 @@ enum MonitorArrangement {
             // tray lands on, since it never takes both.
             canvas: CGSize(
                 width: canvas.width,
-                height: max(
-                    1,
-                    canvas.height - trayHeight - trayGap
-                )
+                height: hostsChips
+                    ? max(
+                        1,
+                        canvas.height - trayHeight - trayGap
+                    )
+                    : canvas.height
             )
         )
         let cards = capped.map { entry in
@@ -165,6 +186,14 @@ enum MonitorArrangement {
                     scale: scale
                 )
             )
+        }
+        // No band reserved, no band returned — a `Layout` whose
+        // `tray` a caller could draw into space that was never
+        // set aside for it is the same bug one step later.
+        guard hostsChips else {
+            var bare = Layout()
+            bare.displays = cards
+            return bare
         }
         return MonitorTray.fold(cards: cards, main: mainID)
     }
@@ -224,15 +253,22 @@ enum MonitorArrangement {
     /// a chip onto is a broken control, while a picture wider
     /// than its pane is one the user can still reach every part
     /// of.
+    ///
+    /// `floored` is what keeps a card big enough to hold a chip,
+    /// at the price of overflowing a canvas too small to honour
+    /// it. A picture nobody can drop onto wants the fit alone —
+    /// see `hostsChips` on `layout`.
     private static func scale(
         for sizes: [CGSize],
         bounds: CGSize,
+        floored: Bool,
         canvas: CGSize
     ) -> CGFloat {
         let fit = min(
             canvas.width / max(bounds.width, 1),
             canvas.height / max(bounds.height, 1)
         )
+        guard floored else { return fit }
         let floor =
             sizes.map { size in
                 max(

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsPicture.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsPicture.swift
@@ -24,12 +24,25 @@ struct MonitorsPicture: View {
     /// time a monitor was plugged in.
     private static let canvasHeight: CGFloat = 240
 
+    /// The breathing room around the picture inside its well.
+    ///
+    /// SUBTRACTED from the canvas the arrangement is fitted into,
+    /// not merely added around it: `layout` fills the canvas it
+    /// is handed almost exactly — it fits the displays into
+    /// `canvas − trayHeight − trayGap` and then puts the band
+    /// back — so padding applied afterwards pushed the content
+    /// past the frame by twice this, and the picture scrolled by
+    /// a few points on a desk that fits comfortably (owner,
+    /// 2026-08-04). A many-display desk still scrolls, which is
+    /// the minimum-card floor doing its job.
+    private static let inset: CGFloat = 4
+
     var body: some View {
         GeometryReader { proxy in
             let layout = arrangement(
                 for: CGSize(
-                    width: proxy.size.width,
-                    height: Self.canvasHeight
+                    width: proxy.size.width - Self.inset * 2,
+                    height: Self.canvasHeight - Self.inset * 2
                 )
             )
             ScrollView([.horizontal, .vertical]) {
@@ -38,7 +51,7 @@ struct MonitorsPicture: View {
                         width: layout.contentSize.width,
                         height: layout.contentSize.height
                     )
-                    .padding(4)
+                    .padding(Self.inset)
             }
             .frame(
                 width: proxy.size.width,

--- a/Sources/KiwiDesk/Settings/HomeCardPreview.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardPreview.swift
@@ -162,7 +162,15 @@ enum HomeCardPreview {
             let layout = MonitorArrangement.layout(
                 displays: model.displays,
                 mainID: mainID,
-                canvas: proxy.size
+                canvas: proxy.size,
+                // Nothing is dropped on this picture, so it
+                // takes neither concession the droppable one
+                // makes: no reserved tray band, and no
+                // minimum-card floor. Both overflowed a 56 pt
+                // canvas — the floor by 135 pt on its own — and
+                // shipped as a display rectangle drawn outside
+                // its own card (owner, 2026-08-04).
+                hostsChips: false
             )
             ZStack(alignment: .topLeading) {
                 ForEach(layout.displays) { drawn in

--- a/Tests/KiwiDeskGuiTests/MonitorArrangementFitTests.swift
+++ b/Tests/KiwiDeskGuiTests/MonitorArrangementFitTests.swift
@@ -1,0 +1,174 @@
+import CoreGraphics
+import KiwiDeskCore
+import Testing
+
+@testable import KiwiDesk
+
+/// **A laid-out arrangement fits the canvas it was given.**
+///
+/// The defect had two halves, both concessions to being
+/// droppable on, and both applied to a canvas that hosts no
+/// chips at all. The tray's band (`trayHeight` + `trayGap`, 62)
+/// was reserved from a 56 pt canvas, so the subtraction clamped
+/// to 1 pt; and the minimum-card floor then beat the fit
+/// outright, so the displays were drawn at chip-holding size
+/// regardless of the canvas. The floor is the dominant half —
+/// removing only the band still overflowed by 135 pt into 56.
+/// It shipped as a display rectangle drawn outside its own Home
+/// card and across the subtitle beneath it.
+///
+/// Guarded by **arithmetic over the returned rects**, never by a
+/// scan for the parameter: a scan would pass the moment someone
+/// passed the flag and still mis-sized the canvas, and it is the
+/// geometry that was wrong. The tall canvases are here so the fix
+/// cannot be "always subtract nothing" — the band still has to be
+/// reserved where a tray is actually drawn.
+@Suite("Monitor arrangement fits its canvas")
+struct MonitorArrangementFitTests {
+    private func display(
+        _ id: UInt32,
+        _ frame: CGRect
+    ) -> Display {
+        Display(
+            id: DisplayID(id),
+            name: "D\(id)",
+            frame: frame
+        )
+    }
+
+    /// One 16:10 display, the single-display desk the Home card
+    /// draws for most users.
+    private var single: [Display] {
+        [display(1, CGRect(x: 0, y: 0, width: 2560, height: 1600))]
+    }
+
+    /// A laptop under a desk display — the height-bound shape the
+    /// tray reservation exists for.
+    private var stacked: [Display] {
+        [
+            display(1, CGRect(x: 0, y: 0, width: 2560, height: 1440)),
+            display(2, CGRect(x: 300, y: 1440, width: 1440, height: 900)),
+        ]
+    }
+
+    /// The Home card's own thumbnail size (`HomeCardPreview`'s
+    /// 56 pt band inside a ~240 pt card) — SHORTER than
+    /// `trayHeight + trayGap`, which is the case that broke.
+    private let cardCanvas = CGSize(width: 212, height: 56)
+
+    @Test("a chip-less canvas holds every display")
+    func chipLessFitsTheCanvas() {
+        for displays in [single, stacked] {
+            let layout = MonitorArrangement.layout(
+                displays: displays,
+                mainID: DisplayID(1),
+                canvas: cardCanvas,
+                hostsChips: false
+            )
+            #expect(!layout.displays.isEmpty)
+            for drawn in layout.displays {
+                #expect(
+                    drawn.rect.maxX <= cardCanvas.width + 0.5,
+                    "a display overflows the canvas horizontally"
+                )
+                #expect(
+                    drawn.rect.maxY <= cardCanvas.height + 0.5,
+                    "a display overflows the canvas vertically"
+                )
+                #expect(drawn.rect.minX >= -0.5)
+                #expect(drawn.rect.minY >= -0.5)
+            }
+        }
+    }
+
+    /// The band is still reserved where a tray IS drawn, so the
+    /// fix cannot be "stop subtracting". Asserted on a canvas
+    /// tall enough for one, since the short-canvas case has no
+    /// room for a tray at all.
+    @Test("a tray canvas leaves room for the tray")
+    func trayCanvasReservesTheBand() {
+        let canvas = CGSize(width: 420, height: 300)
+        let layout = MonitorArrangement.layout(
+            displays: single,
+            mainID: DisplayID(1),
+            canvas: canvas
+        )
+        let tray = try? #require(layout.tray)
+        #expect(tray != nil)
+        for drawn in layout.displays {
+            #expect(drawn.rect.maxY <= canvas.height + 0.5)
+        }
+        if let tray {
+            #expect(
+                tray.maxY <= canvas.height + 0.5,
+                "the tray itself must fit the canvas"
+            )
+        }
+    }
+
+    /// An ordinary desk must not make the picture SCROLL.
+    ///
+    /// `layout` fills the canvas it is handed almost exactly — it
+    /// fits the displays into `canvas − trayHeight − trayGap` and
+    /// then puts the band back — so `contentSize` lands on the
+    /// canvas height, and any padding the view adds afterwards
+    /// pushes it past the frame. That is what scrolled a
+    /// one-display desk by a few points.
+    ///
+    /// Asserted against the canvas `MonitorsPicture` actually
+    /// hands over (its 240 pt band less its 4 pt inset either
+    /// side), so the test fails if either constant moves without
+    /// the other.
+    @Test("a one-display desk fits without scrolling")
+    func oneDisplayDoesNotScroll() {
+        let inset: CGFloat = 4
+        let canvas = CGSize(
+            width: 520 - inset * 2,
+            height: 240 - inset * 2
+        )
+        let layout = MonitorArrangement.layout(
+            displays: single,
+            mainID: DisplayID(1),
+            canvas: canvas
+        )
+        #expect(
+            layout.contentSize.height <= canvas.height + 0.5,
+            "the picture would scroll vertically on one display"
+        )
+        #expect(
+            layout.contentSize.width <= canvas.width + 0.5,
+            "the picture would scroll horizontally"
+        )
+    }
+
+    /// The two arms differ, which is what says `hostsChips` is
+    /// read at all: on one canvas the tray-less fit must be
+    /// strictly the taller of the two, because it has the band
+    /// back. Without this a defaulted-true parameter that nothing
+    /// consulted would pass both tests above.
+    @Test("reserving the band changes the fit")
+    func theFlagIsLoadBearing() {
+        let canvas = CGSize(width: 420, height: 300)
+        let reserved = MonitorArrangement.layout(
+            displays: single,
+            mainID: DisplayID(1),
+            canvas: canvas
+        )
+        let bare = MonitorArrangement.layout(
+            displays: single,
+            mainID: DisplayID(1),
+            canvas: canvas,
+            hostsChips: false
+        )
+        let reservedHeight = reserved.displays.first?.rect.height
+        let bareHeight = bare.displays.first?.rect.height
+        #expect(reservedHeight != nil && bareHeight != nil)
+        if let reservedHeight, let bareHeight {
+            #expect(
+                bareHeight > reservedHeight,
+                "the tray-less fit should use the band back"
+            )
+        }
+        #expect(bare.tray == nil)
+    }
+}


### PR DESCRIPTION
Two reports from the owner's fidelity walk, one root cause.

## The bug

`MonitorArrangement.layout` makes two concessions to being **dropped on**:
it reserves the follows-main tray's band (`trayHeight` + `trayGap` = 62),
and it floors every card at `minimumCard` — the size that holds one space
chip. It made both unconditionally, including on canvases that host no
chips at all.

**Home card thumbnail.** 56 pt tall against a 62 pt band, so the
subtraction clamped to a 1 pt canvas; the floor then beat the fit outright
and the displays were laid out at chip-holding size regardless. It shipped
as a display rectangle drawn *outside its own card*, across the subtitle
beneath it.

The floor is the dominant half — dropping only the band still overflowed by
135 pt into 56, which is why one flag governs both. They are one decision:
a chip needs somewhere to land, and a thumbnail has no chips.

**The Monitors picture itself.** It scrolled by a few points on a desk that
fits comfortably. `layout` fills its canvas almost exactly — displays into
`canvas − band`, then the band put back — so the view's `.padding(4)`
pushed the content 8 pt past the frame. The inset is now subtracted from
the canvas that gets fitted rather than only added around it. A
many-display desk still scrolls, which is the floor doing its job (see
`minimumCard`'s docstring, which chose the one-chip floor for exactly that
trade).

## Tests

`MonitorArrangementFitTests` asserts the **returned rectangles fit**, never
that the flag was passed at a call site — a scan would go green on a caller
that passed it and still mis-sized the canvas, and it was the geometry that
was wrong.

It holds both directions on purpose, so the fix cannot be "stop
subtracting": the band is still reserved where a tray *is* drawn, the tray
itself must fit, and the two arms must produce different heights — so a
defaulted parameter that nothing consulted reds.

## Verification

`swift build`, `swift test` (**2890 tests**; the only failures are the 9
pre-existing `MonitorReadoutTests` locale failures tracked as #740, which
fail identically on `main` and are green on CI), `scripts/lint.sh` clean.

Refs #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
