### PR TITLE
chore(release): stamp version 0.9.5

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
+++ b/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
@@ -25,7 +25,7 @@
 /// guard against the real file.
 public enum KiwiDeskVersion {
     /// Semantic version, bumped per release.
-    public static let semantic = "0.9.4"
+    public static let semantic = "0.9.5"
 
     /// Short commit SHA of the build, stamped by the release
     /// workflow; `"unknown"` in every other build.


### PR DESCRIPTION
The version stamp for **v0.9.5**, on a branch because `main` is protected —
`scripts/release.sh` pushes `main` directly, which the branch rule declines,
so the stamp comes through a PR and the tag is pushed onto the merged
commit afterwards.

## What is in 0.9.5

The #678 Phase 3 Settings redesign, complete and translated, plus the
turn-16b token skin and the fidelity fixes that followed it:

- `SettingsTheme` — 15 dynamic colour tokens, light/dark resolved per draw;
  the whole Settings shell repainted, kiwi accent on controls (#738)
- the space-override offer withheld until earned (#739, #741)
- the monitor picture fits its canvas, and the tray grows with its chips
  (#742, #743)
- Layers is an always-open card leading Shortcuts, gated on
  layers-exist-or-Power-User; Layout Defaults moved into Simple; the Lua
  import drawer withheld in Simple (#743)

## Verification

CI verified each merged commit. The local gate is skipped deliberately:
`MonitorReadoutTests` asserts English literals through `L()` and so fails
on any non-English machine (#740), which is what blocks `release.sh` on the
maintainer's Mac. CI runs English and is green.

## After merge

`git tag v0.9.5 <merge-sha> && git push origin v0.9.5` — the tag fires
`release.yml`, which re-verifies the tag, builds the artifact and drafts
the release for publishing.

Refs #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
