### PR TITLE
docs(readme): structure highlights by key feature areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,38 +77,37 @@ pure functions over that list:
 Switching layouts instantly rearranges the same window list with
 a different formula — no tree surgery, no lost state.
 
-**More highlights:**
+### Workspaces & Customization
 
-- **GUI *and* full scriptability**: everyday settings live in a
-  visual Settings app; power users control everything through
-  Lua, the CLI, or both — same features, two paths.
-- **Smooth spring animations**, one display link per monitor, so
-  mixed 60 Hz / 120 Hz setups each animate at native cadence.
-- **Lua configuration** (`~/.config/KiwiDesk/init.lua`) with a
-  sandboxed Lua 5.5 VM — a broken config can never freeze your
-  windows (500 ms timeout, faulty callbacks auto-disabled).
-- **CLI + UNIX socket IPC**: script everything, stream events to
-  SketchyBar, JankyBorders, or your own tools.
-- **Real-time event stream**: `kiwidesk subscribe` emits
-  newline-delimited JSON — hook SketchyBar, JankyBorders, shell
-  scripts, or any external tool into live window events.
-- **Optional App Bar & Space Bar**: built-in window-tab and
-  space-overview overlays with Liquid Glass, fully themeable.
-- **Virtual spaces** with per-space window hiding — your own
-  workspace layer on top of native macOS Spaces, switchable
-  instantly via shortcut or the Space Bar.
-- **Per-app rules**: route apps to spaces, auto-float specific
-  windows, or fully ignore apps from tiling — from the GUI or
-  via `float_rules`, `app_rules`, and `ignore_rules` in Lua.
-- **Modal keybindings** via the Carbon API — no Input Monitoring
-  (keylogger) permission needed.
-- **Profiles that follow your displays**: save a layout per
-  monitor arrangement and it loads automatically when you connect
-  those screens — with per-native-Space bindings on top.
-- **Crash recovery** and **sleep/wake restore** keep your window
-  arrangement across restarts and lid cycles.
-- **15 languages** out of the box — and contributions for more
-  are always welcome.
+- **Virtual Spaces Layer**: Per-space window hiding on top of
+  native macOS Spaces — switch workspaces instantly via shortcut,
+  CLI, or Space Bar.
+- **Full Control (GUI, CLI & Lua)**: Everyday tweaks live in the
+  SwiftUI Settings app; power users can query and trigger everything
+  via the `kiwidesk` CLI or script custom hooks in the sandboxed Lua 5.5 VM.
+- **Modal Layers & Instant App Switching**: Bind hotkeys for window
+  management, vim-style modal layers (`define_layer`), or instant app activation
+  (`pull_or_spawn` — open, pull windows explicitly to the front, or cycle through
+  an app's windows on repeated presses, unlike native macOS `⌘Tab` which often leaves
+  windows hidden). Powered by Carbon hotkeys — no Input Monitoring (keylogger) permission needed.
+- **Global & Per-Profile Config Cascade**: Create custom profiles for
+  specific display setups or bind them to native Spaces. Profiles inherit
+  global defaults while supporting sparse layout, shortcut, and rule overrides.
+
+### Visuals, IPC & Performance
+
+- **Focus Rings, Borders & Overlays**: High-visibility focus rings (rounded
+  or crisp square, optional glow), sticky window badges, and App Bar & Space Bar
+  overlays (with optional Liquid Glass styling).
+- **Real-Time Event Stream**: UNIX socket IPC and `kiwidesk subscribe`
+  JSON event stream to integrate SketchyBar, JankyBorders, or external scripts.
+- **Per-App & Window Rules**: Route apps to spaces, set auto-floating rules
+  (`float_rules`), or completely ignore helper apps (`ignore_rules`).
+- **Performance & State Restore**: DisplayLink-synced spring animations
+  per monitor (60 Hz / 120 Hz native cadence), zero SIP modification, and
+  full layout restore across restarts and lid cycles.
+- **15 Languages Included**: Full UI localization out of the box — with
+  contributions for more always welcome.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Restructured feature highlights into organized, punchy feature categories.
- Highlighted **Virtual Spaces Layer** at the top of the highlights.
- Added **Modal Keybinding Layers** (`define_layer`) and Carbon hotkey security details.
- Added **Global & Per-Profile Config Cascade** (display arrangement profiles & sparse overrides).
- Added **Focus Rings, Borders & Overlays** (focus rings, sticky badges, App Bar, Space Bar).
- Emphasized **Dual-Path Control** (SwiftUI Settings app vs sandboxed Lua VM).
- Preserved accurate terminology from `localization-naming.md` and `user-guide.md`.