### PR TITLE
feat(gui): polish the Monitors picture

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Monitors/DisplayCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/DisplayCard.swift
@@ -17,8 +17,11 @@ import SwiftUI
 /// whole point of the area — was then invisible.
 ///
 /// Three states, three channels, because an opacity step on one
-/// hue separates nothing: **main** is the badge, **selected** is
-/// the border, **targeted** is a fill wash.
+/// hue separates nothing: **main** is the badge (plus an accent
+/// glow, which is decoration — the badge is the answer, since a
+/// glow is hue alone and dies under colour-vision deficiency,
+/// #758), **selected** is the border, **targeted** is a fill
+/// wash.
 struct DisplayCard: View {
     @ObservedObject var model: SettingsModel
     let display: Display
@@ -59,6 +62,22 @@ struct DisplayCard: View {
         .overlay(dropWash)
         .overlay(border)
         .clipShape(RoundedRectangle(cornerRadius: 6))
+        // The main display's glow — OUTSIDE the clip, so it can
+        // spill past the card's edge onto the well. Decoration
+        // only; the header's "main" badge stays the answer
+        // (#758). The compositing group is load-bearing:
+        // `.shadow` shadows every drawing primitive separately,
+        // so without flattening first the main card's text,
+        // chips and strokes each grow their own green halo
+        // while the silhouette gets none (ui-designer,
+        // 2026-08-09).
+        .compositingGroup()
+        .shadow(
+            color: isMain
+                ? SettingsTheme.accent.opacity(0.55)
+                : .clear,
+            radius: isMain ? 6 : 0
+        )
         .contentShape(RoundedRectangle(cornerRadius: 6))
         .dropDestination(for: DraggableSpace.self) { items, _ in
             pin(items)
@@ -200,7 +219,9 @@ struct DisplayCard: View {
                     : AnyShapeStyle(
                         SettingsTheme.hairline
                     ),
-                lineWidth: isSelected ? 2 : 1
+                lineWidth: isSelected
+                    ? SettingsTheme.monitorCardStrokeSelected
+                    : SettingsTheme.monitorCardStroke
             )
     }
 

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorCardChips.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorCardChips.swift
@@ -26,10 +26,12 @@ enum MonitorCardChips {
     /// padding, top and bottom (`SpaceAssignmentChip`).
     static let chipHeight: CGFloat = 22
     /// The narrowest a chip gets — horizontal padding either
-    /// side, a one-character name, and the clear button's hit
-    /// target. A longer name makes it wider, so a capacity
-    /// computed from this is an UPPER bound on how many fit;
-    /// erring that way keeps the card honest, since a `+n` that
+    /// side, a one-character name, and its kind glyph. The
+    /// clear button no longer takes flow width (#758 moved it
+    /// to a corner-badge overlay), so 52 now carries ~16 pt of
+    /// deliberate breathing room — kept, because a capacity
+    /// computed from this is an UPPER bound on how many fit,
+    /// and erring that way keeps the card honest: a `+n` that
     /// appears one chip early costs nothing and a chip that
     /// silently does not fit costs the affordance.
     static let minChipWidth: CGFloat = 52

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsPicture.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsPicture.swift
@@ -115,7 +115,13 @@ struct MonitorsPicture: View {
             ),
             SettingsTheme.monitorStandMax
         )
-        let neck = min(max(base * 0.26, 14), 44)
+        let neck = min(
+            max(
+                base * SettingsTheme.monitorNeckScale,
+                SettingsTheme.monitorNeckMin
+            ),
+            SettingsTheme.monitorNeckMax
+        )
         return VStack(spacing: 0) {
             Rectangle()
                 .fill(SettingsTheme.hairline)

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsPicture.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsPicture.swift
@@ -104,10 +104,17 @@ struct MonitorsPicture: View {
     /// which is true of desks and false of this picture, where a
     /// single display fills the whole canvas and a 34 pt foot
     /// under a 520 pt screen reads as a speck of dirt (owner,
-    /// 2026-08-04). The clamp is what stops the same proportion
-    /// giving a laptop thumbnail a plinth.
+    /// 2026-08-04). The share, its clamp and the card stroke all
+    /// come from `SettingsTheme` (#758), which is the one copy
+    /// of the numbers.
     private func stand(cardWidth: CGFloat) -> some View {
-        let base = min(max(cardWidth * 0.38, 44), 190)
+        let base = min(
+            max(
+                cardWidth * SettingsTheme.monitorStandScale,
+                SettingsTheme.monitorStandMin
+            ),
+            SettingsTheme.monitorStandMax
+        )
         let neck = min(max(base * 0.26, 14), 44)
         return VStack(spacing: 0) {
             Rectangle()

--- a/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
@@ -18,10 +18,15 @@ struct SpaceAssignment: Identifiable, Hashable {
 /// One space chip inside a display card. Semantic micro-icons
 /// (pin / arrow) encode the resolution kind — border style alone
 /// would be an accessibility risk (§3.13). Explicit chips clear
-/// back to automatic via an always-visible ⓧ (a reserved trailing
-/// slot, like a Mail address token — a hover-only button grew the
-/// chip after the flow layout had sized it, so its ⓧ overflowed a
-/// narrow card).
+/// back to automatic via an always-visible ⓧ drawn as a CORNER
+/// BADGE overlay on the trailing-top corner (#758): an overlay
+/// never contributes to the parent's size, so the chip's metrics
+/// stop depending on whether it is pinned. Its two ancestors
+/// died of the same measurement — a hover-only button grew the
+/// chip after the flow layout had sized it, so its ⓧ overflowed
+/// a narrow card, and the in-flow trailing slot that replaced it
+/// ate label width on every pinned chip and made each read as a
+/// delete button.
 ///
 /// **A `Menu` inside the chip is what makes the keyboard route
 /// real** (#678 turn 13b). Before it, the chip was an `HStack`
@@ -119,27 +124,6 @@ struct SpaceAssignmentChip: View {
                 // 8-language add (#95) — localized names run
                 // longer.
                 .frame(maxWidth: 120, alignment: .leading)
-            if kind != .auto {
-                Button {
-                    clear()
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 9))
-                        // A 9 pt glyph inside a draggable surface
-                        // is a click that starts a drag two points
-                        // off centre. The hit target is the
-                        // affordance, not the drawing.
-                        .frame(width: 16, height: 16)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.borderless)
-                .iconButtonAffordance(
-                    L(
-                        "monitors.clear_pin.label",
-                        "Back to automatic placement"
-                    )
-                )
-            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
@@ -164,6 +148,57 @@ struct SpaceAssignmentChip: View {
                 ? AnyShapeStyle(.secondary)
                 : AnyShapeStyle(.primary)
         )
+        // Always visible, never hover-revealed: a hover-inserted
+        // control changes the pill's size, which is the trap the
+        // overlay exists to close — hover may change only the
+        // badge's tint, never its presence or any metric.
+        .overlay(alignment: .topTrailing) { clearBadge }
+    }
+
+    /// The clear-pin control, riding the trailing-top corner and
+    /// slightly overlapping the border. In the accessibility
+    /// tree at full strength however quietly it draws: the
+    /// 16 × 16 hit target (the affordance is the target, not the
+    /// 9 pt glyph), the spoken label and keyboard reachability
+    /// all survive the move out of the flow (#758).
+    @ViewBuilder private var clearBadge: some View {
+        if kind != .auto {
+            Button {
+                clear()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 9))
+                    // Grey disc, light x — the NSSearchField
+                    // cancel shape. The chip renders on three
+                    // surfaces (card plate, the tray's bare
+                    // well, the overflow popover), and a
+                    // card-coloured disc is invisible by
+                    // construction on the first and a punched
+                    // hole on the second; an ink2 disc reads on
+                    // all three, masks whatever stroke it
+                    // overlaps, and separates by lightness, not
+                    // hue (ui-designer, 2026-08-09).
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(
+                        SettingsTheme.card,
+                        SettingsTheme.ink2
+                    )
+                    .frame(width: 16, height: 16)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.borderless)
+            .iconButtonAffordance(
+                L(
+                    "monitors.clear_pin.label",
+                    "Back to automatic placement"
+                )
+            )
+            // y −2, not −4: the 16 pt hit target's top edge
+            // stays inside `stackSpacing`'s gap, so a click on
+            // the tail of a truncated header name cannot land
+            // on "clear this pin" (ui-designer, 2026-08-09).
+            .offset(x: 4, y: -2)
+        }
     }
 
     /// One glyph per kind, and the follows-main one is an ARROW

--- a/Sources/KiwiDesk/Settings/SettingsTheme.swift
+++ b/Sources/KiwiDesk/Settings/SettingsTheme.swift
@@ -162,6 +162,28 @@ enum SettingsTheme {
     /// beside a segmented control reads as a second control.
     static let chipRadius: CGFloat = 9
 
+    /// The Monitors picture's card stroke at rest — heavier than
+    /// the app's hairline so a display card reads as an OBJECT
+    /// on the recessed well rather than as outlined content
+    /// (#758). Selection keeps its own, still-heavier weight:
+    /// the border is the SELECTED channel, and the two weights
+    /// must stay apart or one state swallows the other.
+    static let monitorCardStroke: CGFloat = 1.5
+    static let monitorCardStrokeSelected: CGFloat = 3
+
+    /// A display card's stand: the foot as a share of the card's
+    /// width, clamped. Long enough that the card sits ON its
+    /// foot rather than floating above a speck (#758); the clamp
+    /// is what stops the same share giving a laptop thumbnail a
+    /// plinth. The FLOOR stays at the pre-#758 44: the share
+    /// only takes over above ~85 pt of card, so a floor-sized
+    /// 64 pt card keeps its approved proportion instead of an
+    /// 87 % plinth, and neighbouring floored cards' feet do not
+    /// fuse into a rail (ui-designer, 2026-08-09).
+    static let monitorStandScale: CGFloat = 0.52
+    static let monitorStandMin: CGFloat = 44
+    static let monitorStandMax: CGFloat = 230
+
     // MARK: - Construction
 
     /// One dynamic colour from a light/dark `0xRRGGBB` pair.

--- a/Sources/KiwiDesk/Settings/SettingsTheme.swift
+++ b/Sources/KiwiDesk/Settings/SettingsTheme.swift
@@ -172,17 +172,28 @@ enum SettingsTheme {
     static let monitorCardStrokeSelected: CGFloat = 3
 
     /// A display card's stand: the foot as a share of the card's
-    /// width, clamped. Long enough that the card sits ON its
-    /// foot rather than floating above a speck (#758); the clamp
-    /// is what stops the same share giving a laptop thumbnail a
-    /// plinth. The FLOOR stays at the pre-#758 44: the share
-    /// only takes over above ~85 pt of card, so a floor-sized
-    /// 64 pt card keeps its approved proportion instead of an
-    /// 87 % plinth, and neighbouring floored cards' feet do not
-    /// fuse into a rail (ui-designer, 2026-08-09).
+    /// width and the neck as a share of the foot, each clamped.
+    /// Long enough that the card sits ON its foot rather than
+    /// floating above a speck (#758); the clamps stop the same
+    /// shares giving a laptop thumbnail a plinth. The foot's
+    /// FLOOR stays at its pre-#758 value: on a floor-sized card
+    /// (`MonitorArrangement.minimumCard`) the raised share
+    /// alone reads as a plinth, and neighbouring floored cards'
+    /// feet fuse into one rail (ui-designer, 2026-08-09).
+    ///
+    /// These are AREA-SCOPED metrics in the app-wide theme, on
+    /// a stated boundary: a number the picture's capacity
+    /// arithmetic derives from lives beside that arithmetic in
+    /// `MonitorCardChips`; pure chrome — strokes and stands
+    /// nothing computes on — lives here with the radii. The
+    /// colour suites cannot see these, so their wiring guard is
+    /// `MonitorsChromeWiringTests`' themed-metrics test.
     static let monitorStandScale: CGFloat = 0.52
     static let monitorStandMin: CGFloat = 44
     static let monitorStandMax: CGFloat = 230
+    static let monitorNeckScale: CGFloat = 0.26
+    static let monitorNeckMin: CGFloat = 14
+    static let monitorNeckMax: CGFloat = 44
 
     // MARK: - Construction
 

--- a/Tests/KiwiDeskGuiTests/MonitorsChromeWiringTests.swift
+++ b/Tests/KiwiDeskGuiTests/MonitorsChromeWiringTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// The Monitors picture's CHROME is wired to its owners — the
+/// geometry to `MonitorArrangement`, the drawn numbers to
+/// `SettingsTheme` (#758).
+///
+/// Split from `MonitorsGateWiringTests` (the gate, seam and
+/// surfacing-branch needles) as that suite reached the 350-line
+/// ceiling; same needle idiom — whitespace-squashed,
+/// comment-stripped source, keyed on use sites.
+@Suite("Monitors chrome wiring")
+struct MonitorsChromeWiringTests {
+    private var settingsDir: URL {
+        SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDesk/Settings")
+    }
+
+    private func read(_ path: String) throws -> String {
+        try String(
+            contentsOf: settingsDir.appendingPathComponent(path),
+            encoding: .utf8
+        )
+    }
+
+    /// Whitespace-free source, so a needle survives the formatter
+    /// wrapping a call across lines.
+    private func squashed(_ path: String) throws -> String {
+        SourceScan.stripComments(try read(path))
+            .split(whereSeparator: \.isWhitespace)
+            .joined()
+    }
+
+    /// The picture asks `MonitorArrangement` for its geometry and
+    /// computes none of its own.
+    ///
+    /// This is the #702 rule one surface over: a drawing that
+    /// re-derives what a shared function owns is right the day it
+    /// is written and drifts the day the rule moves. Here the
+    /// shared function is also the only thing the geometry guards
+    /// can see — a card positioned by arithmetic inline in the
+    /// view would pass every assertion in
+    /// `MonitorArrangementTests` while drawing something else.
+    @Test("the picture asks the arrangement for its geometry")
+    func pictureAsksTheArrangement() throws {
+        let name = "Components/Monitors/MonitorsPicture.swift"
+        let source = try squashed(name)
+        #expect(source.contains("MonitorArrangement.layout("))
+        for forbidden in ["frame.minX", "frame.width", "NSScreen"] {
+            #expect(
+                !source.contains(forbidden),
+                Comment(
+                    rawValue:
+                        "\(name) reads display geometry itself "
+                        + "(`\(forbidden)`) instead of drawing "
+                        + "the arrangement it was given"
+                )
+            )
+        }
+    }
+
+    /// The picture's chrome reads its numbers from
+    /// `SettingsTheme`, which is the one copy (#758) — a stand
+    /// or stroke re-hardcoded beside the drawing is the drift
+    /// the theme constants exist to end.
+    ///
+    /// The stroke needle is the WHOLE ternary: the rest-weight
+    /// name is a substring of the selected-weight name, so a
+    /// bare `monitorCardStroke` check would stay green with the
+    /// rest weight hardcoded back to a literal.
+    @Test("the chrome reads its themed metrics")
+    func chromeReadsThemedMetrics() throws {
+        let picture = try squashed(
+            "Components/Monitors/MonitorsPicture.swift"
+        )
+        for needle in [
+            "SettingsTheme.monitorStandScale",
+            "SettingsTheme.monitorStandMin",
+            "SettingsTheme.monitorStandMax",
+            "SettingsTheme.monitorNeckScale",
+            "SettingsTheme.monitorNeckMin",
+            "SettingsTheme.monitorNeckMax",
+        ] {
+            #expect(
+                picture.contains(needle),
+                Comment(
+                    rawValue:
+                        "MonitorsPicture no longer reads "
+                        + "`\(needle)` — the stand's size went "
+                        + "inline"
+                )
+            )
+        }
+        let card = try squashed(
+            "Components/Monitors/DisplayCard.swift"
+        )
+        #expect(
+            card.contains(
+                "SettingsTheme.monitorCardStrokeSelected"
+                    + ":SettingsTheme.monitorCardStroke)"
+            ),
+            Comment(
+                rawValue:
+                    "DisplayCard's border no longer takes both "
+                    + "weights from SettingsTheme"
+            )
+        )
+    }
+}

--- a/Tests/KiwiDeskGuiTests/MonitorsGateWiringTests.swift
+++ b/Tests/KiwiDeskGuiTests/MonitorsGateWiringTests.swift
@@ -180,6 +180,19 @@ struct MonitorsGateWiringTests {
                 // needle two entries down, and the same fix.
                 "split.overflow>0",
                 "overflowChip(assignments,split.overflow)",
+                // The main display's glow (#758). Decoration —
+                // the badge is the answer — but a decoration
+                // branch deletes as silently as any other.
+                "isMain?SettingsTheme.accent",
+            ],
+            "Components/Monitors/SpaceAssignmentChip.swift": [
+                // The clear-pin corner badge (#758): the overlay
+                // that mounts it, keyed on the USE site, and the
+                // glyph inside the branch — deleting either
+                // strands every pinned chip with no route back
+                // to automatic except the context menu.
+                ".overlay(alignment:.topTrailing){clearBadge}",
+                "Image(systemName:\"xmark.circle.fill\")",
             ],
             "Sections/MonitorsSection+Details.swift": [
                 // The orphan row's spoken label: its value is a
@@ -238,6 +251,51 @@ struct MonitorsGateWiringTests {
                 )
             )
         }
+    }
+
+    /// The picture's chrome reads its numbers from
+    /// `SettingsTheme`, which is the one copy (#758) — a stand
+    /// or stroke re-hardcoded beside the drawing is the drift
+    /// the theme constants exist to end.
+    ///
+    /// The stroke needle is the WHOLE ternary: the rest-weight
+    /// name is a substring of the selected-weight name, so a
+    /// bare `monitorCardStroke` check would stay green with the
+    /// rest weight hardcoded back to a literal.
+    @Test("the chrome reads its themed metrics")
+    func chromeReadsThemedMetrics() throws {
+        let picture = try squashed(
+            "Components/Monitors/MonitorsPicture.swift"
+        )
+        for needle in [
+            "SettingsTheme.monitorStandScale",
+            "SettingsTheme.monitorStandMin",
+            "SettingsTheme.monitorStandMax",
+        ] {
+            #expect(
+                picture.contains(needle),
+                Comment(
+                    rawValue:
+                        "MonitorsPicture no longer reads "
+                        + "`\(needle)` — the stand's size went "
+                        + "inline"
+                )
+            )
+        }
+        let card = try squashed(
+            "Components/Monitors/DisplayCard.swift"
+        )
+        #expect(
+            card.contains(
+                "SettingsTheme.monitorCardStrokeSelected"
+                    + ":SettingsTheme.monitorCardStroke)"
+            ),
+            Comment(
+                rawValue:
+                    "DisplayCard's border no longer takes both "
+                    + "weights from SettingsTheme"
+            )
+        )
     }
 
     /// The card's chip capacity comes from the shared arithmetic,

--- a/Tests/KiwiDeskGuiTests/MonitorsGateWiringTests.swift
+++ b/Tests/KiwiDeskGuiTests/MonitorsGateWiringTests.swift
@@ -182,8 +182,14 @@ struct MonitorsGateWiringTests {
                 "overflowChip(assignments,split.overflow)",
                 // The main display's glow (#758). Decoration —
                 // the badge is the answer — but a decoration
-                // branch deletes as silently as any other.
+                // branch deletes as silently as any other. TWO
+                // needles: the branch, and the flatten-shadow
+                // PAIRING — a shadow without the compositing
+                // group regresses to a per-primitive halo on
+                // every glyph with the branch needle still
+                // green (architect review, 2026-08-09).
                 "isMain?SettingsTheme.accent",
+                ".compositingGroup().shadow(",
             ],
             "Components/Monitors/SpaceAssignmentChip.swift": [
                 // The clear-pin corner badge (#758): the overlay
@@ -225,78 +231,9 @@ struct MonitorsGateWiringTests {
         }
     }
 
-    /// The picture asks `MonitorArrangement` for its geometry and
-    /// computes none of its own.
-    ///
-    /// This is the #702 rule one surface over: a drawing that
-    /// re-derives what a shared function owns is right the day it
-    /// is written and drifts the day the rule moves. Here the
-    /// shared function is also the only thing the geometry guards
-    /// can see — a card positioned by arithmetic inline in the
-    /// view would pass every assertion in
-    /// `MonitorArrangementTests` while drawing something else.
-    @Test("the picture asks the arrangement for its geometry")
-    func pictureAsksTheArrangement() throws {
-        let name = "Components/Monitors/MonitorsPicture.swift"
-        let source = try squashed(name)
-        #expect(source.contains("MonitorArrangement.layout("))
-        for forbidden in ["frame.minX", "frame.width", "NSScreen"] {
-            #expect(
-                !source.contains(forbidden),
-                Comment(
-                    rawValue:
-                        "\(name) reads display geometry itself "
-                        + "(`\(forbidden)`) instead of drawing "
-                        + "the arrangement it was given"
-                )
-            )
-        }
-    }
-
-    /// The picture's chrome reads its numbers from
-    /// `SettingsTheme`, which is the one copy (#758) — a stand
-    /// or stroke re-hardcoded beside the drawing is the drift
-    /// the theme constants exist to end.
-    ///
-    /// The stroke needle is the WHOLE ternary: the rest-weight
-    /// name is a substring of the selected-weight name, so a
-    /// bare `monitorCardStroke` check would stay green with the
-    /// rest weight hardcoded back to a literal.
-    @Test("the chrome reads its themed metrics")
-    func chromeReadsThemedMetrics() throws {
-        let picture = try squashed(
-            "Components/Monitors/MonitorsPicture.swift"
-        )
-        for needle in [
-            "SettingsTheme.monitorStandScale",
-            "SettingsTheme.monitorStandMin",
-            "SettingsTheme.monitorStandMax",
-        ] {
-            #expect(
-                picture.contains(needle),
-                Comment(
-                    rawValue:
-                        "MonitorsPicture no longer reads "
-                        + "`\(needle)` — the stand's size went "
-                        + "inline"
-                )
-            )
-        }
-        let card = try squashed(
-            "Components/Monitors/DisplayCard.swift"
-        )
-        #expect(
-            card.contains(
-                "SettingsTheme.monitorCardStrokeSelected"
-                    + ":SettingsTheme.monitorCardStroke)"
-            ),
-            Comment(
-                rawValue:
-                    "DisplayCard's border no longer takes both "
-                    + "weights from SettingsTheme"
-            )
-        )
-    }
+    // The picture-asks-the-arrangement and themed-metrics
+    // guards live in `MonitorsChromeWiringTests` — split there
+    // as this suite reached the 350-line ceiling.
 
     /// The card's chip capacity comes from the shared arithmetic,
     /// so a card can never resolve "more chips than fit" by

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -4190,12 +4190,13 @@ than a limit of the identity.
 (pin, arrow) rather than border styles alone (accessibility), and
 automatic is drawn as an outline rather than a dimmed capsule —
 dimming is this app's inert vocabulary, and an automatic chip is
-the one most worth dragging. Two routes into a chip's menu —
-drag, or right-click — and the keyboard route is knowingly
-absent: a whole-chip `Menu` made it real for one release and
-consumed the mouse-down that `.draggable` needs, so a restored
-keyboard route must not reach for the control shape that took
-the drag (the argument lives on `SpaceAssignmentChip`). The
+the one most worth dragging. Two routes to move a space — drag
+it, or its right-click menu — and the keyboard and VoiceOver
+routes are knowingly absent: a whole-chip `Menu` made them real
+and consumed the mouse-down that `.draggable` needs, so a
+restored keyboard route must not reach for the control shape
+that took the drag (the argument lives on
+`SpaceAssignmentChip`). The
 clear affordance never participates in the chip's layout: a
 pinned chip and an automatic chip measure identically — the ⓧ
 rides the trailing-top corner as an overlay, and hover may

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -4190,13 +4190,22 @@ than a limit of the identity.
 (pin, arrow) rather than border styles alone (accessibility), and
 automatic is drawn as an outline rather than a dimmed capsule —
 dimming is this app's inert vocabulary, and an automatic chip is
-the one most worth dragging. The chip is a menu CONTROL, and
-that is what makes its menu reachable: the same items were
-available as a context menu for a year, on a plain stack with a
-drag gesture, which cannot take focus — so the route billed as
-the keyboard and VoiceOver fallback existed only for people using
-a mouse, the one group it was not for. Right-click still opens
-it; the control is what added the other two.
+the one most worth dragging. Two routes into a chip's menu —
+drag, or right-click — and the keyboard route is knowingly
+absent: a whole-chip `Menu` made it real for one release and
+consumed the mouse-down that `.draggable` needs, so a restored
+keyboard route must not reach for the control shape that took
+the drag (the argument lives on `SpaceAssignmentChip`). The
+clear affordance never participates in the chip's layout: a
+pinned chip and an automatic chip measure identically — the ⓧ
+rides the trailing-top corner as an overlay, and hover may
+change only its tint, never its presence or any metric —
+because the chips are sized by a flow layout whose arithmetic
+(`MonitorCardChips.minChipWidth`) must hold for both states,
+and both a hover-revealed button and an in-flow trailing slot
+have shipped and died of that measurement. Decoration may ride
+the accent (the main card's bloom); the answer never rides hue
+alone (the "main" badge).
 
 ### App rules
 

--- a/docs/ui-patterns.md
+++ b/docs/ui-patterns.md
@@ -435,7 +435,11 @@ quiet to spot at list speed.
 **Status badges stay flat.** The thumb/pill shadow is the
 settings' vocabulary for "interactive, movable"; putting it
 on a passive `BadgeChip` would promise interaction the chip
-doesn't have. Depth comes from the hairline stroke both chip
+doesn't have. One mark sits outside both vocabularies: the
+Monitors picture's main-display card wears a soft accent
+bloom — decoration stating a fact, promising neither
+interaction nor an armed input, and always beside the
+textual "main" badge that carries the answer. Depth comes from the hairline stroke both chip
 types now share, matching the flat capsule language of
 native tags. A non-interactive value state in a control row
 (the slot size's "Default — orientation standard") renders in
@@ -829,7 +833,7 @@ search (or any later cross-reference) sends the user to a
 specific place in a pane, the pane scrolls that place's *card* to
 the top — a control landing without the heading that names it
 reads as disembodied — and its **heading** takes a brief accent
-wash: `Color.accentColor` at `0.18`, a corner-6 rounded rect
+wash: `SettingsTheme.accent` at `0.18`, a corner-6 rounded rect
 bleeding 4 pt past the content, flat for 300 ms, then eased out
 over 900 ms (`SettingsReveal` owns the numbers). Reduce Motion
 drops the cross-fade only: the wash still shows for the same

--- a/docs/ui-patterns.md
+++ b/docs/ui-patterns.md
@@ -439,7 +439,8 @@ doesn't have. One mark sits outside both vocabularies: the
 Monitors picture's main-display card wears a soft accent
 bloom — decoration stating a fact, promising neither
 interaction nor an armed input, and always beside the
-textual "main" badge that carries the answer. Depth comes from the hairline stroke both chip
+textual "main" badge that carries the answer. Depth comes
+from the hairline stroke both chip
 types now share, matching the flat capsule language of
 native tags. A non-interactive value state in a control row
 (the slot size's "Default — orientation standard") renders in


### PR DESCRIPTION
## Description

Polishes the Monitors picture (#678 Phase 4): a display card now
reads as an object, the picture answers "which screen is main",
and a space chip's metrics stop depending on whether it is
pinned.

- **Longer stand foot, heavier card border.** Foot at 0.52 of
  the card's width (floor kept at the approved 44 so a
  floor-sized card gets no plinth), border 1.5 pt rest / 3 pt
  selected. All eight numbers (foot, neck, strokes) live in
  `SettingsTheme` on a stated boundary — capacity-feeding
  anatomy stays beside its arithmetic in `MonitorCardChips`,
  pure chrome joins the radii — wired by
  `MonitorsChromeWiringTests`.
- **Main-display mark.** A soft accent bloom on the main card,
  flattened by a `compositingGroup` so the silhouette glows
  rather than every glyph. Decoration only: the textual "main"
  badge stays the answer, per the colour-vision clause.
- **Chip clear-x as a corner badge.** Moved out of the pill's
  flow to an `.overlay(alignment: .topTrailing)` — a pin no
  longer reflows the row, and hover can change nothing but
  tint. Grey disc, light x (the search-field cancel shape),
  visible on all three backing surfaces. The 16×16 hit target,
  `monitors.clear_pin.label` and keyboard reachability all
  survive the move.

**Skipped as pre-authorized:** the issue's "mark the screen the
Settings window is on, live" alternative — it needs a
window-screen observation seam plus its machine-touch guards,
which is a feature, not polish. Filed thinking: revisit after
Phase 5 (the Settings window starts tiling there anyway, which
changes what "its screen" means).

Docs ride along: ui-patterns exempts the bloom from the
shadow/halo vocabulary (and drops a stale `Color.accentColor`
mention); design-decisions' chips paragraph updates to the
shipped two-route ruling and carries the corner-badge rule.

## Related Issue(s)

Closes #758

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [ ] Release build green — no concurrency touched; CI's
  Release Build job reports on this PR
- [x] PR is focused; refactors separated from features

## How I verified

- Full suite green: 2938 tests / 543 suites (one transient
  `MouseWarpHoldTests` red mid-session reproduced the
  documented live-mouse environmental class and passed alone
  and on rerun).
- Two `guard-prover` rounds, 8 mutations, all red-proofed —
  including deleting ONLY the `compositingGroup` (the
  per-primitive-halo regression) and re-hardcoding the theme's
  own values back inline (a pixel-identical one-copy
  violation).
- `ui-designer` consult before commit; its three majors are
  applied (compositingGroup, inverted badge palette, stand
  floor kept).

**Owner eye-confirm OWED (visual change), one sitting:**
- glow on the well in light AND dark; a touching two-display
  desk with main first and last in draw order (the halo can
  tuck under a later-drawn neighbour and clips at the well
  edge, `inset` 4 < radius 6 — eye-only, by design);
- an unselected main card beside a selected one (blurred
  accent bloom vs crisp 3 pt accent stroke — the discriminator
  is crispness; flagged as a watch-item);
- pinned chip badge on card, tray and overflow popover;
- floor-sized cards' feet (no rail), and the "Delete layer"
  red from #778 in the same sitting.

## Notes for Reviewer

- review-change ran in full: code-reviewer,
  architect-reviewer and docs-steward in parallel; all
  findings fixed (neck joined the theme to make the one-copy
  claim true; pairing needle; suite split at 287/350;
  de-numbered doc comments; docs corrections) and re-verified
  by the docs lane. Remaining verdicts: 0 blockers, 0 major.
- Consciously dismissed: moving the metrics to
  `MonitorCardChips` (ui-designer's option A) — the issue's
  own text asked for `SettingsTheme`, and the stated boundary
  plus the wiring needle close the drift either way; the owner
  can re-home them later without breaking anything but two
  needle paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
