### PR TITLE
test(gui): pin MonitorReadoutTests to the English catalog

### DIFF
--- a/Tests/KiwiDeskGuiTests/MonitorReadoutTests.swift
+++ b/Tests/KiwiDeskGuiTests/MonitorReadoutTests.swift
@@ -20,6 +20,16 @@ import Testing
 @MainActor
 @Suite("Monitor readout sentence")
 struct MonitorReadoutTests {
+    /// Every assertion below compares `L()` output to English,
+    /// so the shared manager must be pinned per test — "System
+    /// default" resolves the HOST's language, and on a German
+    /// machine every sentence here came back from `de.json`
+    /// (caught 2026-08-09; `ShortcutsSelfRowTests` is the
+    /// standing idiom).
+    init() {
+        LocalizationManager.shared.select("en")
+    }
+
     private func display(
         _ id: UInt32,
         _ name: String = "Desk"


### PR DESCRIPTION
## What

Pins `MonitorReadoutTests` to the English catalog in the suite's `init()` — `LocalizationManager.shared.select("en")`, the standing idiom (`ShortcutsSelfRowTests`, `ConfigIssueTextTests`, `PresetSummaryCoverageTests`).

## Why

The suite (new in #779) asserts `L()` output against English while the shared manager sits on "System default", which resolves the **host** language. On a German-language Mac all 7 tests fail in isolation, on every branch — the local gate is red for any non-English-host contributor. English hosts and CI never see it, which is how it survived the #779 gate.

fixes #782

## Verification

- `swift test --filter MonitorReadoutTests` on a German-language host: 9 issues before, green after.
- Revert-red is the host itself: without the pin this suite is red on this machine, so the fix carries its own proof here. On an English host the pin is invisible by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
