### PR TITLE
chore: native issue fields replace type labels — templates + file-issue skill

### DIFF
--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -3,21 +3,29 @@ description: File a KiwiDesk GitHub issue the way an agent must — render the t
 argument-hint: "[template: bug_report|feature_request|docs_report|collector|roadmap]"
 ---
 
-File a GitHub issue for this repository. `gh issue create` does
-not apply the `.github/ISSUE_TEMPLATE/*.yml` forms — neither the
-body fields nor the `type:` key — so an agent reproduces by hand
-what the web form gives a human for free. AGENTS.md §3
-(Branching & Pull Requests) owns the *why* of the templates and
-which template an issue takes; this skill owns the mechanics.
+File a GitHub issue for this repository. AGENTS.md §3 (Branching
+& Pull Requests) owns the *why* — which template an issue takes,
+and why its questions must be answered rather than skipped. This
+skill owns the mechanics.
+
+`gh issue create` does not apply the
+`.github/ISSUE_TEMPLATE/*.yml` forms: the body observation is
+AGENTS.md §3's (2026-08-02, `gh` 2.x — a `--body-file` filing
+starts blank), and since the form never runs, its `type:` key
+cannot apply either (inferred from that observation, not
+separately tested — a filing that does land with a Type set is
+news worth updating this line with). So reproduce by hand what
+the web form gives a human for free.
 
 ## 1. Render the template
 
-Read the chosen `.github/ISSUE_TEMPLATE/<template>.yml` and
+The template to use is `$ARGUMENTS` (pick per AGENTS.md §3 if
+not given). Read `.github/ISSUE_TEMPLATE/$ARGUMENTS.yml` and
 reproduce it:
 
 - each `label:` becomes a `###` heading, in declared order,
-  answered honestly (an internal issue answers the user-shaped
-  questions from the dev machine — never drops them);
+  answered honestly — an internal issue answers the user-shaped
+  questions from the dev machine, never drops them;
 - the template's `title:` prefix goes on the title;
 - any `labels:` the template declares go on the command line
   (`--label …`).
@@ -30,12 +38,13 @@ gh issue create --title "<prefix> <title>" --body-file <file>
 
 ## 2. Set the Type
 
-The template's `type:` key applies only via the web form. Set it
-explicitly — `Bug`, `Feature`, or `Task`, matching the template's
-`type:` value:
+Set it explicitly — `Bug`, `Feature`, or `Task`, matching the
+template's `type:` value. `{owner}/{repo}` is literal: `gh`
+resolves it from the current repository, so never substitute a
+hand-written owner.
 
 ```sh
-gh api -X PATCH repos/hajiboy95/KiwiDesk/issues/<n> -f type=Bug
+gh api -X PATCH repos/{owner}/{repo}/issues/<n> -f type=Bug
 ```
 
 ## 3. Set Priority and Effort
@@ -46,17 +55,19 @@ Priority/Effort.
 
 For everything else, set both single-select issue fields.
 Discover the current field and option IDs rather than trusting a
-stale copy:
+stale copy (`:owner`/`:repo` are literal too — `gh` fills them):
 
 ```sh
-gh api graphql -f query='{ repository(owner:"hajiboy95",
-  name:"KiwiDesk") { issueFields(first:20) { nodes {
-  ... on IssueFieldSingleSelect { id name
-  options { id name } } } } } }'
+gh api graphql -F owner=':owner' -F name=':repo' -f query='
+  query($owner:String!, $name:String!) {
+    repository(owner:$owner, name:$name) {
+      issueFields(first:20) { nodes {
+        ... on IssueFieldSingleSelect { id name
+          options { id name } } } } } }'
 ```
 
 Then, with the issue's node id
-(`gh api repos/hajiboy95/KiwiDesk/issues/<n> --jq .node_id`):
+(`gh api repos/{owner}/{repo}/issues/<n> --jq .node_id`):
 
 ```sh
 gh api graphql -f query='mutation($id:ID!){
@@ -100,7 +111,7 @@ The honest size of the fix, not its importance:
 Read the issue back and confirm all three landed:
 
 ```sh
-gh api repos/hajiboy95/KiwiDesk/issues/<n> \
+gh api repos/{owner}/{repo}/issues/<n> \
   --jq '{type: .type.name, fields: [.issue_field_values[]
   | {(.issue_field_name): .single_select_option.name}]}'
 ```

--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -1,0 +1,106 @@
+---
+description: File a KiwiDesk GitHub issue the way an agent must — render the template body by hand, then set the Type and the Priority/Effort issue fields the web form would have set for a human. Use whenever creating an issue with `gh`.
+argument-hint: "[template: bug_report|feature_request|docs_report|collector|roadmap]"
+---
+
+File a GitHub issue for this repository. `gh issue create` does
+not apply the `.github/ISSUE_TEMPLATE/*.yml` forms — neither the
+body fields nor the `type:` key — so an agent reproduces by hand
+what the web form gives a human for free. AGENTS.md §3
+(Branching & Pull Requests) owns the *why* of the templates and
+which template an issue takes; this skill owns the mechanics.
+
+## 1. Render the template
+
+Read the chosen `.github/ISSUE_TEMPLATE/<template>.yml` and
+reproduce it:
+
+- each `label:` becomes a `###` heading, in declared order,
+  answered honestly (an internal issue answers the user-shaped
+  questions from the dev machine — never drops them);
+- the template's `title:` prefix goes on the title;
+- any `labels:` the template declares go on the command line
+  (`--label …`).
+
+Then:
+
+```sh
+gh issue create --title "<prefix> <title>" --body-file <file>
+```
+
+## 2. Set the Type
+
+The template's `type:` key applies only via the web form. Set it
+explicitly — `Bug`, `Feature`, or `Task`, matching the template's
+`type:` value:
+
+```sh
+gh api -X PATCH repos/hajiboy95/KiwiDesk/issues/<n> -f type=Bug
+```
+
+## 3. Set Priority and Effort
+
+Skip this step for `collector` and `roadmap` issues — they
+sequence work rather than being work, so they take a Type but no
+Priority/Effort.
+
+For everything else, set both single-select issue fields.
+Discover the current field and option IDs rather than trusting a
+stale copy:
+
+```sh
+gh api graphql -f query='{ repository(owner:"hajiboy95",
+  name:"KiwiDesk") { issueFields(first:20) { nodes {
+  ... on IssueFieldSingleSelect { id name
+  options { id name } } } } } }'
+```
+
+Then, with the issue's node id
+(`gh api repos/hajiboy95/KiwiDesk/issues/<n> --jq .node_id`):
+
+```sh
+gh api graphql -f query='mutation($id:ID!){
+  setIssueFieldValue(input:{issueId:$id, issueFields:[
+    {fieldId:"<priority-field-id>",
+     singleSelectOptionId:"<option-id>"},
+    {fieldId:"<effort-field-id>",
+     singleSelectOptionId:"<option-id>"}]})
+  { issue { number } } }' -f id=<node-id>
+```
+
+### The Priority ladder
+
+Read it against the current roadmap issue (the open `🗺️`
+issue), whose waves are the authority on what the release
+contains:
+
+- **Urgent** — blocks the next release, or daily use is broken
+  now.
+- **High** — the release's own work: an open wave item, or a
+  defect that belongs in one.
+- **Medium** — the quality bar behind it: localization and
+  terminology defects, docs parity, test debt, polish the
+  release wants but does not gate on.
+- **Low** — deferred, icebox, or blocked on the OS; behind the
+  release by the roadmap's own guiding rule.
+
+### The Effort ladder
+
+The honest size of the fix, not its importance:
+
+- **Low** — one sitting: a pin, a caption, a rename with a
+  parity guard, a worksheet fix.
+- **Medium** — a lane: one subsystem, its tests and its review
+  round.
+- **High** — a dedicated session or more: cross-subsystem, a
+  new surface, or an unscoped investigation.
+
+## 4. Verify
+
+Read the issue back and confirm all three landed:
+
+```sh
+gh api repos/hajiboy95/KiwiDesk/issues/<n> \
+  --jq '{type: .type.name, fields: [.issue_field_values[]
+  | {(.issue_field_name): .single_select_option.name}]}'
+```

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Something is not working as expected
-labels: ["bug"]
+type: "Bug"
 title: "🐛 "
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/collector.yml
+++ b/.github/ISSUE_TEMPLATE/collector.yml
@@ -1,6 +1,7 @@
 name: Collector (tracking)
 description: Themed collecting issue grouping related issues
 labels: ["roadmap"]
+type: "Task"
 title: "📦 Collector: "
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -1,6 +1,6 @@
 name: Docs
 description: Report missing, wrong, or unclear documentation
-labels: ["documentation"]
+type: "Task"
 title: "📝 "
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an enhancement or new behavior
-labels: ["enhancement"]
+type: "Feature"
 title: "💡 "
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/roadmap.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap.yml
@@ -1,6 +1,7 @@
 name: Roadmap
 description: Wave-sequenced execution plan across open issues
 labels: ["roadmap"]
+type: "Task"
 title: "🗺️ Roadmap: "
 body:
   - type: markdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,20 @@ fields that fit awkwardly — answer them honestly from the dev
 machine rather than dropping them or inventing a new shape
 inline.
 
+Beyond the body: give every issue GitHub's **Type** (Bug /
+Feature / Task) and the repo's **Priority** and **Effort**
+issue fields at filing, not in a later sweep — an unranked
+issue is invisible to the roadmap's ordering. The templates
+stamp the Type for a human on the web form; `gh` applies
+neither the form nor its `type:` key, so an agent sets Type
+and both fields itself. The **`file-issue` skill**
+([.claude/skills/file-issue](.claude/skills/file-issue/SKILL.md))
+owns that procedure and the Priority/Effort ladders. Collector
+and roadmap issues take a Type but no Priority/Effort — they
+sequence work rather than being work. Type replaced the old
+`bug` / `enhancement` / `documentation` labels; do not re-add
+them.
+
 ### Commit messages (Angular / Conventional Commits)
 
 `type(scope): subject` — imperative, lower-case, no trailing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,10 +198,8 @@ writing whatever shape it likes.** GitHub applies a `.yml` form
 only when a human opens the *New issue* page (observed
 2026-08-02, `gh` 2.x), so `gh issue create --body-file` — the way
 an agent files one — starts from a blank body and silently keeps
-none of it. Read the
-template, then reproduce it: each `label:` as a `###` heading in
-declared order, its `labels:` on the command line, its `title:`
-prefix on the title. The reason is not tidiness. Those fields are
+none of it. The reason the template must be reproduced anyway is
+not tidiness. Those fields are
 the questions a maintainer needs answered *before* triaging, and
 an agent that skips them is skipping the questions, not just the
 formatting — the templates ask for the macOS version and the
@@ -223,16 +221,14 @@ inline.
 Beyond the body: give every issue GitHub's **Type** (Bug /
 Feature / Task) and the repo's **Priority** and **Effort**
 issue fields at filing, not in a later sweep — an unranked
-issue is invisible to the roadmap's ordering. The templates
-stamp the Type for a human on the web form; `gh` applies
-neither the form nor its `type:` key, so an agent sets Type
-and both fields itself. The **`file-issue` skill**
+issue is invisible to the roadmap's ordering. The
+**`file-issue` skill**
 ([.claude/skills/file-issue](.claude/skills/file-issue/SKILL.md))
-owns that procedure and the Priority/Effort ladders. Collector
-and roadmap issues take a Type but no Priority/Effort — they
-sequence work rather than being work. Type replaced the old
-`bug` / `enhancement` / `documentation` labels; do not re-add
-them.
+owns the whole filing procedure — the template reproduction,
+setting the Type and both fields, and the Priority/Effort
+ladders. Type says what the retired `bug` / `enhancement` /
+`documentation` / `feat` labels used to say; never apply those
+labels to an issue again.
 
 ### Commit messages (Angular / Conventional Commits)
 


### PR DESCRIPTION
## Description

The repo's native issue fields — Type (Bug/Feature/Task),
Priority (Urgent/High/Medium/Low), Effort (High/Medium/Low) —
replace the type-duplicating labels. This PR carries the repo
side of that switch:

- all five issue templates gain a `type:` key, so a web-form
  filing stamps the Type automatically; the redundant
  `labels: ["bug"|"enhancement"|"documentation"]` lines are
  gone (collector/roadmap keep `roadmap`)
- new `file-issue` skill owns the agent-side filing procedure:
  render the template body by hand, PATCH the Type, set
  Priority + Effort via `setIssueFieldValue`, plus the
  Priority/Effort ladders — with owner/repo derived through
  gh's `{owner}/{repo}` / `:owner` placeholders, never
  hand-written
- AGENTS.md §3 keeps the *why* and routes all mechanics to the
  skill; the retired `bug`/`enhancement`/`documentation`/`feat`
  labels are named as never-re-add

Done outside the tree (already live): every open issue typed +
Priority/Effort set, ~240 closed issues back-typed from their
labels, all ~300 label carriers stripped, 1.0 milestone set per
roadmap #663.

## Related Issue(s)

Supports #663 (triage layer for the road to 1.0).

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [ ] New behavior is tested (no Swift changes — prose and
  templates only)
- [x] User-facing changes are documented in `docs/` (none —
  contributor-facing only)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes (RuleCitationTests run against the AGENTS.md edit)
- [ ] Release build green (not applicable — no Swift changes)
- [x] PR is focused; refactors separated from features

## How I verified

- `RuleCitationTests` green after each AGENTS.md edit.
- Both gh placeholder forms (`repos/{owner}/{repo}`,
  `-F owner=':owner'`) resolved live to `KiwiCanopy/KiwiDesk`.
- The skill's step-3 discovery query and step-4 verify readback
  were exercised for real during the triage round (47 issues
  fielded, readback confirmed on #808).

## Notes for Reviewer

docs-steward reviewed the first commit; the second commit
addresses all six findings (hardcoded owner, mechanics
duplication, twice-stated `type:` claim, missing `feat`,
unwired argument-hint). Label definitions for the four retired
labels still exist and are deleted by the owner by hand —
classifier blocks agent label deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
