### PR TITLE
docs(skill): file-issue rules the milestone, including ruling it empty

### DIFF
--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -106,12 +106,41 @@ The honest size of the fix, not its importance:
 - **High** — a dedicated session or more: cross-subsystem, a
   new surface, or an unscoped investigation.
 
-## 4. Verify
+## 4. Set the milestone, or deliberately don't
 
-Read the issue back and confirm all three landed:
+Unlike the three above, this is not something the web form would
+have set — it is a triage decision, and it has its own question.
+**A milestone says which release must not ship without this.** It
+is not a second priority: Priority ranks work *within* a release,
+the milestone decides whether the release *waits*.
+
+- **Set `1.0`** for a defect a user can meet in a shipped
+  surface, a terminology or docs error that would ship wrong, or
+  work an open roadmap wave names.
+- **Leave it empty** for new behavior deliberately deferred, an
+  icebox idea, or anything blocked on the OS. Empty is an
+  ANSWER — it says the release does not wait for this — so
+  decide it rather than skipping it.
+
+```sh
+gh issue edit <n> --milestone "1.0"
+```
+
+Read the bar off the milestone's current contents, not off the
+two lines above: `gh issue list --milestone "1.0"` is the
+authority on what the release has actually committed to, and a
+ladder restated here would rot against it.
+
+Collector and roadmap issues take a milestone when they scope a
+release (`#663` does) — they only skip Priority and Effort.
+
+## 5. Verify
+
+Read the issue back and confirm all four landed:
 
 ```sh
 gh api repos/{owner}/{repo}/issues/<n> \
-  --jq '{type: .type.name, fields: [.issue_field_values[]
+  --jq '{type: .type.name, milestone: .milestone.title,
+  fields: [.issue_field_values[]
   | {(.issue_field_name): .single_select_option.name}]}'
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,12 +221,16 @@ inline.
 Beyond the body: give every issue GitHub's **Type** (Bug /
 Feature / Task) and the repo's **Priority** and **Effort**
 issue fields at filing, not in a later sweep — an unranked
-issue is invisible to the roadmap's ordering. The
+issue is invisible to the roadmap's ordering. **Rule the
+milestone at filing too**, including ruling it EMPTY: a
+milestone says which release must not ship without the issue,
+so leaving it unanswered is not the same as answering "the
+release does not wait for this". The
 **`file-issue` skill**
 ([.claude/skills/file-issue](.claude/skills/file-issue/SKILL.md))
 owns the whole filing procedure — the template reproduction,
-setting the Type and both fields, and the Priority/Effort
-ladders. Type says what the retired `bug` / `enhancement` /
+setting the Type and both fields, the milestone question, and
+the Priority/Effort ladders. Type says what the retired `bug` / `enhancement` /
 `documentation` / `feat` labels used to say; never apply those
 labels to an issue again.
 


### PR DESCRIPTION
## What

`file-issue` set Type, Priority and Effort and said nothing about milestones. Two issues filed straight from the skill — #820 and #821 — came out with none, which the maintainer noticed and the procedure did not.

Adds step 4, and updates AGENTS.md §3 to match what the skill now owns.

## Why it is a question, not an instruction

Empty is a real answer. A milestone says *which release must not ship without this*, so "none" positively states that the release does not wait for it. Skipping the question silently leaves that unsaid — which is how both issues ended up ambiguous rather than deliberately unscheduled.

It is also not a second Priority. Priority ranks work *within* a release; the milestone decides whether the release *waits*.

## Why it does not restate the bar

The step points at `gh issue list --milestone "1.0"` rather than copying a ladder of what belongs there. The milestone's own contents are the authority on what the release has committed to, and a list copied into the skill rots against it — the same reasoning `rule-authoring.md` applies when it makes a number-pin derive its number instead of restating it.

Priority and Effort keep their ladders on purpose: those are judgements about one issue, with nothing else to read them off. This one is a judgement about a release, and the release can be read.

## Verification

- `scripts/lint.sh` — exit 0
- `RuleCitationTests` — passes (both files carry citations)
- Docs-only; no Swift touched

Refs #663