### PR TITLE
fix(settings): the keyboard path — segments, focus destinations, gate reasons (#823, #816, #815, #833)

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -788,10 +788,11 @@ Every surface, border and ink in the Settings tree comes from
   ring alone** — converting one to `.plain` to paint it kiwi
   removes the platform's indicator, and a control that does that
   owes an indicator of its own plus the contrast the platform's
-  had. The header's search chip is the one control in that
-  position, by way of the chip shape rather than by preference,
-  and the argument is in `docs/design-decisions.md` ▸ a focus
-  ring is the platform's.
+  had — the search chip is the worked example, which took
+  `.plain` for the chip shape and then owed itself an indicator
+  (its accent at 0.55 measured 1.52:1 on `sunken` and had to go
+  to full strength). The argument is in
+  `docs/design-decisions.md` ▸ a focus ring is the platform's.
 - **The accent marks control FILLS, never text naming a value.**
   A toggle track, a selected segment, a prominent Save.
   **A control style that colours its label from the tint owes a

--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -655,8 +655,8 @@ that fall on a change here:
 "Accessible with VoiceOver" and "usable without a mouse" are two
 claims, and this tree has historically shipped the first while
 believing it shipped both. The argument is in
-`docs/design-decisions.md`; the obligations a change here takes
-on:
+`docs/design-decisions.md` ▸ usable without a mouse is a second
+claim; the obligations a change here takes on:
 
 - **A `.contextMenu` is right-click and nothing else**, macOS
   having no default key that opens a focused control's
@@ -679,10 +679,19 @@ on:
   rather than leaving one value spoken as three elements.
 - **A dim is not a sentence.** A greyed row that announces only
   "dimmed" is a dead end: the dimming says an answer exists and
-  withholds it. The reachable form is the one `NativeSpacesGroup`
-  already uses and `GreyOutAnchorTests` records — the reason
-  drawn INLINE, outside the dimmed subtree, where it is read
-  without a click. **A hint is not a proven substitute**: an
+  withholds it. **Which channel carries the reason is derived,
+  not chosen** (#815): `GateReasonPlacement` reads the census —
+  a block gate keeps its `?` anchor, a row whose cause is in its
+  own container needs nothing, a row gated from another
+  destination takes the `?` that names where to go, and only
+  what falls through all three draws the reason INLINE, outside
+  the dimmed subtree, the way `NativeSpacesGroup` and
+  `GeneralRestartRow` already do. So do NOT caption every greyed
+  row — a `GreyOut` inside a `ForEach` stamps its sentence under
+  every child, and several of these greys are ordinary states.
+  `GateReasonPlacementTests` holds the derivation against the
+  sites that already draw one and records the one class still
+  waiting on its anchor. **A hint is not a proven substitute**: an
   `.accessibilityHint` on `GreyOut` was written and backed out
   because that modifier wraps whole blocks, so whether it
   reaches the controls inside — and whether its empty value
@@ -769,6 +778,20 @@ Every surface, border and ink in the Settings tree comes from
   not choose. Retired outright, along with the two `NSColor`
   window surfaces, by the lens in `SettingsThemeWiringTests` —
   which carries no exemption map on purpose.
+- **A focus RING is the exception, and stays the platform's**
+  (#833). `NSColor.keyboardFocusIndicatorColor` reads the user's
+  system accent and ignores `.tint` exactly as
+  `Color.accentColor` does, but here that is right: a focus ring
+  follows their accent AND their "Increase contrast" and
+  focus-ring settings, which is behavior, and the north star
+  binds behavior to the platform. So **leave a `TextField`'s
+  ring alone** — converting one to `.plain` to paint it kiwi
+  removes the platform's indicator, and a control that does that
+  owes an indicator of its own plus the contrast the platform's
+  had. The header's search chip is the one control in that
+  position, by way of the chip shape rather than by preference,
+  and the argument is in `docs/design-decisions.md` ▸ a focus
+  ring is the platform's.
 - **The accent marks control FILLS, never text naming a value.**
   A toggle track, a selected segment, a prominent Save.
   **A control style that colours its label from the tint owes a

--- a/Sources/KiwiDesk/Settings/Census/GateReasonPlacement.swift
+++ b/Sources/KiwiDesk/Settings/Census/GateReasonPlacement.swift
@@ -56,9 +56,14 @@ enum GateReasonPlacement {
     /// Container gates are NOT this type's business — they have
     /// the `?` anchor — so a row is judged on its own `gate:`
     /// alone.
+    /// The `placement` seam defaults to the census itself, so
+    /// the wiring point is PRODUCTION's and a test overriding it
+    /// is the exception rather than the only caller.
     static func owesInlineReason(
         _ key: SettingKey,
-        placement: (SettingKey) -> SettingPlacement
+        placement: (SettingKey) -> SettingPlacement = {
+            $0.placement
+        }
     ) -> Bool {
         channel(key, placement: placement) == .inline
     }
@@ -67,7 +72,9 @@ enum GateReasonPlacement {
     /// row carries no gate of its own.
     static func channel(
         _ key: SettingKey,
-        placement: (SettingKey) -> SettingPlacement
+        placement: (SettingKey) -> SettingPlacement = {
+            $0.placement
+        }
     ) -> Channel? {
         let row = placement(key)
         guard let gate = row.gate, let area = row.area else {
@@ -93,12 +100,25 @@ enum GateReasonPlacement {
             }
             return .inline
         case .runtime(let condition):
+            // A SURFACING condition dims nothing — it decides
+            // whether the row is drawn — so it has no reason to
+            // carry and no channel. Answered by the condition's
+            // own declared flavour rather than by folding
+            // "surfaces" into "legible", which made one name
+            // answer two questions and would have inherited
+            // `.adjacent` for a condition that later became a
+            // grey (architect review, 2026-08-12).
+            guard condition.greys else { return nil }
             return condition.causeIsOnSurface ? .adjacent : .inline
         case .runtimeAnyOf(let conditions):
-            // Every arm has to be legible: a row dead for a
-            // reason the reader cannot see is not rescued by
+            guard conditions.contains(where: \.greys) else {
+                return nil
+            }
+            // Every GREYING arm has to be legible: a row dead for
+            // a reason the reader cannot see is not rescued by
             // another reason they can.
-            return conditions.allSatisfy(\.causeIsOnSurface)
+            return conditions.filter(\.greys)
+                .allSatisfy(\.causeIsOnSurface)
                 ? .adjacent : .inline
         }
     }
@@ -116,8 +136,14 @@ extension SettingTier {
     /// outcome this design refuses.
     var visibilityRank: Int {
         switch self {
-        case .atRest, .immediate: return 0
-        case .showMore: return 1
+        case .atRest: return 0
+        // NOT `atRest`'s peer, against the first cut: an
+        // `.immediate` row is the one whose gate says the thing
+        // already exists, and while that gate withholds it the
+        // row is not on screen at all — so a row gated BY one
+        // cannot claim its cause is beside it (architect
+        // review, 2026-08-12).
+        case .immediate, .showMore: return 1
         case .luaOnly, .internalOnly, .outsideSettings:
             // No surface at all, so it can never be the thing a
             // reader looks at.
@@ -127,8 +153,35 @@ extension SettingTier {
 }
 
 extension SettingRuntimeGate {
+    /// Whether this condition GREYS a row or decides whether it
+    /// is drawn at all. Two different questions, and folding
+    /// them into one predicate hid the second: five conditions
+    /// answered "the cause is on the surface" when what they
+    /// meant was "there is no dimmed control here", so a
+    /// condition that later became a grey would have inherited
+    /// "owes nothing" with nothing red.
+    ///
+    /// The flavour is already stated in prose on each case in
+    /// `SettingGate.swift`; this is the machine-readable half.
+    var greys: Bool {
+        switch self {
+        case .perEdgeValuesDiffer, .editingStoredProfile,
+            .displaysHaveSeparateSpaces, .screenCountMismatch,
+            .loginItemServiceStatus, .autoStartLoginOff,
+            .spaceHasNoOverrides, .reduceMotion:
+            return true
+        case .orphanPinsExist, .monitorsDisconnected,
+            .paletteGlowPairing, .luaImportAvailable,
+            .layersExist, .liquidGlassUnavailable:
+            // Presence, not greying: these decide whether a row
+            // or card is drawn.
+            return false
+        }
+    }
+
     /// Whether the thing this condition names is visible on the
-    /// surface the gated row is on.
+    /// surface the gated row is on. Only meaningful where
+    /// `greys` — a row that is not drawn has no reason to give.
     ///
     /// Exhaustive on purpose — no `default` — so a new condition
     /// has to answer rather than inherit a guess, and each arm
@@ -149,24 +202,23 @@ extension SettingRuntimeGate {
         case .reduceMotion, .loginItemServiceStatus,
             .autoStartLoginOff, .displaysHaveSeparateSpaces:
             // System state, with nothing in this window to look
-            // at. The rows gated on the last three already draw
+            // at. The rows gated on the middle two already draw
             // their reason inline today, which is what
             // `GateReasonPlacementTests` checks this answer
             // against.
             return false
-        case .editingStoredProfile, .screenCountMismatch,
-            .monitorsDisconnected:
+        case .editingStoredProfile, .screenCountMismatch:
             // Which profile is being edited, and which monitors
-            // it wants, are the page's own subject — the edit
-            // target rides the header chip and the preset cards
-            // name their screen count.
+            // a preset wants, are the page's own subject — the
+            // edit target rides the header chip and the preset
+            // cards name their screen count.
             return true
-        case .orphanPinsExist, .paletteGlowPairing,
-            .luaImportAvailable, .layersExist,
-            .liquidGlassUnavailable:
-            // Surfacing conditions rather than greys: they
-            // decide whether a row is drawn at all, so there is
-            // no dimmed control needing a sentence.
+        case .orphanPinsExist, .monitorsDisconnected,
+            .paletteGlowPairing, .luaImportAvailable,
+            .layersExist, .liquidGlassUnavailable:
+            // Presence conditions: `greys` is false, so this
+            // answer is never read. Stated rather than defaulted
+            // so the switch stays exhaustive by hand.
             return true
         }
     }

--- a/Sources/KiwiDesk/Settings/Census/GateReasonPlacement.swift
+++ b/Sources/KiwiDesk/Settings/Census/GateReasonPlacement.swift
@@ -1,0 +1,173 @@
+/// Which greyed rows owe their reason INLINE (#815).
+///
+/// A dim says an answer exists; without a reason it withholds
+/// it, and the reason reached `.help()` only — a hover string,
+/// which needs a pointer. But the answer is not "caption every
+/// greyed row": several of these greys are ordinary states (an
+/// auto-sized grid, an App Bar off in a layout), a `GreyOut`
+/// inside a `ForEach` would stamp the same sentence under every
+/// child, and the tree already answers "why" three other ways.
+/// So the three channels, in the order a reader meets them:
+///
+/// 1. a **block** gate keeps its live `?` anchor outside the
+///    dimmed subtree (#527, `GreyOutAnchorTests`);
+/// 2. a row whose **cause is legible on this surface** — the
+///    gating control sits in the same container, or a standing
+///    caption already names it — needs nothing more; the hover
+///    string stays for the pointer user;
+/// 3. a row gated from **another destination** takes the live
+///    `?` whose sentence names where to go (`docs/ui-patterns.md`
+///    ▸ a remote control-scoped gate; Advanced Colours is
+///    entirely this);
+/// 4. everything else owes the sentence INLINE, because there
+///    is nothing on screen to connect the dim to.
+///
+/// This type answers 2 vs 3 from the census rather than from a
+/// hand-kept list, which is the half a future row cannot
+/// forget: a new gated row inherits the answer the day it is
+/// declared. `GateReasonPlacementTests` pins it against the
+/// sites that already draw a reason inline.
+enum GateReasonPlacement {
+    /// Which channel carries a gated row's reason. Three, not
+    /// two — the middle one is why a first cut of this
+    /// derivation claimed twenty-four rows owed an inline
+    /// sentence when three do.
+    enum Channel: Hashable {
+        /// The gating control is in the same container, drawn at
+        /// rest, or the condition is legible on the surface.
+        /// Adjacency answers "why"; the hover string stays for
+        /// the pointer user.
+        case adjacent
+        /// The gating control lives on ANOTHER destination.
+        /// `docs/ui-patterns.md` already rules this one: a live
+        /// `?` on the nearest label above the dimmed rows, whose
+        /// sentence names the destination to go to (Advanced
+        /// Colours is the case that forced it, and every gate on
+        /// that page is this).
+        case remote
+        /// Same page, no adjacency, nothing else to look at —
+        /// the case neither of the other two covers, and the one
+        /// #815 is about.
+        case inline
+    }
+
+    /// Whether this row's gate needs its reason drawn inline.
+    ///
+    /// Container gates are NOT this type's business — they have
+    /// the `?` anchor — so a row is judged on its own `gate:`
+    /// alone.
+    static func owesInlineReason(
+        _ key: SettingKey,
+        placement: (SettingKey) -> SettingPlacement
+    ) -> Bool {
+        channel(key, placement: placement) == .inline
+    }
+
+    /// The channel this row's reason travels by, or nil when the
+    /// row carries no gate of its own.
+    static func channel(
+        _ key: SettingKey,
+        placement: (SettingKey) -> SettingPlacement
+    ) -> Channel? {
+        let row = placement(key)
+        guard let gate = row.gate, let area = row.area else {
+            return nil
+        }
+        switch gate {
+        case .setting, .anyOf:
+            let owners = gate.settings.map(placement)
+            if owners.contains(where: {
+                $0.area == area && $0.container == row.container
+                    && $0.tier.visibilityRank
+                        <= row.tier.visibilityRank
+            }) {
+                return .adjacent
+            }
+            // Every owner on another page: the `?` anchor names
+            // where to go, and an inline sentence here would be
+            // a second copy of it. A row gated from BOTH places
+            // counts as remote too — the anchor is drawn either
+            // way, and it is the channel that can point.
+            if owners.allSatisfy({ $0.area != area }) {
+                return .remote
+            }
+            return .inline
+        case .runtime(let condition):
+            return condition.causeIsOnSurface ? .adjacent : .inline
+        case .runtimeAnyOf(let conditions):
+            // Every arm has to be legible: a row dead for a
+            // reason the reader cannot see is not rescued by
+            // another reason they can.
+            return conditions.allSatisfy(\.causeIsOnSurface)
+                ? .adjacent : .inline
+        }
+    }
+}
+
+extension SettingTier {
+    /// How far the reader has to go to see a row at this tier —
+    /// lower is nearer. Adjacency compares the gating row
+    /// against the gated one rather than testing either alone:
+    /// what matters is that the cause is on screen WHENEVER the
+    /// dimmed row is, and two rows inside one disclosure satisfy
+    /// that while neither draws at rest. Testing the owner for
+    /// `atRest` instead claimed the App Bar's whole Show-more
+    /// block owed inline sentences, which is the caption-per-row
+    /// outcome this design refuses.
+    var visibilityRank: Int {
+        switch self {
+        case .atRest, .immediate: return 0
+        case .showMore: return 1
+        case .luaOnly, .internalOnly, .outsideSettings:
+            // No surface at all, so it can never be the thing a
+            // reader looks at.
+            return .max
+        }
+    }
+}
+
+extension SettingRuntimeGate {
+    /// Whether the thing this condition names is visible on the
+    /// surface the gated row is on.
+    ///
+    /// Exhaustive on purpose — no `default` — so a new condition
+    /// has to answer rather than inherit a guess, and each arm
+    /// names WHAT the reader sees, since that is the claim being
+    /// made and it is the part that goes stale when a surface
+    /// moves.
+    var causeIsOnSurface: Bool {
+        switch self {
+        case .perEdgeValuesDiffer:
+            // The per-edge drawer sits directly below the
+            // master it disagrees with — the reader repairs it
+            // there.
+            return true
+        case .spaceHasNoOverrides:
+            // Every row above the reset action reads "follows
+            // the defaults", which IS the condition.
+            return true
+        case .reduceMotion, .loginItemServiceStatus,
+            .autoStartLoginOff, .displaysHaveSeparateSpaces:
+            // System state, with nothing in this window to look
+            // at. The rows gated on the last three already draw
+            // their reason inline today, which is what
+            // `GateReasonPlacementTests` checks this answer
+            // against.
+            return false
+        case .editingStoredProfile, .screenCountMismatch,
+            .monitorsDisconnected:
+            // Which profile is being edited, and which monitors
+            // it wants, are the page's own subject — the edit
+            // target rides the header chip and the preset cards
+            // name their screen count.
+            return true
+        case .orphanPinsExist, .paletteGlowPairing,
+            .luaImportAvailable, .layersExist,
+            .liquidGlassUnavailable:
+            // Surfacing conditions rather than greys: they
+            // decide whether a row is drawn at all, so there is
+            // no dimmed control needing a sentence.
+            return true
+        }
+    }
+}

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard.swift
@@ -158,50 +158,74 @@ struct AppBarCard: View {
     /// caveat rides a persistent caption, never hover alone.
     private var copyAppearanceRow: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Button {
-                model.config.settings.appBarStyle
-                    .copyAppearance(
-                        from: model.config.settings
-                            .spaceBarStyle
+            VStack(alignment: .leading, spacing: 4) {
+                Button {
+                    model.config.settings.appBarStyle
+                        .copyAppearance(
+                            from: model.config.settings
+                                .spaceBarStyle
+                        )
+                } label: {
+                    Text(
+                        L(
+                            "app_bar.copy_appearance",
+                            "Copy sizes and style from Space Bar…"
+                        )
                     )
-            } label: {
+                }
+                .settingsActionButton()
+                .controlSize(.small)
+                .help(copyAppearanceHelp)
                 Text(
                     L(
-                        "app_bar.copy_appearance",
-                        "Copy sizes and style from Space Bar…"
+                        "app_bar.copy_appearance.caption",
+                        "Copies the Space Bar's current sizes "
+                            + "and style — not its colors — as a "
+                            + "one-time starting point, never a "
+                            + "live link."
                     )
                 )
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
-            .settingsActionButton()
-            .controlSize(.small)
-            .help(
-                L(
-                    "app_bar.copy_appearance.help",
-                    "Takes the Space Bar's current sizes and "
-                        + "style once — thickness, background, "
-                        + "indicator and the rest. Colors are "
-                        + "not copied; edits afterwards stay "
-                        + "independent."
+            .modifier(
+                GreyOut(
+                    active: sourceBarOff,
+                    help: BarsGateHelp.sentence(for: .spaceBarOff)
                 )
             )
-            Text(
-                L(
-                    "app_bar.copy_appearance.caption",
-                    "Copies the Space Bar's current sizes and "
-                        + "style — not its colors — as a "
-                        + "one-time starting point, never a "
-                        + "live link."
-                )
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            // The gate's reason, INLINE and OUTSIDE the dimmed
+            // subtree (#815): a dim says an answer exists, and
+            // this row's answer is on another card of this same
+            // page, so nothing beside the button connects the
+            // two. The caption above says what the verb does,
+            // never why it is dead — which is exactly the
+            // distinction that let this ship with the reason in
+            // a tooltip. `GateReasonPlacement` is what puts the
+            // row in this class; it is not a judgement made
+            // here.
+            if sourceBarOff {
+                Text(BarsGateHelp.sentence(for: .spaceBarOff))
+                    .font(.caption)
+                    .foregroundStyle(SettingsTheme.ink2)
+            }
         }
-        .modifier(
-            GreyOut(
-                active: !model.config.settings
-                    .spaceBarStyle.enabled,
-                help: BarsGateHelp.sentence(for: .spaceBarOff)
-            )
+    }
+
+    /// The source bar being off is what kills the copy — read
+    /// once, so the dim and the sentence cannot disagree.
+    private var sourceBarOff: Bool {
+        !model.config.settings.spaceBarStyle.enabled
+    }
+
+    private var copyAppearanceHelp: String {
+        L(
+            "app_bar.copy_appearance.help",
+            "Takes the Space Bar's current sizes and "
+                + "style once — thickness, background, "
+                + "indicator and the rest. Colors are "
+                + "not copied; edits afterwards stay "
+                + "independent."
         )
     }
 

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard.swift
@@ -201,10 +201,16 @@ struct AppBarCard: View {
             // two. The caption above says what the verb does,
             // never why it is dead — which is exactly the
             // distinction that let this ship with the reason in
-            // a tooltip. `GateReasonPlacement` is what puts the
-            // row in this class; it is not a judgement made
-            // here.
-            if sourceBarOff {
+            // a tooltip.
+            //
+            // The census is ASKED rather than quoted: a comment
+            // claiming `GateReasonPlacement` puts this row in
+            // that class, over an `if` that re-derives it, is
+            // the dead-resolver shape gui.md names — the type
+            // would then answer for nobody and a row whose
+            // adjacency changed would keep drawing this
+            // (architect review, 2026-08-12).
+            if sourceBarOff, owesInlineGateReason {
                 Text(BarsGateHelp.sentence(for: .spaceBarOff))
                     .font(.caption)
                     .foregroundStyle(SettingsTheme.ink2)
@@ -216,6 +222,16 @@ struct AppBarCard: View {
     /// once, so the dim and the sentence cannot disagree.
     private var sourceBarOff: Bool {
         !model.config.settings.spaceBarStyle.enabled
+    }
+
+    /// Whether this row's reason travels inline, per the census.
+    /// Nothing here decides it: give the copy action a gating
+    /// control on this card and the derivation answers
+    /// `.adjacent`, and this sentence retires itself.
+    private var owesInlineGateReason: Bool {
+        GateReasonPlacement.owesInlineReason(
+            .spaceBar(.copyAppearance)
+        )
     }
 
     private var copyAppearanceHelp: String {

--- a/Sources/KiwiDesk/Settings/Components/Colors/PaletteShelf+Actions.swift
+++ b/Sources/KiwiDesk/Settings/Components/Colors/PaletteShelf+Actions.swift
@@ -109,12 +109,10 @@ extension PaletteShelf {
     /// tiles wrap across rows, so "next" is the next tile in
     /// reading order, which is what a keyboard walk follows too.
     func neighbourAfterDeleting(_ name: String) -> String? {
-        let names = userPalettes.map(\.name)
-        guard let index = names.firstIndex(of: name) else {
-            return nil
-        }
-        if index + 1 < names.count { return names[index + 1] }
-        return index > 0 ? names[index - 1] : nil
+        DeletionFocus.neighbour(
+            after: name,
+            in: userPalettes.map(\.name)
+        )
     }
 
     // MARK: - Export / import

--- a/Sources/KiwiDesk/Settings/Components/Colors/PaletteShelf+Actions.swift
+++ b/Sources/KiwiDesk/Settings/Components/Colors/PaletteShelf+Actions.swift
@@ -93,9 +93,28 @@ extension PaletteShelf {
         reload()
     }
 
+    /// Deleting a saved palette lands the keyboard on the next
+    /// tile, else the previous, else nothing (#816). Read BEFORE
+    /// the delete: `reload()` re-reads the store, so afterwards
+    /// the neighbour can only be named by whichever tile slid
+    /// into the gap.
     func deletePalette(_ name: String) {
+        let neighbour = neighbourAfterDeleting(name)
         try? store.delete(name)
         reload()
+        returningTile = neighbour
+    }
+
+    /// Grid order is the order `userPalettes` renders in — the
+    /// tiles wrap across rows, so "next" is the next tile in
+    /// reading order, which is what a keyboard walk follows too.
+    func neighbourAfterDeleting(_ name: String) -> String? {
+        let names = userPalettes.map(\.name)
+        guard let index = names.firstIndex(of: name) else {
+            return nil
+        }
+        if index + 1 < names.count { return names[index + 1] }
+        return index > 0 ? names[index - 1] : nil
     }
 
     // MARK: - Export / import

--- a/Sources/KiwiDesk/Settings/Components/Colors/PaletteShelf.swift
+++ b/Sources/KiwiDesk/Settings/Components/Colors/PaletteShelf.swift
@@ -15,6 +15,11 @@ struct PaletteShelf: View {
     @State var saveName = ""
     @State var renaming: String?
     @State var renameDraft = ""
+    /// Where the keyboard lands after a saved palette's tile
+    /// stops existing (#816). `internal`, like the state around
+    /// it: the delete lives in `PaletteShelf+Actions.swift` (file
+    /// ceiling) and `@FocusState` cannot move to an extension.
+    @FocusState var returningTile: String?
 
     var store: PaletteStore { model.paletteStore }
 
@@ -120,6 +125,12 @@ struct PaletteShelf: View {
             ) {
                 ForEach(userPalettes, id: \.name) { palette in
                     chip(palette, builtin: false, live: live)
+                        // The tile IS the destination: it is a
+                        // `Button` that takes focus already, so a
+                        // deletion elsewhere in the grid can name
+                        // it without anything new being drawn
+                        // (#816).
+                        .focused($returningTile, equals: palette.name)
                         .contextMenu { userMenu(palette) }
                         // Same builder as named VoiceOver actions
                         // (#678 Phase 4 pass 10, turn 20a rule 1).

--- a/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
@@ -94,11 +94,13 @@ struct SegmentedPicker<Value: Hashable>: View {
         .background { slidingPill }
         .padding(3)
         .background(
-            Capsule().fill(Color.primary.opacity(0.08))
+            Capsule().fill(
+                Color.primary.opacity(SegmentedPickerMetrics.trackAlpha)
+            )
         )
         .overlay(
             Capsule().strokeBorder(
-                Color.primary.opacity(0.08),
+                Color.primary.opacity(SegmentedPickerMetrics.trackAlpha),
                 lineWidth: 0.5
             )
         )
@@ -233,4 +235,20 @@ struct SegmentedPicker<Value: Hashable>: View {
         Capsule()
             .fill(SettingsTheme.accent)
     }
+}
+
+/// The segmented picker's own metrics, in a non-generic type so
+/// they can be named from outside (a `static` stored property is
+/// not allowed on a generic one).
+///
+/// `trackAlpha` is here rather than inline because
+/// `SegmentedPickerCoverageTests` MEASURES the unselected label
+/// against it: with the number restated in the test, washing the
+/// track to 0.6 — a near-white track under a near-white label in
+/// dark — passed green, the guard's input never having touched
+/// this file (guard-prover, 2026-08-12).
+enum SegmentedPickerMetrics {
+    /// The track's wash over its card, and the same value its
+    /// hairline takes.
+    static let trackAlpha = 0.08
 }

--- a/Sources/KiwiDesk/Settings/DeletionFocus.swift
+++ b/Sources/KiwiDesk/Settings/DeletionFocus.swift
@@ -1,0 +1,36 @@
+/// Where the keyboard lands after a deletion (#816).
+///
+/// The rule is one sentence — **the next row, else the previous,
+/// else nowhere, read from the list BEFORE the mutation** — and
+/// it was written six times in six comments across five lists
+/// before this existed. Each copy was correct; none of them
+/// owned the rule, so a seventh list would have restated it, and
+/// the parity guard cannot tell a neighbour read before the
+/// delete from one read after (both spell
+/// `returningRow = neighbour`).
+///
+/// Reading it AFTER the mutation is the failure worth naming:
+/// the list then reports whichever row slid into the gap, which
+/// is right by accident everywhere except at the end of a list,
+/// where the deleted row's index no longer exists and focus
+/// falls off it.
+///
+/// Deliberately a free function over the DISPLAY order rather
+/// than a protocol: what varies between the lists is which order
+/// is on screen (sorted by display name in App Rules, profile
+/// order in Profiles, the drag order in Spaces), and that is the
+/// argument, not the stepping.
+enum DeletionFocus {
+    /// The neighbour of `item` in `list`: the next one, else the
+    /// previous, else nil when it was the only row.
+    static func neighbour<Item: Equatable>(
+        after item: Item,
+        in list: [Item]
+    ) -> Item? {
+        guard let index = list.firstIndex(of: item) else {
+            return nil
+        }
+        if index + 1 < list.count { return list[index + 1] }
+        return index > 0 ? list[index - 1] : nil
+    }
+}

--- a/Sources/KiwiDesk/Settings/Sections/AppRuleRow.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRuleRow.swift
@@ -36,6 +36,12 @@ struct AppRuleRow: View {
     /// removes the draft itself.
     let isDraft: Bool
     let onDelete: () -> Void
+    /// The list's focus key, so a deletion elsewhere can land on
+    /// THIS row (#816). Bound to the space menu below — the
+    /// first control the sentence draws, always present, and
+    /// non-destructive, unlike the trash at the row's end which
+    /// also disables itself in override mode.
+    @FocusState.Binding var returningRow: String?
     /// Keeps the titled editor visible while it has no
     /// patterns yet (an empty pattern set stores nothing).
     @State private var editingTitles = false
@@ -110,7 +116,9 @@ struct AppRuleRow: View {
             Text(KeybindingCatalog.displayName(forBundleID: app))
                 .fontWeight(.medium)
         case .space:
-            spaceMenu.opacity(spaceInherited ? 0.55 : 1)
+            spaceMenu
+                .opacity(spaceInherited ? 0.55 : 1)
+                .focused($returningRow, equals: app)
         case .float:
             floatMenu.opacity(floatInherited ? 0.55 : 1)
         case nil:

--- a/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
@@ -188,32 +188,36 @@ struct AppRulesSection: View {
         }
     }
 
+    /// Deleting a rule row, and where the keyboard lands (#816).
+    ///
+    /// The focus move is conditional on the row actually LEAVING
+    /// the list, which in override mode it does not: `apps`
+    /// unions the base's pinned apps, so a tombstoned row stays
+    /// drawn as "Automatic" overriding the base pin (#109). Focus
+    /// belongs where the user left it there — moving it to the
+    /// next row would step off a row that is still on screen
+    /// (code review, 2026-08-12).
     private func delete(_ app: String) {
-        // Before the mutation (#816): afterwards `apps` no
-        // longer contains the deleted row, so its neighbour
-        // cannot be identified from it.
+        // Before the mutation (#816): afterwards the list cannot
+        // name the deleted row's neighbour, only whichever row
+        // slid into the gap.
         let neighbour = neighbourAfterDeleting(app)
         model.config.appRules[app] = nil
         model.config.floatRules.removeAll {
             FloatFacet.appSegment(of: $0) == app
         }
         draftApps.removeAll { $0 == app }
-        returningRow = neighbour
+        if !apps.contains(app) {
+            returningRow = neighbour
+        }
     }
 
-    /// The row a deletion should leave focus on: the next one
-    /// down, else the previous, else nothing — read from `apps`,
-    /// which is the display order (sorted by the name the row
-    /// shows, #333), not from the rules dictionary.
+    /// `apps` is the DISPLAY order (sorted by the name the row
+    /// shows, #333), not the rules dictionary's.
     private func neighbourAfterDeleting(
         _ app: String
     ) -> String? {
-        let rows = apps
-        guard let index = rows.firstIndex(of: app) else {
-            return nil
-        }
-        if index + 1 < rows.count { return rows[index + 1] }
-        return index > 0 ? rows[index - 1] : nil
+        DeletionFocus.neighbour(after: app, in: apps)
     }
 }
 

--- a/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
@@ -14,6 +14,9 @@ struct AppRulesSection: View {
     /// (both facets still at their defaults) — they live only
     /// in the GUI until a facet is set.
     @State private var draftApps: [String] = []
+    /// Where the keyboard lands after a rule row stops existing
+    /// (#816), keyed by the row's app id.
+    @FocusState private var returningRow: String?
     @State private var newApp = ""
 
     /// The base rules while editing a stored profile — the
@@ -44,7 +47,8 @@ struct AppRulesSection: View {
                             overrideBase: overrideBase,
                             overrideFloatBase: overrideFloatBase,
                             isDraft: draftApps.contains(app),
-                            onDelete: { delete(app) }
+                            onDelete: { delete(app) },
+                            returningRow: $returningRow
                         )
                         Divider()
                     }
@@ -185,11 +189,31 @@ struct AppRulesSection: View {
     }
 
     private func delete(_ app: String) {
+        // Before the mutation (#816): afterwards `apps` no
+        // longer contains the deleted row, so its neighbour
+        // cannot be identified from it.
+        let neighbour = neighbourAfterDeleting(app)
         model.config.appRules[app] = nil
         model.config.floatRules.removeAll {
             FloatFacet.appSegment(of: $0) == app
         }
         draftApps.removeAll { $0 == app }
+        returningRow = neighbour
+    }
+
+    /// The row a deletion should leave focus on: the next one
+    /// down, else the previous, else nothing — read from `apps`,
+    /// which is the display order (sorted by the name the row
+    /// shows, #333), not from the rules dictionary.
+    private func neighbourAfterDeleting(
+        _ app: String
+    ) -> String? {
+        let rows = apps
+        guard let index = rows.firstIndex(of: app) else {
+            return nil
+        }
+        if index + 1 < rows.count { return rows[index + 1] }
+        return index > 0 ? rows[index - 1] : nil
     }
 }
 

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection.swift
@@ -108,25 +108,20 @@ struct GeneralSection: View {
     /// mutually exclusive choices whose whole set fits on one
     /// line is the case `docs/ui-patterns.md` gives segmented,
     /// and unlike the locale list it can never grow.
+    /// A direct `SegmentedPicker`, not one inside a
+    /// `DropdownRow` (#823): the shared component draws its own
+    /// `SettingsRowShape` when it carries a label, and
+    /// `DropdownRow` forces `.pickerStyle(.menu)` onto whatever
+    /// it wraps. So the wrapper comes off rather than the picker
+    /// inside it changing.
     private var appearanceRow: some View {
-        DropdownRow(
-            label: L("general.appearance", "Appearance")
-        ) {
-            Picker(
-                L("general.appearance", "Appearance"),
-                selection: appearanceBinding
-            ) {
-                ForEach(
-                    AppearanceChoice.allCases,
-                    id: \.rawValue
-                ) { choice in
-                    Text(choice.label).tag(choice)
-                }
+        SegmentedPicker(
+            L("general.appearance", "Appearance"),
+            selection: appearanceBinding,
+            options: AppearanceChoice.allCases.map {
+                ($0.label, $0)
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .fixedSize()
-        }
+        )
     }
 
     private var appearanceBinding: Binding<AppearanceChoice> {

--- a/Sources/KiwiDesk/Settings/Sections/LayerStripEditor.swift
+++ b/Sources/KiwiDesk/Settings/Sections/LayerStripEditor.swift
@@ -280,15 +280,39 @@ struct LayerStripEditor: View {
     /// already moves the selection to the default layer, and
     /// every row below the strip is that layer's now, so landing
     /// anywhere else would leave the keyboard on a chip that
-    /// does not match what is on screen. The default chip is
-    /// always drawn — the base layer cannot be deleted, which is
-    /// what the guard above says.
+    /// does not match what is on screen.
+    ///
+    /// But only WHERE THE STRIP SURVIVES. `LayersCard` withholds
+    /// itself entirely on `layersExist || mode == .powerUser`,
+    /// and `layersExist` is "more than the default layer" — so in
+    /// Simple mode, deleting the last custom layer retires the
+    /// whole card in the same mutation, the default chip
+    /// included. Naming it then sends focus to a view that left
+    /// the tree, which lands at the top of the window: the exact
+    /// outcome this rule exists to prevent, reached by the road
+    /// gui.md warns about (code review, 2026-08-12). Nil is the
+    /// honest answer there — the card the user was in is gone.
     private func deleteLayer() {
         guard selected != KeyLayer.defaultName else { return }
         model.config.layers.removeAll {
             $0.name == selected
         }
         selected = KeyLayer.defaultName
-        focusedChip = KeyLayer.defaultName
+        focusedChip =
+            stripSurvivesDeletion
+            ? KeyLayer.defaultName : nil
+    }
+
+    /// Whether the card still draws after the deletion — asked
+    /// of the card's OWN offer, never re-derived here: a second
+    /// copy of an offer predicate is the drift
+    /// `HomeCardOrder.isOffered` exists to prevent one level up,
+    /// and an inverted copy is how a Simple-mode user ends up
+    /// with focus on a card that left the tree.
+    private var stripSurvivesDeletion: Bool {
+        LayersCard.isOffered(
+            config: model.config,
+            mode: model.settingsMode
+        )
     }
 }

--- a/Sources/KiwiDesk/Settings/Sections/LayerStripEditor.swift
+++ b/Sources/KiwiDesk/Settings/Sections/LayerStripEditor.swift
@@ -27,6 +27,9 @@ struct LayerStripEditor: View {
     @State private var renamingLayer = false
     @State private var renameDraft = ""
     @State private var addLayerHovered = false
+    /// Where the keyboard lands after the selected layer's chip
+    /// stops existing (#816).
+    @FocusState private var focusedChip: String?
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
     @Environment(\.isEnabled) private var isEnabled
@@ -74,6 +77,9 @@ struct LayerStripEditor: View {
         ) {
             selected = name
         }
+        // Every chip is a focus destination, so a deletion can
+        // name one (#816).
+        .focused($focusedChip, equals: name)
     }
 
     /// Defining a layer is rare — the "+" chip's popover
@@ -268,11 +274,21 @@ struct LayerStripEditor: View {
         addingLayer = false
     }
 
+    /// Focus FOLLOWS the selection rather than stepping to the
+    /// neighbouring chip (#816). The strip is a selector, not a
+    /// list of independent rows: deleting the selected layer
+    /// already moves the selection to the default layer, and
+    /// every row below the strip is that layer's now, so landing
+    /// anywhere else would leave the keyboard on a chip that
+    /// does not match what is on screen. The default chip is
+    /// always drawn — the base layer cannot be deleted, which is
+    /// what the guard above says.
     private func deleteLayer() {
         guard selected != KeyLayer.defaultName else { return }
         model.config.layers.removeAll {
             $0.name == selected
         }
         selected = KeyLayer.defaultName
+        focusedChip = KeyLayer.defaultName
     }
 }

--- a/Sources/KiwiDesk/Settings/Sections/LayersCard.swift
+++ b/Sources/KiwiDesk/Settings/Sections/LayersCard.swift
@@ -60,8 +60,24 @@ struct LayersCard: View {
     /// someone's own setup from them, which is the failure this
     /// card's earlier draft actually shipped by reading the tier
     /// as `.showMore`.
+    /// Static, so the STRIP inside this card can ask the same
+    /// predicate rather than keep a second copy of it: deleting
+    /// the last custom layer retires this whole card in Simple
+    /// mode, and the strip has to know that to decide whether
+    /// naming a focus destination inside it means anything
+    /// (#816). One predicate, the `HomeCardOrder.isOffered`
+    /// shape one level down.
+    static func isOffered(
+        config: GuiConfig,
+        mode: SettingsMode
+    ) -> Bool {
+        ShortcutsGates(config: config)
+            .inertReason(for: .shortcuts(.switchToLayer)) == nil
+            || mode == .powerUser
+    }
+
     private func offered(in mode: SettingsMode) -> Bool {
-        layersExist || mode == .powerUser
+        Self.isOffered(config: model.config, mode: mode)
     }
 
     private var offered: Bool {

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Broken.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Broken.swift
@@ -35,18 +35,13 @@ extension ProfilesSection {
         }
     }
 
-    /// The broken row a deletion should leave focus on: the next
-    /// one down, else the previous, else nothing. A twin of the
-    /// healthy list's helper rather than a shared one — the two
-    /// read different lists, and folding them into one function
-    /// taking a list would hide which list a call site meant.
+    /// The BROKEN list, which is its own list under its own
+    /// heading — a broken row's neighbour is never a healthy one.
     func neighbourBrokenAfter(_ name: String) -> String? {
-        let names = model.brokenProfiles.map(\.name)
-        guard let index = names.firstIndex(of: name) else {
-            return nil
-        }
-        if index + 1 < names.count { return names[index + 1] }
-        return index > 0 ? names[index - 1] : nil
+        DeletionFocus.neighbour(
+            after: name,
+            in: model.brokenProfiles.map(\.name)
+        )
     }
 
     private func brokenRow(_ broken: BrokenProfile) -> some View {
@@ -68,11 +63,6 @@ extension ProfilesSection {
                 Image(systemName: "magnifyingglass")
             }
             .buttonStyle(.borderless)
-            // The Config Issues panel's own key, not a second
-            // one: it labels this exact action on this exact
-            // file, and coining a twin is the defect this file's
-            // docstring argues against, one level down from the
-            // sentence (code review, 2026-08-11).
             // This row's return destination (#816): Reveal is
             // the always-drawn, non-destructive control here,
             // exactly as Load is on a healthy row. A broken row
@@ -80,6 +70,11 @@ extension ProfilesSection {
             // the two lists name different controls for the same
             // reason rather than sharing one by symmetry.
             .focused($returningRow, equals: name)
+            // The Config Issues panel's own key, not a second
+            // one: it labels this exact action on this exact
+            // file, and coining a twin is the defect this file's
+            // docstring argues against, one level down from the
+            // sentence (code review, 2026-08-11).
             .iconButtonAffordance(
                 L("config_issues.reveal", "Reveal in Finder")
             )

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Broken.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Broken.swift
@@ -35,6 +35,20 @@ extension ProfilesSection {
         }
     }
 
+    /// The broken row a deletion should leave focus on: the next
+    /// one down, else the previous, else nothing. A twin of the
+    /// healthy list's helper rather than a shared one — the two
+    /// read different lists, and folding them into one function
+    /// taking a list would hide which list a call site meant.
+    func neighbourBrokenAfter(_ name: String) -> String? {
+        let names = model.brokenProfiles.map(\.name)
+        guard let index = names.firstIndex(of: name) else {
+            return nil
+        }
+        if index + 1 < names.count { return names[index + 1] }
+        return index > 0 ? names[index - 1] : nil
+    }
+
     private func brokenRow(_ broken: BrokenProfile) -> some View {
         let name = broken.name
         return HStack(alignment: .firstTextBaseline) {
@@ -59,6 +73,13 @@ extension ProfilesSection {
             // file, and coining a twin is the defect this file's
             // docstring argues against, one level down from the
             // sentence (code review, 2026-08-11).
+            // This row's return destination (#816): Reveal is
+            // the always-drawn, non-destructive control here,
+            // exactly as Load is on a healthy row. A broken row
+            // has no Load — that is what makes it broken — so
+            // the two lists name different controls for the same
+            // reason rather than sharing one by symmetry.
+            .focused($returningRow, equals: name)
             .iconButtonAffordance(
                 L("config_issues.reveal", "Reveal in Finder")
             )
@@ -78,7 +99,15 @@ extension ProfilesSection {
                         "discard.delete_profile.confirm",
                         "Discard & delete"
                     )
-                ) { model.deleteProfile(named: name) }
+                ) {
+                    // Before the mutation, and within THIS list:
+                    // a broken row's neighbour is another broken
+                    // row, never a healthy one that renders
+                    // above under its own heading (#816).
+                    let neighbour = neighbourBrokenAfter(name)
+                    model.deleteProfile(named: name)
+                    returningRow = neighbour
+                }
             } label: {
                 Image(systemName: "trash")
             }

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
@@ -154,18 +154,14 @@ struct ProfilesSection: View {
         )
     }
 
-    /// The row a deletion should leave focus on: the next one
-    /// down, else the previous, else nothing — the shape
-    /// `SpacesSection+Remove` settled (#678 Phase 4 pass 10),
-    /// read from the ORDER the rows render in rather than from
-    /// the model's own list.
+    /// This list's display order, handed to the shared rule
+    /// (`DeletionFocus`) — which order it is IS this call site's
+    /// contribution; the stepping is not.
     func neighbourAfterDeleting(_ name: String) -> String? {
-        let names = orderedSummaries.map(\.name)
-        guard let index = names.firstIndex(of: name) else {
-            return nil
-        }
-        if index + 1 < names.count { return names[index + 1] }
-        return index > 0 ? names[index - 1] : nil
+        DeletionFocus.neighbour(
+            after: name,
+            in: orderedSummaries.map(\.name)
+        )
     }
 
     private func profileRow(

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
@@ -26,6 +26,13 @@ struct ProfilesSection: View {
     /// (file ceiling), and `@State` cannot move to an extension.
     @State var renaming: String?
     @State var renameDraft = ""
+    /// Where the keyboard lands after a row stops existing
+    /// (#816). Keyed by profile NAME across both lists — a
+    /// profile is either loaded or broken, never in both, so one
+    /// key cannot be claimed by two rows. `internal` for the
+    /// same reason the rename state is: the rows that bind it
+    /// live in extensions, and `@FocusState` cannot move there.
+    @FocusState var returningRow: String?
 
     var body: some View {
         ScrollView {
@@ -147,6 +154,20 @@ struct ProfilesSection: View {
         )
     }
 
+    /// The row a deletion should leave focus on: the next one
+    /// down, else the previous, else nothing — the shape
+    /// `SpacesSection+Remove` settled (#678 Phase 4 pass 10),
+    /// read from the ORDER the rows render in rather than from
+    /// the model's own list.
+    func neighbourAfterDeleting(_ name: String) -> String? {
+        let names = orderedSummaries.map(\.name)
+        guard let index = names.firstIndex(of: name) else {
+            return nil
+        }
+        if index + 1 < names.count { return names[index + 1] }
+        return index > 0 ? names[index - 1] : nil
+    }
+
     private func profileRow(
         _ summary: ProfileSummary
     ) -> some View {
@@ -238,6 +259,12 @@ struct ProfilesSection: View {
         }
         .settingsActionButton()
         .controlSize(.large)
+        // The row's return destination (#816). Load is the
+        // always-drawn, non-destructive one: "make default" is
+        // conditional on the row not already being default, the
+        // name opens a rename, and Delete would put a
+        // destructive action under the next keypress.
+        .focused($returningRow, equals: summary.name)
         .help(
             summary.matchesLive
                 ? ""
@@ -262,7 +289,15 @@ struct ProfilesSection: View {
                     "discard.delete_profile.confirm",
                     "Discard & delete"
                 )
-            ) { model.deleteProfile(named: name) }
+            ) {
+                // Read BEFORE the mutation (#816): afterwards
+                // the list names whichever row slid into the
+                // gap, which is right by accident and wrong at
+                // the end of a list.
+                let neighbour = neighbourAfterDeleting(name)
+                model.deleteProfile(named: name)
+                returningRow = neighbour
+            }
         } label: {
             Image(systemName: "trash")
         }

--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar.swift
@@ -245,9 +245,21 @@ struct SettingsHeaderBar: View {
         .chipSurface()
     }
 
+    /// The shared component, not `.pickerStyle(.segmented)`
+    /// (#823): a native `NSSegmentedControl` draws AppKit's own
+    /// track beside the window's capsules AND lets AppKit pick
+    /// the selected label's ink, which in dark mode put
+    /// near-white on the accent at ~2.4:1 — the pairing the dark
+    /// pass removed from this very control. Here the ink comes
+    /// from `accentInk` by construction.
+    ///
+    /// The label is applied by the CALLER because the unlabeled
+    /// path deliberately attaches none (an empty accessibility
+    /// label would override the group's inferred name), and this
+    /// instance is visually unlabeled — without this the mode
+    /// segment ships nameless to VoiceOver.
     private var modeSegment: some View {
-        Picker(
-            L("home.mode_ax", "Settings mode"),
+        SegmentedPicker(
             selection: Binding(
                 get: { model.settingsMode },
                 // The EXPLICIT flip — the one entry point that
@@ -258,18 +270,18 @@ struct SettingsHeaderBar: View {
                         reduceMotion: reduceMotion
                     )
                 }
-            )
-        ) {
-            Text(L("mode.simple", "Simple"))
-                .tag(SettingsMode.simple)
-            // The site's slider keeps its own "Nerd" flair —
-            // different surface, different register (owner
-            // 2026-08-04; docs/localization-naming.md).
-            Text(L("mode.power_user", "Power User"))
-                .tag(SettingsMode.powerUser)
-        }
-        .pickerStyle(.segmented)
-        .labelsHidden()
+            ),
+            options: [
+                (L("mode.simple", "Simple"), SettingsMode.simple),
+                // The site's slider keeps its own "Nerd" flair —
+                // different surface, different register (owner
+                // 2026-08-04; docs/localization-naming.md).
+                (
+                    L("mode.power_user", "Power User"),
+                    SettingsMode.powerUser
+                ),
+            ]
+        )
         .fixedSize()
         .accessibilityLabel(L("home.mode_ax", "Settings mode"))
     }

--- a/Tests/KiwiDeskGuiTests/GateReasonPlacementTests.swift
+++ b/Tests/KiwiDeskGuiTests/GateReasonPlacementTests.swift
@@ -35,6 +35,16 @@ struct GateReasonPlacementTests {
     /// the set is a real answer — draw its reason — and one
     /// leaving it means an adjacency changed, which is equally
     /// worth reading.
+    ///
+    /// Stated reach, since a green here is narrower than it
+    /// looks: `channel` reads a row's OWN `gate:`, so a
+    /// condition used only as a CONTAINER gate never reaches
+    /// `causeIsOnSurface` at all — flipping `.reduceMotion`'s
+    /// answer changes nothing here, proven by mutation
+    /// (guard-prover, 2026-08-12). Promoting a container-only
+    /// condition to a row gate therefore arrives carrying an
+    /// answer nothing has ever checked; that promotion owes a
+    /// case in this set.
     @Test("the derivation names the rows that owe a sentence")
     func owedRowsAreTheKnownSet() {
         let owed = SettingKey.allCases.filter {
@@ -112,7 +122,10 @@ struct GateReasonPlacementTests {
         // The gap itself: the rows' own file draws no `?`, so
         // `.remote` currently points at nothing for them. When
         // this stops being true, this suite is where the claim
-        // gets re-stated.
+        // gets re-stated. ONE file, deliberately — the editor's
+        // siblings could gain the anchor with this green, and
+        // the issue tracking it (#841) names the surface rather
+        // than this line.
         let path = SourceScan.repoRoot(from: #filePath)
             .appendingPathComponent(
                 "Sources/KiwiDesk/Settings/Components/"
@@ -150,7 +163,10 @@ struct GateReasonPlacementTests {
         .joined()
         // The GreyOut closes BEFORE the sentence opens: the
         // dimmed subtree is the inner stack, and the `if` is its
-        // sibling.
+        // sibling. Both ranges are FIRST occurrences, so a
+        // second dim block later in this file wrapping the
+        // sentence would compare against the first and pass —
+        // stated rather than chased, the file having one.
         let dim = try #require(
             source.range(of: "GreyOut(active:sourceBarOff")
         )

--- a/Tests/KiwiDeskGuiTests/GateReasonPlacementTests.swift
+++ b/Tests/KiwiDeskGuiTests/GateReasonPlacementTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// The census answer to "does this greyed row owe its reason
+/// inline?" (#815), checked against the rows that already draw
+/// one.
+///
+/// That check is the whole point of deriving it rather than
+/// listing it: a hand-kept register of which rows owe a sentence
+/// is one more thing to forget, while a derivation that
+/// reproduces every shipped instance on the day it lands is
+/// checkable — and it answers for a row nobody has written yet.
+///
+/// Two earlier cuts of the derivation are recorded here because
+/// each was wrong in a way the suite now pins. The first tested
+/// the GATING row for `atRest` and so claimed the App Bar's
+/// whole Show-more block owed inline sentences — two rows inside
+/// one disclosure are adjacent when the reader sees them, which
+/// is what `visibilityRank` compares. The second had no `remote`
+/// channel and claimed every Advanced Colours row owed one,
+/// against `docs/ui-patterns.md`, which routes a gate on another
+/// destination to a live `?` naming where to go.
+@Suite("Gate reason placement (#815)")
+@MainActor
+struct GateReasonPlacementTests {
+    private func channel(
+        _ key: SettingKey
+    ) -> GateReasonPlacement.Channel? {
+        GateReasonPlacement.channel(key) { $0.placement }
+    }
+
+    /// Exactly these rows, no others. A new gated row joining
+    /// the set is a real answer — draw its reason — and one
+    /// leaving it means an adjacency changed, which is equally
+    /// worth reading.
+    @Test("the derivation names the rows that owe a sentence")
+    func owedRowsAreTheKnownSet() {
+        let owed = SettingKey.allCases.filter {
+            GateReasonPlacement.owesInlineReason($0) {
+                $0.placement
+            }
+        }
+        #expect(
+            Set(owed) == [
+                // Shipped inline before #815, and the reason the
+                // derivation is checkable at all.
+                .general(.startAtLogin),
+                .general(.advancedRestartOnCrash),
+                .profiles(.profileBindings),
+                // Found BY the derivation: the copy action sits
+                // on the App Bar card while the switch that
+                // kills it is on the Space Bar card, so nothing
+                // beside it says why it is dead.
+                .spaceBar(.copyAppearance),
+            ]
+        )
+    }
+
+    /// The other two channels, pinned by one member each — a
+    /// derivation that collapsed to "everything is inline" would
+    /// satisfy the test above only by also emptying these.
+    @Test("adjacency and remoteness are still distinguished")
+    func theOtherChannelsHoldMembers() {
+        // Both inside the App Bar's Style disclosure: the reader
+        // opens one thing and sees the cause beside the effect.
+        #expect(
+            channel(.appBar(.appBarBackgroundFit)) == .adjacent
+        )
+        // Advanced Colours: its bar-colour rows are gated by
+        // switches that live on the Bars destination, which is
+        // the case `AdvancedColorsHelp`'s anchors answer.
+        #expect(
+            channel(.appBar(.appBarActiveItemColor)) == .remote
+        )
+        // A row with no gate has no channel at all.
+        #expect(channel(.appBar(.appBarThickness)) == nil)
+    }
+
+    /// The per-space override editor is `remote` — its gating
+    /// control is declared in Layout Defaults — so by
+    /// `docs/ui-patterns.md` it wants a live `?` naming that
+    /// destination, and it has none: the reason reaches
+    /// `.help()` only (`SpaceOverrideRows+ModeRows.swift`).
+    ///
+    /// Stated as a test rather than left as prose so the gap
+    /// cannot be mistaken for coverage, and so the day someone
+    /// adds the anchor this fails and asks them to move the
+    /// row's entry out of here.
+    @Test("the per-space overrides' remote gap is recorded")
+    func perSpaceOverridesAwaitTheirAnchor() {
+        for key: SettingKey in [
+            .layout(.gridOverrideColumns),
+            .layout(.gridOverrideRows),
+            .layout(.trackOverrideLimit),
+        ] {
+            #expect(
+                channel(key) == .remote,
+                Comment(
+                    rawValue:
+                        "\(key.id) changed channel — if its "
+                        + "gating control now has a row on the "
+                        + "per-space surface, this class is no "
+                        + "longer waiting on a `?` anchor"
+                )
+            )
+        }
+    }
+
+    /// The one row the derivation found is actually drawn, and
+    /// drawn OUTSIDE the dim — a sentence inside the greyed
+    /// subtree is the dead end the rule exists to remove.
+    @Test("the found row draws its reason outside the dim")
+    func theFoundRowDrawsItsReason() throws {
+        let path = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Components/Bars/"
+                    + "AppBarCard.swift"
+            )
+        let source = SourceScan.stripComments(
+            try String(contentsOf: path, encoding: .utf8)
+        )
+        .split(whereSeparator: \.isWhitespace)
+        .joined()
+        // The GreyOut closes BEFORE the sentence opens: the
+        // dimmed subtree is the inner stack, and the `if` is its
+        // sibling.
+        let dim = try #require(
+            source.range(of: "GreyOut(active:sourceBarOff")
+        )
+        let sentence = try #require(
+            source.range(
+                of: "ifsourceBarOff{Text(BarsGateHelp.sentence("
+            )
+        )
+        #expect(
+            dim.upperBound < sentence.lowerBound,
+            "the reason must be a sibling of the dimmed stack"
+        )
+    }
+}

--- a/Tests/KiwiDeskGuiTests/GateReasonPlacementTests.swift
+++ b/Tests/KiwiDeskGuiTests/GateReasonPlacementTests.swift
@@ -78,18 +78,21 @@ struct GateReasonPlacementTests {
         #expect(channel(.appBar(.appBarThickness)) == nil)
     }
 
-    /// The per-space override editor is `remote` — its gating
-    /// control is declared in Layout Defaults — so by
-    /// `docs/ui-patterns.md` it wants a live `?` naming that
-    /// destination, and it has none: the reason reaches
-    /// `.help()` only (`SpaceOverrideRows+ModeRows.swift`).
+    /// `.remote` means "the `?` anchor on the other page names
+    /// where to go", which is a claim about a surface — so it is
+    /// CHECKED against the file that draws the anchor, not
+    /// assumed. Anything else lets the channel assert an
+    /// affordance nobody built.
     ///
-    /// Stated as a test rather than left as prose so the gap
-    /// cannot be mistaken for coverage, and so the day someone
-    /// adds the anchor this fails and asks them to move the
-    /// row's entry out of here.
+    /// The per-space override editor is the case in hand: its
+    /// gating control is declared in Layout Defaults, so the
+    /// derivation answers `.remote`, and the editor draws no
+    /// anchor — the reason reaches `.help()` only. Recorded here
+    /// rather than left as prose so the gap cannot be mistaken
+    /// for coverage, and so the day the anchor lands this fails
+    /// and asks for the entry to move out.
     @Test("the per-space overrides' remote gap is recorded")
-    func perSpaceOverridesAwaitTheirAnchor() {
+    func perSpaceOverridesAwaitTheirAnchor() throws {
         for key: SettingKey in [
             .layout(.gridOverrideColumns),
             .layout(.gridOverrideRows),
@@ -106,6 +109,28 @@ struct GateReasonPlacementTests {
                 )
             )
         }
+        // The gap itself: the rows' own file draws no `?`, so
+        // `.remote` currently points at nothing for them. When
+        // this stops being true, this suite is where the claim
+        // gets re-stated.
+        let path = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Components/"
+                    + "SpaceOverrides/SpaceOverrideRows"
+                    + "+ModeRows.swift"
+            )
+        let source = SourceScan.stripComments(
+            try String(contentsOf: path, encoding: .utf8)
+        )
+        #expect(
+            !source.contains("HelpButton"),
+            Comment(
+                rawValue:
+                    "the per-space rows gained an anchor — "
+                    + "#815's remote class is closed, so move "
+                    + "these keys out of this test"
+            )
+        )
     }
 
     /// The one row the derivation found is actually drawn, and
@@ -131,12 +156,37 @@ struct GateReasonPlacementTests {
         )
         let sentence = try #require(
             source.range(
-                of: "ifsourceBarOff{Text(BarsGateHelp.sentence("
+                of: "ifsourceBarOff,owesInlineGateReason{"
+                    + "Text(BarsGateHelp.sentence("
             )
         )
         #expect(
             dim.upperBound < sentence.lowerBound,
             "the reason must be a sibling of the dimmed stack"
         )
+        // And it is DRAWN off the derivation rather than off a
+        // hand-rolled copy of it: a comment claiming the census
+        // decides this, over an `if` that re-derives it, is the
+        // dead-resolver shape (`gui.md`), and it would leave
+        // this type answering for nobody.
+        #expect(
+            source.contains(
+                "GateReasonPlacement.owesInlineReason("
+                    + ".spaceBar(.copyAppearance))"
+            )
+        )
+    }
+
+    /// A surfacing condition dims nothing, so it carries no
+    /// channel at all — the distinction that keeps
+    /// `causeIsOnSurface` from answering two questions with one
+    /// name.
+    @Test("a presence condition has no reason to place")
+    func surfacingConditionsCarryNoChannel() {
+        #expect(SettingRuntimeGate.layersExist.greys == false)
+        #expect(SettingRuntimeGate.reduceMotion.greys)
+        // The Layers card surfaces on `layersExist`; nothing
+        // there is dimmed, so nothing owes a sentence.
+        #expect(channel(.shortcuts(.layers)) == nil)
     }
 }

--- a/Tests/KiwiDeskGuiTests/KeyboardActionParityTests.swift
+++ b/Tests/KiwiDeskGuiTests/KeyboardActionParityTests.swift
@@ -226,10 +226,14 @@ struct KeyboardActionParityTests {
             ),
             Wiring(
                 "LayerStripEditor.swift",
-                "focusedChip = KeyLayer.defaultName",
+                "focusedChip = stripSurvivesDeletion",
                 "and deleting the selected layer moves focus "
-                    + "WITH the selection to the base chip, which "
-                    + "cannot itself be deleted"
+                    + "WITH the selection to the base chip — but "
+                    + "only where the card survives the "
+                    + "deletion, since in Simple mode losing the "
+                    + "last custom layer retires the strip and "
+                    + "naming a chip inside it lands at the top "
+                    + "of the window"
             ),
             Wiring(
                 "PaletteShelf.swift",

--- a/Tests/KiwiDeskGuiTests/KeyboardActionParityTests.swift
+++ b/Tests/KiwiDeskGuiTests/KeyboardActionParityTests.swift
@@ -175,6 +175,74 @@ struct KeyboardActionParityTests {
                 "returningRow = neighbour",
                 "a deletion lands on the next row, not the top"
             ),
+            // The four lists #816 brought up to the same shape.
+            // Each needs BOTH halves — the destination a row
+            // draws, and the assignment the deletion makes —
+            // because either alone moves focus nowhere: an
+            // unattached key is silent, and an attached key
+            // nothing ever sets is decoration.
+            Wiring(
+                "ProfilesSection.swift",
+                ".focused($returningRow, equals: summary.name)",
+                "a profile row's always-drawn Load is its "
+                    + "destination — the trash would put a "
+                    + "destructive action under the next keypress "
+                    + "and \"make default\" is conditional"
+            ),
+            Wiring(
+                "ProfilesSection.swift",
+                "returningRow = neighbour",
+                "and the deletion has to name it"
+            ),
+            Wiring(
+                "ProfilesSection+Broken.swift",
+                ".focused($returningRow, equals: name)",
+                "a broken row has no Load, so Reveal is its "
+                    + "always-drawn control"
+            ),
+            Wiring(
+                "ProfilesSection+Broken.swift",
+                "returningRow = neighbour",
+                "and its deletion names a neighbour inside the "
+                    + "broken list, never a healthy row under "
+                    + "another heading"
+            ),
+            Wiring(
+                "AppRuleRow.swift",
+                ".focused($returningRow, equals: app)",
+                "the rule sentence's space menu is the row's "
+                    + "always-drawn control; the trash disables "
+                    + "itself in override mode"
+            ),
+            Wiring(
+                "AppRulesSection.swift",
+                "returningRow = neighbour",
+                "and the list that owns the deletion names it"
+            ),
+            Wiring(
+                "LayerStripEditor.swift",
+                ".focused($focusedChip, equals: name)",
+                "every layer chip is a destination"
+            ),
+            Wiring(
+                "LayerStripEditor.swift",
+                "focusedChip = KeyLayer.defaultName",
+                "and deleting the selected layer moves focus "
+                    + "WITH the selection to the base chip, which "
+                    + "cannot itself be deleted"
+            ),
+            Wiring(
+                "PaletteShelf.swift",
+                ".focused($returningTile, equals: palette.name)",
+                "a saved palette's tile is already a Button, so "
+                    + "it is the destination"
+            ),
+            Wiring(
+                "PaletteShelf+Actions.swift",
+                "returningTile = neighbour",
+                "and the delete names the next tile in reading "
+                    + "order"
+            ),
         ]
         let files = try SourceScan.swiftSources(under: settingsDir)
         for wiring in wirings {

--- a/Tests/KiwiDeskGuiTests/KeyboardActionParityTests.swift
+++ b/Tests/KiwiDeskGuiTests/KeyboardActionParityTests.swift
@@ -226,7 +226,12 @@ struct KeyboardActionParityTests {
             ),
             Wiring(
                 "LayerStripEditor.swift",
-                "focusedChip = stripSurvivesDeletion",
+                // The whole expression, both arms: stopping at
+                // the condition let the ternary be INVERTED —
+                // focus named INTO a card that just retired —
+                // and stay green (guard-prover, 2026-08-12).
+                "focusedChip = stripSurvivesDeletion "
+                    + "? KeyLayer.defaultName : nil",
                 "and deleting the selected layer moves focus "
                     + "WITH the selection to the base chip — but "
                     + "only where the card survives the "
@@ -256,11 +261,19 @@ struct KeyboardActionParityTests {
                 },
                 "\(wiring.file) is gone"
             )
-            let source = SourceScan.stripComments(
-                try String(contentsOf: file, encoding: .utf8)
+            // Squashed on BOTH sides: this suite matched raw
+            // source until `swift format` wrapped one of these
+            // ternaries across three lines and reddened a guard
+            // whose subject had not changed — a reflow owes
+            // nothing (tests.md), so the needle must survive one
+            // (guard-prover, 2026-08-12).
+            let source = squashed(
+                SourceScan.stripComments(
+                    try String(contentsOf: file, encoding: .utf8)
+                )
             )
             #expect(
-                source.contains(wiring.needle),
+                source.contains(squashed(wiring.needle)),
                 Comment(
                     rawValue:
                         "\(wiring.file) lost `\(wiring.needle)` "
@@ -270,6 +283,12 @@ struct KeyboardActionParityTests {
                 )
             )
         }
+    }
+
+    /// Whitespace-free source, so a needle survives the
+    /// formatter wrapping a call — or a ternary — across lines.
+    private func squashed(_ source: String) -> String {
+        source.split(whereSeparator: \.isWhitespace).joined()
     }
 
     /// One focus wiring: the file it lives in, the use site that

--- a/Tests/KiwiDeskGuiTests/SegmentedPickerCoverageTests.swift
+++ b/Tests/KiwiDeskGuiTests/SegmentedPickerCoverageTests.swift
@@ -32,6 +32,10 @@ struct SegmentedPickerCoverageTests {
     /// So the ban is a source scan, with the usual `allowed` map
     /// for a site that earns an exemption — empty today, and an
     /// entry must say what makes the native control right there.
+    /// Stated reach: the map is keyed on a file's NAME, so an
+    /// entry would exempt every same-named file in the tree, and
+    /// a style reached through a variable is invisible to any
+    /// scan.
     @Test("no view takes the native segmented style")
     func nativeSegmentedStyleIsBanned() throws {
         let allowed: [String: String] = [:]
@@ -49,8 +53,18 @@ struct SegmentedPickerCoverageTests {
             )
             .split(whereSeparator: \.isWhitespace)
             .joined()
+            // BOTH spellings: the shorthand and the legacy
+            // `SegmentedPickerStyle()` initialiser, which is the
+            // same control and passed the first cut green
+            // (guard-prover, 2026-08-12). What a scan still
+            // cannot see is `.pickerStyle(someVar)`.
+            let native =
+                source.contains(".pickerStyle(.segmented)")
+                || source.contains(
+                    ".pickerStyle(SegmentedPickerStyle())"
+                )
             #expect(
-                !source.contains(".pickerStyle(.segmented)"),
+                !native,
                 Comment(
                     rawValue:
                         "\(name) takes the native segmented "
@@ -131,7 +145,11 @@ struct SegmentedPickerCoverageTests {
             let ratio = try contrast(
                 SettingsTheme.ink,
                 over: SettingsTheme.card,
-                wash: (Color.primary, 0.08),
+                // READ from the control, never restated: the
+                // first cut carried its own 0.08 and measured
+                // two tokens while claiming to measure the
+                // track.
+                wash: (Color.primary, SegmentedPickerMetrics.trackAlpha),
                 dark: dark
             )
             #expect(

--- a/Tests/KiwiDeskGuiTests/SegmentedPickerCoverageTests.swift
+++ b/Tests/KiwiDeskGuiTests/SegmentedPickerCoverageTests.swift
@@ -73,10 +73,14 @@ struct SegmentedPickerCoverageTests {
     /// reasons — a brand tweak — would red only after crossing
     /// the line, with every other lens still green.
     ///
-    /// Derived, not restated: the floor is computed by bisecting
-    /// on the luminance that puts `accentInk` at exactly 4.5:1,
-    /// so the number below is checked against the arithmetic
-    /// instead of being a second copy of it.
+    /// Derived, not restated: the boundary is SOLVED from the
+    /// shipped `accentInk` — WCAG's ratio is linear in the
+    /// lighter luminance, so the AA point is
+    /// `4.5 * (inkL + 0.05) - 0.05` — and the literal below is
+    /// checked against that, never used as the source. The
+    /// number also appears in #823's `ui-designer` ruling, which
+    /// is prose nothing can guard; this is what makes it
+    /// re-derivable.
     @Test("the accent keeps room above the AA boundary")
     func accentLuminanceFloor() throws {
         let ink = try resolved(SettingsTheme.accentInk)
@@ -92,8 +96,9 @@ struct SegmentedPickerCoverageTests {
                 rawValue: String(
                     format:
                         "the AA boundary moved to %.4f — "
-                        + "accentInk changed, so the 0.244 in "
-                        + "the docstring and in #823 is stale",
+                        + "accentInk changed, so the 0.244 this "
+                        + "test and #823's ruling both name is "
+                        + "stale",
                     boundary
                 )
             )

--- a/Tests/KiwiDeskGuiTests/SegmentedPickerCoverageTests.swift
+++ b/Tests/KiwiDeskGuiTests/SegmentedPickerCoverageTests.swift
@@ -1,0 +1,202 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import KiwiDesk
+
+/// What the #823 migration is worth only if nothing undoes it:
+/// the shared `SegmentedPicker` is the ONLY segmented chooser,
+/// its accent pill keeps an ink that clears AA, and the track it
+/// draws — a system colour, so invisible to
+/// `SettingsRawColorTests`' lens — is measured rather than
+/// assumed.
+///
+/// Split from `SettingsThemeContrastTests` because that suite is
+/// at the §2.1 ceiling; the WCAG arithmetic below is a per-file
+/// copy by the same convention its own helpers are (tests.md),
+/// and it measures the same resolved-token truth.
+@Suite("Segmented picker coverage (#823)")
+@MainActor
+struct SegmentedPickerCoverageTests {
+    /// A native `.pickerStyle(.segmented)` is an
+    /// `NSSegmentedControl`: AppKit draws its own track beside
+    /// the window's capsules and picks the selected label's ink
+    /// itself. Neither is visible to any colour lens — the ink
+    /// is never written down, so `SettingsRawColorTests` sees no
+    /// literal and `SettingsThemeContrastTests` can only weigh
+    /// inks the tree actually draws. The header's mode segment
+    /// and General's Appearance row shipped that way until #823
+    /// and put near-white on the accent at ~2.4:1 in dark.
+    ///
+    /// So the ban is a source scan, with the usual `allowed` map
+    /// for a site that earns an exemption — empty today, and an
+    /// entry must say what makes the native control right there.
+    @Test("no view takes the native segmented style")
+    func nativeSegmentedStyleIsBanned() throws {
+        let allowed: [String: String] = [:]
+        let root = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDesk")
+        let files = try SourceScan.swiftSources(under: root)
+        // A scan that read nothing would pass having looked at
+        // nothing (#635).
+        #expect(files.count > 50)
+        for file in files {
+            let name = file.lastPathComponent
+            guard allowed[name] == nil else { continue }
+            let source = SourceScan.stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            .split(whereSeparator: \.isWhitespace)
+            .joined()
+            #expect(
+                !source.contains(".pickerStyle(.segmented)"),
+                Comment(
+                    rawValue:
+                        "\(name) takes the native segmented "
+                        + "style — AppKit then draws its own "
+                        + "track and picks the selected "
+                        + "label's ink, which no colour lens "
+                        + "can see. Use SegmentedPicker, or "
+                        + "add an entry to `allowed` saying "
+                        + "what makes the native control right "
+                        + "here (#823)."
+                )
+            )
+        }
+    }
+
+    /// The floor the pairing rests on, stated as the boundary
+    /// rather than as today's value. `SettingsThemeContrastTests`
+    /// asserts the shipped accent passes; it cannot say how much
+    /// room is left, so an accent retune made for unrelated
+    /// reasons — a brand tweak — would red only after crossing
+    /// the line, with every other lens still green.
+    ///
+    /// Derived, not restated: the floor is computed by bisecting
+    /// on the luminance that puts `accentInk` at exactly 4.5:1,
+    /// so the number below is checked against the arithmetic
+    /// instead of being a second copy of it.
+    @Test("the accent keeps room above the AA boundary")
+    func accentLuminanceFloor() throws {
+        let ink = try resolved(SettingsTheme.accentInk)
+        let accent = try resolved(SettingsTheme.accent)
+        let inkLuminance = luminance(ink)
+        // `accentInk` is the darker of the pair, so the ratio is
+        // (accentL + 0.05) / (inkL + 0.05); AA at 4.5 is reached
+        // when accentL = 4.5 * (inkL + 0.05) - 0.05.
+        let boundary = 4.5 * (inkLuminance + 0.05) - 0.05
+        #expect(
+            abs(boundary - 0.244) < 0.001,
+            Comment(
+                rawValue: String(
+                    format:
+                        "the AA boundary moved to %.4f — "
+                        + "accentInk changed, so the 0.244 in "
+                        + "the docstring and in #823 is stale",
+                    boundary
+                )
+            )
+        )
+        #expect(
+            luminance(accent) > boundary,
+            Comment(
+                rawValue: String(
+                    format:
+                        "accent luminance %.3f is under the "
+                        + "%.3f floor — accentInk drops below "
+                        + "AA on it, everywhere the pair is "
+                        + "drawn",
+                    luminance(accent),
+                    boundary
+                )
+            )
+        )
+    }
+
+    /// The track and the UNSELECTED label, which appear in no
+    /// pairing list: the track is `Color.primary.opacity(0.08)`,
+    /// mode-varying, so it is not a fixed hue, an RGB literal or
+    /// a fixed white/black and escapes `SettingsRawColorTests`
+    /// entirely. Measured here rather than left as a gap the
+    /// migration widened by putting two more call sites on it.
+    @Test("the unselected label clears AA on the track")
+    func unselectedLabelOnTrack() throws {
+        for dark in [false, true] {
+            let ratio = try contrast(
+                SettingsTheme.ink,
+                over: SettingsTheme.card,
+                wash: (Color.primary, 0.08),
+                dark: dark
+            )
+            #expect(
+                ratio >= 4.5,
+                Comment(
+                    rawValue: String(
+                        format: "ink on track %@: %.2f",
+                        dark ? "dark" : "light",
+                        ratio
+                    )
+                )
+            )
+        }
+    }
+
+    // MARK: - WCAG arithmetic over resolved tokens
+
+    private func contrast(
+        _ ink: Color,
+        over surface: Color,
+        wash: (color: Color, alpha: Double)? = nil,
+        dark: Bool
+    ) throws -> Double {
+        let inkRGB = try resolved(ink, dark: dark)
+        var surfaceRGB = try resolved(surface, dark: dark)
+        if let wash {
+            let washRGB = try resolved(wash.color, dark: dark)
+            surfaceRGB = (
+                r: wash.alpha * washRGB.r
+                    + (1 - wash.alpha) * surfaceRGB.r,
+                g: wash.alpha * washRGB.g
+                    + (1 - wash.alpha) * surfaceRGB.g,
+                b: wash.alpha * washRGB.b
+                    + (1 - wash.alpha) * surfaceRGB.b
+            )
+        }
+        let la = luminance(inkRGB)
+        let lb = luminance(surfaceRGB)
+        return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+    }
+
+    private func resolved(
+        _ color: Color,
+        dark: Bool = false
+    ) throws -> (r: Double, g: Double, b: Double) {
+        let appearance = try #require(
+            NSAppearance(named: dark ? .darkAqua : .aqua)
+        )
+        var resolvedColor: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            resolvedColor =
+                NSColor(color).usingColorSpace(.sRGB)
+        }
+        let srgb = try #require(resolvedColor)
+        return (
+            Double(srgb.redComponent),
+            Double(srgb.greenComponent),
+            Double(srgb.blueComponent)
+        )
+    }
+
+    private func luminance(
+        _ rgb: (r: Double, g: Double, b: Double)
+    ) -> Double {
+        func lin(_ v: Double) -> Double {
+            v <= 0.04045
+                ? v / 12.92
+                : pow((v + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * lin(rgb.r) + 0.7152 * lin(rgb.g)
+            + 0.0722 * lin(rgb.b)
+    }
+}

--- a/Tests/KiwiDeskGuiTests/SilentDimTests.swift
+++ b/Tests/KiwiDeskGuiTests/SilentDimTests.swift
@@ -20,6 +20,13 @@ import Testing
 /// `.opacity` — so a fourth would have arrived silent with
 /// nothing red.
 ///
+/// It is fail-CLOSED by construction: every conditional opacity
+/// of the dim shape is listed, colour alphas included. An
+/// earlier cut tried to be clever and excluded a call whose
+/// RECEIVER looked like a colour, which let a control's own
+/// accent fill fade on a gate with nothing red — the entry for
+/// a colour alpha costs one line and cannot do that.
+///
 /// Stated limit: this counts the DIMMERS, not the reasons. A row
 /// listed below whose reason later stops being drawn stays green
 /// here; that half is the render guards' and the eye's.
@@ -71,6 +78,14 @@ struct SilentDimTests {
             + "the row above it",
         "DragVisualPreview.swift":
             "the same, for the drag visuals preview",
+        "FollowsMainTray.swift":
+            "a COLOUR's alpha, not a view dim: the drop-target "
+            + "highlight's own fill fades in and out with the "
+            + "drag. Listed rather than excluded by its "
+            + "receiver — a receiver test let a real dim hide "
+            + "behind `.tint(SettingsTheme.accent.opacity(…))`, "
+            + "which is a control's fill saying \"inert\" with "
+            + "no reason anywhere (guard-prover, 2026-08-12)",
     ]
 
     @Test("a conditional dim is GreyOut's or is listed")
@@ -167,9 +182,7 @@ struct SilentDimTests {
                 argument.append(character)
                 index = after.index(after: index)
             }
-            if argument.contains("?"), isDimPair(argument),
-                !isColourAlpha(receiver)
-            {
+            if argument.contains("?"), isDimPair(argument) {
                 return true
             }
             consumed += scanned.distance(
@@ -181,35 +194,21 @@ struct SilentDimTests {
         return false
     }
 
-    /// One branch exactly `1`, the other a fade tier.
+    /// One branch fully drawn (`1`), the other ANY fade short of
+    /// it. The first cut bounded the fade to 0.2...0.6, which is
+    /// the tiers this tree happens to use — so a dim written at
+    /// 0.7 was not a dim to the guard, and escaped both halves
+    /// at once (guard-prover, 2026-08-12). The band bought
+    /// nothing: a hover wash moves between two fractions and an
+    /// appear/disappear touches 0, so neither reaches `1` and
+    /// neither is caught by widening this.
     private func isDimPair(_ argument: String) -> Bool {
         let numbers = argument.split {
             !$0.isNumber && $0 != "."
         }
         .compactMap { Double($0) }
         guard numbers.contains(1) else { return false }
-        return numbers.contains { $0 >= 0.2 && $0 <= 0.6 }
+        return numbers.contains { $0 > 0 && $0 < 1 }
     }
 
-    /// A colour's own alpha rather than a view's. Kept as a
-    /// short receiver list rather than a general parser: every
-    /// case in this tree is a `Color` or a `ShapeStyle` reached
-    /// by name, and a wrong answer here is fail-OPEN (an unseen
-    /// dim), so a new spelling joins this list rather than the
-    /// list being widened to a guess.
-    private func isColourAlpha(_ receiver: String) -> Bool {
-        // The receiver arrives with the dot that joins it to the
-        // call (`.tint.`), so trim it before comparing.
-        let receiver =
-            receiver.hasSuffix(".")
-            ? String(receiver.dropLast()) : receiver
-        for name in [
-            ".tint", "Color.primary", "Color.secondary",
-            "Color.white", "Color.black", "SettingsTheme",
-            ".accent", ".ink",
-        ] where receiver.hasSuffix(name) {
-            return true
-        }
-        return false
-    }
 }

--- a/Tests/KiwiDeskGuiTests/SilentDimTests.swift
+++ b/Tests/KiwiDeskGuiTests/SilentDimTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// A dim makes a claim, so something has to say what it is
+/// (#815). "Grey, don't hide" keeps a control visible precisely
+/// because the dimming means *switch that on and I act* — and a
+/// dim that says only "dimmed" tells the reader an answer exists
+/// and then withholds it, which is worse than a control that was
+/// never gated.
+///
+/// The invariant this holds is deliberately structural rather
+/// than semantic, because "the reason is reachable" is not
+/// something a scan can read: **a conditional `.opacity` in the
+/// Settings tree is `GreyOut`'s, or it is listed here with what
+/// it dims for and where its reason lives.** Three separate
+/// implementations of "dim this" already shipped — `GreyOut`,
+/// `keybindingRowStyle(inherited:)` and a hand-rolled
+/// `.opacity` — so a fourth would have arrived silent with
+/// nothing red.
+///
+/// Stated limit: this counts the DIMMERS, not the reasons. A row
+/// listed below whose reason later stops being drawn stays green
+/// here; that half is the render guards' and the eye's.
+@Suite("No silent dim (#815)")
+struct SilentDimTests {
+    /// Every conditional dim outside `GreyOut`, and why each is
+    /// allowed to be its own. The value is the reason the dim
+    /// stands for — an entry that cannot state one is the
+    /// finding, not a formality.
+    private let allowed: [String: String] = [
+        "AutoGatedGroup.swift":
+            "GreyOut itself — the modifier every gate should use",
+        "InactiveDimmed.swift":
+            "not a gate: the whole window fades while it is not "
+            + "the key window, so nothing is being withheld and "
+            + "there is no per-control reason to give",
+        "AppBarOverrideControls.swift":
+            "override mode's no-value branch, which cannot use "
+            + "GreyOut because it must not compound inside a "
+            + "gated block; it carries its own accessibilityHint "
+            + "on the single control (`space_override.off.help`), "
+            + "which is the LEAF case the backed-out block hint "
+            + "was not",
+        "KeybindingOverrideEnvironment.swift":
+            "inheritance, not a gate: the row still works and the "
+            + "dim says the value comes from the base. It carries "
+            + "its own accessibilityHint on the row "
+            + "(`shortcuts.row.inherited.axhint`), the same leaf "
+            + "case as the entry above",
+        "AppRuleRow.swift":
+            "the same inheritance dim, per facet, for the two "
+            + "menus inside the rule sentence",
+        "SettingsSlider.swift":
+            "the shared slider's own disabled fade, which rides "
+            + "`isEnabled` — set by whatever gate disabled it, so "
+            + "the reason belongs to that gate and not here",
+        "FocusBorderPreview.swift":
+            "a PICTURE, not a control: the preview fades while "
+            + "the feature is off, and the toggle saying so is "
+            + "the row above it",
+        "DragVisualPreview.swift":
+            "the same, for the drag visuals preview",
+    ]
+
+    @Test("a conditional dim is GreyOut's or is listed")
+    func everyDimIsAccountedFor() throws {
+        let root = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDesk/Settings")
+        let files = try SourceScan.swiftSources(under: root)
+        // A scan that read nothing would pass having looked at
+        // nothing (#635).
+        #expect(files.count > 50)
+        var found: Set<String> = []
+        for file in files {
+            let source = SourceScan.stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            .split(whereSeparator: \.isWhitespace)
+            .joined()
+            guard source.contains("opacity(") else { continue }
+            guard dimmingOpacity(in: source) else { continue }
+            let name = file.lastPathComponent
+            found.insert(name)
+            #expect(
+                allowed[name] != nil,
+                Comment(
+                    rawValue:
+                        "\(name) dims a control on a condition "
+                        + "without GreyOut. A dim says an answer "
+                        + "exists, so route it through GreyOut "
+                        + "(which carries the reason), or add an "
+                        + "entry to `allowed` saying what it "
+                        + "dims for and where the reason is "
+                        + "readable without a pointer (#815)."
+                )
+            )
+        }
+        // The map is the one copy of who may, so an entry whose
+        // file stopped dimming is stale and says so — the same
+        // rule every `allowed` map in this tree carries.
+        for name in allowed.keys {
+            #expect(
+                found.contains(name),
+                Comment(
+                    rawValue:
+                        "\(name) no longer dims conditionally — "
+                        + "drop its `allowed` entry"
+                )
+            )
+        }
+    }
+
+    /// The dim SHAPE: a conditional opacity where one branch is
+    /// fully drawn (`1`) and the other is a fade in 0.2...0.6 —
+    /// "sometimes present, sometimes faded", which is what makes
+    /// a claim about state.
+    ///
+    /// Everything else a conditional opacity does in this tree
+    /// is decoration and is deliberately out of scope: a hover
+    /// wash moves between two fractions (0.12 → 0.18), and an
+    /// appear/disappear moves to or from 0. Neither says a
+    /// control is inert, so neither owes a reason.
+    ///
+    /// Matched WITHOUT requiring a leading dot, because
+    /// `keybindingRowStyle(inherited:)` calls a bare `opacity(`
+    /// inside a `View` extension — the first cut required the
+    /// dot and silently missed one of the three dimmers this
+    /// suite was written for. And a COLOUR's alpha is not a
+    /// view dim: `.tint.opacity(targeted ? 1 : 0.55)` fades a
+    /// drop-target highlight's fill, so the receiver is checked
+    /// rather than the shape alone.
+    private func dimmingOpacity(in source: String) -> Bool {
+        var scanned = Substring(source)
+        var consumed = 0
+        while let call = scanned.range(of: "opacity(") {
+            let prefixEnd = source.index(
+                source.startIndex,
+                offsetBy: consumed
+                    + scanned.distance(
+                        from: scanned.startIndex,
+                        to: call.lowerBound
+                    )
+            )
+            let receiver = String(source[..<prefixEnd].suffix(12))
+            let after = scanned[call.upperBound...]
+            var depth = 1
+            var index = after.startIndex
+            var argument = ""
+            while index < after.endIndex, depth > 0 {
+                let character = after[index]
+                if character == "(" { depth += 1 }
+                if character == ")" {
+                    depth -= 1
+                    if depth == 0 { break }
+                }
+                argument.append(character)
+                index = after.index(after: index)
+            }
+            if argument.contains("?"), isDimPair(argument),
+                !isColourAlpha(receiver)
+            {
+                return true
+            }
+            consumed += scanned.distance(
+                from: scanned.startIndex,
+                to: call.upperBound
+            )
+            scanned = after
+        }
+        return false
+    }
+
+    /// One branch exactly `1`, the other a fade tier.
+    private func isDimPair(_ argument: String) -> Bool {
+        let numbers = argument.split {
+            !$0.isNumber && $0 != "."
+        }
+        .compactMap { Double($0) }
+        guard numbers.contains(1) else { return false }
+        return numbers.contains { $0 >= 0.2 && $0 <= 0.6 }
+    }
+
+    /// A colour's own alpha rather than a view's. Kept as a
+    /// short receiver list rather than a general parser: every
+    /// case in this tree is a `Color` or a `ShapeStyle` reached
+    /// by name, and a wrong answer here is fail-OPEN (an unseen
+    /// dim), so a new spelling joins this list rather than the
+    /// list being widened to a guess.
+    private func isColourAlpha(_ receiver: String) -> Bool {
+        // The receiver arrives with the dot that joins it to the
+        // call (`.tint.`), so trim it before comparing.
+        let receiver =
+            receiver.hasSuffix(".")
+            ? String(receiver.dropLast()) : receiver
+        for name in [
+            ".tint", "Color.primary", "Color.secondary",
+            "Color.white", "Color.black", "SettingsTheme",
+            ".accent", ".ink",
+        ] where receiver.hasSuffix(name) {
+            return true
+        }
+        return false
+    }
+}

--- a/Tests/KiwiDeskGuiTests/SilentDimTests.swift
+++ b/Tests/KiwiDeskGuiTests/SilentDimTests.swift
@@ -23,6 +23,15 @@ import Testing
 /// Stated limit: this counts the DIMMERS, not the reasons. A row
 /// listed below whose reason later stops being drawn stays green
 /// here; that half is the render guards' and the eye's.
+///
+/// Scope is `Settings/` rather than `ChromeScanRoots`, and the
+/// reason is the invariant's own subject: a dim owes a reason
+/// where a GATE withheld an answer, which is a settings-row
+/// idea — Onboarding and the bars fade for presentation (a step
+/// out of the flow, a bar at rest), not to say a control is
+/// inert. A gated control shipping outside this tree would be
+/// invisible here, so a new tree that GATES something joins
+/// these roots, not merely one that dims.
 @Suite("No silent dim (#815)")
 struct SilentDimTests {
     /// Every conditional dim outside `GreyOut`, and why each is

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1460,6 +1460,124 @@ kiwi (the chrome KiwiDesk draws) and half whatever the user set
 (the native controls), which reads as unfinished rather than as
 respectful. (Owner rulings 2026-08-04, in chat.)
 
+### Usable without a mouse is a second claim, and a dim is not a sentence
+
+**[Principle]**
+
+**"Accessible with VoiceOver" and "usable without a mouse" are
+two claims, and this tree shipped the first for a long time
+believing it had both.** Two rules fall out, and they are the
+ones a Settings change keeps paying.
+
+*A shape change states where focus goes.* When the view holding
+focus stops existing — a deleted row, a pushed sub-view — nothing
+claims it and the next Tab starts from the top of the window, so
+a keyboard user re-walks the list after every deletion. The
+destination is read BEFORE the mutation (afterwards the list
+names whichever row slid into the gap, right by accident and
+wrong at the end of a list), and it must be a control that is
+always DRAWN and non-destructive: the first cut of this bound the
+spaces list to a mode-gated button, which on a fresh install is
+not drawn at all, so focus went to the top by a second road.
+
+*A dim is not a sentence.* Greying keeps a control visible
+because the dimming means *switch that on and I act* — so a
+greyed control that announces only "dimmed" tells the reader an
+answer exists and withholds it, which is worse than one that was
+never gated. The reason therefore travels by one of three
+channels, in the order a reader meets them:
+
+1. a **block** gate keeps a live `?` anchor outside the dimmed
+   subtree (#527);
+2. a row whose **cause is legible on its own surface** — the
+   gating control in the same container, or a standing caption
+   that already names it — needs nothing more, and the hover
+   string stays for the pointer user;
+3. a row gated from **another destination** takes the live `?`
+   whose sentence names where to go (Advanced Colours is
+   entirely this class);
+
+and what falls through all three — same page, no adjacency,
+nothing else to look at — draws the reason INLINE, outside the
+dim. Which rows those are is derived from the census rather than
+listed, because a hand-kept register of who owes a sentence is
+one more thing to forget: `GateReasonPlacement` answers it, and
+it reproduces every site that already drew one, which is what
+makes it checkable.
+
+The temptation to answer all of this with `.accessibilityHint`
+is why the ladder is written down. A hint on a **leaf** control
+is ordinary and two rows ship one. A hint on `GreyOut` is not:
+that modifier wraps whole blocks, so whether it reaches the
+controls inside — and whether its empty value in the un-gated
+state displaces a hint a descendant sets for itself — cannot be
+observed headlessly, and it was written and backed out for
+exactly that reason. Re-adding it needs a recorded Accessibility
+Inspector session, not an argument.
+
+What breaks if this is ignored: the window keeps passing every
+accessibility guard in the suite while being unusable from the
+keyboard, because both failures are silent — an unattached
+`@FocusState` compiles and moves focus nowhere, and a reason in
+a tooltip is invisible to everything except a pointer. Stated
+residue, so it is not mistaken for coverage: for the co-located
+class the VoiceOver reader hears the cause before the dimmed row
+but must infer the link, and macOS gates keyboard focus for
+non-text controls behind System Settings ▸ Keyboard ▸ Keyboard
+navigation, which no app may set for the user — so a focus
+destination is verified with that ON. (#678 turn 20a, #815,
+#816.)
+
+### A focus ring is the platform's; a chip that removes it draws its own
+
+**[Trade-off]**
+
+**The Settings window's text fields keep macOS's focus ring, in
+the user's system accent, while the header's search chip draws a
+kiwi outline of its own — and that difference is deliberate, not
+a surface someone forgot to convert.**
+
+It reads at first like the defect the entry above describes: one
+window, two focus colours, the green one on the chip and the
+system accent (blue on a default Mac) on every field. AppKit
+rings a standard `TextField` with
+`NSColor.keyboardFocusIndicatorColor`, which follows System
+Settings and is unaffected by `.tint` — the same class as
+`Color.accentColor`, which #678 turn 16b retired for exactly that
+reason.
+
+Three answers were weighed. **Convert the sixteen fields**: each
+takes `.textFieldStyle(.plain)` to lose the platform ring, then
+re-earns a focus indicator by hand, then needs its own contrast
+pairing against its own ground, and the pairing wants a seal plus
+a guard the way `settingsActionButton()` pairs a style with its
+ink — and every future field pays it again. **Give the chip the
+platform ring**: not free either, because the ring arrives with
+AppKit's bezel, so keeping the chip shape means macOS draws no
+ring at all, and the header loses the one thing that makes the
+search read as the same kind of object as the back chip and the
+profile chip. **Rule the difference deliberate**: nothing to
+build and nothing new to own.
+
+The third is the ruling, and the north star is why: *Apple-native
+binds behavior* while the window's look is KiwiDesk's own. A
+focus ring is behavior — it follows the user's accent AND their
+"Increase contrast" and focus-ring accessibility settings, none
+of which an app should answer for them. So the fields keep the
+platform's, and the chip is not an exception to that rule but a
+control that never had a platform ring to keep: `.plain` removed
+the bezel for the chip's shape, and a control that removes the
+platform's focus indicator owes one of its own.
+
+What breaks if this is ignored: someone "fixes" the inconsistency
+in the cheap direction and converts a field to `.plain` without
+replacing what it removed, which is a field that shows no focus
+at all — worse than either colour. And a custom indicator owes
+the contrast the platform's had: the search field's accent at
+0.55 measured 1.52:1 on `sunken` and had to go to full strength,
+which is the floor any second one starts from. (#833, owner
+ruling 2026-08-12.)
+
 ### The header search is a field, not a button that opens one
 
 **[Trade-off]**

--- a/docs/ui-patterns.md
+++ b/docs/ui-patterns.md
@@ -1141,7 +1141,14 @@ was written down:
   adjacent (Background style over Background size, a toggle
   over its slider) — keeps just the `GreyOut` hover string: the
   adjacency answers "why", and a header `?` would gloss a
-  single self-explaining row. A **master** control higher up
+  single self-explaining row. **Adjacent is the operative word,
+  and it is derived** (#815): same area, same container, and the
+  gating row drawn whenever the gated one is — two rows inside
+  one disclosure qualify, a row on the same page but in another
+  card does not, and that last case draws its reason inline
+  instead (`GateReasonPlacement`, argued in
+  `docs/design-decisions.md` ▸ usable without a mouse is a
+  second claim). A **master** control higher up
   the *same* page, driving rows in later cards, is not a fourth
   case to reach for: Gaps & Borders shipped one for a commit
   (#754) and it was the wrong shape twice over — the followers


### PR DESCRIPTION
## Description

Branch 2 of the road to 1.0 — the Settings keyboard path, and
the two controls that were not the shared component.

**#823 — the mode and Appearance segments were native
`NSSegmentedControl`s.** The only two `.pickerStyle(.segmented)`
sites left, so AppKit drew its own track beside the window's
capsules and picked the selected label's ink itself: near-white
on the accent at ~2.4:1 in dark, which is the pairing the dark
pass had already removed from the shared component. Both migrate
to `SegmentedPicker`, where the ink comes from `accentInk` by
construction. Appearance drops its `DropdownRow` wrapper (the
component draws its own row shape) and the header re-applies
`home.mode_ax`, the unlabeled path attaching none. **No colour
changes hands.** The two coverage items the `ui-designer` ruling
added are closed with it: the accent's AA luminance floor, SOLVED
from the shipped ink rather than restated, and the track's own
pairings — the track being a system colour that no existing lens
could see.

**#816 — deleting a row dropped keyboard focus to the top.**
Five sites (profiles, broken profiles, app rules, the layer
strip, palettes) now read the neighbour BEFORE the mutation and
land on a control that is always drawn and non-destructive. Two
of them are not the obvious answer, and the reasons are in the
code: a broken profile row has no Load, so Reveal is its
destination; and the layer strip's focus follows the SELECTION
to the base chip — but only where the card survives, because in
Simple mode deleting the last custom layer retires the whole
card, base chip included.

**#815 — a greyed row's reason was pointer-only.** The answer is
not a caption under every greyed row: `GreyOut` inside a
`ForEach` would stamp one under every child, and several of these
greys are ordinary states. `GateReasonPlacement` derives the
channel from the census — block gate keeps its `?`, an adjacent
cause needs nothing, a gate on another destination takes the `?`
that names where to go, and only what falls through all three
draws its reason inline. It reproduces the three rows that
already drew one, which is what makes it checkable, and found a
fourth that did not: **Copy sizes and style from Space Bar…**,
killed by a switch on a different card. `SilentDimTests` closes
the other half — no silent dim.

**#833 — docs only**, per the owner ruling on the issue.

## Related Issue(s)

Closes #823
Closes #816
Closes #815
Closes #833

## Checklist

- [ ] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build green — CI's `Release Build` job (read it
  before merging; it reports, it does not block), or locally
  for concurrency / `@Sendable` changes — CI's job passed in
  3m35s
- [x] PR is focused; refactors separated from features

## How I verified

Gate: build, 3248 tests in 603 suites, lint 0, plus the site
build (`docs/` moved). Release build skipped locally — nothing
here touches concurrency or `Sendable` — so read CI's job.

**Device QA is owed and has a precondition**: System Settings ▸
Keyboard ▸ **Keyboard navigation must be ON**, or every #816 fix
looks like a no-op. macOS gates keyboard focus for non-text
controls behind it, and with it off, focus falls to the window's
first text field (the search chip) no matter what the app names.
That is the road `gui.md` warns about, and it is why the spaces
list looked broken on the owner's machine while its destination
was correct.

1. Turn keyboard navigation on. Delete a profile, a rule, a
   layer and a palette by keyboard; focus should land on the
   next row's Load / space menu / chip / tile, and on the
   previous one when deleting the last.
2. In **Simple** mode, delete the only custom layer. The Layers
   card retires itself; focus must not jump to the search field
   at the top.
3. In Bars, turn the Space Bar off and look at **Copy sizes and
   style from Space Bar…** — it should now say why it is dead,
   in an undimmed line under the button.
4. Compare the header's Simple/Power User segment and General ▸
   Appearance against Layout Defaults ▸ Focus anchor. In **dark**
   mode, the selected label was the thing to fix.

## Notes for Reviewer

- Round 1 (`code-reviewer` + `architect-reviewer`) returned two
  blockers, both the same shape — a rule stated in a comment that
  the code did not ask. `GateReasonPlacement` had no production
  consumer while `AppBarCard` re-derived its verdict inline (the
  dead-resolver trap), and the layer strip named a focus
  destination inside a card that its own deletion can retire.
  Both fixed in the second commit; the layer strip now asks
  `LayersCard.isOffered`, hoisted so there is ONE offer predicate
  rather than an inverted copy.
- `guard-prover` then found the suite **red at that commit**:
  `swift format` had reflowed a ternary after the full-suite run.
  Fixed, and the parity needles now squash whitespace like the
  other three source-scan suites — a reflow owes nothing.
- It also found one guard INERT and two fail-open holes, all
  three closed and re-proven: the track-contrast test restated
  the alpha it claimed to measure; `SilentDimTests` excluded
  anything whose receiver looked like a colour, which hid a
  control's accent fill fading on a gate; and its 0.2...0.6 band
  meant a dim at 0.7 was not a dim.
- **Deliberately not closed here**: the per-space override rows
  come out `remote` with no `?` anchor. Filed as #841 (Bug,
  Medium/Medium, 1.0) rather than widened into this branch — a
  different mechanism, on a surface branch 4 will move anyway —
  and `GateReasonPlacementTests` fails the moment an anchor
  lands, so it cannot be forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195wpjJSXZoYWvujqXa3pnL

