### PR TITLE
fix(site): add space before maker link in footer credits

### DIFF
--- a/site/src/components/Guide.astro
+++ b/site/src/components/Guide.astro
@@ -802,7 +802,7 @@ const jsonLd = [
         </nav>
         <p class="footer__copy">{s.footer_copy}</p>
         <p class="footer__credit">
-          {s.footer_credit_built_by}
+          {s.footer_credit_built_by}{' '}
           <a href={makerProfile} target="_blank" rel="noopener">
             {s.footer_credit_name} · {s.footer_credit_handle}
           </a>

--- a/site/src/components/Landing.astro
+++ b/site/src/components/Landing.astro
@@ -928,7 +928,7 @@ KiwiDesk.bind(<span class="str">"cmd+alt+left"</span>, <span class="fn">function
         {/* Low-key maker credit — the maker's personal profile,
              distinct from the project repo link above. */}
         <p class="footer__credit">
-          {t.footer_credit_built_by}
+          {t.footer_credit_built_by}{' '}
           <a href={makerProfile} target="_blank" rel="noopener">
             {t.footer_credit_name} · {t.footer_credit_handle}
           </a>


### PR DESCRIPTION
## Description

Add explicit space (`{' '}`) between the `footer_credit_built_by` localized text and the maker profile `<a>` link in `Landing.astro` and `Guide.astro`.

In Astro templates, whitespace/newlines between dynamic `{expression}` interpolations and adjacent HTML tags on subsequent lines are stripped during HTML compilation, causing the text to render as "Gebaut vonMaikel..." or "Built byMaikel...".

## Related Issue(s)

None

## Checklist

- [x] I understand what this change does and have run it in the app to confirm it works as intended (see "How I verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format (see AGENTS.md §3)
- [ ] New behavior is tested (pure logic / layout code required)
- [ ] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] PR is focused; refactors separated from features

## How I verified

1. Built and ran Astro dev server locally.
2. Verified rendered HTML for both `/de` and `/` (`curl -s http://localhost:4321/de | grep "footer__credit"` -> `Gebaut von <a href="...">Maikel...</a>`).
3. Ran `npm run build` in `site/` — passed cleanly (all 27 static routes generated).

## Notes for Reviewer

None.
