### PR TITLE
ci: refuse a tag whose milestone still has open issues

### DIFF
--- a/.github/workflows/manage-milestones-on-tag.yml
+++ b/.github/workflows/manage-milestones-on-tag.yml
@@ -1,0 +1,118 @@
+name: Milestones on tag
+
+# A milestone says which release must not ship without those issues
+# (AGENTS.md §3). So a tag whose milestone still has open issues is a
+# mistake, not an event to tidy up after: this refuses the tag rather
+# than rescheduling the work.
+#
+# Deliberately NOT ported from KiwiCV: automatic migration of open
+# issues to the next patch milestone. Migrating means a machine
+# silently overrides "the release waits for this", which empties the
+# milestone of meaning. Moving an issue forward is a decision — it
+# says "we shipped without it" — and a human makes it.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  issues: write
+
+jobs:
+  milestones:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Refuse the tag if its milestone has open issues
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+
+          MS=$(gh api "/repos/$REPO/milestones?state=all&per_page=100" \
+                 --jq ".[] | select(.title == \"$TAG\" or .title == \"v$TAG\")")
+
+          if [ -z "$MS" ]; then
+            echo "No milestone named $TAG or v$TAG — nothing gates this tag."
+            exit 0
+          fi
+
+          NUMBER=$(echo "$MS" | jq -r '.number')
+          OPEN=$(echo "$MS" | jq -r '.open_issues')
+          echo "MILESTONE_NUMBER=$NUMBER" >> "$GITHUB_ENV"
+
+          if [ "$OPEN" -gt 0 ]; then
+            echo "::error::Milestone $TAG still has $OPEN open issue(s). The release waits for them."
+            gh issue list --repo "$REPO" --milestone "$TAG" --state open \
+              --json number,title --jq '.[] | "  #\(.number) \(.title)"' || true
+            echo ""
+            echo "Close them, or move each one to a later milestone deliberately:"
+            echo "  gh issue edit <n> --milestone \"<next>\"    # we shipped without it"
+            echo "  gh issue edit <n> --remove-milestone       # no release waits for it"
+            exit 1
+          fi
+
+          echo "Milestone $TAG is clear."
+
+      - name: Close the shipped milestone and any older open ones
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          version_le() { [ "$1" = "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" ]; }
+
+          gh api "/repos/$REPO/milestones?state=open&per_page=100" \
+            --jq '.[] | "\(.number)\t\(.title)\t\(.open_issues)"' |
+          while IFS=$'\t' read -r number title open; do
+            ver="${title#v}"
+            [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+            version_le "$ver" "$TAG" || continue
+
+            # An older milestone with open work is the same mistake as the
+            # tagged one — surface it, do not quietly close over it.
+            if [ "$open" -gt 0 ]; then
+              echo "::warning::Milestone $title is older than $TAG but still has $open open issue(s); leaving it open."
+              continue
+            fi
+            echo "Closing $title"
+            gh api -X PATCH "/repos/$REPO/milestones/$number" -f state=closed >/dev/null
+          done
+
+      - name: Delete milestones that never held anything
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          version_le() { [ "$1" = "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" ]; }
+
+          gh api "/repos/$REPO/milestones?state=all&per_page=100" \
+            --jq '.[] | select(.open_issues == 0 and .closed_issues == 0) | "\(.number)\t\(.title)"' |
+          while IFS=$'\t' read -r number title; do
+            ver="${title#v}"
+            [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+            version_le "$ver" "$TAG" || continue
+            echo "Deleting empty milestone $title"
+            gh api -X DELETE "/repos/$REPO/milestones/$number" >/dev/null
+          done
+
+      - name: Open the next milestones
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          [[ "$TAG" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] || {
+            echo "::error::tag $TAG is not X.Y.Z"; exit 1; }
+          MAJOR="${BASH_REMATCH[1]}"; MINOR="${BASH_REMATCH[2]}"; PATCH="${BASH_REMATCH[3]}"
+
+          NEXT=("$MAJOR.$MINOR.$((PATCH + 1))")
+          if [ "$PATCH" -eq 0 ]; then NEXT+=("$MAJOR.$((MINOR + 1)).0"); fi
+          if [ "$PATCH" -eq 0 ] && [ "$MINOR" -eq 0 ]; then NEXT+=("$((MAJOR + 1)).0.0"); fi
+
+          for m in "${NEXT[@]}"; do
+            if gh api "/repos/$REPO/milestones?state=all&per_page=100" \
+                 --jq '.[].title' | grep -qx "$m"; then
+              echo "Milestone $m already exists"
+            else
+              echo "Creating milestone $m"
+              gh api -X POST "/repos/$REPO/milestones" -f title="$m" >/dev/null
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,8 @@ jobs:
     runs-on: macos-26
     permissions:
       contents: read
+      # Read-only, for the milestone gate below.
+      issues: read
     # The commit this job vetted, for the release job to build.
     # A tag NAME is re-resolved against the remote at each job's
     # own checkout, so it cannot carry this assertion — see the
@@ -84,6 +86,30 @@ jobs:
           # Needed for the "tag is on main" assertion below,
           # which resolves origin/main.
           fetch-depth: 0
+
+      # Backstop for scripts/release.sh's copy of this check. The
+      # script refuses to cut the tag at all; this catches a tag cut
+      # by hand, or on a machine without gh. Placed before Xcode is
+      # selected, so a release the milestone forbids costs seconds
+      # rather than a whole build — and withholds the artifacts,
+      # which is all CI can still do once the tag exists.
+      - name: Milestone must be clear
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG_NAME#v}"
+          OPEN=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+                   --milestone "$VERSION" --state open --json number \
+                   --jq 'length' 2>/dev/null || echo 0)
+          if [ "$OPEN" -gt 0 ]; then
+            echo "::error::Milestone $VERSION still has $OPEN open issue(s) — the release waits for them."
+            gh issue list --repo "$GITHUB_REPOSITORY" --milestone "$VERSION" \
+              --state open --json number,title --jq '.[] | "  #\(.number) \(.title)"' || true
+            exit 1
+          fi
+          echo "Milestone $VERSION is clear, or does not exist."
 
       # Not `github.sha`: on a workflow_dispatch run that is the
       # DEFAULT branch's tip, not the tag's commit — only the

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -65,6 +65,32 @@ fi
 TAG="v$VERSION"
 cd "$ROOT"
 
+# A milestone says which release must not ship without those issues, so
+# a version whose milestone is not clear must not be cut. Checked here,
+# before anything is stamped or tagged, because failing at this point
+# costs nothing to undo — release.yml's copy runs after the tag already
+# exists and can only withhold the artifacts.
+#
+# Best effort: without gh the check cannot run, and release.yml is then
+# the authority. Missing local tooling must not block a release by itself.
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    MILESTONE_OPEN=$(gh issue list --milestone "$VERSION" --state open \
+        --json number --jq 'length' 2>/dev/null || echo "")
+    if [ -n "$MILESTONE_OPEN" ] && [ "$MILESTONE_OPEN" -gt 0 ]; then
+        echo "✗ milestone $VERSION still has $MILESTONE_OPEN open issue(s):" >&2
+        gh issue list --milestone "$VERSION" --state open \
+            --json number,title --jq '.[] | "    #\(.number) \(.title)"' >&2
+        echo "" >&2
+        echo "  The release waits for these. Close them, or move each one" >&2
+        echo "  deliberately — moving it records that we shipped without it:" >&2
+        echo "    gh issue edit <n> --milestone \"<next>\"" >&2
+        echo "    gh issue edit <n> --remove-milestone" >&2
+        exit 1
+    fi
+else
+    echo "! gh unavailable — skipping the milestone check (release.yml still enforces it)" >&2
+fi
+
 # ---------------------------------------------------------------
 # 1. Preconditions — all read-only
 


### PR DESCRIPTION
## What changed and why

Ports KiwiCV's `manage-milestones-on-tag` and adds the gate that was missing from it.

A milestone says which release must not ship without those issues (AGENTS.md §3). So a tag whose milestone is not clear is a mistake, not something to tidy up after. The first step lists the offenders and fails, printing the two commands that resolve it deliberately.

**Deliberately not ported: automatic migration of open issues to the next patch milestone.** Migration lets a machine silently override "the release waits for this", which empties the milestone of meaning. Moving an issue forward is a decision — it records "we shipped without it" — and a human should make it.

Older milestones still holding open work are warned about and left open, for the same reason.

## Steps

1. Refuse the tag if its milestone has open issues
2. Close the shipped milestone and older clear ones
3. Delete milestones that never held anything
4. Open the next milestones (patch always; minor at `.0`; major at `.0.0`)

## Known gap

`release.yml` triggers on the same `v*` tags and runs **in parallel**, so this failing does not by itself stop a release — today it is a loud complaint, not a gate. Making it real needs the same check as `release.yml`'s first step, or both workflows calling one reusable check. Left out of this PR because the release pipeline is load-bearing and the wiring is a separate decision.

## Verification

Not exercised against a real tag — it only runs on `v*` push. Workflow YAML parses and the step logic was read through; the first real tag is the test.