### PR TITLE
docs: re-argue the App Store ruling on the reasons that survive

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -161,35 +161,44 @@ never promise it again.
 It sits next to the SIP entry because a reader who accepts that
 one asks about the App Store next, and both are doors that stay
 shut. The shared root is only the private symbols, though — the
-second reason below is a sandbox constraint, unrelated to SIP.
+second reason below is economics, unrelated to SIP.
 
-Two independent reasons, either alone sufficient:
+Two reasons, of different kinds — one technical, one economic:
 
 - **Private API.** The SkyLight/CGS symbols the section above
-  discusses — dozens of them, and Desktop management does
-  not work without them — put this squarely against review
-  guideline 2.5.1, which permits public API only.
+  discusses put Desktop management squarely against review
+  guideline 2.5.1, which permits public API only — and no
+  public replacement exists: detecting *that* a Desktop
+  switch happened is public, knowing *which* Desktop is not.
   Resolving them through `dlsym` is a robustness measure
   (`AGENTS.md` §5: a vanished symbol must return nil, not
-  crash at launch), never a way around the guideline.
-- **The sandbox**, which every App Store app must adopt, and
-  which is the *harder* blocker because it survives removing
-  every private symbol. It forbids the `kiwidesk` CLI on
-  `PATH` (one binary serves both roles — `main.swift`), the
-  LaunchAgent `ServiceManager` writes, the subprocesses
-  `ExecLauncher` spawns, and reading a Lua config from a fixed
-  path.
+  crash at launch), never a way around the guideline — review
+  scans the binary's string table, so a compliant build has
+  to compile the resolver out, not disable it.
+- **The economics.** A store edition is buildable — the
+  2026-08-18 feasibility pass
+  ([#882](https://github.com/KiwiCanopy/KiwiDesk/issues/882),
+  the full inventory) found most of the app survives the
+  sandbox: KiwiDesk's own spaces and the default focus ring
+  are public-API already, crash-restart ports to
+  `SMAppService`, and Lua-as-local-config is permissible.
+  What it costs is a **permanent second product**: a split
+  build with its own entitlements, packaging and edition
+  guards, doubled CI, and App Review latency on every release
+  — paid forever, for reach the project does not need and
+  that store search does not deliver a niche utility against
+  Magnet-class incumbents with a decade of ratings. And the
+  losses that do remain (Desktop integration, `KiwiDesk.exec`,
+  the `kiwidesk` CLI on `PATH`) land exactly on the users the
+  product is built for.
 
 Note what is *not* the reason: driving other apps' windows
 through Accessibility is fine sandboxed — Magnet and Moom do
-exactly that on the App Store. Anyone re-opening this should
-argue about the sandbox, not about AX.
-
-A cut-down App Store build is conceivable and pointless: it
-would drop Desktop management, the CLI, Lua config and the
-service — nearly everything the README advertises. Every
-comparable tool (yabai, Amethyst, AeroSpace, Rectangle) is
-distributed directly for the same reasons.
+exactly that on the App Store. Anyone re-opening this argues
+the economics, priced with [#882](https://github.com/KiwiCanopy/KiwiDesk/issues/882)'s
+inventory; the trigger it names is 1.0 shipped *plus* a
+concrete demand signal. Every comparable tool (yabai,
+Amethyst, AeroSpace, Rectangle) is distributed directly.
 
 The practical consequence: **notarization is on the critical
 path, not a nicety.** A Homebrew user who meets Gatekeeper runs


### PR DESCRIPTION
## Description

Re-argues the design-decisions "Distribution: direct download,
not the Mac App Store" entry on the reasons that survive
re-litigation, and files the detailed feasibility inventory as
#882 so the entry stays lean.

The entry argued impossibility — "two independent reasons,
either alone sufficient" — but a 2026-08-18 feasibility pass
found half the sandbox leg stale: crash-restart supervision
ports to `SMAppService` (#342 already moved the login item
there), Lua-as-local-config is permissible under Guideline
2.5.2, and an app-group-container socket still serves an
outside, non-sandboxed CLI. The entry now rests on the two legs
that hold:

- **Private API** — Desktop management has no public
  replacement (knowing *which* Desktop is private-only), and a
  compliant build must compile the resolver out because review
  scans binary string tables.
- **Economics** — a store edition is buildable but is a
  permanent second product (split build, entitlements, edition
  guards, doubled CI, review latency), paid forever for reach
  the project does not need.

The verdict, the heading/anchor (README and site link to it),
and the never-promise-it instruction are unchanged. #882 holds
the full inventory and the revisit trigger (1.0 shipped plus a
concrete demand signal).

## Related Issue(s)

References #882 (stays open — it is the icebox inventory the
entry now points to). Does not close it.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [ ] New behavior is tested (pure logic / layout code
  required) — N/A: docs-only, no behavior change
- [x] User-facing changes are documented in `docs/` (the
  change *is* the doc)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes (3557 tests in 665 suites, lint OK)
- [ ] Release build green — N/A: docs-only, no concurrency
  or `Sendable` surface touched; CI's job reports as usual
- [x] PR is focused; refactors separated from features

## How I verified

Docs-only change, so "run it in the app" is anchor and parity
checking rather than app behavior:

- The section heading is unchanged, so the README's
  `#distribution-direct-download-not-the-mac-app-store` link
  and the site's template-comment references still resolve.
- Grepped README, `docs/`, `site/` and `Tests/` for other
  statements of the old reasons — the only other App Store
  claims are the README's verdict-plus-link (still true) and
  the accepted-limitations auto-start row (its sandbox
  sentence is accurate and untouched).
- `swift build && swift test` (3557/3557) and
  `./scripts/lint.sh` (exit 0) — `docs/**` is deliberately
  not in `.github/ci-ignore.txt` because tests read docs, so
  the suite is the gate for this change class.

## Notes for Reviewer

- The feasibility analysis itself lives in #882, not the doc —
  the entry keeps only what a re-litigator needs: the two
  load-bearing reasons and the pointer to the pricing sheet.
- The dated "2026-08-18 feasibility pass" phrasing is
  deliberate: a claim about the world outside the repo, scoped
  to when it was observed, per the rule-authoring ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
