### PR TITLE
perf(release): phase B skips a gate already paid for

### DIFF
--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -152,6 +152,23 @@ same failure from memory. A release procedure that is only
 correct when the operator remembers to deviate from it is the
 thing being fixed here.
 
+**Phase B skips its gate only on an exact tree match, and fails
+closed.** A release otherwise runs the gate five times — phase A
+locally, CI on the stamp PR, CI again on `main` post-merge, phase
+B locally, `release.yml` on the tag — and phase B's is the one
+that buys nothing, being the tree CI just verified. So phase A
+records `HEAD^{tree}` and phase B compares against it.
+
+Key the skip on the tree hash and nothing weaker. A version
+match, a timestamp, or "phase B trusts CI" would each skip on a
+tree nothing had verified; a squash merge of only the stamp
+reproduces phase A's tree exactly, and any other commit landing
+between changes the hash so the gate runs. Write no record on a
+`--skip-verify` run — it attests to nothing — and treat a
+missing, empty or unreadable record as "run the gate".
+`ReleaseGateSkipTests` holds that shape and states in its own doc
+comment what a text scan cannot see.
+
 **A version is three integers — no prerelease suffix.** `0.9.0-rc1`
 is valid SemVer and cannot be a `CFBundleVersion`, which takes 1-3
 dot-separated integers and nothing else. Both `bump-version.sh`

--- a/Tests/KiwiDeskCoreTests/ReleaseGateSkipTests.swift
+++ b/Tests/KiwiDeskCoreTests/ReleaseGateSkipTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+/// Phase B may skip its gate only on an exact tree match.
+///
+/// A release ran the gate five times: phase A locally, CI on the
+/// stamp PR, CI again on `main` post-merge, phase B locally, and
+/// `release.yml` on the tag. Phase B's bought nothing — the same
+/// tree CI had just verified — so it is skipped when phase A
+/// recorded a byte-identical tree hash.
+///
+/// The hash is the whole safety argument. A squash merge of
+/// nothing but the stamp reproduces phase A's tree exactly; any
+/// other commit landing in between changes it and the gate runs.
+/// Skipping on anything weaker — "phase B trusts CI", a version
+/// match, a timestamp — would skip on a tree nothing verified.
+///
+/// **What this suite cannot see.** It reads the script as text,
+/// so it holds the *shape* of the decision, not its runtime
+/// behaviour: it cannot prove the comparison is reached, and it
+/// would not notice the gate being deleted outright.
+/// `VerifyGateParityTests` owns what the gate must contain, and
+/// `release.yml` re-verifies every tag regardless — which is why
+/// a wrongly-skipped phase B costs a red CI run rather than an
+/// unverified artifact.
+@Suite("Release gate skip")
+struct ReleaseGateSkipTests {
+    private static func releaseScript() throws -> String {
+        try String(
+            contentsOf: scriptFixtureRepoRoot()
+                .appendingPathComponent("scripts/release.sh"),
+            encoding: .utf8
+        )
+    }
+
+    /// Non-vacuity: every assertion below is about *how* the skip
+    /// is spelled, so an absent skip must red rather than pass.
+    @Test("the skip mechanism is present")
+    func mechanismIsPresent() throws {
+        let script = try Self.releaseScript()
+        #expect(
+            script.contains("VERIFIED_RECORD"),
+            "no verified-tree record — the skip is gone"
+        )
+        #expect(
+            script.contains("GATE_ALREADY_PAID"),
+            "no skip flag"
+        )
+        #expect(
+            script.contains("HEAD^{tree}"),
+            "the skip is not keyed on a tree hash"
+        )
+    }
+
+    @Test("the skip requires a non-empty exact match")
+    func skipRequiresExactMatch() throws {
+        let script = try Self.releaseScript()
+        #expect(
+            script.contains("[ \"$recorded\" = \"$current\" ]"),
+            "the recorded and current trees are not compared"
+        )
+        #expect(
+            script.contains("[ -n \"$recorded\" ]"),
+            "an empty record would satisfy the comparison"
+        )
+    }
+
+    @Test("it fails closed when nothing was verified")
+    func failsClosed() throws {
+        let script = try Self.releaseScript()
+        #expect(
+            script.contains("GATE_ALREADY_PAID:-0"),
+            "the skip flag does not default to off"
+        )
+        // A --skip-verify run attests to nothing, so it must not
+        // write a record phase B would then honour.
+        #expect(
+            script.contains(
+                """
+                    if [ "$SKIP_VERIFY" -eq 0 ]; then
+                        git rev-parse "HEAD^{tree}" > "$VERIFIED_RECORD"
+                """
+            ),
+            "the record is written without checking the gate ran"
+        )
+    }
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -202,10 +202,59 @@ STAMPED=1
 "$ROOT/scripts/bump-version.sh" "$VERSION"
 
 # ---------------------------------------------------------------
+# 2b. Which phase, and whether phase B's gate is already paid for
+
+# The phase is answerable here, ahead of the gate, because it is
+# only a question about the stamp: bump-version.sh either changed
+# the version file or the tree already declared this version.
+# Asked of git rather than by re-reading the file, which keeps
+# bump-version.sh the one owner of its shape.
+PHASE="stamp"
+if git diff --quiet -- "$VERSION_FILE"; then
+    PHASE="tag"
+fi
+
+# A release used to run this gate FIVE times: phase A locally, CI
+# on the stamp PR, CI again on main after the merge, phase B
+# locally, and release.yml on the tag. Phase B's was the one that
+# bought nothing — same tree CI had just verified.
+#
+# So phase A records the tree it verified and phase B skips its
+# gate only when the tree it is about to tag hashes identically.
+# The tree hash is what makes that safe rather than optimistic: a
+# squash merge of nothing but the stamp reproduces phase A's tree
+# exactly, and ANY other commit landing in between changes the
+# hash, so the gate runs. This is deliberately not "phase B trusts
+# CI" — that would skip on a tree nothing had verified.
+#
+# Fails closed in every direction: no record, an empty or
+# unreadable one, a mismatch, or a git that cannot answer, all
+# leave the gate running. A stale record is harmless by
+# construction, since it can only ever match the one tree it
+# attests to.
+VERIFIED_RECORD="$(git rev-parse --git-dir)/kiwidesk-release-verified"
+
+if [ "$PHASE" = "tag" ] && [ "$SKIP_VERIFY" -eq 0 ]; then
+    if recorded="$(cat "$VERIFIED_RECORD" 2>/dev/null)" \
+        && current="$(git rev-parse "HEAD^{tree}" 2>/dev/null)" \
+        && [ -n "$recorded" ] \
+        && [ "$recorded" = "$current" ]; then
+        GATE_ALREADY_PAID=1
+        echo "==> gate already passed on this exact tree" \
+             "(${current:0:12}) — skipping it"
+        echo "    CI verified it on the merge and release.yml" \
+             "re-verifies the tag."
+    fi
+fi
+GATE_ALREADY_PAID="${GATE_ALREADY_PAID:-0}"
+
+# ---------------------------------------------------------------
 # 3. Verify
 
 if [ "$SKIP_VERIFY" -eq 1 ]; then
     echo "==> skipping the verification gate (--skip-verify)"
+elif [ "$GATE_ALREADY_PAID" -eq 1 ]; then
+    : # 2b explained it and said so on stdout
 else
     # AGENTS.md §3 / the verify-gate skill. The release build is
     # conditional there because CI runs it per PR; it is
@@ -269,6 +318,14 @@ if ! git diff --cached --quiet; then
     # The commit carries the stamp, so there is nothing to revert
     # and the handler must not run.
     STAMPED=0
+
+    # The tree the gate just passed on, for phase B to match
+    # against. Written only when the gate ACTUALLY ran: a
+    # --skip-verify run has no verification to attest to, and
+    # recording one would let phase B skip on its word.
+    if [ "$SKIP_VERIFY" -eq 0 ]; then
+        git rev-parse "HEAD^{tree}" > "$VERIFIED_RECORD"
+    fi
 
     if [ "$ASSUME_YES" -eq 0 ]; then
         echo


### PR DESCRIPTION
A release ran the verification gate five times: phase A locally, CI on the stamp PR, CI again on main post-merge, phase B locally, and release.yml on the tag. Phase B's bought nothing — the same tree CI had just verified.

Phase A now records `HEAD^{tree}` after its commit, and phase B skips its gate only when the tree it is about to tag hashes identically. The tree hash is the whole safety argument: a squash merge of nothing but the stamp reproduces phase A's tree exactly, and any other commit landing in between changes it, so the gate runs. Deliberately not "phase B trusts CI" — that would skip on a tree nothing verified.

Fails closed in every direction: no record, an empty or unreadable one, a mismatch, or a git that cannot answer all leave the gate running; the flag defaults off; and a `--skip-verify` run writes no record, having nothing to attest to.

ReleaseGateSkipTests holds the shape and states what a text scan cannot see. Both fail-closed properties were proven to red by mutation. release.yml still re-verifies every tag, so a wrongly skipped phase B costs a red CI run, never an unverified artifact.