### PR TITLE
docs: the Sparkle gate is two build properties, not a version number

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -265,6 +265,50 @@ it buys something back — Sparkle's update path is first
 exercised against a real previous release instead of being
 debugged on the release everyone downloads.
 
+**Corollary: the updater ships before the release that matters,
+and *ships* means published.** The trade-off above buys something
+only if a Sparkle-carrying release exists for the next one to
+update *from*. Merge the updater, go straight to the release
+people arrive at, and the first genuine update is that release to
+its own first patch — debugged on the largest cohort the project
+has had, which is the outcome a smaller first audience was being
+accepted to avoid. So the updater lands in an ordinary release of
+its own, and the release that opens the channel is one a person
+can arrive at by updating.
+
+A merged updater nobody has installed from a published release
+has exercised none of that. A test appcast rehearses the feed
+parse, the version compare and the install-on-quit; it cannot
+rehearse signed, notarized, stapled bytes fetched over the
+network from the production URL, or the cask and the in-app
+updater not fighting over one install. Which release this binds
+is whichever one opens the channel — 1.0 on the current plan
+([#874](https://github.com/KiwiCanopy/KiwiDesk/issues/874)) — and
+the obligation holds wherever that lands.
+
+**Corollary: the gate is Sparkle-in-the-build, never a version
+number.** The rule above says "until Sparkle lands" and names no
+version deliberately: what it asks is whether the build a person
+installs can update itself, and a version number answers that in
+neither direction. So the question is never "have we reached
+1.0". A release shipped without an updater keeps the channel shut
+however large its number, and a release carrying one satisfies
+**this** condition whatever number it lands at.
+
+It satisfies this one, not the gate. The gate is two conditions
+and both are properties of builds rather than of a version:
+Sparkle is in the build a person installs, **and** — by the
+corollary above — that build is one they can have arrived at by
+updating. The first Sparkle-carrying release meets the first and
+cannot meet the second, which is why a promoted download opens on
+the one after it and not on a number.
+
+A promoted `.dmg` then owes
+`.claude/rules/packaging-and-release.md` ▸ *Every distributable
+artifact needs its OWN ticket*. `scripts/build-app.sh` already
+implements it; the change that promotes one carries it into the
+release workflow, which asks for `--zip` alone.
+
 ### Linking the notes is not opening a channel
 
 **[Rationale]**


### PR DESCRIPTION
## Description

Folds two corollaries into `docs/design-decisions.md` ▸ *No
distribution channel without an update path*. Both were settled
while planning the distribution lane, and both lived only on #874
and in a gitignored plan file — so neither survived the machine.

**Ordering.** The trade-off that entry already accepts (a smaller
first audience, bought back by exercising the update path against
a real previous release) pays out only if such a release exists.
Merge the updater and go straight to the release people arrive
at, and the first genuine update is that release to its own first
patch — debugged on the largest cohort the project has had. So
the updater ships in an ordinary release of its own, **published
rather than merely merged**, and the release that opens the
channel is one a person can arrive at by updating.

**The predicate.** The entry says "until Sparkle lands" and names
no version, deliberately — what it asks is whether the build a
person installs can update itself, and a version number answers
that in neither direction.

Stated together, the gate is **two conditions, both properties of
builds rather than of a version**: Sparkle is in the build
installed, *and* that build is reachable by an update. The first
Sparkle-carrying release meets the first and cannot meet the
second, so a promoted download opens on the one after it — not on
1.0, and not on any number.

Folded into the existing entry rather than opened as a new one:
same argument, one step further on. No new `###` heading, so no
new kind tag — it takes the shape of the entry's existing
`**Homebrew is the deliberate exception**` sub-paragraph.

## Related Issue(s)

Refs #874, #873 (neither closed — this is the documentation half
the lane owes before it writes any code).

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended — n/a, prose only; the
  site build is the render check and is green
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested — n/a, no behavior
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
      (3588 tests / 678 suites)
- [ ] Release build green — skipped locally (prose only, no
      concurrency or `Sendable` surface). **Read CI's `Release
      Build` job before merging.**
- [x] PR is focused

## How I verified

Full gate rather than a docs shortcut, because `docs/**` is
deliberately not on `.github/ci-ignore.txt` and `RuleCitationTests`
reads that tree:

- `swift build` — pass
- `swift test` — 3588 tests in 678 suites, pass
- `./scripts/lint.sh` — exit 0
- `site/ npm run build` — pass (27 pages), run because the change
  touches `docs/`, which is symlinked into the site

Citation checked by hand: `.claude/rules/packaging-and-release.md`
▸ *Every distributable artifact needs its OWN ticket* exists with
that exact heading. `RuleCitationTests` scans `AGENTS.md`,
`.claude/rules/` and `.claude/agents/` — **not** `docs/` — so a
pointer written from this file is unguarded either way. Five such
pointers already exist in the file, so this follows precedent
rather than setting one.

## Notes for Reviewer

A `docs-steward` round on the first draft returned one blocker and
three majors; all four are addressed here rather than dismissed:

- **Blocker — the two corollaries contradicted each other.** The
  draft ruled that the channel opens on the release *after* the
  updater's, and also that a promoted `.dmg` becomes permissible
  *on* the first Sparkle build. A contributor got yes and no from
  one entry. Resolved by naming the gate as two conditions
  explicitly, which is the shape that makes both sentences true at
  once.
- **Major — it re-argued `packaging-and-release.md`.** The draft
  restated that rule file's own double-submit and
  quarantine-invisibility sentences. Now a pointer only.
- **Major — a false claim.** The draft said the `.dmg`
  notarization obligation is "not yet exercised". `build-app.sh`
  already implements it (`notarize_and_staple` runs for the app
  and again for the image). The real gap is `release.yml`, which
  passes `--zip` alone, and the entry now says that instead.
- **Major — a forecast.** "For KiwiDesk that binds 1.0" pinned a
  version nineteen lines above a corollary headlined "never a
  version number", and #895's own ruling in this file strikes
  forecasts. Now scoped to "whichever release opens the channel",
  with 1.0 named as the current plan on #874 rather than asserted.

**One finding deliberately not acted on.** Three shipped site
strings (`build_body`, `cta_body`, `guide_gs_install_later`) and
`README.md:45` say a direct download "follows once the app can
update itself". Under the two-condition gate that is imprecise by
exactly one release. Left alone: it is true in substance, the gap
is invisible to a visitor, and rewording it costs three keys
across three hand-maintained site catalogs for a nuance nobody is
tracking. Raising it here so the choice is visible rather than
missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)