### PR TITLE
docs(release): clarify blank line separation before What's Changed in notes skeleton

### DIFF
--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -350,13 +350,14 @@ owns the generated file and the rest of that contract.
 **Write the highlights for the installer, not for yourself.** A
 release body is two tiers: a curated highlights block on top, and
 beneath it the `--generate-notes` list the workflow already
-creates, unedited. The highlights name symptoms a reader would
-recognise rather than the mechanism that produced them, carry no
-issue numbers (the generated list below is the linked record),
-and stop at the few that are genuinely news. The argument, the
-test to apply, and the worked before/after that produced the rule
-are `docs/design-decisions.md` ▸ *Release notes are written for
-the person installing* — which also records why this one has no
+creates, unedited, separated by an empty line. The highlights
+name symptoms a reader would recognise rather than the mechanism
+that produced them, carry no issue numbers (the generated list
+below is the linked record), and stop at the few that are
+genuinely news. The argument, the test to apply, and the worked
+before/after that produced the rule are
+`docs/design-decisions.md` ▸ *Release notes are written for the
+person installing* — which also records why this one has no
 guard.
 
 **Publishing is not this file's call.** The workflow drafts the

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -460,7 +460,7 @@ cat <<SKELETON
 
 --------------------------------------------------------------
 Curate the draft, THEN publish. Paste above the generated
-"What's Changed" list and fill it in:
+"What's Changed" list, leaving a blank line between the two:
 
 ## Highlights
 
@@ -473,6 +473,7 @@ One or two sentences: what this release is about, plainly.
 ### <Another one>
 
 - ...
+
 
 --------------------------------------------------------------
 The rules, in four lines:


### PR DESCRIPTION
## Description

Explicitly require and prompt for a blank line between the curated `## Highlights` block and GitHub's generated `## What's Changed` list in:
- `scripts/release.sh` (the skeleton printed during Phase B)
- `.claude/rules/packaging-and-release.md`

## Checklist

- [x] Commits follow Conventional Commits format (see AGENTS.md §3)
- [x] User-facing changes are documented in `docs/`
- [x] `swift build && swift test && ./scripts/lint.sh` passes
- [x] PR is focused; refactors separated from features