### PR TITLE
fix(bar): bound title refresh debounce with a max wait ceiling (#900)

### DIFF
--- a/Sources/KiwiDeskCore/App/DeferredTasks.swift
+++ b/Sources/KiwiDeskCore/App/DeferredTasks.swift
@@ -77,6 +77,7 @@ final class DeferredTasks {
     }
 
     private var tasks: [Key: Task<Void, Never>] = [:]
+    private var burstStarts: [Key: ContinuousClock.Instant] = [:]
 
     /// Runs `body` after `delay` unless the key is rescheduled
     /// or cancelled first. Cancellation is checked once, after
@@ -85,15 +86,33 @@ final class DeferredTasks {
     /// `body` is retained until it fires or is cancelled, so
     /// capture the core weakly (see the type doc) — a strong
     /// capture would pin it for the pending delay.
+    ///
+    /// When `maxWait` is provided, continuous reschedules within
+    /// a burst will not delay execution past `maxWait` from the
+    /// burst's initial schedule (#900).
     func schedule(
         _ key: Key,
         after delay: Duration,
+        maxWait: Duration? = nil,
         _ body: @escaping @MainActor () -> Void
     ) {
         tasks[key]?.cancel()
+        let start = burstStarts[key] ?? ContinuousClock.now
+        burstStarts[key] = start
+
+        let sleepDuration: Duration
+        if let maxWait {
+            let elapsed = ContinuousClock.now - start
+            let remaining = maxWait - elapsed
+            sleepDuration = min(delay, max(.zero, remaining))
+        } else {
+            sleepDuration = delay
+        }
+
         tasks[key] = Task { @MainActor in
-            try? await Task.sleep(for: delay)
+            try? await Task.sleep(for: sleepDuration)
             guard !Task.isCancelled else { return }
+            burstStarts[key] = nil
             body()
         }
     }
@@ -101,6 +120,7 @@ final class DeferredTasks {
     func cancel(_ key: Key) {
         tasks[key]?.cancel()
         tasks[key] = nil
+        burstStarts[key] = nil
     }
 
     /// The task currently stored for a key — lets tests pin the
@@ -118,5 +138,6 @@ final class DeferredTasks {
     func cancelAll() {
         for task in tasks.values { task.cancel() }
         tasks.removeAll()
+        burstStarts.removeAll()
     }
 }

--- a/Sources/KiwiDeskCore/App/KiwiCore+BarTitles.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+BarTitles.swift
@@ -42,6 +42,10 @@ extension KiwiCore {
     /// change, never a wrong window position.
     static let barTitleRefreshDelay = Duration.milliseconds(200)
 
+    /// Maximum time a continuous burst of title changes may delay
+    /// the bar refresh before one is forced (#900).
+    static let barTitleRefreshMaxWait = Duration.seconds(1)
+
     /// Folds a `.windowTitleChanged` into the bars, or drops it.
     ///
     /// Dropping is the common case and has to stay cheap: most
@@ -52,7 +56,8 @@ extension KiwiCore {
         guard barsShowTitle(of: id) else { return }
         deferred.schedule(
             .barTitleRefresh,
-            after: Self.barTitleRefreshDelay
+            after: Self.barTitleRefreshDelay,
+            maxWait: Self.barTitleRefreshMaxWait
         ) { [weak self] in
             self?.runBarTitleRefresh()
         }

--- a/Tests/KiwiDeskCoreTests/BarTitleRefreshTests.swift
+++ b/Tests/KiwiDeskCoreTests/BarTitleRefreshTests.swift
@@ -179,6 +179,13 @@ struct BarTitleRefreshTests {
         #expect(!second.isCancelled)
     }
 
+    /// Continuous title updates cannot starve the debounce
+    /// indefinitely (#900).
+    @Test("Refresh debounce has a max wait ceiling (#900)")
+    func maxWaitConstant() {
+        #expect(KiwiCore.barTitleRefreshMaxWait == .seconds(1))
+    }
+
     /// Teardown reaches it, because it is a `DeferredTasks` slot
     /// rather than a bespoke dispatch hop — the #48 argument.
     @Test("Teardown cancels a pending refresh")

--- a/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
+++ b/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
@@ -130,4 +130,54 @@ struct DeferredTasksTests {
         #expect(settle?.isCancelled == true)
         #expect(core.deferred.task(for: .spaceSettle) == nil)
     }
+
+    @Test("maxWait forces execution during a continuous burst")
+    func maxWaitForcesExecution() async {
+        let owner = DeferredTasks()
+        var fireCount = 0
+        let body: @MainActor () -> Void = {
+            fireCount += 1
+        }
+        owner.schedule(
+            .barTitleRefresh,
+            after: .milliseconds(50),
+            maxWait: .milliseconds(80),
+            body
+        )
+        for _ in 1...6 {
+            try? await Task.sleep(for: .milliseconds(20))
+            owner.schedule(
+                .barTitleRefresh,
+                after: .milliseconds(50),
+                maxWait: .milliseconds(80),
+                body
+            )
+        }
+        await owner.task(for: .barTitleRefresh)?.value
+        #expect(fireCount >= 1)
+    }
+
+    @Test("cancel() clears the maxWait burst tracking")
+    func cancelClearsBurstTracking() async {
+        let owner = DeferredTasks()
+        var fired = false
+        owner.schedule(
+            .barTitleRefresh,
+            after: .milliseconds(50),
+            maxWait: .milliseconds(80)
+        ) {
+            fired = true
+        }
+        owner.cancel(.barTitleRefresh)
+        #expect(!fired)
+        owner.schedule(
+            .barTitleRefresh,
+            after: .milliseconds(5),
+            maxWait: .milliseconds(80)
+        ) {
+            fired = true
+        }
+        await owner.task(for: .barTitleRefresh)?.value
+        #expect(fired)
+    }
 }

--- a/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
+++ b/Tests/KiwiDeskCoreTests/DeferredTasksTests.swift
@@ -144,6 +144,9 @@ struct DeferredTasksTests {
             maxWait: .milliseconds(80),
             body
         )
+        // 6 iterations spaced 20 ms apart = 120 ms stream.
+        // maxWait (80 ms) forces at least one execution mid-stream,
+        // and the trailing reschedule produces a second execution.
         for _ in 1...6 {
             try? await Task.sleep(for: .milliseconds(20))
             owner.schedule(
@@ -153,8 +156,9 @@ struct DeferredTasksTests {
                 body
             )
         }
+        // An inert maxWait would produce 0 mid-stream and only 1 total.
         await owner.task(for: .barTitleRefresh)?.value
-        #expect(fireCount >= 1)
+        #expect(fireCount >= 2)
     }
 
     @Test("cancel() clears the maxWait burst tracking")
@@ -164,19 +168,27 @@ struct DeferredTasksTests {
         owner.schedule(
             .barTitleRefresh,
             after: .milliseconds(50),
-            maxWait: .milliseconds(80)
+            maxWait: .milliseconds(60)
         ) {
             fired = true
         }
+        // Advance 40 ms into the 60 ms maxWait window, then cancel.
+        try? await Task.sleep(for: .milliseconds(40))
         owner.cancel(.barTitleRefresh)
         #expect(!fired)
+
+        // Reschedule with 50 ms delay and 60 ms maxWait. If cancel()
+        // did not clear the start timestamp, remaining maxWait would
+        // be 20 ms (60 - 40) and it would fire after 20 ms.
         owner.schedule(
             .barTitleRefresh,
-            after: .milliseconds(5),
-            maxWait: .milliseconds(80)
+            after: .milliseconds(50),
+            maxWait: .milliseconds(60)
         ) {
             fired = true
         }
+        try? await Task.sleep(for: .milliseconds(25))
+        #expect(!fired, "must not inherit pre-cancel burst time")
         await owner.task(for: .barTitleRefresh)?.value
         #expect(fired)
     }


### PR DESCRIPTION
## Description

Adds a max wait ceiling (`barTitleRefreshMaxWait = .seconds(1)`) to the window title refresh debouncer:
- Extends `DeferredTasks.schedule(_:after:maxWait:_:)` to track burst start timestamps (`burstStarts`) and cap effective sleep delay at `maxWait` from the burst's initial schedule.
- In `KiwiCore+BarTitles.swift`, passes `maxWait: Self.barTitleRefreshMaxWait` so apps with live progress in their titles (e.g. "45% — Downloading") cannot starve the 200 ms debounce indefinitely.
- Cleans up `burstStarts` upon task firing, cancellation, and `cancelAll()`.
- Adds tests in `DeferredTasksTests.swift` and `BarTitleRefreshTests.swift`.

## Related Issue(s)

Fixes #900

## Checklist

- [x] I understand what this change does and have run it in the app to confirm it works as intended
- [x] Commits follow Conventional Commits format (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
- [x] Release build green — CI's `Release Build` job (read it before merging; it reports, it does not block), or locally for concurrency / `@Sendable` changes
- [x] PR is focused; refactors separated from features

## How I verified

- Ran `swift test --filter DeferredTasksTests` and `swift test --filter BarTitleRefreshTests`.
- Ran full `swift test` (3,712 tests in 696 suites passing).
- Ran `./scripts/lint.sh` (0 errors).