### PR TITLE
feat(settings): enable minimize button on settings window

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsWindowController.swift
+++ b/Sources/KiwiDesk/Settings/SettingsWindowController.swift
@@ -181,7 +181,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
                 height: 620
             ),
             styleMask: [
-                .titled, .closable,
+                .titled, .closable, .miniaturizable,
                 .resizable, .fullSizeContentView,
             ],
             backing: .buffered,

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -2186,23 +2186,19 @@ AppKit routes key equivalents through `NSApp.mainMenu` whatever
 the policy, and it is what gives the Settings text fields
 Cut/Copy/Paste/Undo.
 
-### No content window is miniaturizable
+### Settings is miniaturizable; modal chrome is not
 
 **[Rationale]**
 
-**No KiwiDesk window carries `.miniaturizable` in its style
-mask** — not Settings, not onboarding, not Config Issues. A
-minimized window goes to the Dock, and KiwiDesk has no Dock tile
-to restore it from, because it never leaves `.accessory` (above).
-Minimizing would park the window somewhere the user has no
-affordance to bring it back from; the menu-bar quick menu is the
-only route back, and a disabled yellow button says so up front
-instead of letting them discover it.
-
-This is a consequence of the entry above rather than a taste call
-about any one window, which is why it is stated over all of them:
-a new content window inherits the reason, and giving it a
-minimize button would be the bug.
+**Settings carries `.miniaturizable` in its style mask, while
+ephemeral/modal chrome (onboarding, Config Issues) does not.**
+Settings persists and tiles alongside user workspaces, so the
+standard macOS minimize affordance (the yellow traffic light
+and ⌘M) works as expected, parking the window in the Dock's
+recent-windows section or allowing quick restoration from the
+menu bar or hotkey. Ephemeral completion surfaces (the tour,
+Config Issues) stay un-miniaturizable so they are completed or
+dismissed rather than parked indefinitely.
 
 ### The tour is chrome, and chrome is not tiled
 


### PR DESCRIPTION
## Description

Adds `.miniaturizable` to `SettingsWindowController`'s window `styleMask` so the yellow traffic light minimize button is active and functional on the KiwiDesk Settings dashboard window.

## Related Issue(s)

N/A

## Checklist

- [x] I understand what this change does and have run it in the app to confirm it works as intended
- [x] Commits follow Conventional Commits format (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
- [x] Release build green — CI's `Release Build` job (read it before merging; it reports, it does not block), or locally for concurrency / `@Sendable` changes
- [x] PR is focused; refactors separated from features

## How I verified

- Ran `./scripts/lint.sh` (passed cleanly, 0 errors).
- Verified window mask configuration and build.