### PR TITLE
feat(site): move header changelog link to nerd mode and trim uncurated release stubs

### DIFF
--- a/scripts/changelog-sync
+++ b/scripts/changelog-sync
@@ -605,7 +605,8 @@ def run_all(check: bool) -> int:
             entry, warning = build_entry(release, strict=False)
         except NotesError as error:
             return _report(error)
-        entries.append(entry)
+        if entry.get("summary") or entry.get("sections"):
+            entries.append(entry)
         if warning:
             warnings.append(f"{entry['tag']}: {warning}")
     for warning in warnings:
@@ -614,10 +615,8 @@ def run_all(check: bool) -> int:
         )
     if warnings:
         print(
-            f"changelog-sync: {len(warnings)} release(s) kept "
-            "without a curated block. Expected for releases "
-            "predating the convention; a release that SHOULD "
-            "carry one is caught by `--release` on publish.",
+            f"changelog-sync: {len(warnings)} historical release(s) "
+            "skipped (no curated block).",
             file=sys.stderr,
         )
     if check:

--- a/site/src/components/Changelog.astro
+++ b/site/src/components/Changelog.astro
@@ -72,7 +72,10 @@ interface Release {
   sections?: Section[];
 }
 
-const releases = changelog.releases as Release[];
+const releases = (changelog.releases as Release[]).filter(
+  (release) =>
+    Boolean(release.summary) || Boolean(release.sections?.length),
+);
 
 // Items carry inline markdown (`**bold**`, `code`) because a
 // release body is markdown. `parseInline` renders exactly that
@@ -177,6 +180,17 @@ const ogImage = new URL(ogBanner.src, Astro.site).href;
       </section>
     ))
   }
+
+  <div class="clog__older">
+    <p>
+      {t("changelog_older_label")}{" "}
+      <a class="rel__out"
+        href="https://github.com/KiwiCanopy/KiwiDesk/releases"
+        target="_blank" rel="noopener">
+        {t("changelog_older_link")} ↗
+      </a>
+    </p>
+  </div>
 </PageShell>
 
 <style>
@@ -319,5 +333,16 @@ const ogImage = new URL(ogBanner.src, Astro.site).href;
   }
   .rel__out:hover {
     color: var(--text);
+  }
+
+  .clog__older {
+    padding-top: 2.2rem;
+    border-top: 1px solid var(--border);
+    margin-top: 1rem;
+    color: var(--text-dim);
+    font-size: 0.95rem;
+  }
+  .clog__older p {
+    margin: 0;
   }
 </style>

--- a/site/src/components/Landing.astro
+++ b/site/src/components/Landing.astro
@@ -308,10 +308,9 @@ const jsonLd = [
                it's useful in Nerd mode too. */}
           <a class="nav__link nav__link--guide" href="/guide/"
             >{t.nav_guide}</a>
-          {/* Release Notes: shown in BOTH modes too. "What changed"
-               is not a nerd question, and the page carries one
-               register for everyone (#873). */}
-          <a class="nav__link nav__link--changelog"
+          {/* Release Notes: shown in Nerd mode (dev-only). "What changed"
+               is accessible to everyone via the footer and About window. */}
+          <a class="nav__link nav__link--changelog dev-only"
             href={`${homeHref}changelog/`}>{t.nav_changelog}</a>
           {/* Docs + GitHub live in the DOM always but are hidden in
                Simple mode (dev-only, via .dev-only). */}

--- a/site/src/data/changelog.json
+++ b/site/src/data/changelog.json
@@ -80,55 +80,6 @@
           ]
         }
       ]
-    },
-    {
-      "version": "0.9.6",
-      "tag": "v0.9.6",
-      "date": "2026-08-12",
-      "prerelease": true,
-      "url": "https://github.com/KiwiCanopy/KiwiDesk/releases/tag/v0.9.6"
-    },
-    {
-      "version": "0.9.5",
-      "tag": "v0.9.5",
-      "date": "2026-08-04",
-      "prerelease": true,
-      "url": "https://github.com/KiwiCanopy/KiwiDesk/releases/tag/v0.9.5"
-    },
-    {
-      "version": "0.9.4",
-      "tag": "v0.9.4",
-      "date": "2026-07-31",
-      "prerelease": true,
-      "url": "https://github.com/KiwiCanopy/KiwiDesk/releases/tag/v0.9.4"
-    },
-    {
-      "version": "0.9.3",
-      "tag": "v0.9.3",
-      "date": "2026-07-30",
-      "prerelease": true,
-      "url": "https://github.com/KiwiCanopy/KiwiDesk/releases/tag/v0.9.3"
-    },
-    {
-      "version": "0.9.2",
-      "tag": "v0.9.2",
-      "date": "2026-07-30",
-      "prerelease": true,
-      "url": "https://github.com/KiwiCanopy/KiwiDesk/releases/tag/v0.9.2"
-    },
-    {
-      "version": "0.9.1",
-      "tag": "v0.9.1",
-      "date": "2026-07-30",
-      "prerelease": true,
-      "url": "https://github.com/KiwiCanopy/KiwiDesk/releases/tag/v0.9.1"
-    },
-    {
-      "version": "0.9.0",
-      "tag": "v0.9.0",
-      "date": "2026-07-30",
-      "prerelease": true,
-      "url": "https://github.com/KiwiCanopy/KiwiDesk/releases/tag/v0.9.0"
     }
   ]
 }

--- a/site/src/i18n/de.json
+++ b/site/src/i18n/de.json
@@ -30,6 +30,8 @@
   "changelog_meta_desc": "Was sich in jeder KiwiDesk-Version geändert hat, neueste zuerst — neue Funktionen, Verbesserungen und Fehlerbehebungen, verständlich erklärt.",
   "changelog_meta_title": "KiwiDesk Release-Notes — was sich geändert hat, Version für Version",
   "changelog_no_notes": "Erschienen, bevor es diese Notes gab — die vollständige Liste steht auf GitHub.",
+  "changelog_older_label": "Ältere Versionen gesucht?",
+  "changelog_older_link": "Alle bisherigen Releases auf GitHub ansehen",
   "changelog_title": "Release-Notes",
   "cli_body": "Jede Aktion ist ein Befehl. Binde sie an Tasten, skripte sie oder streame Live-Events über einen Unix-Socket in SketchyBar, JankyBorders oder deine eigenen Tools.",
   "cli_cmt": "# Live-Events streamen (für SketchyBar, eigene Tools…)",

--- a/site/src/i18n/en.json
+++ b/site/src/i18n/en.json
@@ -30,6 +30,8 @@
   "changelog_meta_desc": "What changed in each KiwiDesk release, newest first — new features, improvements and fixes for every version, in plain language.",
   "changelog_meta_title": "KiwiDesk Release Notes — what changed, version by version",
   "changelog_no_notes": "Released before these notes existed — the full list is on GitHub.",
+  "changelog_older_label": "Looking for older releases?",
+  "changelog_older_link": "View all releases on GitHub",
   "changelog_title": "Release Notes",
   "cli_body": "Every action is a command. Bind them to keys, script them, or stream live events over a Unix socket into SketchyBar, JankyBorders, or your own tools.",
   "cli_cmt": "# stream live events (feed SketchyBar, your own tools…)",

--- a/site/src/i18n/ja.json
+++ b/site/src/i18n/ja.json
@@ -30,6 +30,8 @@
   "changelog_meta_desc": "KiwiDesk の各バージョンの変更点を新しい順に。新機能・改善・修正を、わかりやすい言葉でまとめています。",
   "changelog_meta_title": "KiwiDesk リリースノート — バージョンごとの変更点",
   "changelog_no_notes": "このリリースノートができる前のバージョンです。全リストは GitHub にあります。",
+  "changelog_older_label": "以前のバージョンをお探しですか？",
+  "changelog_older_link": "GitHub で過去の全リリースを見る",
   "changelog_title": "リリースノート",
   "cli_body": "すべての操作がコマンドです。キーに割り当てても、スクリプトから呼び出しても、Unix ソケット経由でイベントを SketchyBar や JankyBorders、自作のツールへ流し込んでも構いません。",
   "cli_cmt": "# ライブイベントを配信（SketchyBar や自作ツールへ）",


### PR DESCRIPTION
## Description

1. **Header navigation**:
   - Added `dev-only` to the Release Notes navbar link in `Landing.astro`, keeping Simple mode clean and Apple-native while surfacing it in Nerd mode.
   - Release Notes remains accessible to all visitors via the footer and the app's About window.
2. **Changelog page cutoff & cleanup**:
   - Filtered uncurated historical releases (< 0.9.7) from `Changelog.astro` and `changelog-sync --all`, removing 7 empty placeholder boxes.
   - Added a clean bottom archive callout on `/changelog/` linking to the full GitHub releases history for older versions.
   - Added localized `changelog_older_label` and `changelog_older_link` keys across `en.json`, `de.json`, and `ja.json`.

## Checklist

- [x] Commits follow Conventional Commits format
- [x] Site builds cleanly (`npm run build`)
- [x] Site localization catalogs pass parity check (`./scripts/extract-keys --site --check`)
- [x] All changelog & appcast tests pass (`ChangelogParserTests`, `Appcast*`)
- [x] `./scripts/lint.sh` passes

## How I verified

- Ran `npm --prefix site run build`: 30 pages built cleanly with zero errors.
- Ran `./scripts/extract-keys --site --check`: 274 keys synced.
- Ran `swift test --filter Changelog && swift test --filter Appcast`: 100% passed.
- Ran `./scripts/lint.sh`: `Lint OK`.
