### PR TITLE
chore(release): stamp version 0.9.9

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
+++ b/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
@@ -25,7 +25,7 @@
 /// guard against the real file.
 public enum KiwiDeskVersion {
     /// Semantic version, bumped per release.
-    public static let semantic = "0.9.8"
+    public static let semantic = "0.9.9"
 
     /// Short commit SHA of the build, stamped by the release
     /// workflow; `"unknown"` in every other build.


### PR DESCRIPTION
Version stamp for 0.9.9, produced by
scripts/release.sh.

main is protected (#487), so the stamp reaches it through this
PR. The v0.9.9 tag is pushed by re-running the script once this
has merged, which takes its tag phase and creates no second
commit.