### PR TITLE
fix(borders): pill both resize ends, trigger ring stand-down on own key changes

### DIFF
--- a/.claude/rules/state-and-layout.md
+++ b/.claude/rules/state-and-layout.md
@@ -222,8 +222,9 @@ editing here:
   `.scrollWidth` drag crossed the floor the keyboard path
   refused. The writers clamp each side at its members'
   effective minimums (`min_window_size`, raised by a #677
-  learned bound) and cue a truncated attempt — the pill on the
-  window that cannot shrink, the bounce on the trier
+  learned bound) and cue a truncated attempt — a pill on each end
+  (the trier names the reason, the blocker marks itself), the
+  bounce on the trier
   (`ResizeSizeLimitFeedbackTests`,
   `ResizeNeighborLimitTests`). And a weight clamp divides the
   span the LAYOUT divides — the one

--- a/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
@@ -45,6 +45,7 @@ extension KiwiCore {
         // pins the ring and mark to the AX-fallback path.
         borders.configureFromEnvironment()
         wireDrag()
+        wireOwnKeyWindowRefresh()
         appBars.onSelect = { [weak self] id in
             self?.focusWindow(id, warp: true)
         }

--- a/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Borders.swift
@@ -1,4 +1,6 @@
+import AppKit
 import CoreGraphics
+import Foundation
 
 /// Drives the focus-border overlays (#278). `updateBorders()`
 /// snapshots the active space and hands the manager the desired
@@ -19,6 +21,45 @@ extension KiwiCore {
         // enabled guard so a re-enable rebuilds on the right backend.
         borders.setDrawOrder(tiler.settings.borderStyle.drawOrder)
         borders.sync(desiredBorderSpecs())
+    }
+
+    /// Re-evaluates the ring set when one of OUR OWN windows
+    /// gains or resigns key (#933 follow-up). The stand-down
+    /// predicate in `desiredBorderSpecs` is only as live as its
+    /// triggers: Sparkle's update alert can take key without
+    /// producing a single `KiwiEvent` (nothing tracked
+    /// changes), so no retile re-ran the specs and the stale
+    /// focused ring stayed drawn behind the alert — the
+    /// predicate was right and simply never re-asked (device
+    /// QA, 2026-08-22). Both directions, so the ring also
+    /// returns on dismiss without an app switch.
+    /// `NotificationCenter.default` carries only this
+    /// process's window notifications, so no sender filter is
+    /// needed. Tokens live on `BorderManager`
+    /// (`ownKeyWindowObservers`); the handler body is named so
+    /// a test can drive the refresh without a real `NSWindow`.
+    func wireOwnKeyWindowRefresh() {
+        let names = [
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didResignKeyNotification,
+        ]
+        for name in names {
+            let token = NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.ownKeyWindowDidChange()
+                }
+            }
+            borders.ownKeyWindowObservers.append(token)
+        }
+    }
+
+    /// The observer body: one cheap, idempotent spec rebuild.
+    func ownKeyWindowDidChange() {
+        updateBorders()
     }
 
     /// The rings the active space should show right now — the pure

--- a/Sources/KiwiDeskCore/App/KiwiCore+SizeLimitPill.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+SizeLimitPill.swift
@@ -37,11 +37,18 @@ extension KiwiCore {
         )
     }
 
-    /// Cues a grow refused because a NEIGHBOR sits at its own
+    /// Cues a resize refused because a NEIGHBOR sits at its own
     /// effective minimum (#933): the bump stays on the resized
-    /// window (the gesture hit a wall), while the pill goes on
-    /// `anchor` — the window that cannot shrink, not the trier,
-    /// the #435 sticky-swap rule.
+    /// window (the gesture hit a wall), and BOTH ends pill with
+    /// the text that fits its anchor — the resized window
+    /// explains why nothing moved ("Neighboring window at its
+    /// minimum size"), the blocking window marks itself
+    /// ("Minimum window size reached"). One pill on the blocker
+    /// alone read absurd there — from its own perspective IT
+    /// reached the minimum, not a neighbor — and one on the
+    /// trier alone leaves which window blocks unnamed (owner
+    /// ruling, 2026-08-22; the #435 anchor rule still holds:
+    /// the window that cannot move is marked).
     func refuseGrowAtNeighborMinimum(
         _ focused: WindowID,
         anchor: WindowID,
@@ -53,10 +60,17 @@ extension KiwiCore {
         let direction: Direction = axis == "y" ? .down : .right
         flashDeadEnd(focused, direction: direction)
         flashSizeLimitPill(
-            anchor,
+            focused,
             text: L(
                 "resize.neighbor_min_size",
                 "Neighboring window at its minimum size"
+            )
+        )
+        flashSizeLimitPill(
+            anchor,
+            text: L(
+                "resize.min_size_reached",
+                "Minimum window size reached"
             )
         )
     }

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -144,6 +144,12 @@ public final class BorderManager {
     /// observe refusals here. Production leaves the no-op.
     var onResizeRefusal: (ResizeRefusal) -> Void = { _ in }
 
+    /// Tokens for the own-key-window notifications that
+    /// re-evaluate the ring set (#933 follow-up) — stored here
+    /// because `KiwiCore` sits at the file-size ceiling; wired
+    /// by `KiwiCore.wireOwnKeyWindowRefresh`.
+    var ownKeyWindowObservers: [NSObjectProtocol] = []
+
     public init() {}
 
     /// Enables the private WindowServer fast path once KiwiDesk's

--- a/Sources/KiwiDeskCore/Borders/SizeLimitOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/SizeLimitOverlay.swift
@@ -3,14 +3,22 @@ import CoreGraphics
 
 /// Visual plate and panel for the minimum-size refusal pill (#933).
 ///
-/// Flashed at the top-center of a window when a keyboard resize
-/// attempts to shrink past the window's effective minimum size
-/// (`min_window_size` or app-enforced `EffectiveSizeBound`).
+/// Flashed at the top-center of a window when a resize attempt
+/// runs into an effective minimum size (`min_window_size` or an
+/// app-enforced `EffectiveSizeBound`). Holds one panel PER
+/// window: a blocked grow pills BOTH ends — the resized window
+/// explains why nothing moved, the blocking window marks itself
+/// at its minimum — so two pills must be able to stand at once
+/// (owner ruling, 2026-08-22).
 @MainActor
 final class SizeLimitOverlay {
-    private var panel: NSPanel?
-    private let plate = SizeLimitPillPlate()
-    private var hideWork: DispatchWorkItem?
+    private struct Pill {
+        let panel: NSPanel
+        let plate: SizeLimitPillPlate
+        var hideWork: DispatchWorkItem?
+    }
+
+    private var pills: [CGWindowID: Pill] = [:]
 
     private static let holdDuration: TimeInterval = 1.4
     private static let fadeDuration: TimeInterval = 0.2
@@ -25,23 +33,22 @@ final class SizeLimitOverlay {
         frame: CGRect,
         text: String
     ) {
-        let panel = self.panel ?? makePanel()
-        self.panel = panel
+        var pill = pills[window] ?? makePill()
+        pill.hideWork?.cancel()
+        pill.hideWork = nil
 
-        hideWork?.cancel()
-        hideWork = nil
-
-        plate.setText(text)
-        let textSize = plate.fittingSize
+        pill.plate.setText(text)
+        let textSize = pill.plate.fittingSize
         let pillWidth = min(
             frame.width - 24,
             max(textSize.width + Self.pillPadding, 120)
         )
-        // `hideWork` was already cancelled above, so a bare
-        // return here would strand a previous pill at alpha 1
+        // The hide timer was already cancelled above, so a bare
+        // return here would strand a showing pill at alpha 1
         // forever — fade it out instead of leaving it.
         guard pillWidth > 40 else {
-            fadeOut()
+            pills[window] = pill
+            fadeOut(window)
             return
         }
 
@@ -56,44 +63,69 @@ final class SizeLimitOverlay {
             primaryHeight: GeometryUtils.primaryHeight
         )
 
-        panel.setFrame(screenRect, display: true)
-        panel.order(.above, relativeTo: Int(window))
-        panel.alphaValue = 1
+        pill.panel.setFrame(screenRect, display: true)
+        pill.panel.order(.above, relativeTo: Int(window))
+        pill.panel.alphaValue = 1
 
         if !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
-            popEntrance()
+            popEntrance(pill.plate)
         }
 
         let work = DispatchWorkItem { [weak self] in
-            self?.fadeOut()
+            self?.fadeOut(window)
         }
-        hideWork = work
+        pill.hideWork = work
+        pills[window] = pill
         DispatchQueue.main.asyncAfter(
             deadline: .now() + Self.holdDuration,
             execute: work
         )
     }
 
-    private func fadeOut() {
-        guard let panel, panel.isVisible else { return }
+    private func fadeOut(_ window: CGWindowID) {
+        guard let pill = pills[window], pill.panel.isVisible
+        else {
+            retire(window)
+            return
+        }
         if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
-            panel.orderOut(nil)
+            pill.panel.orderOut(nil)
+            retire(window)
             return
         }
         NSAnimationContext.runAnimationGroup { context in
             context.duration = Self.fadeDuration
-            panel.animator().alphaValue = 0
+            pill.panel.animator().alphaValue = 0
         } completionHandler: { [weak self] in
             // AppKit calls the completion on the main thread;
             // the closure is typed `@Sendable`, so hop back
             // into the actor explicitly.
             MainActor.assumeIsolated {
-                self?.panel?.orderOut(nil)
+                guard let self else { return }
+                // A re-flash between fade start and completion
+                // re-armed the timer; only a pill still fading
+                // retires (ids churn, the map must not grow for
+                // the session).
+                if let pill = self.pills[window],
+                    pill.panel.alphaValue == 0
+                {
+                    pill.panel.orderOut(nil)
+                    self.retire(window)
+                }
             }
         }
     }
 
-    private func popEntrance() {
+    /// Closes and forgets a window's pill; ids are reused, so
+    /// the map holds only pills currently showing or fading.
+    private func retire(_ window: CGWindowID) {
+        guard let pill = pills.removeValue(forKey: window)
+        else { return }
+        pill.hideWork?.cancel()
+        pill.panel.close()
+    }
+
+    private func popEntrance(_ plate: SizeLimitPillPlate) {
         guard let layer = plate.layer else { return }
         let pop = CAKeyframeAnimation(keyPath: "transform.scale")
         pop.values = [0.95, 1.03, 1.0]
@@ -106,7 +138,18 @@ final class SizeLimitOverlay {
         layer.add(pop, forKey: "entrancePop")
     }
 
-    private func makePanel() -> NSPanel {
+    private func makePill() -> Pill {
+        let plate = SizeLimitPillPlate()
+        return Pill(
+            panel: makePanel(plate),
+            plate: plate,
+            hideWork: nil
+        )
+    }
+
+    private func makePanel(
+        _ plate: SizeLimitPillPlate
+    ) -> NSPanel {
         let panel = NSPanel(
             contentRect: .zero,
             styleMask: [.borderless, .nonactivatingPanel],

--- a/Tests/KiwiDeskCoreTests/OwnKeyWindowRefreshTests.swift
+++ b/Tests/KiwiDeskCoreTests/OwnKeyWindowRefreshTests.swift
@@ -1,0 +1,66 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The ring stand-down's TRIGGER (#933 follow-up): an own
+/// window taking or resigning key re-evaluates the ring set via
+/// the `NSWindow` key notifications, because Sparkle's update
+/// alert can take key without producing a single `KiwiEvent` —
+/// the suppression predicate was right and simply never re-ran
+/// (device QA, 2026-08-22). Asserted through
+/// `BorderManager.specs`, which `sync` stores unconditionally.
+@Suite("Own key window ring refresh (#933)", .serialized)
+@MainActor
+struct OwnKeyWindowRefreshTests {
+    private func makeCore() -> KiwiCore {
+        let core = makeTestCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-own-key-refresh-\(UUID().uuidString)"
+                )
+        )
+        core.tiler.visibleBounds = { _ in
+            CGRect(x: 0, y: 0, width: 1200, height: 800)
+        }
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(
+                    id: WindowID(1),
+                    pid: 1,
+                    appName: "App"
+                )
+            )
+        )
+        let space = core.state.workspaces.space(of: WindowID(1))!
+        core.state.workspaces.focus(WindowID(1), in: space)
+        return core
+    }
+
+    @Test("A key-window change re-evaluates the ring set")
+    func keyChangeRefreshesRings() {
+        let core = makeCore()
+        core.updateBorders()
+        #expect(core.borders.specs[WindowID(1)] != nil)
+        // An own untracked window takes key: the posted
+        // notification alone must stand the ring down — no
+        // KiwiEvent fires in Sparkle's no-update flow.
+        core.eventLoop.ownKeyWindowNumber = { 999_999 }
+        NotificationCenter.default.post(
+            name: NSWindow.didBecomeKeyNotification,
+            object: nil
+        )
+        #expect(core.borders.specs[WindowID(1)] == nil)
+        // Dismissed (key resigned, no app switch): the ring
+        // returns the same way.
+        core.eventLoop.ownKeyWindowNumber = { nil }
+        NotificationCenter.default.post(
+            name: NSWindow.didResignKeyNotification,
+            object: nil
+        )
+        #expect(core.borders.specs[WindowID(1)] != nil)
+    }
+}

--- a/Tests/KiwiDeskGuiTests/CoreLocalizationBoundaryTests.swift
+++ b/Tests/KiwiDeskGuiTests/CoreLocalizationBoundaryTests.swift
@@ -83,7 +83,7 @@ struct CoreLocalizationBoundaryTests {
         // neighbor-minimum sentences it hands to the Core-drawn
         // `SizeLimitOverlay`. Same caveat as `+StickyMarks` if
         // the overlays ever move out of Core.
-        "App/KiwiCore+SizeLimitPill.swift": 2,
+        "App/KiwiCore+SizeLimitPill.swift": 3,
         "Borders/StickyMarkOverlay.swift": 1,
         // The Space Bar's item labels and a11y strings, and the
         // App Bar's a11y labels (#901), drawn by Core.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1580,10 +1580,16 @@ Four rulings sharpen that:
   minimums (`StackLayout.weightStep(minSizes:)`, the two-sided
   `SplitDomain`), never one blanket value. When a grow (or a
   shrink whose group floor is carried by a group-mate) is
-  refused, the pill goes on **the window that cannot shrink, not
-  the trier** — the #435 sticky-swap rule — with its own copy
-  (`"Neighboring window at its minimum size"`); the bounce stays
-  on the resized window, whose gesture hit the wall.
+  refused, BOTH ends pill, each with the copy that fits its
+  anchor: the resized window explains why nothing moved
+  (`"Neighboring window at its minimum size"`), while the
+  blocking window marks itself (`"Minimum window size
+  reached"`). One pill on the blocker alone read absurd there —
+  from its own perspective IT reached the minimum, not a
+  neighbor — and one on the trier alone leaves which window
+  blocks unnamed; the #435 rule's core survives (the window
+  that cannot move is marked). The bounce stays on the resized
+  window, whose gesture hit the wall.
 - **A weight clamp divides the layout's exact span.** The ratio
   caps deliberately use the raw region span (a superset can never
   block reaching the visible bound; the render clamp is the net),

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -3632,7 +3632,9 @@ drop below its own — still applies the part that fits, and
 cues the refusal visually on the first truncated attempt: the
 focus ring gives the same rubber-band bounce as a dead-end
 focus move (#436), and a pill names the reason on the window
-that cannot shrink — the neighbor, on a refused grow. Keyboard
+that cannot shrink — and on a refused grow the resized
+window additionally names the reason while the blocking
+neighbor marks itself at its minimum. Keyboard
 and mouse resizes share these clamps and cues. What the
 `delta` actually adjusts depends on the layout:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1314,10 +1314,11 @@ go (the configured minimum window size, or a larger minimum the
 app itself enforces) bounces the ring the same way and shows a
 small frosted pill on the window: "Minimum window size
 reached". Growing stops where a *neighbor* would drop below its
-own minimum; the pill then appears on that neighbor
-("Neighboring window at its minimum size") — the window that
-can't shrink, not the one you resized — while the bounce stays
-on the window whose gesture hit the wall. The cues fire on the
+own minimum; both windows then say so, each from its own
+perspective — the one you resized explains why nothing moved
+("Neighboring window at its minimum size") while the blocking
+neighbor marks itself ("Minimum window size reached") — and
+the bounce stays on the window whose gesture hit the wall. The cues fire on the
 first press or drag that gets only part of what it asked for,
 not just once you are already at the floor, and keyboard and
 mouse resizes behave identically.


### PR DESCRIPTION
## Description

Two device-QA findings against the just-merged #933 behavior
(#942), caught by the owner within the hour:

1. **The neighbor pill's text and anchor disagreed.** The copy
   describes the situation from the RESIZED window's
   perspective, but the pill was drawn on the blocking window —
   where "Neighboring window at its minimum size" is absurd
   (from its own view IT hit the minimum). Now BOTH ends pill,
   each with the copy that fits: the trier explains why nothing
   moved, the blocker marks itself "Minimum window size
   reached". `SizeLimitOverlay` reworked to one panel per
   window so two pills can stand at once.
2. **The ring stand-down had no trigger in Sparkle's no-update
   flow.** The alert takes key without producing any
   `KiwiEvent`, so `desiredBorderSpecs` never re-ran and the
   stale ring stayed behind the alert — the predicate was right
   and never re-asked. The specs now refresh on our own
   `NSWindow` key notifications, both directions, so the ring
   also returns on OK without an app switch.

Docs (design-decisions ruling, user-guide, lua-reference,
state-and-layout row) updated to the both-pill shape; no new
locale keys (both texts already exist in all catalogs).

## Related Issue(s)

Follow-up to #933 / PR #942.

## Checklist

- [ ] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build green — CI's `Release Build` job (read it
  before merging; it reports, it does not block), or locally
  for concurrency / `@Sendable` changes
- [x] PR is focused; refactors separated from features

## How I verified

Full suite (3774 green) + lint. The new trigger test
(`OwnKeyWindowRefreshTests`) proven red by removing the
wiring. Device confirmation owed on relaunch: the update alert
must show no stale ring behind it (and the ring must return on
OK), and a blocked grow must pill both windows with the right
texts — that is the unchecked first box; the owner is
re-testing live immediately after merge.

## Notes for Reviewer

The per-window pill map retires entries on fade-out completion
so window-id churn cannot grow it for the session; a re-flash
mid-fade re-arms instead of retiring (the alpha check in the
completion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Si2HssgkgYLv2wzf1VaHS
