### PR TITLE
feat(site): the changelog's download says which version it hands you

### DIFF
--- a/site/src/components/Changelog.astro
+++ b/site/src/components/Changelog.astro
@@ -134,7 +134,7 @@ const ogImage = new URL(ogBanner.src, Astro.site).href;
     <a class="btn btn--primary clog__download" href={downloadHref}>
       <Icon name="lucide:download" width={16} height={16}
         aria-hidden="true" />
-      {t("download_cta")}
+      {t("changelog_download_cta")}
     </a>
   )}
 

--- a/site/src/i18n/de.json
+++ b/site/src/i18n/de.json
@@ -25,6 +25,7 @@
   "calm_point_6": "Hefte ein Fenster an, und es folgt dir überall hin — Musik, Notizen, immer dabei",
   "calm_title": "Dinge, von denen du dachtest, sie gehören beim Mac einfach dazu",
   "changelog_beta": "Beta",
+  "changelog_download_cta": "Jetzt die aktuellste Version herunterladen",
   "changelog_empty": "Bisher keine Versionen veröffentlicht.",
   "changelog_full_list": "Vollständige Liste der Änderungen auf GitHub",
   "changelog_intro": "Was sich in jeder Version geändert hat, neueste zuerst.",

--- a/site/src/i18n/de.json
+++ b/site/src/i18n/de.json
@@ -25,7 +25,7 @@
   "calm_point_6": "Hefte ein Fenster an, und es folgt dir überall hin — Musik, Notizen, immer dabei",
   "calm_title": "Dinge, von denen du dachtest, sie gehören beim Mac einfach dazu",
   "changelog_beta": "Beta",
-  "changelog_download_cta": "Jetzt die aktuellste Version herunterladen",
+  "changelog_download_cta": "Aktuellste Version herunterladen",
   "changelog_empty": "Bisher keine Versionen veröffentlicht.",
   "changelog_full_list": "Vollständige Liste der Änderungen auf GitHub",
   "changelog_intro": "Was sich in jeder Version geändert hat, neueste zuerst.",

--- a/site/src/i18n/en.json
+++ b/site/src/i18n/en.json
@@ -25,6 +25,7 @@
   "calm_point_6": "Pin a window and it follows you everywhere — your music, your notes, always there",
   "calm_title": "The things you assumed were just how Macs work",
   "changelog_beta": "Beta",
+  "changelog_download_cta": "Download the most recent version now",
   "changelog_empty": "No releases published yet.",
   "changelog_full_list": "Full list of changes on GitHub",
   "changelog_intro": "What changed in each release, newest first.",

--- a/site/src/i18n/en.json
+++ b/site/src/i18n/en.json
@@ -25,7 +25,7 @@
   "calm_point_6": "Pin a window and it follows you everywhere — your music, your notes, always there",
   "calm_title": "The things you assumed were just how Macs work",
   "changelog_beta": "Beta",
-  "changelog_download_cta": "Download the most recent version now",
+  "changelog_download_cta": "Download the most recent version",
   "changelog_empty": "No releases published yet.",
   "changelog_full_list": "Full list of changes on GitHub",
   "changelog_intro": "What changed in each release, newest first.",

--- a/site/src/i18n/ja.json
+++ b/site/src/i18n/ja.json
@@ -25,6 +25,7 @@
   "calm_point_6": "ウインドウを固定すれば、どこへでも付いてくる — 音楽もメモも、いつでもそばに",
   "calm_title": "Mac とはそういうものだと思っていたこと",
   "changelog_beta": "ベータ",
+  "changelog_download_cta": "最新バージョンを今すぐダウンロード",
   "changelog_empty": "まだ公開されたバージョンはありません。",
   "changelog_full_list": "変更点の全リストを GitHub で見る",
   "changelog_intro": "各バージョンの変更点を、新しい順に。",

--- a/site/src/i18n/ja.json
+++ b/site/src/i18n/ja.json
@@ -25,7 +25,7 @@
   "calm_point_6": "ウインドウを固定すれば、どこへでも付いてくる — 音楽もメモも、いつでもそばに",
   "calm_title": "Mac とはそういうものだと思っていたこと",
   "changelog_beta": "ベータ",
-  "changelog_download_cta": "最新バージョンを今すぐダウンロード",
+  "changelog_download_cta": "最新バージョンをダウンロード",
   "changelog_empty": "まだ公開されたバージョンはありません。",
   "changelog_full_list": "変更点の全リストを GitHub で見る",
   "changelog_intro": "各バージョンの変更点を、新しい順に。",

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -1649,5 +1649,13 @@ section {
    `.btn .btn--primary`, the same one the landing and guide use,
    because one action should not wear a fifth button style. */
 .clog__download {
-  margin-bottom: 2.4rem;
+  /* Centred, because it belongs to the PAGE rather than to the
+     column of prose it sits under — the entries below are
+     left-aligned reading, and a left-aligned button reads as
+     another line of that rather than as the page's own action.
+     `display: flex` overrides `.btn`'s `inline-flex` so the
+     auto margins have a block box to centre. */
+  display: flex;
+  width: fit-content;
+  margin: 0 auto 2.6rem;
 }


### PR DESCRIPTION
The release-notes page lists every version, so its download button now says which one it gives you — "Download the most recent version now" rather than the CTA pages' bare "Download now" — and it is centred, because it is the page's own action rather than another line of the prose column above it.

A second key, deliberately: those are two different statements, and only one of them is true of a page with four versions on it. The CTA buttons on the landing and guide pages are unchanged.

Verified: site build green, `check-site-tokens.py` exit 0, `extract-keys --site --check` OK at 285 keys across en/de/ja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Y4PdTwTbpkKSqmY1T6J8N