### PR TITLE
feat(docs): add GitHub Sponsors badge and refine version dot glow

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# GitHub native funding configuration
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: KiwiCanopy
+ko_fi: kiwicanopy

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Powerful when you reach for it, never in your way.
 [![Documentation](https://img.shields.io/badge/📖_Documentation-8DB354?style=for-the-badge)](https://kiwidesk.kiwicanopy.com/docs/)
 [![Quick Start](https://img.shields.io/badge/🚀_Quick_Start-627D3A?style=for-the-badge)](https://kiwidesk.kiwicanopy.com/docs/user-guide/)
 [![Recipes](https://img.shields.io/badge/🧩_Recipes-AACB5D?style=for-the-badge)](https://kiwidesk.kiwicanopy.com/docs/recipes/)
-[![Support on Ko-fi](https://img.shields.io/badge/Support-FF5E5B?style=for-the-badge&logo=kofi&logoColor=white)](https://ko-fi.com/kiwicanopy)
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/KiwiCanopy)
+[![Support on Ko-fi](https://img.shields.io/badge/Ko--fi-FF5E5B?style=for-the-badge&logo=kofi&logoColor=white)](https://ko-fi.com/kiwicanopy)
 
 </div>
 

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -209,13 +209,13 @@
 
   /* Pill on the hero band — ink is the same text-safe accent
      links/eyebrows use (never the warm tertiary, see AGENTS.md);
-     warm stays confined to the fill/border/dot, given a bit more
-     presence here (elevated from sparse, issue #439 follow-up). */
+     warm stays confined to the fill/border/dot, given a rich
+     glow to stay present on the light ground. */
   --pill-ink: var(--accent);
   --pill-bg: rgba(139, 94, 60, 0.12);
   --pill-border: rgba(139, 94, 60, 0.34);
   --pill-dot: var(--kiwi-shell);
-  --pill-dot-glow: rgba(139, 94, 60, 0.55);
+  --pill-dot-glow: rgba(139, 94, 60, 0.65);
 
   /* Terminal / code block (kept dark for legibility + contrast
      against the light page — a familiar terminal look) */
@@ -762,7 +762,7 @@ body::before {
   height: 7px;
   border-radius: 50%;
   background: var(--pill-dot);
-  box-shadow: 0 0 10px var(--pill-dot-glow);
+  box-shadow: 0 0 8px var(--pill-dot-glow);
 }
 
 /* =========================================================


### PR DESCRIPTION
## Summary

- **Funding**: Adds `.github/FUNDING.yml` to configure GitHub Sponsors (`KiwiCanopy`) and Ko-fi (`kiwicanopy`).
- **README**: Adds the **GitHub Sponsors** badge beside **Ko-fi** in the header badge cluster.
- **Site**: Refines the version banner dot glow on light mode in `site/src/styles/landing.css`.

## Verification
- `./scripts/lint.sh` passed cleanly.
- `scripts/check-site-tokens.py` passed on built site.