### PR TITLE
fix(test): await reveal timelines instead of polling a clock

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -432,6 +432,23 @@ early-returned awaits the *previous* cycle's finished task and
 asserts nothing. A handle whose staleness goes undocumented is a
 vacuous await waiting to be written.
 
+**The main actor is a budget shared across suites, and a new
+`@MainActor` suite says what it spends.** Heavy synchronous
+`@MainActor` work — a source scan, a filesystem walk, an AppKit
+measurement per row — backs the main actor up past 30 s in a full
+run, which is where the starvation above comes from. Measured
+twice: the mode-reveal timeline's 0.3 s clear missed a 30 s
+deadline (2026-08-09), and `PresetGridFloorTests` went
+`@MainActor` wholesale and timed a suite out against a 120 s
+guard while passing in 1.3 s alone (2026-08-17). Two
+obligations: keep off the main actor everything that does not
+need it — the fix in that second case was to run the catalog
+reads and the source scans off it and memoize the AppKit
+measurement — and state the spend in the new suite's own
+docstring, the shape `LayoutScreensQuickMenuTests` uses. Sizing
+a deadline against the backlog instead is what the clause above
+forbids; #979 is where that was paid on the mode reveal.
+
 The tell that a suite is on the wrong side of this: a green that
 takes the *whole* hang guard. `SleepWakeManagerTests` was
 reported as failing only while KiwiDesk itself ran, which read as

--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -110,6 +110,14 @@ final class SettingsModel: ObservableObject {
     /// Cancels a running reveal timeline when a newer flip
     /// supersedes it, so a rapid Simple→Power-User→Simple→…
     /// cannot clear the latest wash early.
+    ///
+    /// Production must not read this as state, and a test
+    /// awaiting it (`SettingsModeRevealTests`, #979) must read
+    /// it straight after a flip that reveals: it is not an
+    /// in-flight predicate — never cleared when the timeline
+    /// finishes, and left in place by a flip that does not
+    /// reveal — so anywhere else it is a finished predecessor,
+    /// and awaiting it asserts nothing.
     var modeRevealTask: Task<Void, Never>?
     /// Distinct settings the draft changes — the header's
     /// "N unsaved changes" count, recomputed beside `isDirty`

--- a/Tests/KiwiDeskGuiTests/LayoutScreensQuickMenuTests.swift
+++ b/Tests/KiwiDeskGuiTests/LayoutScreensQuickMenuTests.swift
@@ -22,9 +22,9 @@ private final class FakeStatusItem: StatusItemHandle {
 /// does on the main actor**: it builds menus and reads their
 /// items. No source scan, no filesystem walk, no layout pass. The
 /// main actor is a budget shared with the heavy synchronous
-/// scanning suites — `SettingsModeRevealTests`' hang guard is
-/// sized at 120 s because of them — so a new `@MainActor` suite
-/// says what it spends.
+/// scanning suites — they back it up past 30 s in a full run
+/// (`tests.md` ▸ Async tests) — so a new `@MainActor` suite says
+/// what it spends.
 ///
 /// `.serialized` because titles are matched in English and
 /// `LocalizationManager` is a process-wide singleton.

--- a/Tests/KiwiDeskGuiTests/PresetGridFloorTests.swift
+++ b/Tests/KiwiDeskGuiTests/PresetGridFloorTests.swift
@@ -41,14 +41,13 @@ import Testing
 /// **Main-actor load is deliberately minimal here.** Only the
 /// AppKit measurement is `@MainActor`, and it memoizes by title;
 /// the catalog reads and the two source scans run off it. That is
-/// not tidiness — `SettingsModeRevealTests`' hang guard is sized
-/// against heavy synchronous `@MainActor` suites backing the main
-/// actor up "past 30 s in a full run", and the first cut of this
-/// suite was one of them: it went `@MainActor` wholesale, and CI
-/// timed that suite out against its 120 s guard while the whole
-/// thing passes in 1.3 s locally (2026-08-17). A guard sized for
-/// a starved main actor is a shared budget, and a new suite
-/// spends it.
+/// not tidiness — `tests.md` ▸ Async tests carries the
+/// measurement and the obligation: heavy synchronous `@MainActor`
+/// work backs the main actor up past 30 s in a full run, and the
+/// first cut of this suite was one of them. It went `@MainActor`
+/// wholesale, and CI timed a suite out against its 120 s guard
+/// while the whole thing passes in 1.3 s locally (2026-08-17).
+/// The main actor is a shared budget, and a new suite spends it.
 ///
 /// **And it cannot see ADDITIVE drift**, which `guard-prover`
 /// demonstrated: keep `.padding(Self.padding)` and add a second
@@ -99,10 +98,9 @@ struct PresetGridFloorTests {
     /// constants, not the size. Stated rather than asserted
     /// because pinning it would mean rendering the real card.
     /// Memoized, and the memo is not a micro-optimisation.
-    /// `SettingsModeRevealTests`' hang guard is sized against
-    /// "heavy synchronous `@MainActor` suites back the main actor
-    /// up past 30 s in a full run" — its own docstring — and this
-    /// suite is one. Distinct titles are far fewer than catalogs
+    /// Heavy synchronous `@MainActor` suites back the main actor
+    /// up past 30 s in a full run (`tests.md` ▸ Async tests), and
+    /// this suite is one. Distinct titles are far fewer than catalogs
     /// times keys, so measuring each once is most of the load
     /// gone for free.
     @MainActor private static var widths: [String: CGFloat] = [:]

--- a/Tests/KiwiDeskGuiTests/SettingsModeRevealTests.swift
+++ b/Tests/KiwiDeskGuiTests/SettingsModeRevealTests.swift
@@ -19,24 +19,30 @@ struct SettingsModeRevealTests {
         return makeTestModel(defaults: defaults)
     }
 
-    /// One generous hang-guard, never a tight deadline (#344),
-    /// sized for THIS wait's observed worst case: heavy
-    /// synchronous `@MainActor` suites (the source scans) back
-    /// the main actor up past 30 s in a full run — a 30 s
-    /// guard here failed three tests whose timeline is 0.3 s
-    /// (2026-08-09) — so the bound is 120 s. The poll exits
-    /// the instant the clear lands; the deadline only bounds a
-    /// genuine hang (a timeline that stops completing must
-    /// fail the run, not wedge it).
-    private func awaitCleared(
-        _ model: SettingsModel
-    ) async -> Bool {
-        let deadline = Date().addingTimeInterval(120)
-        while Date() < deadline {
-            if !model.modeRevealActive { return true }
-            try? await Task.sleep(nanoseconds: 50_000_000)
-        }
-        return false
+    /// Awaits the reveal's own completion signal rather than
+    /// polling for its effect — tests.md ▸ Async tests argues
+    /// that measurement once. The fact local to this wait: its
+    /// bound went 30 s → 120 s on 2026-08-09 and then timed out
+    /// at 120 s anyway, because the clear runs on the main
+    /// actor and the deadline was really measuring how long the
+    /// scan-heavy suites held it.
+    ///
+    /// With no deadline, a timeline that never completed would
+    /// stall the job rather than name an assertion — `Tests/`
+    /// has no `.timeLimit` precedent, so this is the trade
+    /// `SocketServerTests` already makes. It is a safe one
+    /// here: the timeline is a `Task.sleep` over a fixed hold.
+    ///
+    /// Call it ONLY after a flip that reveals — `modeRevealTask`
+    /// is not an in-flight predicate, and its own doc says what
+    /// that costs a caller who reads it elsewhere. The non-nil
+    /// assertion is what stops `await nil?.value` from passing
+    /// instantly on a timeline that was never scheduled.
+    private func awaitCleared(_ model: SettingsModel) async {
+        let timeline = model.modeRevealTask
+        #expect(timeline != nil, "the flip scheduled no reveal")
+        await timeline?.value
+        #expect(!model.modeRevealActive)
     }
 
     @Test("the explicit flip washes, then clears itself")
@@ -45,7 +51,7 @@ struct SettingsModeRevealTests {
         model.flipSettingsMode(.powerUser, reduceMotion: false)
         #expect(model.settingsMode == .powerUser)
         #expect(model.modeRevealActive)
-        #expect(await awaitCleared(model))
+        await awaitCleared(model)
     }
 
     /// Reduce Motion keeps the affordance — the wash still shows
@@ -58,7 +64,7 @@ struct SettingsModeRevealTests {
         let model = model()
         model.flipSettingsMode(.powerUser, reduceMotion: true)
         #expect(model.modeRevealActive)
-        #expect(await awaitCleared(model))
+        await awaitCleared(model)
     }
 
     @Test("the way back to Simple never washes")
@@ -102,13 +108,54 @@ struct SettingsModeRevealTests {
     /// A newer flip supersedes the running timeline rather than
     /// racing it: the second wash keeps its own full window, and
     /// the first task's clear must not land inside it early.
+    /// The superseded handle is captured and awaited FIRST,
+    /// which is what makes the contract observable at all.
+    /// Sampling only once the NEWEST timeline has finished
+    /// cannot tell a cancelled predecessor from one that ran
+    /// and cleared the wash under it — by then both have
+    /// written the same `false`, and the suite stays green with
+    /// the supersede machinery removed, which is the only
+    /// reason the handle is stored.
+    ///
+    /// **The superseded handle is inspected, never awaited.**
+    /// A draft did `await superseded?.value` and then asserted
+    /// the wash was still up, which reads as the stronger
+    /// check and is the same defect #979 is about, one level
+    /// in: both timelines are queued on the main actor, so
+    /// under a starved full run the cancelled one and the live
+    /// one resume together and the live one has already
+    /// cleared the wash by the time the await returns. It
+    /// passed alone and failed in a 3877-test run at 73 s.
+    /// `isCancelled` is the same fact read synchronously, with
+    /// no suspension point to race across.
+    ///
+    /// What this can and cannot catch, measured rather than
+    /// assumed (guard-prover): removing BOTH `cancel()` calls
+    /// reds it. Removing either one alone does not, and that is
+    /// not a hole — `flipSettingsMode` is the one writer of the
+    /// handle, so the flip-away branch leaves the reveal's task
+    /// in place for the next reveal's cancel to reach, and vice
+    /// versa. Either call alone is sufficient today; no test at
+    /// this altitude can tell them apart.
     @Test("a rapid re-flip keeps the newest wash its window")
     func rapidReflipSupersedes() async {
         let model = model()
         model.flipSettingsMode(.powerUser, reduceMotion: false)
+        let superseded = model.modeRevealTask
+        #expect(superseded != nil)
         model.flipSettingsMode(.simple, reduceMotion: false)
         model.flipSettingsMode(.powerUser, reduceMotion: false)
         #expect(model.modeRevealActive)
-        #expect(await awaitCleared(model))
+        #expect(superseded?.isCancelled == true)
+        // Not a supersede assertion — a fresh task is stored
+        // whether or not the old one was cancelled, so nothing
+        // in `flipSettingsMode` reds this (guard-prover). It
+        // guards the WAIT that follows: `awaitCleared` reads
+        // the handle again, and if the third flip had scheduled
+        // nothing it would await this finished predecessor and
+        // assert on an already-cleared wash — the staleness
+        // `modeRevealTask`'s own doc warns about.
+        #expect(model.modeRevealTask != superseded)
+        await awaitCleared(model)
     }
 }

--- a/Tests/KiwiDeskGuiTests/SettingsSearchPlacesTests.swift
+++ b/Tests/KiwiDeskGuiTests/SettingsSearchPlacesTests.swift
@@ -138,23 +138,28 @@ struct SettingsSearchPlacesTests {
 
     /// The self-clear half, previously unguarded: guard-prover
     /// (2026-08-10) showed the clear task could be deleted with
-    /// this suite green. A generous hang-guard poll, never a
-    /// tight deadline (#344): the notice clears at ~5 s, the
-    /// poll exits the moment it does, and the 30 s bound only
-    /// catches a genuine never-clears.
+    /// this suite green.
+    ///
+    /// Awaits the timeline rather than polling for its effect —
+    /// the same fix as #979 on this same model, made in the same
+    /// change because it is the same defect: the clear runs on
+    /// the main actor, so a wall clock measured how long the
+    /// scanning suites held it (`tests.md` ▸ Async tests). The
+    /// handle is read straight after the switch that schedules
+    /// it and asserted non-nil, because `await nil?.value`
+    /// returns instantly and would pass on a clear that was
+    /// never scheduled — which is precisely what guard-prover
+    /// caught here once already.
     @Test("the mode-switch notice clears itself")
-    func modeNoticeSelfClears() async throws {
+    func modeNoticeSelfClears() async {
         pinEnglish()
         defer { reset() }
         let model = makeTestModel()
         model.noteSearchModeSwitch(.advancedColors)
         #expect(model.searchModeNotice != nil)
-        let deadline = ContinuousClock.now + .seconds(30)
-        while model.searchModeNotice != nil,
-            ContinuousClock.now < deadline
-        {
-            try await Task.sleep(for: .milliseconds(100))
-        }
+        let timeline = model.searchNoticeTask
+        #expect(timeline != nil, "no self-clear was scheduled")
+        await timeline?.value
         #expect(model.searchModeNotice == nil)
     }
 }


### PR DESCRIPTION
## Description

`SettingsModeRevealTests` waited on `modeRevealActive` by polling
it every 50 ms against a wall-clock deadline. The flag is cleared
by a `@MainActor` task, so the wait was really bounded by how
long *other* suites held the main actor — the scan-heavy suites
hold it for stretches this test neither controls nor predicts.
The deadline measured the runner's mood, not the code under test.

Raising it 30 s → 120 s (2026-08-09) did not help, and no number
would: a deadline can only ever be wrong in one of two
directions. The 50 ms poll made it worse, since each wake was
itself main-actor work competing with the task it waited for.

The timeline is already stored as `modeRevealTask` — kept so a
newer flip can supersede a running one — so the wait can be
exact:

```swift
let timeline = model.modeRevealTask
#expect(timeline != nil, "the flip scheduled no reveal")
await timeline?.value
#expect(!model.modeRevealActive)
```

The real `SettingsReveal.hold` still elapses; nothing is stubbed,
so the test keeps testing what it tested. A genuine hang now ends
the run through the harness's own timeout rather than a tuned
deadline — `.claude/rules/tests.md` ▸ Async tests ("await the
handle rather than polling for its effect") applied literally.

Three further things came out of review and are fixed here
rather than left for the issue to be reopened over: the
supersede test could not fail on the invariant it names;
deleting the old docstring orphaned three citations in two
other suites that quoted it for the shared-main-actor-budget
convention (the measurement is re-homed to `tests.md` and the
citations repointed); and
`SettingsSearchPlacesTests.modeNoticeSelfClears` is the
identical defect on the identical model — a 30 s poll for
`searchNoticeTask` — so it is fixed in the same change.

The non-nil assertion is load-bearing, not decoration:
`await nil?.value` returns instantly, so a regression that
stopped scheduling the clear would otherwise pass in 0.16 s
looking green. That same rule obliges an awaited handle to
document what it does **not** mean, so `modeRevealTask` now says
it is not an in-flight predicate — it is never cleared, so a
caller reading it after a flip that schedules nothing would await
a finished predecessor and assert nothing.

## Related Issue(s)

Closes #979

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/` — n/a, no
  user-visible behavior changes; the only `Sources/` edit is a
  doc comment
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build green — skipped locally and left to CI's
  `Release Build` job: no production concurrency, `@Sendable`
  boundary or `Sendable` conformance changes, and
  `swift build -c release` does not compile the test target,
  so it cannot observe this diff
- [x] PR is focused; refactors separated from features

## How I verified

- The two changed suites: green, **1.4 s** and **5.4 s**,
  against the 120 s and 30 s ceilings they used to wait under.
- The full suite — which is the condition the flake actually
  needs, main-actor contention from the concurrent scan-heavy
  suites: **3877 tests in 729 suites, green in 114 s**.
- `swift build` and `scripts/lint.sh` exit 0.
- `guard-prover`, every mutation applied and restored
  separately:
  1. **the clear removed** → RED on `!modeRevealActive`, run
     ending on its own in 1.4 s. The load-bearing one: the
     awaited task still *completes*, only its side effect is
     gone, so the await returns and the assertion fires.
  2. **the timeline never scheduled** → RED on
     `timeline != nil`, run ending in **0.16 s** — exactly what
     would otherwise have sailed through looking green.
  3. **the wash never activated** → RED at the pre-wait
     assertions.
  4. **both `cancel()` calls removed** → RED on
     `superseded?.isCancelled`.
  5. **the twin's clear removed** → RED; **the twin's task
     never scheduled** → RED on both its assertions.

## Notes for Reviewer

**The one I got wrong, since it is the most useful thing here.**
The first draft of the supersede check did
`await superseded?.value` and then asserted the wash was still
up. That reads as the stronger assertion and is the same defect
this PR fixes, one level in: both timelines are queued on the
main actor, so under a starved full run the cancelled task and
the live one resume together and the live one has already
cleared the wash by the time the await returns. It passed in
isolation and **failed at 73 s in the full 3877-test run**. The
shipped form reads `isCancelled` synchronously — same fact, no
suspension point to race across. It is worth knowing that the
"await the handle" rule does not extend to a handle that was
*cancelled*: there, inspect it.

Three more things, stated rather than hidden:

- **A timeline that genuinely never completes now stalls the job
  rather than naming an assertion.** `Tests/` has no `.timeLimit`
  precedent and CI sets no per-test timeout, so that is the
  honest description — the same trade `SocketServerTests`
  already documents, safe here because the timeline is a
  `Task.sleep` over a fixed hold. No mutation can red that
  class, so this suite's green does not cover it.
- **Either `cancel()` alone is sufficient today.** guard-prover
  found that removing just one leaves the suite green, and that
  is not a hole: `flipSettingsMode` is the one writer of the
  handle, so each branch leaves the other's task in place to be
  cancelled. No test at this altitude can tell them apart, and
  the test docstring says so.
- **`SettingsModel.swift` is now 343 lines**, under the 350
  ceiling but close. The doc comment has to live on the handle,
  so the next addition to that file will want a split. Not done
  here — a refactor riding a test fix is the thing AGENTS.md §3
  asks us not to do.

Also worth a look while you are in here: `MoveFocusLatchTests`
and `MoveToSpaceTests` poll for `DeferredTasks` slots that are
awaitable handles, one of them on a 2000 ms deadline. Same
class, Core rather than GUI, deliberately not swept into this
PR.
