### PR TITLE
fix(test): await the dwell and settle timelines instead of polling a clock

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -398,20 +398,19 @@ notice it breaking.
 
 ## Async tests: a generous hang-guard, never a tight deadline (#344)
 
-A test that spawns a real subprocess (`ExecTests`) or schedules an
-unstructured `Task` (`DragCoordinatorTests`) and then awaits its
-**main-actor callback** cannot use a sub-second or few-second poll
-deadline. swift-testing runs suites concurrently, so under
+A test that spawns a real subprocess (`ExecTests`) and then awaits
+its **main-actor callback** cannot use a sub-second or few-second
+poll deadline. swift-testing runs suites concurrently, so under
 full-suite load the shared main actor is starved for seconds and
 the tight deadline trips spuriously (the callback landed, just
 late) while the suite passes in isolation.
 
 Each such wait uses one shared generous hang-guard
-(`execHangGuard` / `dragSettleHangGuard`, 30 s): the poll exits
-the instant the condition holds, so a passing run is never slowed
-— the deadline only bounds a genuine hang. Prove the *behavior* by
-the gap (a short watchdog against a much longer sleep), never by a
-tight wait. New async tests here follow suit.
+(`execHangGuard`, 30 s): the poll exits the instant the condition
+holds, so a passing run is never slowed — the deadline only bounds
+a genuine hang. Prove the *behavior* by the gap (a short watchdog
+against a much longer sleep), never by a tight wait. New async
+tests here follow suit.
 
 **Where the thing waited on IS an awaitable handle, await it
 rather than polling for its effect.** A wall-clock deadline
@@ -421,8 +420,8 @@ a full concurrent run one 10 ms `Task.sleep` resumption measured
 without giving the pending continuation a turn, and the result
 comes down to which continuation drains first. Reach for a poll
 only when there is nothing to await — a real subprocess
-(`ExecTests`), a `DisplayLink` callback (`DragCoordinatorTests`).
-When a `Task` or a `DeferredTasks` slot exists, take it:
+(`ExecTests`), a `DisplayLink` callback. When a `Task` or a
+`DeferredTasks` slot exists, take it:
 `await core.deferred.task(for: .startupSweep)?.value`,
 `await manager.pendingReplay?.value`. **Expose such a handle with
 a doc comment barring production from reading it, and say what it
@@ -431,6 +430,20 @@ the task is never cleared — so awaiting it after a leg that
 early-returned awaits the *previous* cycle's finished task and
 asserts nothing. A handle whose staleness goes undocumented is a
 vacuous await waiting to be written.
+
+**Two more ways such an await goes vacuous**, both paid for in
+#994 when the drag and Space Bar dwells traded their deadlines
+for handles. A handle that its own callback CLEARS
+(`SpaceBarDropCoordinator.dwellTask`,
+`DragCoordinator.settleTask(for:)`) is nil by the time the effect
+has landed, so it is read BEFORE the await, and the `!= nil`
+assertion beside it is load-bearing rather than decorative —
+`await nil?.value` returns at once, so a scheduler that stopped
+scheduling sails through green. And a handle that RESCHEDULES
+itself says less than it looks: `settleTask(for:)` awaited while
+the mouse button is down completes each release-poll leg having
+fired no drop at all. Both facts belong in the seam's own doc
+comment, which is where those two carry them.
 
 **The main actor is a budget shared across suites, and a new
 `@MainActor` suite says what it spends.** Heavy synchronous

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -398,19 +398,20 @@ notice it breaking.
 
 ## Async tests: a generous hang-guard, never a tight deadline (#344)
 
-A test that spawns a real subprocess (`ExecTests`) and then awaits
-its **main-actor callback** cannot use a sub-second or few-second
-poll deadline. swift-testing runs suites concurrently, so under
-full-suite load the shared main actor is starved for seconds and
-the tight deadline trips spuriously (the callback landed, just
-late) while the suite passes in isolation.
+A test that waits on something it holds no handle to — a real
+subprocess (`ExecTests`), a socket connect (`SocketServerTests`) —
+and then awaits its **main-actor callback** cannot use a
+sub-second or few-second poll deadline. swift-testing runs suites
+concurrently, so under full-suite load the shared main actor is
+starved for seconds and the tight deadline trips spuriously (the
+callback landed, just late) while the suite passes in isolation.
 
-Each such wait uses one shared generous hang-guard
-(`execHangGuard`, 30 s): the poll exits the instant the condition
-holds, so a passing run is never slowed — the deadline only bounds
-a genuine hang. Prove the *behavior* by the gap (a short watchdog
-against a much longer sleep), never by a tight wait. New async
-tests here follow suit.
+Each such wait takes one generous hang-guard named in its own
+suite (`execHangGuard`, `socketConnectHangGuard`, 30 s): the poll
+exits the instant the condition holds, so a passing run is never
+slowed — the deadline only bounds a genuine hang. Prove the
+*behavior* by the gap (a short watchdog against a much longer
+sleep), never by a tight wait. New async tests here follow suit.
 
 **Where the thing waited on IS an awaitable handle, await it
 rather than polling for its effect.** A wall-clock deadline
@@ -431,19 +432,42 @@ early-returned awaits the *previous* cycle's finished task and
 asserts nothing. A handle whose staleness goes undocumented is a
 vacuous await waiting to be written.
 
-**Two more ways such an await goes vacuous**, both paid for in
+**Three more ways such an await goes vacuous**, all paid for in
 #994 when the drag and Space Bar dwells traded their deadlines
-for handles. A handle that its own callback CLEARS
-(`SpaceBarDropCoordinator.dwellTask`,
-`DragCoordinator.settleTask(for:)`) is nil by the time the effect
-has landed, so it is read BEFORE the await, and the `!= nil`
-assertion beside it is load-bearing rather than decorative —
-`await nil?.value` returns at once, so a scheduler that stopped
-scheduling sails through green. And a handle that RESCHEDULES
-itself says less than it looks: `settleTask(for:)` awaited while
-the mouse button is down completes each release-poll leg having
-fired no drop at all. Both facts belong in the seam's own doc
-comment, which is where those two carry them.
+for handles. Each is a property of the handle, so each belongs in
+the seam's own doc comment beside what awaiting it does NOT mean.
+
+- A handle its own callback **clears** is nil by the time the
+  effect has landed, so read it BEFORE the await — and the
+  `!= nil` assertion beside it is load-bearing rather than
+  decorative. `await nil?.value` returns at once, so a scheduler
+  that stopped scheduling sails through green, and any *further*
+  assertion reading that handle (an identity check, say) goes
+  vacuously true beside it. Keep the pair a pair.
+- A handle that **reschedules** itself says less than it looks:
+  awaited from a leg that is not the last one, it completes
+  having fired nothing at all.
+- A **cancelled** handle completes immediately, so an await on
+  one bounds nothing. It proves that timeline unwound, never that
+  no other one is still pending — prove that negative by the gap
+  (tests.md's rule above), and read `isCancelled` synchronously
+  for the cancel itself.
+
+**A handle exposed only for a test is wrapped in `#if DEBUG`**,
+the idiom `NativeSpaces`' overrides already use, so a production
+read reds the release build rather than waiting for a reviewer to
+notice — a doc comment saying "production must not read this" is
+not greppable and does not fail anything. Handles exposed before
+this rule were not wrapped; a new one takes it.
+
+**A hang is now a hang, and that is the accepted trade.** A poll
+recorded an `Issue` and returned, so a genuinely stuck condition
+failed one test at its deadline; an await on a timeline that
+never completes stalls the run until the job's own timeout,
+because `Tests/` sets no `.timeLimit`. That is the same trade
+`SocketServerTests` documents, and it is the right way round
+here: the deadline it replaces was failing runs that were not
+stuck at all.
 
 **The main actor is a budget shared across suites, and a new
 `@MainActor` suite says what it spends.** Heavy synchronous

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -399,7 +399,7 @@ notice it breaking.
 ## Async tests: a generous hang-guard, never a tight deadline (#344)
 
 A test that waits on something it holds no handle to — a real
-subprocess (`ExecTests`), a socket connect (`SocketServerTests`) —
+subprocess (`ExecTests`), a socket connect (`SocketTests`) —
 and then awaits its **main-actor callback** cannot use a
 sub-second or few-second poll deadline. swift-testing runs suites
 concurrently, so under full-suite load the shared main actor is
@@ -464,10 +464,10 @@ this rule were not wrapped; a new one takes it.
 recorded an `Issue` and returned, so a genuinely stuck condition
 failed one test at its deadline; an await on a timeline that
 never completes stalls the run until the job's own timeout,
-because `Tests/` sets no `.timeLimit`. That is the same trade
-`SocketServerTests` documents, and it is the right way round
-here: the deadline it replaces was failing runs that were not
-stuck at all.
+because `Tests/` sets no `.timeLimit`. Accept it knowingly: the
+deadline it replaces was not failing runs that were stuck, it was
+failing runs that were merely slow, and no mutation can red the
+hang class — so a green suite here does not cover it.
 
 **The main actor is a budget shared across suites, and a new
 `@MainActor` suite says what it spends.** Heavy synchronous

--- a/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
@@ -82,19 +82,24 @@ final class SpaceBarDropCoordinator {
     /// gestures. Lets an abnormal drag end (window closed / tab
     /// rekeyed mid-drag) scope its teardown to the right window.
     private(set) var draggingWindow: WindowID?
-    /// The pending spring's timeline, exposed so a test can await
-    /// the dwell instead of polling a clock for its effect (#994;
-    /// `.claude/rules/tests.md` ▸ Async tests). Production must
-    /// not read it — `isArmed` is the in-flight predicate.
-    ///
-    /// What awaiting it does **not** mean. It is cleared the
-    /// instant the dwell fires or is disarmed, so it is only
-    /// readable while a spring is pending: read it afterwards and
-    /// it is nil, whose `await` returns at once and asserts
-    /// nothing. It also completes for a *cancelled* dwell, so it
-    /// says the dwell ended, never that it sprang — that fact is
-    /// `sprungSpace`.
-    private(set) var dwellTask: Task<Void, Never>?
+    private var pendingDwell: Task<Void, Never>?
+
+    #if DEBUG
+        /// The pending spring's timeline, so a test can await the
+        /// dwell instead of polling a clock for its effect (#994;
+        /// `.claude/rules/tests.md` ▸ Async tests). Debug-only so
+        /// a production read fails the release build rather than
+        /// a review — `isArmed` is the in-flight predicate.
+        ///
+        /// What awaiting it does **not** mean. It is cleared the
+        /// instant the dwell fires or is disarmed, so it is only
+        /// readable while a spring is pending: read it afterwards
+        /// and it is nil, whose `await` returns at once and
+        /// asserts nothing. It also completes for a *cancelled*
+        /// dwell, so it says the dwell ended, never that it
+        /// sprang — that fact is `sprungSpace`.
+        var dwellTask: Task<Void, Never>? { pendingDwell }
+    #endif
 
     /// True while a bar target is armed pre-spring — the caller
     /// hides its own drag ghost/drop-zone then.
@@ -153,8 +158,8 @@ final class SpaceBarDropCoordinator {
         let delay = min(Self.springPreDelay, dwell)
         setHover(target)
         beginSweep(target, dwell - delay, delay)
-        dwellTask?.cancel()
-        dwellTask = Task { [weak self] in
+        pendingDwell?.cancel()
+        pendingDwell = Task { [weak self] in
             let ns = UInt64(dwell * 1_000_000_000)
             try? await Task.sleep(nanoseconds: ns)
             guard !Task.isCancelled else { return }
@@ -163,14 +168,14 @@ final class SpaceBarDropCoordinator {
     }
 
     private func disarm() {
-        dwellTask?.cancel()
-        dwellTask = nil
+        pendingDwell?.cancel()
+        pendingDwell = nil
         armedSpace = nil
         clearFeedback()
     }
 
     private func fire(_ target: SpaceID, _ id: WindowID) {
-        dwellTask = nil
+        pendingDwell = nil
         armedSpace = nil
         clearFeedback()
         // Record the spring only if it actually switched: a refused

--- a/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
@@ -82,7 +82,19 @@ final class SpaceBarDropCoordinator {
     /// gestures. Lets an abnormal drag end (window closed / tab
     /// rekeyed mid-drag) scope its teardown to the right window.
     private(set) var draggingWindow: WindowID?
-    private var dwellTask: Task<Void, Never>?
+    /// The pending spring's timeline, exposed so a test can await
+    /// the dwell instead of polling a clock for its effect (#994;
+    /// `.claude/rules/tests.md` ▸ Async tests). Production must
+    /// not read it — `isArmed` is the in-flight predicate.
+    ///
+    /// What awaiting it does **not** mean. It is cleared the
+    /// instant the dwell fires or is disarmed, so it is only
+    /// readable while a spring is pending: read it afterwards and
+    /// it is nil, whose `await` returns at once and asserts
+    /// nothing. It also completes for a *cancelled* dwell, so it
+    /// says the dwell ended, never that it sprang — that fact is
+    /// `sprungSpace`.
+    private(set) var dwellTask: Task<Void, Never>?
 
     /// True while a bar target is armed pre-spring — the caller
     /// hides its own drag ghost/drop-zone then.

--- a/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
@@ -135,6 +135,23 @@ public final class DragCoordinator {
         }
     }
 
+    /// The settle timeline pending for `id`, exposed so a test
+    /// can await the settle instead of polling a clock for its
+    /// effect (#994; `.claude/rules/tests.md` ▸ Async tests).
+    /// Production must not read it — it is `schedule`'s
+    /// bookkeeping, never a drag-in-flight predicate.
+    ///
+    /// What awaiting it does **not** mean: that the drag ENDED.
+    /// A settle finding the button still down reschedules itself
+    /// on `releasePollDelay`, so a handle read mid-gesture
+    /// completes its own poll leg having fired nothing; and after
+    /// the drop it is nil, whose `await` returns at once and
+    /// asserts nothing. Read it while the gesture under test is
+    /// the one in flight, and assert on `onDragEnd`.
+    func settleTask(for id: WindowID) -> Task<Void, Never>? {
+        pending[id]
+    }
+
     /// Drops any pending drag for a window (it closed).
     public func cancel(_ id: WindowID) {
         pending[id]?.cancel()

--- a/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
@@ -135,22 +135,28 @@ public final class DragCoordinator {
         }
     }
 
-    /// The settle timeline pending for `id`, exposed so a test
-    /// can await the settle instead of polling a clock for its
-    /// effect (#994; `.claude/rules/tests.md` ▸ Async tests).
-    /// Production must not read it — it is `schedule`'s
-    /// bookkeeping, never a drag-in-flight predicate.
-    ///
-    /// What awaiting it does **not** mean: that the drag ENDED.
-    /// A settle finding the button still down reschedules itself
-    /// on `releasePollDelay`, so a handle read mid-gesture
-    /// completes its own poll leg having fired nothing; and after
-    /// the drop it is nil, whose `await` returns at once and
-    /// asserts nothing. Read it while the gesture under test is
-    /// the one in flight, and assert on `onDragEnd`.
-    func settleTask(for id: WindowID) -> Task<Void, Never>? {
-        pending[id]
-    }
+    #if DEBUG
+        /// The settle timeline pending for `id`, so a test can
+        /// await the settle instead of polling a clock for its
+        /// effect (#994; `.claude/rules/tests.md` ▸ Async tests).
+        /// Debug-only so a production read fails the release
+        /// build rather than a review: this is `schedule`'s
+        /// bookkeeping, never a drag-in-flight predicate. This
+        /// type publishes no such predicate — a site that needs
+        /// one adds it rather than reaching for this.
+        ///
+        /// What awaiting it does **not** mean: that the drag
+        /// ENDED. A settle finding the button still down
+        /// reschedules itself on `releasePollDelay`, so a handle
+        /// read mid-gesture completes its own poll leg having
+        /// fired nothing; and after the drop it is nil, whose
+        /// `await` returns at once and asserts nothing. Read it
+        /// while the gesture under test is the one in flight,
+        /// and assert on `onDragEnd`.
+        func settleTask(for id: WindowID) -> Task<Void, Never>? {
+            pending[id]
+        }
+    #endif
 
     /// Drops any pending drag for a window (it closed).
     public func cancel(_ id: WindowID) {

--- a/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
@@ -62,6 +62,20 @@ public final class DragCrossingCoordinator {
     private var pending:
         (window: WindowID, display: DisplayID, task: Task<Void, Never>)?
 
+    /// The armed dwell's timeline, exposed so a test can await
+    /// the crossing instead of polling a clock for its effect
+    /// (#994; `.claude/rules/tests.md` ▸ Async tests).
+    /// Production must not read it — `pending` is the
+    /// bookkeeping it belongs to.
+    ///
+    /// What awaiting it does **not** mean: that a crossing
+    /// FIRED. The handle also completes for a dwell that was
+    /// disarmed (the cursor came home, `cancelPending`,
+    /// `rekey`), and it is nil whenever none is armed — whose
+    /// `await` returns at once and asserts nothing. `onCross`
+    /// is the fact.
+    var dwellTask: Task<Void, Never>? { pending?.task }
+
     public init() {}
 
     /// Feed every live drag move. Schedules a dwell when the

--- a/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
@@ -62,19 +62,22 @@ public final class DragCrossingCoordinator {
     private var pending:
         (window: WindowID, display: DisplayID, task: Task<Void, Never>)?
 
-    /// The armed dwell's timeline, exposed so a test can await
-    /// the crossing instead of polling a clock for its effect
-    /// (#994; `.claude/rules/tests.md` ▸ Async tests).
-    /// Production must not read it — `pending` is the
-    /// bookkeeping it belongs to.
-    ///
-    /// What awaiting it does **not** mean: that a crossing
-    /// FIRED. The handle also completes for a dwell that was
-    /// disarmed (the cursor came home, `cancelPending`,
-    /// `rekey`), and it is nil whenever none is armed — whose
-    /// `await` returns at once and asserts nothing. `onCross`
-    /// is the fact.
-    var dwellTask: Task<Void, Never>? { pending?.task }
+    #if DEBUG
+        /// The armed dwell's timeline, so a test can await the
+        /// crossing instead of polling a clock for its effect
+        /// (#994; `.claude/rules/tests.md` ▸ Async tests).
+        /// Debug-only so a production read fails the release
+        /// build rather than a review — `pending` is the
+        /// bookkeeping it belongs to.
+        ///
+        /// What awaiting it does **not** mean: that a crossing
+        /// FIRED. `fire` clears the slot, the handle also
+        /// completes for a dwell that was disarmed (the cursor
+        /// came home, `cancelPending`, `rekey`), and it is nil
+        /// whenever none is armed — whose `await` returns at
+        /// once and asserts nothing. `onCross` is the fact.
+        var dwellTask: Task<Void, Never>? { pending?.task }
+    #endif
 
     public init() {}
 

--- a/Tests/KiwiDeskCoreTests/DragCrossingCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragCrossingCoordinatorTests.swift
@@ -4,13 +4,6 @@ import Testing
 
 @testable import KiwiDeskCore
 
-/// Generous hang-guard for waits on the dwell Task's `onCross`
-/// (#344): swift-testing runs suites concurrently, so the main
-/// actor can be starved for seconds under full-suite load. The
-/// polls exit the instant the condition holds, so a passing run
-/// never slows — the deadline only bounds a genuine hang.
-private let crossingHangGuard: Duration = .seconds(30)
-
 @Suite("DragCrossingCoordinator", .serialized)
 @MainActor
 struct DragCrossingCoordinatorTests {
@@ -38,17 +31,23 @@ struct DragCrossingCoordinatorTests {
             cursor: onForeign,
             homeDisplay: DisplayID(1)
         )
-        let deadline = ContinuousClock.now + crossingHangGuard
-        while fired.isEmpty, ContinuousClock.now < deadline {
-            // Same-display moves must keep the armed dwell
-            // running, not restart it.
-            crossing.moved(
-                id,
-                cursor: onForeign,
-                homeDisplay: DisplayID(1)
-            )
-            try await Task.sleep(nanoseconds: 20_000_000)
-        }
+        let dwell = crossing.dwellTask
+        #expect(dwell != nil, "the move armed no dwell")
+        // Same-display moves must keep the armed dwell running,
+        // not restart it — which is the identity of the handle,
+        // asserted rather than hoped for the way re-arming
+        // inside a poll loop had to (#994).
+        crossing.moved(
+            id,
+            cursor: onForeign,
+            homeDisplay: DisplayID(1)
+        )
+        #expect(crossing.dwellTask == dwell)
+        // Await the dwell's own timeline rather than poll a wall
+        // clock for `fired` (`tests.md` ▸ Async tests): the fire
+        // lands on the main actor, so a deadline measured the
+        // other suites' occupancy of it and not this dwell.
+        await dwell?.value
         // Grace window so a wrong second fire would show up.
         try await Task.sleep(nanoseconds: 100_000_000)
         #expect(fired == [DisplayID(2)])

--- a/Tests/KiwiDeskCoreTests/DragTests.swift
+++ b/Tests/KiwiDeskCoreTests/DragTests.swift
@@ -5,15 +5,6 @@ import Testing
 
 @testable import KiwiDeskCore
 
-/// Generous hang-guard for waits on the settle Task's `onDragEnd`
-/// (#344). The drag settle fires from an unstructured `Task` on the
-/// main actor; because swift-testing runs suites concurrently, that
-/// actor can be starved for seconds under full-suite load, so the old
-/// 5s deadline tripped spuriously (the `ended` still empty flake).
-/// The loops exit the instant `ended` fills, so a large value never
-/// slows a passing run — it only bounds a genuine hang.
-private let dragSettleHangGuard: Duration = .seconds(30)
-
 @MainActor
 private final class MouseButtonState {
     var isPressed: Bool
@@ -49,12 +40,16 @@ struct DragCoordinatorTests {
             )
         }
         mouse.isPressed = false
-        // Poll instead of a fixed sleep: under full-suite
-        // load the settle task can get main-actor time late.
-        let deadline = ContinuousClock.now + dragSettleHangGuard
-        while ended.isEmpty, ContinuousClock.now < deadline {
-            try await Task.sleep(nanoseconds: 20_000_000)
-        }
+        // Await the settle's own timeline instead of polling a
+        // clock for `ended` (#994; `tests.md` ▸ Async tests).
+        // The settle fires from an unstructured `Task` on the
+        // main actor, so a deadline here measured how long the
+        // *other* suites held that actor — the `ended` still
+        // empty flake — and never this coordinator. The handle
+        // is the LAST move's: each move cancels its predecessor.
+        let settle = drag.settleTask(for: id)
+        #expect(settle != nil, "the move scheduled no settle")
+        await settle?.value
         // Grace window so a wrong second fire would show up.
         try await Task.sleep(nanoseconds: 100_000_000)
         #expect(ended.count == 1)
@@ -98,17 +93,16 @@ struct DragCoordinatorTests {
             frame: frame,
             validated: true
         )
-        let deadline = ContinuousClock.now + dragSettleHangGuard
-        while ended.isEmpty, ContinuousClock.now < deadline {
-            try await Task.sleep(nanoseconds: 20_000_000)
-        }
+        let settle = drag.settleTask(for: WindowID(1))
+        #expect(settle != nil, "the move scheduled no settle")
+        await settle?.value
         // Grace window so a wrong second fire would show up.
         try await Task.sleep(nanoseconds: 100_000_000)
         #expect(ended == [frame])
     }
 
     @Test("A gesture's start comes from the pre-event frame")
-    func startAnchorsOnPreEventFrame() async throws {
+    func startAnchorsOnPreEventFrame() async {
         let drag = DragCoordinator()
         drag.settleDelay = 0.05
         let mouse = MouseButtonState(isPressed: true)
@@ -134,16 +128,15 @@ struct DragCoordinatorTests {
             )
         )
         mouse.isPressed = false
-        let deadline = ContinuousClock.now + dragSettleHangGuard
-        while ended.isEmpty, ContinuousClock.now < deadline {
-            try await Task.sleep(nanoseconds: 20_000_000)
-        }
+        let settle = drag.settleTask(for: WindowID(1))
+        #expect(settle != nil, "the move scheduled no settle")
+        await settle?.value
         #expect(ended.first?.0.width == 400)
         #expect(ended.first?.1.width == 700)
     }
 
     @Test("Trailing moves after release join the gesture")
-    func trailingMovesJoinGesture() async throws {
+    func trailingMovesJoinGesture() async {
         let drag = DragCoordinator()
         drag.settleDelay = 0.05
         let mouse = MouseButtonState(isPressed: true)
@@ -159,10 +152,11 @@ struct DragCoordinatorTests {
         mouse.isPressed = false
         let trailing = CGRect(x: 400, y: 0, width: 10, height: 10)
         drag.windowMoved(WindowID(1), frame: trailing)
-        let deadline = ContinuousClock.now + dragSettleHangGuard
-        while ended.isEmpty, ContinuousClock.now < deadline {
-            try await Task.sleep(nanoseconds: 20_000_000)
-        }
+        // The trailing move rescheduled the settle, so this is
+        // its handle rather than the released gesture's first.
+        let settle = drag.settleTask(for: WindowID(1))
+        #expect(settle != nil, "the move scheduled no settle")
+        await settle?.value
         #expect(ended.count == 1)
         #expect(ended.first?.start == first)
         #expect(ended.first?.end == trailing)
@@ -241,10 +235,15 @@ struct DragCoordinatorTests {
         try await Task.sleep(nanoseconds: 150_000_000)
         #expect(ended.isEmpty)
         mouse.isPressed = false
-        let deadline = ContinuousClock.now + dragSettleHangGuard
-        while ended.isEmpty, ContinuousClock.now < deadline {
-            try await Task.sleep(nanoseconds: 20_000_000)
-        }
+        // Read the handle AFTER the release, and only because
+        // this test is `@MainActor` throughout: the release and
+        // this read share one synchronous stretch, so the leg
+        // read here cannot already have run its settle. Awaiting
+        // a leg read while the button was still down would prove
+        // nothing — that leg reschedules and fires no drop.
+        let settle = drag.settleTask(for: WindowID(1))
+        #expect(settle != nil, "the release poll stopped early")
+        await settle?.value
         #expect(ended == [frame])
     }
 }

--- a/Tests/KiwiDeskCoreTests/MoveFocusLatchTests.swift
+++ b/Tests/KiwiDeskCoreTests/MoveFocusLatchTests.swift
@@ -38,21 +38,6 @@ struct MoveFocusLatchTests {
         )
     }
 
-    /// One shared generous hang-guard (#344): the poll exits the
-    /// moment its condition holds, so a passing run never waits
-    /// this out — it only bounds a genuine hang.
-    private let latchHangGuardMS = 30_000
-
-    private func pollUntil(
-        _ condition: () -> Bool
-    ) async {
-        var waited = 0
-        while !condition(), waited < latchHangGuardMS {
-            try? await Task.sleep(for: .milliseconds(20))
-            waited += 20
-        }
-    }
-
     @Test("Latch ages out; fresh stamps suppress")
     func latchAging() {
         let latch = MoveIntentLatch()
@@ -213,9 +198,16 @@ struct MoveFocusLatchTests {
             to: SpaceID(2),
             follow: false
         )
-        await pollUntil {
-            logs.contains { $0.contains("re-raising") }
-        }
+        // Await the settle's own `DeferredTasks` slot instead of
+        // polling a 30 s clock for the line it logs (#994;
+        // `tests.md` ▸ Async tests) — the canonical awaitable
+        // case that section already names. The slot is read
+        // after the call that schedules it: it is never cleared,
+        // so a read before one would await a previous cycle's
+        // finished task and assert nothing.
+        let settle = core.deferred.task(for: .moveSettle)
+        #expect(settle != nil, "the move scheduled no settle")
+        await settle?.value
         #expect(
             logs.contains {
                 $0.contains("move settle")

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
@@ -158,7 +158,7 @@ struct SpaceBarDropCoordinatorTests {
     }
 
     @Test("reset cancels a pending spring (abandoned drag)")
-    func resetCancelsSpring() async {
+    func resetCancelsSpring() async throws {
         let (coord, rec) = make(
             current: SpaceID("A"),
             hit: SpaceID("B"),
@@ -178,6 +178,13 @@ struct SpaceBarDropCoordinatorTests {
         // fired instead of that it had not fired *yet*.
         #expect(dwell?.isCancelled == true)
         await dwell?.value
+        // That await returns at once on a cancelled handle, so
+        // it proves only that THIS dwell unwound. Proving the
+        // negative still takes the gap (200 ms against the 50 ms
+        // dwell): a second, uncancelled task — the shape `arm`'s
+        // own `cancel()` exists to prevent — would fire inside
+        // it and no handle here would see it.
+        try await Task.sleep(nanoseconds: 200_000_000)
         #expect(rec.sprang.isEmpty)
     }
 }

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
@@ -158,7 +158,7 @@ struct SpaceBarDropCoordinatorTests {
     }
 
     @Test("reset cancels a pending spring (abandoned drag)")
-    func resetCancelsSpring() async throws {
+    func resetCancelsSpring() async {
         let (coord, rec) = make(
             current: SpaceID("A"),
             hit: SpaceID("B"),
@@ -178,12 +178,40 @@ struct SpaceBarDropCoordinatorTests {
         // fired instead of that it had not fired *yet*.
         #expect(dwell?.isCancelled == true)
         await dwell?.value
-        // That await returns at once on a cancelled handle, so
-        // it proves only that THIS dwell unwound. Proving the
-        // negative still takes the gap (200 ms against the 50 ms
-        // dwell): a second, uncancelled task — the shape `arm`'s
-        // own `cancel()` exists to prevent — would fire inside
-        // it and no handle here would see it.
+        // No gap sleep here, deliberately: this gesture arms
+        // ONCE, so its one timeline is the only thing that could
+        // spring and the await above has already run it out. The
+        // negative that does need a gap is a *surviving
+        // predecessor*, which needs a second arm to exist at all
+        // — `rearmCancelsPreviousDwell` below owns it.
+        #expect(rec.sprang.isEmpty)
+    }
+
+    @Test("Re-arming cancels the previous item's dwell")
+    func rearmCancelsPreviousDwell() async throws {
+        let (coord, rec) = make(
+            current: SpaceID("A"),
+            hit: SpaceID("B"),
+            dwell: 0.05
+        )
+        coord.moved(win, cursor: cursor)
+        let first = coord.dwellTask
+        #expect(first != nil, "arming scheduled no dwell")
+        // Straight onto another item without leaving the bar.
+        // B's dwell has to die with the arm, or it springs a
+        // space the drag moved off seconds ago.
+        coord.hitTest = { _ in SpaceID("C") }
+        coord.moved(win, cursor: cursor)
+        #expect(first?.isCancelled == true)
+        #expect(coord.dwellTask != first)
+        coord.reset()
+        // The gap belongs here rather than beside the other
+        // cancellation tests: a surviving predecessor is the one
+        // spring no handle in this test is holding, so only
+        // elapsed time past the dwell can show it (200 ms
+        // against 50 ms). Awaiting proves the timelines this
+        // test knows about ended; the sleep covers the one it
+        // would not know about.
         try await Task.sleep(nanoseconds: 200_000_000)
         #expect(rec.sprang.isEmpty)
     }

--- a/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceBarDropCoordinatorTests.swift
@@ -4,11 +4,6 @@ import Testing
 
 @testable import KiwiDeskCore
 
-/// The dwell wait's hang-guard, named and shared the way
-/// `execHangGuard` / `dragSettleHangGuard` are (AGENTS.md §5), so
-/// the next wait added here cannot pick its own tighter number.
-private let springHangGuard: TimeInterval = 120
-
 /// The Space Bar drag-drop state machine (#372): the two-speed
 /// gesture (fast drop relocates, dwell springs then places),
 /// hover arming, and cancellation. Injected closures keep the
@@ -110,33 +105,29 @@ struct SpaceBarDropCoordinatorTests {
     @Test(
         "Dwell springs the space, then the drop places in it"
     )
-    func dwellSpringsThenPlaces() async throws {
+    func dwellSpringsThenPlaces() async {
         let (coord, rec) = make(
             current: SpaceID("A"),
             hit: SpaceID("B"),
             dwell: 0.05
         )
         coord.moved(win, cursor: cursor)
-        // Generous hang-guard (AGENTS.md §5): the wait exits the
-        // instant the spring fires, so a passing run is never
-        // slowed — the deadline only bounds a genuine hang.
+        // Await the dwell's own timeline rather than poll a wall
+        // clock for its effect (#994; `tests.md` ▸ Async tests).
+        // The spring fires from a `@MainActor` Task, so a deadline
+        // here measured how long the *other* suites held the main
+        // actor and not this coordinator at all: a 50 ms dwell was
+        // measured taking 29.7 s of wall clock in a full run, and
+        // raising the bound 30 → 120 s only chose the number the
+        // next grown suite would cross.
         //
-        // Raised 30 → 120 when #95 landed the last three locales.
-        // Nothing here regressed: this suite is `@MainActor`, the
-        // dwell fires through an unstructured `Task`, and the wait
-        // needs the main actor back. A bigger suite starves it for
-        // longer, and the measurement is what forced the number —
-        // one run had it *pass* at 29.7s against the 30s bound,
-        // and neighbouring runs crossed it. A 50 ms dwell taking
-        // 30 s of wall clock is a scheduling fact about a
-        // concurrently-run suite, not a latency this test asserts;
-        // pinning it tight only re-reddens the suite the next time
-        // the suite grows. The starvation itself is a test-runner
-        // property, not app behaviour — nothing a user of the
-        // tiling can observe.
-        try await untilTrue(timeout: springHangGuard) {
-            !rec.sprang.isEmpty
-        }
+        // Read the handle before awaiting it — `fire` clears it —
+        // and keep the non-nil check load-bearing: `await
+        // nil?.value` returns at once, so an arm that scheduled no
+        // dwell would otherwise sail through green.
+        let dwell = coord.dwellTask
+        #expect(dwell != nil, "arming scheduled no dwell")
+        await dwell?.value
         #expect(rec.sprang.map(\.0) == [SpaceID("B")])
         #expect(rec.sprang.first?.1 == win)
         #expect(coord.sprungSpace == SpaceID("B"))
@@ -167,7 +158,7 @@ struct SpaceBarDropCoordinatorTests {
     }
 
     @Test("reset cancels a pending spring (abandoned drag)")
-    func resetCancelsSpring() async throws {
+    func resetCancelsSpring() async {
         let (coord, rec) = make(
             current: SpaceID("A"),
             hit: SpaceID("B"),
@@ -176,28 +167,17 @@ struct SpaceBarDropCoordinatorTests {
         coord.moved(win, cursor: cursor)
         #expect(coord.isArmed)
         #expect(coord.draggingWindow == win)
+        let dwell = coord.dwellTask
+        #expect(dwell != nil, "arming scheduled no dwell")
         coord.reset()
         #expect(!coord.isArmed)
         #expect(coord.draggingWindow == nil)
-        // Wait well past the (tiny) dwell: the spring must never
-        // fire — proven by the gap (200ms vs the 50ms dwell).
-        try await Task.sleep(nanoseconds: 200_000_000)
+        // Read the cancelled timeline rather than sleep past the
+        // dwell and hope: `isCancelled` is the fact itself, and
+        // awaiting the handle afterwards says the spring never
+        // fired instead of that it had not fired *yet*.
+        #expect(dwell?.isCancelled == true)
+        await dwell?.value
         #expect(rec.sprang.isEmpty)
-    }
-
-    /// Polls `condition` until true or `timeout` seconds elapse,
-    /// yielding between checks. Passing runs exit at once.
-    private func untilTrue(
-        timeout: TimeInterval,
-        _ condition: @MainActor () -> Bool
-    ) async throws {
-        let start = Date()
-        while !condition() {
-            if Date().timeIntervalSince(start) > timeout {
-                Issue.record("condition never became true")
-                return
-            }
-            try await Task.sleep(nanoseconds: 5_000_000)
-        }
     }
 }

--- a/Tests/KiwiDeskCoreTests/SpaceSwitchFocusHandoffTests.swift
+++ b/Tests/KiwiDeskCoreTests/SpaceSwitchFocusHandoffTests.swift
@@ -40,21 +40,6 @@ struct SpaceSwitchFocusHandoffTests {
         )
     }
 
-    /// One shared generous hang-guard (#344): the poll below
-    /// exits the moment its condition holds, so a passing run
-    /// never waits this out — it only bounds a genuine hang.
-    private let handoffHangGuardMS = 30_000
-
-    private func pollUntil(
-        _ condition: () -> Bool
-    ) async {
-        var waited = 0
-        while !condition(), waited < handoffHangGuardMS {
-            try? await Task.sleep(for: .milliseconds(20))
-            waited += 20
-        }
-    }
-
     private func makeStickyFloat(
         _ raw: UInt32,
         pid: pid_t
@@ -231,9 +216,16 @@ struct SpaceSwitchFocusHandoffTests {
             follow: false
         )
         core.execute("focus_space", args: [.string("2")])
-        await pollUntil {
-            logs.contains { $0.contains("re-raising") }
-        }
+        // Await the settle's own `DeferredTasks` slot instead of
+        // polling a 30 s clock for the line it logs (#994;
+        // `tests.md` ▸ Async tests) — the canonical awaitable
+        // case that section already names. The slot is read
+        // after the call that schedules it: it is never cleared,
+        // so a read before one would await a previous cycle's
+        // finished task and assert nothing.
+        let settle = core.deferred.task(for: .spaceSettle)
+        #expect(settle != nil, "the switch scheduled no space settle")
+        await settle?.value
         #expect(
             logs.contains {
                 $0.contains("space settle")


### PR DESCRIPTION
## Description

`SpaceBarDropCoordinatorTests` polled `rec.sprang` every 5 ms
against a 120 s wall-clock deadline while the thing it waited for
— the dwell's `@MainActor` `Task` — needed the main actor the
scan-heavy suites hold synchronously for stretches. The wait was
bounded by *other suites' occupancy*, not by the coordinator, and
it timed out on #992's CI run. Raising the bound 30 → 120 s had
already failed once; no number can be right in both directions.

The handle exists, so the wait can be exact — the shape #986
landed for the sibling #979:

```swift
let dwell = coord.dwellTask
#expect(dwell != nil, "arming scheduled no dwell")
await dwell?.value
```

**The sweep #994 asked for.** `untilTrue` lived only in that one
suite, but the same class sits elsewhere in Core, and all of it
is converted here: `DragTests` (five polls on a 30 s
`dragSettleHangGuard`), `DragCrossingCoordinatorTests` (one on
`crossingHangGuard`), and — found by both reviewers —
`MoveFocusLatchTests` / `SpaceSwitchFocusHandoffTests`, which
polled 30 s for a line logged by a `DeferredTasks` body, the
canonical awaitable case `tests.md` names two lines from where
it was cited. Four hang-guard constants are gone; `ExecTests` and
`SocketTests` remain the poll's worked cases, because they wait
on something with no handle to await.

**One conversion strengthened a guard rather than preserving it.**
`dwellFires` used to re-arm the dwell inside its poll loop and
*hope* a same-display move would not restart it. It now asserts
the handle's identity is unchanged — and guard-prover showed that
assertion is the sole net for that invariant: under a mutation
that restarts the dwell, `fired == [DisplayID(2)]` stays **green**,
because the restarted dwell still fires exactly one crossing
inside the grace window. The loop it replaced proved nothing
there.

**Three seams are exposed, all `#if DEBUG`.**
`SpaceBarDropCoordinator.dwellTask`,
`DragCoordinator.settleTask(for:)` and
`DragCrossingCoordinator.dwellTask`. Each doc comment states what
awaiting it does NOT mean, per `tests.md`. The wrap is what
enforces the bar — a doc comment saying "production must not read
this" is not greppable and fails nothing; proven load-bearing
below.

## Related Issue(s)

Closes #994

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended — n/a, no runtime
  behavior changes: the only `Sources/` edits are three
  debug-only read accessors and one storage rename
- [x] Commits follow Conventional Commits format
      (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
      required)
- [x] User-facing changes are documented in `docs/` — n/a,
      nothing user-visible
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
- [x] Release build green — run locally (88 s), since the diff
      touches `Sources/`
- [x] PR is focused; refactors separated from features

## How I verified

- **Full suite: 3934 tests in 740 suites green in 117 s.** That
  is the condition the flake actually needs — main-actor
  contention from the concurrently-run scan-heavy suites.
- The converted suites, which used to wait under 120 s and 30 s
  ceilings: **0.06 s**, **1.10 s**, **0.80 s**, and the two swept
  settle tests at **0.32 s** / **0.35 s**.
- `swift build`, `swift build -c release` and `scripts/lint.sh`
  all exit 0.
- **`guard-prover`, two passes, 15 mutations, every one applied
  and restored separately.** 12 red-proofed, 0 inert, 0 vacuous.
  The ones worth naming:
  1. **The scheduler stops scheduling** → RED on `!= nil` in
     **0.002 s**. This is exactly what `await nil?.value` would
     have sailed through green, and it is why every one of those
     assertions is load-bearing rather than decorative.
  2. **The effect removed, the timeline still completing** → RED
     on the effect assertions, the run ending on its own after
     the full dwell. The await genuinely awaits.
  3. **`settle` returning without rescheduling** → RED, not a
     hang, on `waitsForRelease`'s own message ("the release poll
     stopped early").
  4. **A production read of `settleTask(for:)`** → `swift build
     -c release` FAILS in 5.2 s (`no member 'settleTask'`) while
     debug compiles clean. The `#if DEBUG` wrap enforces the bar.
  5. **The `.spaceSettle` slot attribution**, proven two ways:
     removing the re-raise from `.spaceSettle` reds the swept
     test; removing it from `.moveSettle` instead leaves the
     suite green. The test awaits the slot that emits the line
     it asserts on.

## Notes for Reviewer

**The two things review caught that I would have shipped**, since
they are the useful part:

1. **A cancelled handle's await returns at ~0 ms**, so
   `resetCancelsSpring`'s trailing `rec.sprang.isEmpty` was being
   evaluated before the 50 ms dwell could elapse — it could only
   red on a *synchronous* spring. I restored the 200 ms gap.
   guard-prover then showed the restored gap was *still* paying
   for nothing: that test arms ONCE, so the class it guards
   against — a surviving predecessor — cannot arise in its
   fixture, and deleting `arm`'s own `pendingDwell?.cancel()`
   left the whole suite green. **That line was guarded by
   nothing.** So the gap moved to a new test that opens the hole
   (arm B, re-arm C, reset, wait past the dwell), which reds
   twice under that mutation, and `resetCancelsSpring` says in
   prose why it needs no gap.
2. **`RuleCitationTests` redded on my own rule edit**: I cited
   `SocketServerTests`, which is the FILE — the suite it declares
   is `SocketTests`. Both citations were introduced by this
   branch. The second was wrong on substance too, leaning on that
   suite as already documenting this trade when what it documents
   is a *generous deadline*, not an unbounded await.

**Stated rather than hidden:** a timeline that genuinely never
completes now stalls the job instead of naming an assertion —
`Tests/` sets no `.timeLimit`. `tests.md` now carries that ruling
explicitly, including that no mutation can red the hang class, so
a green suite here does not cover it. The trade is the right way
round: the deadline it replaces was not failing runs that were
stuck, it was failing runs that were merely slow.

**Left deliberately:** the architect flagged that this repo now
has three distinct "test-only member of a production type"
mechanisms (`#if DEBUG` overrides, injected closure seams, and
these read-only handles), each with its own enforcement story. A
census of which one a new seam should pick would fit `tests.md`,
but it is larger than this change and not its to write.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
