### PR TITLE
chore(github): let the org's default carry the sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,0 @@
-# GitHub native funding configuration
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
-
-github: KiwiCanopy
-ko_fi: kiwicanopy


### PR DESCRIPTION
## Description

Removes `.github/FUNDING.yml` from KiwiDesk. The two targets it
named — `github: KiwiCanopy` and `ko_fi: kiwicanopy` — are org
identities, not repo ones, so the file was a copy of a fact that
belongs one level up.

The org-wide default now lives at
[KiwiCanopy/.github → FUNDING.yml](https://github.com/KiwiCanopy/.github/blob/main/FUNDING.yml)
and reaches every public repo in the org that does not override
it (KiwiDesk, `homebrew-tap`, and anything public added later).
A funding target changes in one place from here on.

The org file was committed **before** this PR was opened, so
there is no window in which KiwiDesk shows no sponsor button.

## Related Issue(s)

None.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended — n/a, no shipped
  code or resource is touched; the file is GitHub repository
  metadata read by github.com alone
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested — n/a, nothing the suite can
  reach; no test, build step or lint step reads this path
- [x] User-facing changes are documented in `docs/` — n/a,
  `docs/` describes the app, not the repo's GitHub metadata
- [x] No contradictions between code and docs — nothing in the
  tree referenced `FUNDING.yml` (grepped)
- [x] `swift build && swift test && ./scripts/lint.sh` passes —
  unaffected; CI runs the macOS jobs anyway, since
  `.github/FUNDING.yml` is not on `.github/ci-ignore.txt`
- [x] Release build green — unaffected
- [x] PR is focused; refactors separated from features

## How I verified

- `gh api repos/KiwiCanopy/.github/git/trees/HEAD?recursive=1`
  before the change: the org repo carried `CODE_OF_CONDUCT.md`
  and `SECURITY.md` at its root but no `FUNDING.yml`, so the
  default did not yet exist.
- Wrote `FUNDING.yml` to that repo's root — the same location
  the two existing default health files use, which GitHub
  accepts for defaults (root, `.github/` or `docs/`).
- `grep -rn FUNDING` across the worktree: no test, script,
  workflow or doc references the removed path.

## Notes for Reviewer

The org's GitHub Sponsors listing is not published
(`hasSponsorsListing: false`, `sponsorsListing.isPublic:
false`), so the `github: KiwiCanopy` line resolves to nothing
today and only the Ko-fi entry renders. That is unchanged by
this PR — it was equally true of the repo-level file — but it
is now promoted org-wide, so it is worth either publishing the
listing or dropping the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
