### PR TITLE
fix(cli): print JSON a person can read, in an order that holds

### DIFF
--- a/Sources/KiwiDesk/CLIMain.swift
+++ b/Sources/KiwiDesk/CLIMain.swift
@@ -117,8 +117,10 @@ private func runSocketCommand(
         }
         let response = try client.roundTrip(request)
         if let data = response.data,
-            let encoded = try? JSONEncoder().encode(data),
-            let text = String(data: encoded, encoding: .utf8)
+            let text = CLIOutput.render(
+                data,
+                pretty: CLIOutput.stdoutIsTerminal
+            )
         {
             print(text)
         }

--- a/Sources/KiwiDesk/CLIOutput.swift
+++ b/Sources/KiwiDesk/CLIOutput.swift
@@ -1,0 +1,50 @@
+import Foundation
+import KiwiDeskCore
+
+/// Renders a command response's payload for stdout.
+///
+/// Split out of `runSocketCommand` so the formatting decision is
+/// testable without a live socket: the CLI half is one `print`,
+/// and everything that decides *what* gets printed is here.
+enum CLIOutput {
+    /// Encodes `data` the way the CLI prints it.
+    ///
+    /// `.sortedKeys` is unconditional. Without it `JSONEncoder`
+    /// emits dictionary keys in `Dictionary` hash order, so two
+    /// sibling objects inside ONE response can disagree on key
+    /// order and a re-run can disagree with itself — which is
+    /// what #1034 reported from `list_monitors`. Sorting costs
+    /// nothing and makes a captured response diffable.
+    ///
+    /// `.prettyPrinted` is the caller's to decide, because it
+    /// is the half that changes shape: a piped or redirected
+    /// call must keep the compact single line that existing
+    /// scripts already parse, and only a terminal gets the
+    /// indented form.
+    ///
+    /// Returns nil when the payload cannot be encoded, which is
+    /// the same silent-skip the call site had before — a
+    /// `JSONValue` is schema-free and has no unencodable case,
+    /// so this is unreachable rather than a swallowed error.
+    static func render(
+        _ data: JSONValue,
+        pretty: Bool
+    ) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting =
+            pretty ? [.sortedKeys, .prettyPrinted] : [.sortedKeys]
+        guard let encoded = try? encoder.encode(data) else {
+            return nil
+        }
+        return String(data: encoded, encoding: .utf8)
+    }
+
+    /// Whether stdout is a terminal rather than a pipe or file.
+    ///
+    /// The one input to the `pretty` decision, named here so a
+    /// test can drive `render` without owning the process's
+    /// file descriptors.
+    static var stdoutIsTerminal: Bool {
+        isatty(FileHandle.standardOutput.fileDescriptor) == 1
+    }
+}

--- a/Tests/KiwiDeskGuiTests/CLIOutputRenderTests.swift
+++ b/Tests/KiwiDeskGuiTests/CLIOutputRenderTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import KiwiDeskCore
+import Testing
+
+@testable import KiwiDesk
+
+/// How the CLI prints a command response's payload (#1034).
+///
+/// Two facets, deliberately separated: key ORDER must not depend
+/// on where the process's dictionary hashing landed, and only the
+/// terminal gets the indented form. The first is unconditional,
+/// the second is the caller's decision — so a piped call keeps
+/// the exact single line existing scripts already parse.
+@Suite("CLI JSON output shape (#1034)")
+struct CLIOutputRenderTests {
+    /// An object whose insertion order is deliberately NOT
+    /// alphabetical: the `list_monitors` shape from the report.
+    private var monitor: JSONValue {
+        .object([
+            "name": .string("DELL U2720Q"),
+            "width": .number(2560),
+            "fingerprint": .string("DELL U2720Q:2560x1440"),
+            "height": .number(1440),
+            "id": .number(3),
+        ])
+    }
+
+    @Test("keys are sorted whether or not output is pretty")
+    func keysSortInBothModes() {
+        // The bug was two SIBLING objects in one response
+        // disagreeing on key order, so pinning one rendering
+        // against itself would prove nothing — pin the order
+        // against the alphabet, which is the only stable thing
+        // a reader or a diff can rely on.
+        for pretty in [false, true] {
+            let text = CLIOutput.render(monitor, pretty: pretty)
+            let rendered = try! #require(text)
+            let keys = ["fingerprint", "height", "id", "name", "width"]
+            var searchFrom = rendered.startIndex
+            for key in keys {
+                let found = rendered.range(
+                    of: "\"\(key)\"",
+                    range: searchFrom..<rendered.endIndex
+                )
+                #expect(
+                    found != nil,
+                    "\(key) missing (pretty: \(pretty))"
+                )
+                guard let found else { break }
+                searchFrom = found.upperBound
+            }
+        }
+    }
+
+    @Test("a piped call stays on one line")
+    func compactIsSingleLine() {
+        // The contract for scripts: no newline anywhere inside
+        // the payload, however nested it is.
+        let nested = JSONValue.array([monitor, monitor])
+        let text = try! #require(
+            CLIOutput.render(nested, pretty: false)
+        )
+        #expect(!text.contains("\n"))
+    }
+
+    @Test("a terminal gets one element per line")
+    func prettyBreaksLines() {
+        // 262 names on one 6.9 KB line was the reported symptom;
+        // the fix is that a multi-element payload occupies more
+        // lines than it has elements' worth of braces.
+        let names = JSONValue.array(
+            ["focus", "swap", "resize"].map { .string($0) }
+        )
+        let text = try! #require(
+            CLIOutput.render(names, pretty: true)
+        )
+        #expect(text.split(separator: "\n").count >= 3)
+    }
+
+    @Test("the two modes differ only in whitespace")
+    func modesAgreeOnContent() {
+        // Pretty-printing must not add, drop or reorder a thing
+        // — otherwise a user reading the terminal is reading a
+        // different response than their script parsed.
+        let payload = JSONValue.array([monitor, .null, .bool(true)])
+        let compact = try! #require(
+            CLIOutput.render(payload, pretty: false)
+        )
+        let pretty = try! #require(
+            CLIOutput.render(payload, pretty: true)
+        )
+        let stripped = pretty.filter { !$0.isWhitespace }
+        #expect(stripped == compact.filter { !$0.isWhitespace })
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,6 +55,13 @@ Commands are sent over a UNIX domain socket at
 `~/.config/KiwiDesk/KiwiDesk.sock`. Exit code is 0 on
 success, 1 on error (message on stderr, data on stdout).
 
+Data on stdout is JSON with its object keys **sorted**, so two
+captures of the same response can be diffed. It is indented when
+stdout is a terminal and compact — one line — when it is piped or
+redirected, which keeps it exactly what a script or `jq` already
+expects. `subscribe` is unaffected either way: its stream is
+newline-delimited JSON, one event per line, whatever stdout is.
+
 ## Version
 
 ```sh


### PR DESCRIPTION
## Description

`JSONEncoder` was used with no `outputFormatting`
(`CLIMain.swift:120`), which cost two different things.

**Key order was nondeterministic.** It followed `Dictionary`
hashing, so two sibling objects inside one response could
disagree with each other — `list_monitors` returned its two
displays with different key orders in a single call — and a
re-run could disagree with itself. `.sortedKeys` is now
unconditional: it costs nothing and makes a captured response
diffable.

**Everything arrived on one line.** `list_commands` is 6.9 KB of
it. `.prettyPrinted` is applied only when stdout is a TTY, so a
piped or redirected call keeps the exact compact line existing
scripts and `jq` pipelines already parse.

The formatting decision moves to a new `CLIOutput` so it is
testable without a live socket.

**What this deliberately does not touch:** `subscribe` returns
before the encoder (`CLIMain.swift:110`) and prints socket lines
verbatim, so its NDJSON contract — one event per line — holds
whatever stdout is. The wire protocol's own encoders
(`SocketServer.swift:253`, `SocketClient.swift:75`) are
untouched; this is the CLI's *display* encode alone.

## Related Issue(s)

Fixes #1034. Independent of #1033, which wants `list_commands` to
return structured records — this makes whatever the commands
already return readable and stable, so that payload arrives into
a renderer that can print it.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see below)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested — `CLIOutputRenderTests`, 4 tests,
  proved red by three mutations (below)
- [x] User-facing changes are documented in `docs/` —
  `docs/cli.md` now states the sorted-key and TTY behavior, and
  that `subscribe` is unaffected
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
- [ ] Release build green — skipped locally; no concurrency or
  `Sendable` surface is touched. **Read CI's `Release Build` job
  before merging.**
- [x] PR is focused; refactors separated from features

## How I verified

Full gate on the rebased branch:

- `swift build` — Build complete (51.49s).
- `swift test` — **3978 tests in 754 suites passed** (147.67s).
- `./scripts/lint.sh` — `Lint OK` (the file-size WARNINGs are
  pre-existing and not failures; the exit code decides).
- `site/`: `npm ci && npm run build` — 30 pages built, Complete.
  Run because `docs/` changed and no Swift test can see a broken
  Starlight page.

Against the running 1.0.1 app, before the change — the two
symptoms as reported:

```
$ kiwidesk list_monitors
[{"name":…,"width":…,"fingerprint":…,"height":…,"id":3},
 {"width":…,"name":…,"id":1,"fingerprint":…,"height":…}]   # key order differs
$ kiwidesk list_commands | wc -c ; kiwidesk list_commands | wc -l
    6952
       1
```

**Guard proof.** The new suite was proved to red, one mutation
at a time, each hitting exactly one test and leaving the others
green:

| mutation | test that reds |
|---|---|
| drop `.sortedKeys` | keys are sorted whether or not output is pretty |
| never `.prettyPrinted` | a terminal gets one element per line |
| `.prettyPrinted` even when piped | a piped call stays on one line |

Tree restored after each; suite green again, working tree clean.

## Notes for Reviewer

The TTY branch is the one judgement call. The alternative was
pretty-printing unconditionally — simpler, still valid JSON, but
it changes the bytes every existing script sees. Gating on
`isatty` gives humans the readable form at zero cost to machines,
which is why `stdoutIsTerminal` is a named property rather than
an inline call: the test drives `render` directly and never needs
to own the process's file descriptors.

`.sortedKeys` does change the piped bytes — deliberately, since
the order it replaces was not stable in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
