### PR TITLE
test(layout): the vertical ceiling guard passed without growing

### DIFF
--- a/Tests/KiwiDeskCoreTests/ScrollingSlotCeilingTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingSlotCeilingTests.swift
@@ -91,10 +91,14 @@ struct ScrollingSlotCeilingTests {
             )
         }
         // Eight 400pt grows would reach ~4300pt unclamped. The
-        // store stops at exactly the area the layout draws into
-        // — asserted against that area rather than a number,
-        // because capping at the layout REGION instead would
-        // bank the outer gaps and the bar strip.
+        // store stops at exactly the area the layout draws into,
+        // asserted against that area rather than a number.
+        // Capping at the raw display bounds instead would bank
+        // the outer gaps here; note the bar strip is NOT visible
+        // on this axis — `usable` already has the gaps off, and
+        // a horizontal bar carves the height, so
+        // `verticalCeilingClearsTheBarStrip` is the only net on
+        // the strip half.
         #expect(try slotPoints(core, space) == areaExtent(core))
         // ...and it got there by GROWING. Without this a
         // ceiling that binds too low — or a writer that refuses
@@ -181,6 +185,21 @@ struct ScrollingSlotCeilingTests {
             "scroll.set_orientation",
             args: [.string("vertical")]
         )
+        // Seed BELOW the ceiling first. A vertical `auto` slot
+        // resolves against the region and already sits above the
+        // drawn area, so without this the clamp fires on the way
+        // DOWN and the assertion below passes without a single
+        // press having grown anything (guard-prover, 2026-08-27).
+        core.execute(
+            "scroll.set_slot_size",
+            args: [.number(300)]
+        )
+        let seed = try slotPoints(
+            core,
+            space,
+            along: 800,
+            horizontal: false
+        )
         for _ in 0..<8 {
             core.execute(
                 "resize",
@@ -196,6 +215,8 @@ struct ScrollingSlotCeilingTests {
         #expect(
             stored == (try areaExtent(core, horizontal: false))
         )
+        // ...and it grew to get there.
+        #expect(stored > seed)
     }
 
     @Test("A grow never shrinks a config-set oversize slot")


### PR DESCRIPTION
## Description

A test-only follow-up to #966 (PR #1054), from `guard-prover`'s
final pass — which finished after that PR had auto-merged.

`ScrollingSlotCeilingTests.verticalCeilingClearsTheBarStrip`
asserted that eight grow presses leave the store on the area the
layout draws into. It did — but under a writer that never grows
at all (`requested = current`) the test stayed **green**. A
vertical `auto` slot resolves against the layout region and
already sits above the drawn area (729.6 pt against 706), so the
ceiling clamp fires on the way *down* and the assertion is
satisfied with nothing having grown.

It seeds at 300 first now — below the ceiling, and clear of the
configured-length clause since 300 < 706 — after which the
growth assertion is live and reds at `stored → 300.0 > seed →
300.0`.

This is worth a PR of its own rather than a note, because that
test is the **only** net anywhere for the `.points`-only
restriction on the configured-length clause: one assertion out
of 4091, on one axis. It should not also be blind to whether the
writer underneath it grows.

Also corrects a comment that described a mutation which is a
no-op on the axis it was written for: `context.usable` already
has the outer gaps removed, so capping at the region rather than
the drawn area is invisible horizontally — the App Bar strip
only lands on the scroll axis when the orientation is vertical.

## Related Issue(s)

Follow-up to #966 / PR #1054. Closes nothing.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended — N/A: test-only, no
  production code changed, so there is nothing to observe in the
  app that #1054's own device round did not already cover
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested (pure logic / layout code
  required) — the change IS the test
- [x] User-facing changes are documented in `docs/` — none
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes
- [x] Release build green — CI's `Release Build` job
- [x] PR is focused; refactors separated from features

## How I verified

`swift test` 4091 green, `scripts/lint.sh` clean. The guard was
proved red under the mutation it exists for: with
`requested = current` in `writeCappedScrollSlot`, the test now
fails on both clauses where it previously passed on both.

## Notes for Reviewer

The diff is one fixture. The reason it is not simply a copy of
the horizontal siblings' "and it moved" clause is in the commit
message: `stored > seed` is false by construction when the seed
starts above the ceiling, so the fixture had to be seeded rather
than the assertion copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
