### PR TITLE
fix(commands): the scrolling press base reads the engine's frame (#1063)

### DIFF
--- a/.claude/rules/state-and-layout.md
+++ b/.claude/rules/state-and-layout.md
@@ -422,8 +422,14 @@ editing here:
   and since #1057 the whole press DECISION lives in ONE pure
   type (#966/#1057).** `ScrollSlotDomain.decide` — reached only
   from the `writeCapped*` seam, which resolves the base input
-  (the bound's consume of the layout-floored, viewport-capped
-  store) — owns every cap and refusal arm
+  off the ENGINE's computed frame for the focused window
+  (#1063, `ScrollingFreshLedgerPressTests`: a reconstruction
+  beside the layout asked the ladder at a span no layout
+  issued, so a fresh ledger ballooned the press; the consume
+  of the layout-floored, viewport-capped store stays as the
+  fallback for a focus the engine computes no frame for — a
+  floating or native-fullscreen focus, mid-adoption) — owns
+  every cap and refusal arm
   (`ScrollSlotDomainTests`); a new arm goes there, never inline
   in a writer. The obligations it holds: the press measures
   from the focused window's DRAWN span; a press the window's

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeScrollSlot.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+ResizeScrollSlot.swift
@@ -42,9 +42,10 @@ extension KiwiCore {
     /// Since #1057 this writer is PLUMBING: it resolves the
     /// inputs and `ScrollSlotDomain.decide` owns the decision —
     /// every cap and refusal arm — while the ONE base input
-    /// resolved here is the focused window's rendered span:
-    /// the bound's consume of the layout-floored,
-    /// viewport-capped store. The rules and their argument
+    /// resolved here is the focused window's rendered span,
+    /// read off the engine's computed frames (#1063; the
+    /// consume-of-the-store reconstruction below stays as the
+    /// fallback). The rules and their argument
     /// live on `ScrollSlotDomain`; `ScrollSlotDomainTests`
     /// pins the arms and the engine suites pin this wiring.
     func writeCappedScrollSlot(
@@ -68,9 +69,14 @@ extension KiwiCore {
                 effectiveMinSize(of: $0, axis: axis)
             } ?? 0
         )
-        // Built through the same resolver `layoutInput` uses, so
-        // `usable` (bounds less the outer gaps) and the bar carve
-        // cannot drift from what the layout drew.
+        // Built through the same resolver `layoutInput` uses,
+        // so the viewport CARVE — `usable` (bounds less the
+        // outer gaps) and the bar strip — cannot drift from
+        // what the layout drew. The carve is all this local
+        // rebuild serves (the ceiling below); the press BASE
+        // takes the engine's full context via
+        // `calculatedFrames` instead, sticky and size bounds
+        // included.
         let context = tiler.settings.context(
             bounds: bounds,
             space: space,
@@ -107,11 +113,34 @@ extension KiwiCore {
         let appMin: CGFloat? = bound.flatMap {
             axis == "x" ? $0.minWidth : $0.minHeight
         }
-        // The span the focused window actually RENDERS: the
-        // bound's consume where it pins, the layout-floored,
-        // viewport-capped store otherwise — the base the whole
-        // decision is measured against (#1057). The floor
-        // matters (review, 2026-08-28): the layout asks
+        // The span the focused window actually RENDERS — the
+        // base the whole decision is measured against (#1057) —
+        // read off the ENGINE's computed frames: the same
+        // answer the layout draws and the ring wraps, consume
+        // included. Reconstructing it from the store's consume
+        // (this writer's first shape) consulted the ladder at
+        // a span no layout ever issued — an `auto` seed
+        // resolves against the raw axis while the layout
+        // resolves against its carve — so on a fresh ledger
+        // (per-ask entries only, nothing corroborated yet:
+        // every relaunch, #1063) the consume missed and the
+        // press measured from the ~full-axis store, ballooning
+        // the slot the whole row shares around a window that
+        // never moved.
+        let engineDrawn: CGFloat? = space.focused.flatMap {
+            tiler.calculatedFrames(state: state)[$0].map {
+                horizontal ? $0.width : $0.height
+            }
+        }
+        // The reconstruction, kept as the FALLBACK for a focus
+        // the engine computes no frame for. The common takers
+        // are a FLOATING and a native-FULLSCREEN focus — both
+        // keep `space.focused` and leave the tiled derivations
+        // (#670), so `calculatedFrames` assigns them nothing —
+        // plus an untracked, mid-adoption focus; for all of
+        // them the store is the only coherent measure of the
+        // shared slot. The floor matters (review,
+        // 2026-08-28): the layout asks
         // `min(along, max(resolved, minWindowSize))`, so a
         // points store below `min_window_size` (representable —
         // `ScrollSize` floors only at `minPoints`, and the
@@ -133,7 +162,7 @@ extension KiwiCore {
             delta: CGFloat(delta),
             stored: current,
             drawnArea: drawnAlong,
-            drawnFocused: consumed ?? capped,
+            drawnFocused: engineDrawn ?? consumed ?? capped,
             configured: configured,
             globalMin: CGFloat(effectiveMin),
             appMin: appMin,

--- a/Sources/KiwiDeskCore/Layouts/ScrollSlotDomain.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollSlotDomain.swift
@@ -52,8 +52,10 @@ public enum ScrollSlotDomain {
     /// One press. `stored` is the resolved current store;
     /// `drawnArea` the viewport carve the layout draws into;
     /// `drawnFocused` the span the focused window actually
-    /// renders (the caller resolves it through the bound's
-    /// consume, falling back to `min(stored, drawnArea)`);
+    /// renders (the caller reads it off the engine's computed
+    /// frames — #1063 — falling back to the bound's consume of
+    /// the store, then to the layout-floored
+    /// `min(max(stored, globalMin), drawnArea)`);
     /// `configured` the points-store value or 0 (#966's
     /// never-reduce term); `globalMin` the floor from
     /// `min_window_size` and `ScrollSize.minPoints`; `appMin` /

--- a/Tests/KiwiDeskCoreTests/ScrollingFreshLedgerPressTests.swift
+++ b/Tests/KiwiDeskCoreTests/ScrollingFreshLedgerPressTests.swift
@@ -1,0 +1,142 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The scrolling press measures from the drawn span even on a
+/// FRESH ledger (#1063). Split from `ScrollingAppCeilingTests`
+/// at the file ceiling, under the same screen trait for the
+/// same reason: `resizeScrollingSlot` falls back to a 1920x1080
+/// rect when no screen resolves, so headless this would assert
+/// against a viewport the fixture never pinned — a SKIP says
+/// that; a green would not.
+///
+/// The shape this suite pins: a relaunch loses the size-bound
+/// ledger, the boot dance re-confirms ONE per-ask entry at the
+/// LAYOUT's own ask span, and nothing is corroborated yet. The
+/// writer's first #1057 shape reconstructed the drawn span from
+/// the store's consume, which asked the ladder at the raw-axis
+/// auto seed — a span no layout ever issued — so the base fell
+/// back to the ~full-axis store and one shrink ballooned the
+/// slot the whole row shares around a window that never moved.
+@Suite(
+    "Scrolling fresh-ledger press base (#1063)",
+    .enabled(if: NSScreen.main != nil)
+)
+@MainActor
+struct ScrollingFreshLedgerPressTests {
+    /// A scrolling space on a pinned 1200pt-wide display
+    /// (#531), focused on the first of two windows — the
+    /// sibling suites' fixture.
+    private func makeCore() -> (core: KiwiCore, space: SpaceID) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "kiwidesk-fresh-ledger-\(UUID().uuidString)"
+            )
+        let core = makeTestCore(configDirectory: directory)
+        core.tiler.visibleBounds = { _ in
+            CGRect(x: 0, y: 0, width: 1200, height: 800)
+        }
+        for id: UInt32 in 1...2 {
+            core.state.apply(
+                .windowCreated(
+                    ManagedWindow(
+                        id: WindowID(id),
+                        pid: pid_t(id),
+                        appName: "App\(id)"
+                    )
+                )
+            )
+        }
+        let space = core.state.workspaces.space(of: WindowID(1))!
+        core.execute(
+            "set_mode",
+            args: [.string(space.raw), .string("scrolling")]
+        )
+        core.state.workspaces.focus(WindowID(1), in: space)
+        // Pin the default the exact expectations reason from
+        // (#660): the `== 665` assertion holds only while the
+        // global floor sits below it.
+        #expect(core.tiler.settings.minWindowSize == 300)
+        return (core, space)
+    }
+
+    private func slotPoints(
+        _ core: KiwiCore,
+        _ space: SpaceID
+    ) throws -> CGFloat {
+        let live = try #require(core.state.workspaces[space])
+        return core.tiler.settings.resolvedScrolling(for: live)
+            .slotSize
+            .editablePoints(along: 1200, horizontal: true)
+    }
+
+    @Test(
+        "A fresh uncorroborated ledger measures from the drawn span"
+    )
+    func freshLedgerMeasuresFromTheDrawnSpan() throws {
+        let (core, space) = makeCore()
+        // The layout's own ask for the default auto store,
+        // derived exactly as `ScrollingLayout.metrics` derives
+        // it, so the taught entry sits where the boot dance
+        // would put it.
+        let input = try #require(
+            core.tiler.layoutInput(state: core.state)
+        )
+        let context = input.context
+        let area = context.scrolling.windowFrame(
+            in: context.usable,
+            inner: context.gaps.inner,
+            global: context.appBarStyle
+        )
+        let ask = min(
+            area.width,
+            max(
+                context.scrolling.slotSize.resolved(
+                    along: area.width,
+                    horizontal: true
+                ),
+                context.minWindowSize
+            )
+        )
+        // The premise the regression rests on, derived rather
+        // than assumed: the raw-axis seed the old
+        // reconstruction consulted the ladder at is NOT the
+        // layout's ask, past the match tolerance — the two
+        // resolutions diverge by the outer-gap carve.
+        let seed = context.scrolling.slotSize.editablePoints(
+            along: 1200,
+            horizontal: true
+        )
+        #expect(
+            abs(seed - ask) > EffectiveSizeBound.matchTolerance
+        )
+        // ONE ask span, observed twice: confirmed, and
+        // deliberately NOT corroborated — corroboration needs
+        // two distinct spans, and a fresh boot issues one.
+        for _ in 0..<2 {
+            core.tiler.boundLearner.recordAsk(
+                WindowID(1),
+                size: CGSize(width: ask, height: 800)
+            )
+            core.tiler.boundLearner.observe(
+                WindowID(1),
+                currentSize: CGSize(width: 715, height: 800),
+                settledRead: true
+            )
+        }
+        var refusals: [ResizeRefusal] = []
+        core.borders.onResizeRefusal = { refusals.append($0) }
+        core.execute(
+            "resize",
+            args: [.string("x"), .number(-50)]
+        )
+        // Measured from the 715pt the window renders — never
+        // from the auto seed, which is the balloon. Silent:
+        // nothing corroborated pins a minimum yet.
+        #expect(try slotPoints(core, space) == 665)
+        #expect(refusals.isEmpty)
+    }
+}


### PR DESCRIPTION
## Description

The scrolling resize press's base span is now read off the engine's computed frame for the focused window, instead of being reconstructed from the size-bound ladder's consume of the store. The reconstruction asked the ladder at the raw-axis `auto` seed — a span no layout ever issues, since the layout resolves against its carve — so on a fresh ledger (every relaunch: one confirmed per-ask entry, nothing corroborated) the consume missed, the base fell back to the ~full-axis store, and a single shrink press wrote a near-full-width slot: the whole row ballooned around a window that never moved. Mid-session a corroborated bound hid the mismatch by answering any ask beyond it, which is why this only bit right after a relaunch.

The consume-of-store resolution stays as the fallback for a focus the engine computes no frame for (floating or native-fullscreen focus, mid-adoption). Doc comments and the `state-and-layout.md` rule row updated in the same change.

## Related Issue(s)

The balloon half of #1063 — deliberately **not** `Closes`: the issue stays open (owner ruling 2026-08-28) for the accepted residue, the size-bound ledger dying with the process.

## Checklist

- [x] I understand what this change does and have run it in the app to confirm it works as intended (see "How I verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code required)
- [x] User-facing changes are documented in `docs/` (no doc edit owed: the #1057 entries in `docs/design-decisions.md`, `docs/lua-reference.md` and `docs/user-guide.md` state the drawn-span rule this fix restores — audited by docs-steward)
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh` passes (4143 tests / 785 suites, lint exit 0)
- [ ] Release build green — CI's `Release Build` job (no concurrency / `Sendable` touched; read the job before merging)
- [x] PR is focused; refactors separated from features

## How I verified

On-device before/after with the exact owner recipe (System Settings focused across a quit+relaunch, `resize x -50` after the boot dance settles, burst screenshots + unified-log capture, subsystem `com.kiwicanopy.kiwidesk`):

- **Before** (main @ `a922cd41`): press at 11:49:38.6 → the ring ballooned to near-full width within 0.3 s, System Settings shoved mostly off-screen, a fresh learn dance ran for the whole row (`size bound candidate for window 253142 … 11:49:40.623`, the emulator re-confirmed at a different span), clamping back only seconds later.
- **After** (this branch): same recipe at 12:19:49 → no balloon, no giant ask, no candidate storm; System Settings stays at its 825 pt frame. The remaining first-press silence and late min/max pills are the accepted #1063 residue (uncorroborated bounds cannot refuse), eye-confirmed by the owner ("better than before").

Review round: code-reviewer + architect-reviewer + docs-steward + guard-prover (isolated worktree). All findings addressed in the squashed commit — the majors were an accidentally deleted sibling test (`singleRefusalDoesNotBind`, restored) and doc-precision minors. Guard-prover red-proofed the new regression test against wrong-window and wrong-axis mutations beyond the revert-red; its one stated residue is the unexercised `consumed ?? capped` fallback tail, kept because it merely preserves pre-fix behavior for focus classes the press rarely reaches.

## Notes for Reviewer

`TilingEngine.calculatedFrames(state:)` is pure (the only `recordAsk` producer is the retile apply loop) and already an established Commands-layer read — this joins the same seam the border ring and six other command sites use, rather than opening a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
