### PR TITLE
docs(rules): a needle refinement states what it trades

### DIFF
--- a/.claude/rules/rule-authoring.md
+++ b/.claude/rules/rule-authoring.md
@@ -108,6 +108,30 @@ rather than for there being none. A guard over generated or
 rendered output reads the **built artifact** or uses a parser, and
 asserts its input is non-empty before asserting anything about it.
 
+**A refinement to a needle states what it TRADES, not only what
+it buys.** Narrowing a needle, adding a boundary, tightening a
+match — each buys one case and costs another, and the cost is
+what the NEXT prover round finds, because a refinement documented
+by its win alone leaves nothing for a reader to check against.
+
+#1069 ran that loop three times, each fix opening the hole the
+one after it found. Narrowing `symbolEffect` to `symbolEffect(`
+stopped a disabling spelling firing and re-opened the whitespace
+fail-open the walk exists for — `.symbolEffect (…)` compiles.
+Adding a leading identifier boundary then fixed a false positive
+and blinded every DOT-prefixed needle to its own receiver, so
+`field.animation(…)` written inline went unscanned; that one
+weakened the older, load-bearing guard next door, and the site
+counts did not move by one, because the tree happened to write
+every call at the start of a chain line.
+
+So the cost goes in the docstring beside the refinement, in the
+same change — not the commit message, which the next reader is
+not holding. Where the cost is a class the guard now mis-fires
+on, name the class; where it is a shape the guard can no longer
+see, name the shape. A refinement whose trade you cannot state
+is one you have not finished working out.
+
 ## State a fact once
 
 A count or a list copied into a second file rots in both on one


### PR DESCRIPTION
## Description

`.claude/rules/rule-authoring.md` ▸ "Two rules about the guards
themselves" gains a third: **a refinement to a needle states what
it TRADES, not only what it buys.**

Narrowing a needle, adding a boundary, tightening a match — each
buys one case and costs another, and the cost is what the next
`guard-prover` round finds, because a refinement documented by
its win alone leaves a reader nothing to check against.

The clause is written from #1069, which ran that loop three
times, each fix opening the hole the one after it found:

1. Narrowing `symbolEffect` → `symbolEffect(` stopped a
   *disabling* spelling (`.symbolEffectsRemoved()`) firing, and
   re-opened the whitespace fail-open the walk exists for —
   `.symbolEffect (…)` compiles and ships full motion.
2. Adding a leading identifier boundary fixed a `TimelineView`
   false positive and **blinded every dot-prefixed needle to its
   own receiver**, so `field.animation(…)` written inline went
   unscanned.

(2) is the one that earns the rule. It weakened the *older,
load-bearing* `withAnimation` guard next door, and **no site
count moved by one** — the tree happens to write all 55
`.animation` calls at the start of a chain line, so the parity
check stayed exact and hid it completely. Nothing but writing
the inline spelling would have found it.

Each of those fixes documented its win in a commit message and
said nothing about its cost. The clause puts the trade in the
docstring beside the refinement instead, since the commit
message is not what the next reader is holding.

## Related Issue(s)

No issue — the rule is the residue of #1069 (#1076), written
while the evidence was in hand.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build green — CI's `Release Build` job (read it
  before merging; it reports, it does not block), or locally
  for concurrency / `@Sendable` changes
- [x] PR is focused; refactors separated from features

## How I verified

Prose only — no code, no behaviour, nothing to run in the app,
so the first and third boxes are ticked as not-applicable rather
than as claims. `docs/` is untouched: this is a workshop rule,
not a product fact, and `.claude/rules/docs.md` puts it on the
other shelf.

The full gate ran anyway, because `.claude/rules/**` is
deliberately **not** on `.github/ci-ignore.txt` — `RuleCitationTests`
and `InstructionPinTests` read that tree, and a prose-only edit
there has shipped a dangling citation before. `swift build` ·
`swift test` (**4177 tests, 794 suites**) · `scripts/lint.sh`
(exit 0), all green.

The clause cites no test suite and no `scripts/` path, so
`RuleCitationTests` has nothing new to resolve; it cites #1069,
whose evidence is in that PR's prover rounds.

## Notes for Reviewer

**Worth pushing back on if you disagree:** this adds a third
bullet to a section that had two, and §5's row for
`rule-authoring.md` deliberately does **not** grow to mention it
— that row already carries only the number-pin rule and omits
"prove a new guard reds", so summarising selectively is the
existing shape rather than an oversight.

The alternative home was `.claude/rules/tests.md`, beside the
source-scanning conventions. I put it here because its subject is
*how a guard is written and argued*, which is this file's, rather
than what a test must cover, which is that one's. Say if you read
the split the other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
