### PR TITLE
feat(gui): declare Restore Defaults in the settings census

### DIFF
--- a/Sources/KiwiDesk/Settings/Census/GateReasonPlacement.swift
+++ b/Sources/KiwiDesk/Settings/Census/GateReasonPlacement.swift
@@ -172,7 +172,8 @@ extension SettingRuntimeGate {
             return true
         case .orphanPinsExist, .monitorsDisconnected,
             .paletteGlowPairing, .luaImportAvailable,
-            .layersExist, .liquidGlassUnavailable:
+            .layersExist, .liquidGlassUnavailable,
+            .defaultsToRestore:
             // Presence, not greying: these decide whether a row
             // or card is drawn.
             return false
@@ -215,7 +216,8 @@ extension SettingRuntimeGate {
             return true
         case .orphanPinsExist, .monitorsDisconnected,
             .paletteGlowPairing, .luaImportAvailable,
-            .layersExist, .liquidGlassUnavailable:
+            .layersExist, .liquidGlassUnavailable,
+            .defaultsToRestore:
             // Presence conditions: `greys` is false, so this
             // answer is never read. Stated rather than defaulted
             // so the switch stays exhaustive by hand.

--- a/Sources/KiwiDesk/Settings/Census/SettingGate.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingGate.swift
@@ -54,6 +54,15 @@ enum SettingRuntimeGate: Hashable {
     /// edit target — one slot, so this tag carries both arms,
     /// the not-editing-a-stored-profile half included.
     case luaImportAvailable
+    /// Restore Defaults appears only while KiwiDesk has
+    /// defaults this install lacks — a PRESENCE condition,
+    /// not a greying one, which is what makes the button's
+    /// arrival the news rather than a destructive-sounding
+    /// control standing over every new user's list. Like
+    /// `luaImportAvailable` it compares the live config
+    /// against what the seeder would author for THIS
+    /// machine, which no saved `GuiConfig` can answer.
+    case defaultsToRestore
     /// The config defines a layer beyond `default`. Gates the
     /// Layers card's `.immediate` tier: with layers configured
     /// the card is a user's own setup and shows at rest; with

--- a/Sources/KiwiDesk/Settings/Census/SettingKey+Shortcuts.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey+Shortcuts.swift
@@ -29,6 +29,7 @@ enum ShortcutsKey: String, CaseIterable, Hashable {
     case openApplications = "(rows) shortcuts.open_applications"
     case advanced = "(rows) shortcuts.advanced"
     case `import` = "(action) shortcuts.import"
+    case restoreDefaults = "(action) shortcuts.restore_defaults"
 }
 
 extension ShortcutsKey {
@@ -72,6 +73,27 @@ extension ShortcutsKey {
                 .luaBindings,
                 .atRest,
                 gate: .runtime(.luaImportAvailable)
+            )
+        case .restoreDefaults:
+            // Its own container, because its SUBJECT is the
+            // shipped set and that set spans four of them —
+            // focus, move, size & float, and the general keys.
+            // Borrowing one would file a whole-area action under
+            // a quarter of what it acts on, which is what a
+            // reader building a search snippet off the census
+            // would then be told.
+            //
+            // A container is the subject, not the drawing: Import
+            // above declares `.luaBindings` while drawing in the
+            // header, so nothing about this moves the button. It
+            // draws beside Import, at rest, kept absent by its
+            // runtime gate until KiwiDesk actually has defaults
+            // this install lacks.
+            return .row(
+                .shortcuts,
+                .defaultShortcuts,
+                .atRest,
+                gate: .runtime(.defaultsToRestore)
             )
         }
     }
@@ -118,6 +140,11 @@ extension ShortcutsKey {
             return .text("keybinding.open_settings")
         case .`import`:
             return .text("shortcuts.import", help: "shortcuts.import.help")
+        case .restoreDefaults:
+            return .text(
+                "shortcuts.restore_defaults",
+                help: "shortcuts.restore_defaults.help"
+            )
         }
     }
 }

--- a/Sources/KiwiDesk/Settings/Census/SettingsContainer.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingsContainer.swift
@@ -11,6 +11,7 @@ enum SettingsContainer: CaseIterable, Hashable {
     case appBar
     case borders
     case bsp
+    case defaultShortcuts
     case dragAndDrop
     case focus
     case focusBorder
@@ -71,7 +72,8 @@ enum SettingsContainer: CaseIterable, Hashable {
             return .setting(.borders(.borderEnabled))
         case .motion:
             return .runtime(.reduceMotion)
-        case .about, .advanced, .borders, .bsp, .dragAndDrop,
+        case .about, .advanced, .borders, .bsp,
+            .defaultShortcuts, .dragAndDrop,
             .focus, .gaps, .general, .generalKeys, .grid,
             .appliesImmediately, .layers, .luaBindings,
             .monitorFingerprints, .monocle, .mouse,

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/ShortcutsFamilyRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/ShortcutsFamilyRows.swift
@@ -128,7 +128,7 @@ struct ShortcutsFamilyRows {
                 .filter { $0 != currentLayer }
                 .map(KeybindingCatalog.switchLayerCommand)
         case .layers, .layersIcon, .openApplications, .advanced,
-            .`import`:
+            .`import`, .restoreDefaults:
             return nil
         }
     }

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/ShortcutsGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/ShortcutsGates.swift
@@ -84,7 +84,13 @@ struct ShortcutsGates {
     /// profile is being edited) that no saved `GuiConfig` can
     /// answer, so `ShortcutsHeader` keeps it. Naming it is what
     /// keeps the gap deliberate rather than an omission.
+    /// Restore Defaults joins for the same reason: its
+    /// `.defaultsToRestore` gate compares the live config against
+    /// what the seeder would author for this machine's Desktops
+    /// and resize step, which is a live-editor question no saved
+    /// `GuiConfig` answers. `ShortcutsHeader` keeps it.
     static let resolvedElsewhere: Set<SettingKey> = [
-        .shortcuts(.`import`)
+        .shortcuts(.`import`),
+        .shortcuts(.restoreDefaults),
     ]
 }

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/ShortcutsRowOrder.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/ShortcutsRowOrder.swift
@@ -32,6 +32,7 @@ enum ShortcutsRowOrder {
         .openApplications,
         .layers,
         .luaBindings,
+        .defaultShortcuts,
     ]
 
     /// Focus: the four directions, one row per live space, then
@@ -158,5 +159,14 @@ enum ShortcutsRowOrder {
     /// `init.lua` holds something to adopt.
     static let luaBindingsAtRest: [SettingKey] = [
         .shortcuts(.import)
+    ]
+
+    /// Restore Defaults, beside Import in the header. Its
+    /// own container because the set it restores spans four
+    /// of them, and at rest for Import's reason: a runtime
+    /// gate, not a disclosure, keeps it away until there is
+    /// something to restore.
+    static let defaultShortcutsAtRest: [SettingKey] = [
+        .shortcuts(.restoreDefaults)
     ]
 }

--- a/Sources/KiwiDesk/Settings/SettingsSearchSynonyms.swift
+++ b/Sources/KiwiDesk/Settings/SettingsSearchSynonyms.swift
@@ -121,6 +121,21 @@ enum SettingsSearchSynonyms {
             return [
                 "pin", "pinned", "always on top", "all desktops",
             ]
+        // The label says "Restore Defaults", so "restore"
+        // and "defaults" already match. "Reset" is the real
+        // alternate vocabulary: it is the word the OTHER
+        // destructive action in this app uses (General ▸
+        // Advanced ▸ Reset All Settings), so a reader who
+        // has met that one types it here — and this is
+        // exactly the row that must answer, since landing on
+        // the whole-config reset instead is the expensive
+        // near-miss. "Factory" and "original" are the
+        // platform-neutral terms for the same idea.
+        case .shortcuts(.restoreDefaults):
+            return [
+                "reset", "reset shortcuts", "factory",
+                "original shortcuts", "stock shortcuts",
+            ]
         // Behaviour near-misses.
         case .behaviour(.mouseFollowsFocus):
             return ["focus follows mouse", "hover focus"]

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Shortcuts.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Shortcuts.swift
@@ -28,9 +28,13 @@ extension SettingsValueReadout {
             .growHeight, .shrinkHeight, .toggleFloating,
             .toggleSticky, .toggleDisplaySticky, .showShortcuts,
             .openSettings, .switchToLayer, .openApplications,
-            .advanced, .`import`:
+            .advanced, .`import`, .restoreDefaults:
             // no model path — never booked by the diff (these
             // families' bindings book under `config.layers`).
+            // Restore Defaults is an ACTION, and what it does
+            // lands in `config.layers` like any other edit —
+            // so the diff narrates the rows that moved, never
+            // the button that moved them.
             return []
         }
     }

--- a/Tests/KiwiDeskGuiTests/SettingsSearchIndexTests.swift
+++ b/Tests/KiwiDeskGuiTests/SettingsSearchIndexTests.swift
@@ -201,11 +201,14 @@ struct SettingsSearchIndexTests {
                 // that a new census row landed rather than a
                 // catalog anchor going missing.
                 .profiles: 6,
-                // 12: `keybinding.open_settings` joined
+                // 13: `keybinding.open_settings` joined
                 // anchor-less (#678 item 18 — the bindable
                 // "Open Settings" row has no #277 catalog
-                // anchor yet).
-                .shortcuts: 12,
+                // anchor yet), and `(action)
+                // shortcuts.restore_defaults` joined the same
+                // way in #1116 — a new census row landing,
+                // not an anchor going missing.
+                .shortcuts: 13,
                 .appRules: 3,
                 // 9: the backup pair and the other General rows
                 // have no #277 catalog anchor. (The deleted

--- a/Tests/KiwiDeskGuiTests/ShortcutsCensusRenderTests.swift
+++ b/Tests/KiwiDeskGuiTests/ShortcutsCensusRenderTests.swift
@@ -148,6 +148,23 @@ struct ShortcutsCensusRenderTests {
         )
     }
 
+    /// Restore Defaults is the container's only row, at rest.
+    /// A container of one, because the set it restores spans
+    /// four others — declaring it under any of them would file a
+    /// whole-area action under a quarter of what it acts on.
+    /// Bespoke container — membership only (see the suite note).
+    @Test("Default shortcuts renders its one at-rest action")
+    func defaultShortcutsTier() {
+        pin(
+            ShortcutsRowOrder.defaultShortcutsAtRest,
+            .defaultShortcuts,
+            .atRest,
+            "restore defaults row"
+        )
+        #expect(censusRows(.defaultShortcuts, .showMore).isEmpty)
+        #expect(censusRows(.defaultShortcuts, .immediate).isEmpty)
+    }
+
     /// Which containers are drawn by bespoke views is DERIVED
     /// from the source, not restated here.
     ///
@@ -185,6 +202,7 @@ struct ShortcutsCensusRenderTests {
             ("layersMore", .layers),
             ("luaBindingsMore", .luaBindings),
             ("luaBindingsAtRest", .luaBindings),
+            ("defaultShortcutsAtRest", .defaultShortcuts),
         ]
         // Vacuity: the scan must have read something, and every
         // list named must exist in the source it read.
@@ -268,13 +286,13 @@ struct ShortcutsCensusRenderTests {
     /// renderer to publish its mounted containers as data, which
     /// no area does yet — until one does, a deleted card is a
     /// reviewer's catch.
-    @Test("Shortcuts holds exactly the seven rendered containers")
+    @Test("Shortcuts holds exactly the eight rendered containers")
     func shortcutsContainers() {
         #expect(
             containers(of: .shortcuts) == [
                 .focus, .moveWindows, .sizeAndFloat,
                 .openApplications, .generalKeys, .layers,
-                .luaBindings,
+                .luaBindings, .defaultShortcuts,
             ]
         )
     }

--- a/Tests/KiwiDeskGuiTests/ShortcutsFamilyRowsTests.swift
+++ b/Tests/KiwiDeskGuiTests/ShortcutsFamilyRowsTests.swift
@@ -56,6 +56,7 @@ struct ShortcutsFamilyRowsTests {
             .shortcuts(.openApplications),
             .shortcuts(.advanced),
             .shortcuts(.import),
+            .shortcuts(.restoreDefaults),
             .behaviour(.resizeFeedback),
         ]
         let expander = fixture()


### PR DESCRIPTION
## Description

**Restore Defaults…** never joined the `SettingKey` census, so Settings
search could not find "restore", "reset shortcuts" or "defaults" —
and reachability-by-search was half the argument for putting the action
in Shortcuts rather than in General ▸ Advanced's reset ladder. One
omission cost three things: `SettingsSearchIndex` is built from
`SettingKey.allCases`, `SettingsSearchSynonyms` is keyed on `SettingKey`,
and `GateReasonPlacement` never runs on an undeclared row.

**The decision here is the container, and it is why this was its own
issue rather than a rider on #1113.** The action's subject is the shipped
set, and that set spans four containers — focus, move windows, size &
float, general keys. No existing one owns it honestly. `.layers` came
closest, since the button is greyed off the default layer, but
layer-scoping is a *constraint on* the action rather than its *subject*;
filing it there would tell the next person reading the census to build a
search snippet that this is layer management.

So it declares its own `SettingsContainer.defaultShortcuts`. **A
container names the subject, not the drawing** — Import already declares
`.luaBindings` while drawing in the header — so nothing about this moves
the button. It stays beside Import, `.atRest`, kept absent by
`.runtime(.defaultsToRestore)` until KiwiDesk actually has defaults this
install lacks. That gate is a *presence* condition (`greys == false`) for
the reason #1096 gave: the button's arrival is the news, not a
destructive-sounding control standing over every new user's list.

It joins `ShortcutsGates.resolvedElsewhere` beside Import and for
Import's reason — the gate compares the live config against what the
seeder would author for *this* machine's Desktops and resize step, which
no saved `GuiConfig` can answer.

Synonyms carry **"reset"**, because that is the word the app's *other*
destructive action uses (General ▸ Advanced ▸ Reset All Settings), and
landing on the whole-config reset instead is the expensive near-miss.

## Related Issue(s)

Closes #1116

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] `swift build && swift test && ./scripts/lint.sh`
  passes
- [x] Release build green — CI's `Release Build` job (read it
  before merging; it reports, it does not block), or locally
  for concurrency / `@Sendable` changes
- [x] PR is focused; refactors separated from features

## How I verified

`swift build`, `swift test` (**4277 tests in 811 suites passed** — one
more than `main`, the new tier test), `scripts/lint.sh` — all exit 0,
read directly rather than through a pipe.

**`guard-prover`, in an isolated worktree: 5 red-proofed, 0 inert, 0
vacuous.** Every assertion that changed was mutated at the production
side and observed to fail:

- `defaultShortcutsTier` — 4 of 4 mutations red (tier `.atRest`→`.showMore`,
  container →`.luaBindings`, a second key appended to the order list, the
  list emptied).
- `shortcutsContainers` — red when the census stops declaring the
  container. The prover **declined** my suggested mutation of editing the
  expected list, correctly: that edits the guard rather than the thing
  guarded.
- `ShortcutsFamilyRowsTests` — red when `.restoreDefaults` returns `[]`
  instead of `nil`, so the nil/empty discrimination is live.
- The 12→13 count — red when the tier changes to `.luaOnly` and the row
  leaves the index. "Synonyms only decorate indexed keys" fired too, so
  the new synonyms entry is guarded.
- `bespokeContainersAreDeclared` — red when a real `ForEach` walks
  `defaultShortcutsAtRest`. This was the one I was least sure of; the
  derivation did **not** miss the new list.

## Notes for Reviewer

**Three pins move, each a real membership change rather than a
workaround** — which is the distinction #1116 asked for explicitly:
rendered containers seven → eight, the hand-drawn set in
`ShortcutsFamilyRowsTests` gains the action (it expands to no keybinding
rows, exactly like Import), and the anchor-less shortcuts count goes
12 → 13. That count's own docstring names a *rise* as the unusual
direction and gives the reason: a new census row landing, not a catalog
anchor going missing.

**A pre-existing hole the prover found, not introduced here and not fixed
here.** `bespokeContainersAreDeclared` derives bespoke-ness from whether a
`ForEach` walks an order list — but it keys on the list **names**
hand-written in the test's table, not on containers. The prover added a
*second* order list serving an already-bespoke container and walked it
with a real `ForEach`: the suite stayed green while rows mounted that it
believes nothing renders. The existing vacuity clause is one-directional
(every named list must exist in source; never that every list in source is
named), and the compiler closes the rename case but not the addition case.
The guard shape that would close it is a source-side enumeration of the
`static let …: [SettingKey]` declarations, turning that table from a
filter into a census — which would also make the docstring's claim that
bespoke-ness is "DERIVED from the source, not restated here" true of the
list set as well as of the walk. Worth its own issue.

**Not claimed:** the prover's verdicts come from `--filter` runs, so a
test passing on state another suite left behind is outside what it
observed. None of the five touch process-global state
(`SettingsSearchIndexTests` pins the locale per body and resets in a
`defer`), and the full `swift test` run above is green, but the guard
proofs themselves are filtered runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
