### PR TITLE
docs(agents): add the §2 comment budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,22 @@ traced at directory altitude — see **`docs/architecture.md`**.
    it are in [`.claude/rules/gui.md`](.claude/rules/gui.md);
    `docs/ui-patterns.md` holds the shared control conventions
    and `docs/design-decisions.md` the rulings behind them.
+8. **Comments: state the constraint, cite the ruling, stop.**
+   A comment carries only what the code cannot show — a
+   non-obvious invariant, a platform trap, the why behind a
+   choice that looks wrong. Budget: 1–3 lines plus the issue
+   ref (`#NNN`) where an argument exists; the argument itself
+   lives in the issue, the owning rule file, or
+   `docs/design-decisions.md`, never in the source. A
+   docstring states the contract — what it does, units,
+   threading, ownership — not the design history. Never
+   write: how the code got here, alternatives considered and
+   rejected, what the next line visibly does, or justification
+   aimed at a reviewer. One exception: a docstring a rule file
+   or guard names as a canonical home — a census like
+   `OwnWindowTiling`'s doc, or a number-pin's retuning
+   argument ([tests.md](.claude/rules/tests.md), #1021) —
+   keeps whatever length that job needs.
 
 ## 3. Workflow: Refine → Plan → Act → Verify
 


### PR DESCRIPTION
## Summary

Adds **§2 rule 8** to AGENTS.md: a code comment states the
constraint, cites the ruling (`#NNN`), and stops. Docstrings
state the contract, not the design history. Banned content:
how the code got here, alternatives considered and rejected,
restating the adjacent code, reviewer-facing justification.

One exception is carved out: docstrings that a rule file or
guard names as a canonical home (censuses like
`OwnWindowTiling`'s doc, number-pin retuning arguments per
tests.md #1021) keep whatever length that job needs.

## Why

~80k of the tree's 279k Swift lines are comments (57k `///`,
23k `//`), and recent diffs show the pattern: multi-paragraph
essays narrating earlier drafts and rejected alternatives.
That argument content belongs in the issue, the owning rule
file, or `docs/design-decisions.md` — the source keeps the
pointer.

The existing corpus gets trimmed to this budget by a
mechanical follow-up sweep in `chore/comment-diet-*` branches
once this merges.

## Verification

- `RuleCitationTests` passes (3/3) — the new row's citations
  resolve.
- Docs-only change; CI's macOS jobs are expected to gate off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)