### PR TITLE
chore: drop the local-gate checkbox from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,8 +17,6 @@ Closes #... (if applicable)
   required)
 - [ ] User-facing changes are documented in `docs/`
 - [ ] No contradictions between code and docs
-- [ ] `swift build && swift test && ./scripts/lint.sh`
-  passes
 - [ ] Release build green — CI's `Release Build` job (read it
   before merging; it reports, it does not block), or locally
   for concurrency / `@Sendable` changes


### PR DESCRIPTION
## Description

Drops the checklist item "`swift build && swift test &&
./scripts/lint.sh` passes" from the PR template, per the owner's
ruling (2026-08-30). CI (`.github/workflows/ci.yml`) runs that
exact gate on every PR and a red build blocks merging, so the
author-side confirmation was redundant. The "Release build
green" item stays: CI's `Release Build` job reports but does not
block, so its read-before-merging instruction still does work.

CONTRIBUTING.md's "run the gate before pushing" line and the
verify-gate skill are untouched — neither quotes the removed
checkbox, and agents still run the gate locally.

## Related Issue(s)

None.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [ ] New behavior is tested (pure logic / layout code
  required) — N/A, template prose only
- [ ] User-facing changes are documented in `docs/` — N/A, no
  user-visible behavior
- [x] No contradictions between code and docs
- [ ] Release build green — N/A, no code touched
- [x] PR is focused; refactors separated from features

## How I verified

Template-only change; there is nothing to exercise in the
running app. Verified the removed line is not literally quoted
by CONTRIBUTING.md or `.claude/skills/verify-gate/SKILL.md`
(grep), and that CONTRIBUTING.md's before-pushing instruction —
which the ruling keeps — stands on its own.

## Notes for Reviewer

This PR's own checklist is the first rendered without the
removed checkbox (rendered by hand, as the agent workflow
requires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
