### PR TITLE
chore(comments): trim settings census and components (batch 3)

### DIFF
--- a/Sources/KiwiDesk/Settings/Census/SettingKey+LayoutText.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey+LayoutText.swift
@@ -1,5 +1,4 @@
-/// The row text for the layout-parameter slice — split from
-/// `SettingKey+Layout.swift` for the file-size sweet spot.
+/// Row text for the layout-parameter census slice.
 
 extension LayoutKey {
     var text: SettingRowText {

--- a/Sources/KiwiDesk/Settings/Census/SettingKey+Monitors.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey+Monitors.swift
@@ -12,18 +12,8 @@ extension MonitorsKey {
     var placement: SettingPlacement {
         switch self {
         case .spacePins, .mainSpaces:
-            // Ungated on purpose. These were briefly given
-            // `.runtime(.monitorsDisconnected)` — the condition
-            // that surfaces the banner below — to record why the
-            // picture disappears. It records the wrong thing: a
-            // census gate reads "shows while true" everywhere
-            // else in the enum, so the same tag on the banner and
-            // on the rows it REPLACES declares one condition with
-            // two opposite meanings, knowable only inside the
-            // resolver. The banner's own gate already says the
-            // picture is unavailable; these rows need no second,
-            // inverted copy of it (#678 turn 13b, architect
-            // review).
+            // Ungated: picture availability is governed by the banner gate
+            // (#678).
             return .row(.monitors, .spacePlacement, .atRest)
         case .orphanPinClear:
             return .row(

--- a/Sources/KiwiDesk/Settings/Census/SettingKey+Profiles.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey+Profiles.swift
@@ -15,12 +15,7 @@ extension ProfilesKey {
     var placement: SettingPlacement {
         switch self {
         case .profileBindings:
-            // Dead while a stored profile is being edited
-            // (bindings are global). The separate-Spaces arm
-            // retired with #888: a binding now names one event
-            // in every display mode — the main display's
-            // Desktop N activating — so the rows stay live
-            // there.
+            // Inactive while editing a stored profile (#888).
             return .row(
                 .profiles,
                 .profilesPerMacOSSpace,
@@ -32,24 +27,7 @@ extension ProfilesKey {
         case .isStarterSetup:
             return .luaOnly
         case .presetsApply:
-            // Its own card since #678 turn 13a — "Start from a
-            // preset" is a distinct offer from the saved list it
-            // used to sit inside, and the redesign draws it as
-            // one. Apply is greyed by the screen-count match;
-            // `ProfilesGates` also answers the stored-profile
-            // reason for the same row (one gate slot, two
-            // reasons).
-            //
-            // `.atRest` describes the instances that MATTER: the
-            // presets for the connected screen count, which is
-            // the only group whose Apply can fire. The rest
-            // render inside the "For other setups" drawer, so
-            // this one key's instances straddle two tiers — the
-            // first such key in the census. The tier follows the
-            // appliable group deliberately: a search hit on a
-            // preset should offer to apply it, and tiering the
-            // key `.showMore` would describe the group nobody
-            // can act on.
+            // Greys on screen count mismatch or stored profile edit (#678).
             return .row(
                 .profiles,
                 .presets,
@@ -60,25 +38,7 @@ extension ProfilesKey {
                 ])
             )
         case .presetsLayouts:
-            // The preview sheet's opener (#859). **No gate**, and
-            // it is the only row on this card without one: the
-            // sheet writes nothing, and a user whose screen count
-            // does not match — the state that greys Apply — is the
-            // one who most needs to see what a preset contains.
-            //
-            // A census row even though it mutates nothing, which
-            // no other `(action)` case can say. The precedent is
-            // `(action) general.advanced.edit_lua`, whose
-            // immediate effect is also opening a surface: the
-            // census's unit is what a Settings surface OFFERS, not
-            // what writes. Being in it is what gives the button a
-            // search anchor and a label key every catalog must
-            // carry (`SettingKeyLocaleTests`).
-            //
-            // `.atRest` for the same reason `presetsApply` is, and
-            // it inherits that key's straddle: the instances in
-            // the "For other setups" drawer sit behind a
-            // disclosure while these describe the appliable group.
+            // Ungated preview sheet opener (#859, SettingKeyLocaleTests).
             return .row(.profiles, .presets, .atRest)
         }
     }
@@ -88,7 +48,6 @@ extension ProfilesKey {
     var text: SettingRowText {
         switch self {
         case .profileBindings:
-            // "Desktop %1$d" — per-instance rows, so dynamic.
             return .dynamic
         case .profilesLoad:
             return .text("profiles.load")

--- a/Sources/KiwiDesk/Settings/Census/SettingKey+Shortcuts.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey+Shortcuts.swift
@@ -1,6 +1,4 @@
-/// Shortcuts: keybinding families (one case per family — the
-/// xN row expansions are instances, not settings), layers,
-/// and the Lua-binding rows.
+/// Shortcuts census slice: keybinding families, layers, and Lua bindings.
 
 enum ShortcutsKey: String, CaseIterable, Hashable {
     case layers = "config.layers"
@@ -36,10 +34,7 @@ extension ShortcutsKey {
     var placement: SettingPlacement {
         switch self {
         case .layers, .layersIcon, .switchToLayer:
-            // `.immediate`, not `.showMore`: a configured layer
-            // is the user's own setup, so the card surfaces at
-            // rest the moment one exists. Only the offer to
-            // create the first one is withheld.
+            // Surfaces at rest when configured layers exist.
             return .row(
                 .shortcuts,
                 .layers,
@@ -61,13 +56,7 @@ extension ShortcutsKey {
         case .advanced:
             return .row(.shortcuts, .luaBindings, .showMore)
         case .`import`:
-            // At rest, in the header, not in the Lua drawer: the
-            // row it belongs to conceptually is the raw-Lua one,
-            // but Import is the affordance a NEW user needs and
-            // the one thing on this page that must not be behind
-            // a disclosure. Its `.runtime` gate already keeps it
-            // absent until `init.lua` holds something to adopt,
-            // which is what makes surfacing it at rest safe.
+            // Surfaced at rest when unadopted shortcuts exist in init.lua.
             return .row(
                 .shortcuts,
                 .luaBindings,
@@ -75,20 +64,7 @@ extension ShortcutsKey {
                 gate: .runtime(.luaImportAvailable)
             )
         case .restoreDefaults:
-            // Its own container, because its SUBJECT is the
-            // shipped set and that set spans four of them —
-            // focus, move, size & float, and the general keys.
-            // Borrowing one would file a whole-area action under
-            // a quarter of what it acts on, which is what a
-            // reader building a search snippet off the census
-            // would then be told.
-            //
-            // A container is the subject, not the drawing: Import
-            // above declares `.luaBindings` while drawing in the
-            // header, so nothing about this moves the button. It
-            // draws beside Import, at rest, kept absent by its
-            // runtime gate until KiwiDesk actually has defaults
-            // this install lacks.
+            // Surfaced at rest when unseeded defaults are missing.
             return .row(
                 .shortcuts,
                 .defaultShortcuts,
@@ -102,11 +78,6 @@ extension ShortcutsKey {
 extension ShortcutsKey {
     var text: SettingRowText {
         switch self {
-        // Family keys (`keybinding.focus_dir` = "Focus window
-        // %1$@" …) carry positional specifiers and are only
-        // ever formatted per instance — a family ROW's title is
-        // runtime-composed, so these are `.dynamic`, not the
-        // template key.
         case .layers, .openApplications, .advanced, .focusDir,
             .goToSpace, .swapDir, .moveWindowToTrack, .swapWithTrack,
             .moveToSpace, .moveToSpaceFollow, .focusDesktop,

--- a/Sources/KiwiDesk/Settings/Census/SettingKey+Shortcuts.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey+Shortcuts.swift
@@ -56,7 +56,8 @@ extension ShortcutsKey {
         case .advanced:
             return .row(.shortcuts, .luaBindings, .showMore)
         case .`import`:
-            // Surfaced at rest when unadopted shortcuts exist in init.lua.
+            // Surfaced at rest (never behind disclosure) when init.lua has
+            // unadopted shortcuts.
             return .row(
                 .shortcuts,
                 .luaBindings,

--- a/Sources/KiwiDesk/Settings/Census/SettingKey+SpaceBar.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey+SpaceBar.swift
@@ -41,9 +41,7 @@ extension SpaceBarKey {
     var placement: SettingPlacement {
         switch self {
         case .spaceBarEnabled:
-            // Owns the .spaceBar container gate — must stay
-            // live while the container greys, or the editor
-            // could never be re-enabled.
+            // Owns the .spaceBar container gate — stays live while greyed.
             return .row(
                 .bars,
                 .spaceBar,
@@ -59,8 +57,7 @@ extension SpaceBarKey {
             .spaceBarCornerRoundness:
             return .row(.bars, .spaceBar, .showMore)
         case .spaceBarTitleCap:
-            // Only the front segment draws a title, so the cap
-            // is inert while that segment is off.
+            // Inert while front segment is off.
             return .row(
                 .bars,
                 .spaceBar,
@@ -89,7 +86,6 @@ extension SpaceBarKey {
                 gate: .runtime(.liquidGlassUnavailable)
             )
         case .spaceBarBackgroundFit:
-            // Boxed draws no shared plate to size.
             return .row(
                 .bars,
                 .spaceBar,
@@ -99,11 +95,6 @@ extension SpaceBarKey {
         case .spaceBarDimFactor, .spaceBarActiveDimFactor,
             .spaceBarStickyBadge:
             return .luaOnly
-        // The three-state accent ladder is the bar's defining
-        // signature, so it stays at rest; the rest of the palette
-        // sits behind the group's one "More colors" drawer (turn
-        // 12b — the split the live GUI already made, recorded in
-        // the census now that Advanced Colours renders from it).
         case .spaceBarItemColor, .spaceBarActiveItemColor:
             return .row(.advancedColours, .spaceBar, .atRest)
         case .spaceBarFillColor, .spaceBarHighlightColor,
@@ -111,10 +102,7 @@ extension SpaceBarKey {
             .spaceBarGroupBadgeColor, .spaceBarGroupBadgeTextColor:
             return .row(.advancedColours, .spaceBar, .showMore)
         case .spaceBarFocusedItemColor:
-            // Nothing to tint when glyphs are native images and
-            // no front-app name renders (icon source + front
-            // app + edge). Predicate:
-            // `AdvancedColorsGates.focusedItemInert`.
+            // Inert when front-app is off or icon source does not tint.
             return .row(
                 .advancedColours,
                 .spaceBar,
@@ -126,16 +114,7 @@ extension SpaceBarKey {
                 ])
             )
         case .copyAppearance:
-            // At rest on the App Bar card (owner flipped the
-            // direction 2026-08-10: it copies Space Bar → App
-            // Bar, filling in THIS card's bar), never behind
-            // the Style disclosure — the adjust-gaps precedent
-            // for a one-shot verb. Gated on the SOURCE bar
-            // being on, and deliberately EXEMPT from the
-            // card's container gate: styling the App Bar from
-            // the Space Bar before any layout shows one is
-            // configure-before-enable, the icon-source
-            // precedent one entry up.
+            // Copies Space Bar appearance to App Bar.
             return .row(
                 .bars,
                 .appBar,

--- a/Sources/KiwiDesk/Settings/Census/SettingKey+Spaces.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey+Spaces.swift
@@ -1,5 +1,4 @@
-/// Spaces: the space list, per-space assignments and
-/// override reset actions.
+/// Spaces census slice: space list, assignments, and override reset actions.
 
 enum SpacesKey: String, CaseIterable, Hashable {
     case spaceIcon = "settings.spaceIcons[space]"
@@ -20,8 +19,7 @@ extension SpacesKey {
         case .fallbackSpace:
             return .row(.spacesAndLayouts, .spaceList, .showMore)
         case .spaceOverrideResetActive:
-            // Dead while the space has nothing to reset. Drawn in
-            // the editor header (SpacesSection+Overrides), #678 8b.
+            // Inactive when the space has no overrides (#678).
             return .row(
                 .spacesAndLayouts,
                 .perSpaceOverrides,
@@ -37,8 +35,6 @@ extension SpacesKey {
 extension SpacesKey {
     var text: SettingRowText {
         switch self {
-        // reset_active's key is "Reset %1$@ Overrides" — the
-        // layout name is interpolated per space, so dynamic.
         case .spaceIcon, .spaceList, .spacesName, .spaceModes,
             .fallbackSpace, .spaceOverrideResetActive:
             return .dynamic

--- a/Sources/KiwiDesk/Settings/Census/SettingKey.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey.swift
@@ -1,4 +1,6 @@
-/// Settings census (#678): one case per reviewed row. `id` is the row key.
+/// Settings census (#678; contract in `SettingPlacement.swift`).
+/// `id` is the machine-checked key for `settings.*`/`config.*` slices
+/// (parsed by model-parity guard); other prefixes are convention-only.
 enum SettingKey: Hashable, CaseIterable {
     case appBar(AppBarKey)
     case appRules(AppRulesKey)

--- a/Sources/KiwiDesk/Settings/Census/SettingKey.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKey.swift
@@ -1,11 +1,4 @@
-/// The settings census (#678, spec 4f): one case per row of
-/// the reviewed placement table (see `SettingPlacement.swift`
-/// for the contract). `id` is the verbatim table row key —
-/// machine-checked identity for the `settings.*` / `config.*`
-/// slices (the model-parity guard parses those); the other
-/// prefixes (`UserDefaults.`, `(action) `, …) are census
-/// prose, held stable by convention only.
-
+/// Settings census (#678): one case per reviewed row. `id` is the row key.
 enum SettingKey: Hashable, CaseIterable {
     case appBar(AppBarKey)
     case appRules(AppRulesKey)
@@ -39,8 +32,7 @@ enum SettingKey: Hashable, CaseIterable {
             + SpacesKey.allCases.map(Self.spaces)
     }
 
-    /// The verbatim census row (CSV key) —
-    /// the catalog's stable identity.
+    /// Verbatim census row key.
     var id: String {
         switch self {
         case .appBar(let k): return k.rawValue

--- a/Sources/KiwiDesk/Settings/Census/SettingKeyMasterWrites.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKeyMasterWrites.swift
@@ -1,6 +1,8 @@
 /// Stored leaves a master row writes (#754).
-/// Declares multi-leaf writes for unsaved-change attribution in
-/// `SettingsDraftDiff` (`SettingsDraftDiffTests`, `BorderMastersFanOutTests`).
+/// `SettingsDraftDiff` books a leaf to the census row owning the longest
+/// model-path prefix, so masters with followers under them need no entry;
+/// masters writing across the model declare writes here so one edit books
+/// as one change (`SettingsDraftDiffTests`, `BorderMastersFanOutTests`).
 extension SettingKey {
     static let masterWrites: [SettingKey: [String]] = [
         .borders(.borderWidthMaster): [

--- a/Sources/KiwiDesk/Settings/Census/SettingKeyMasterWrites.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingKeyMasterWrites.swift
@@ -1,30 +1,6 @@
-/// Which stored leaves a MASTER row writes (#754) — one
-/// control over several values, declared as data so the
-/// unsaved-changes count can book one edit as one change.
-///
-/// `SettingsDraftDiff` attributes a changed leaf to the census
-/// row whose model path owns the longest prefix of it, which is
-/// enough while a master's followers sit UNDER it: the gaps
-/// outer master's id prefixes the four edges it writes. The
-/// border masters write across the model — the ring's own leaf
-/// and the drag pair's — so no prefix reaches them, and one
-/// nudge of the shared Width slider read as three unsaved
-/// changes until this map existed.
-///
-/// **A master row that writes a leaf with no GUI surface of its
-/// own declares that leaf here.** A leaf that HAS its own row
-/// stays out: the per-edge gap sliders are settings a user
-/// edits one at a time, and editing two of them is honestly two
-/// changes (`SettingsDraftDiffTests.siblingsStayDistinct`) — so
-/// the gap masters' own fan-out is deliberately absent from
-/// this map and their count is still per edge.
-///
-/// The lists are a second copy of what the bindings in
-/// `SettingsModel+Borders` actually write.
-/// `BorderMastersFanOutTests` closes that by writing each
-/// master and comparing the leaves that moved against the
-/// declaration, so a master growing a fourth stroke cannot
-/// leave this behind.
+/// Stored leaves a master row writes (#754).
+/// Declares multi-leaf writes for unsaved-change attribution in
+/// `SettingsDraftDiff` (`SettingsDraftDiffTests`, `BorderMastersFanOutTests`).
 extension SettingKey {
     static let masterWrites: [SettingKey: [String]] = [
         .borders(.borderWidthMaster): [

--- a/Sources/KiwiDesk/Settings/Census/SettingPlacement.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingPlacement.swift
@@ -1,26 +1,12 @@
-/// The placement vocabulary of the settings census (#678,
-/// spec 4f). Every setting KiwiDesk has is one `SettingKey`
-/// case, and each case resolves to its placement and text
-/// through exhaustive switches — an unplaced setting is a
-/// compile error, not a bug report. During the coexistence
-/// phase (old GUI still renders) the census is what the 4f
-/// guards hold against the model and the locale catalogs;
-/// rendering from it starts with the Bars area (Phase 2).
+/// Placement vocabulary of the settings census (#678).
 
-/// The two Settings modes: "Simple" / "Power User" (owner
-/// 2026-08-04), user-facing and wire alike. The marketing
-/// site's slider keeps its own "Nerd" flair — a different
-/// surface, never harmonized either way
-/// (`docs/localization-naming.md` owns the pair's policy). The
-/// design doc's "Easy/Advanced" is spec-internal shorthand and
-/// never appears in code or copy; the word "mode" itself stays
-/// reserved for this pair and for layout modes.
+/// Settings modes: "Simple" and "Power User".
 enum SettingsMode: String, CaseIterable, Hashable {
     case simple
     case powerUser
 }
 
-/// A Home-level area card in the redesigned Settings window.
+/// A Home-level area card in the Settings window.
 enum SettingsArea: CaseIterable, Hashable {
     case gapsAndBorders
     case layoutDefaults
@@ -35,27 +21,11 @@ enum SettingsArea: CaseIterable, Hashable {
     case appRules
     case general
 
-    /// The mode an area first appears in — mode depth is per
-    /// area, never per row. `.simple` areas render in both
-    /// modes; `.powerUser` areas exist only while Power User
-    /// mode is on (it adds surface, never expands it).
+    /// The mode an area first appears in.
     var minimumMode: SettingsMode {
         switch self {
         case .advancedColours, .behaviour, .monitors:
             return .powerUser
-        // Layout Defaults is `.simple` (owner ruling
-        // 2026-08-04), against the digest's own Advanced
-        // placement. The argument that moved it: these are
-        // parameters people LEARN the app by playing with —
-        // change a split ratio, watch the windows move — so
-        // withholding them teaches nothing and hides the thing
-        // a tiling window manager is for. Its size (the largest
-        // card in the app) was the case for Advanced, and size
-        // is a reason to organise a card well, not to hide it.
-        //
-        // The per-space OVERRIDE stays gated (`SpaceOverrideOffer`)
-        // — editing one layout's defaults is the feature; editing
-        // them per space is bookkeeping about exceptions.
         case .layoutDefaults, .gapsAndBorders, .shortcuts,
             .coloursAndMotion, .bars, .spacesAndLayouts,
             .profiles, .appRules, .general:
@@ -63,11 +33,7 @@ enum SettingsArea: CaseIterable, Hashable {
         }
     }
 
-    /// `minimumMode` with the one COMPUTED promotion (turn 9):
-    /// Monitors joins Simple whenever two or more displays are
-    /// connected — a multi-monitor desk needs space placement in
-    /// its first week. Computed at read, never stored: writing
-    /// the promotion back would strand it after a disconnect.
+    /// Effective minimum mode, promoting Monitors to Simple for multi-display.
     func effectiveMinimumMode(
         displayCount: Int
     ) -> SettingsMode {
@@ -78,68 +44,29 @@ enum SettingsArea: CaseIterable, Hashable {
     }
 }
 
-/// How deep a setting sits. "Show more" rows and Power-User-only cards
-/// are different things — never conflate them in copy or code:
-/// `.showMore` is a
-/// row-level disclosure; mode depth is
-/// `SettingsArea.minimumMode`.
+/// How deep a setting sits within its container.
 enum SettingTier: Hashable {
     /// Visible at rest in its container.
     case atRest
-    /// Not visible at rest, one interaction away: behind the
-    /// container's "Show more" disclosure, or — where the
-    /// container's affordance is a menu rather than a drawer —
-    /// in that menu. The palette actions are the second kind
-    /// (Rename / Export / Delete, on a saved palette's context
-    /// menu), and the definition is stated HERE rather than
-    /// only at that use site: the mode-mechanics phase renders
-    /// from this enum, and a renderer trusting the narrower
-    /// wording would put those three in a drawer.
+    /// Behind the container's "Show more" disclosure or context menu.
     case showMore
-    /// Surfaces without disclosure the moment its gate allows.
-    ///
-    /// This is the tier that carries **config presence expands
-    /// the Simple surface**: anything that already EXISTS in the
-    /// user's config — a layer, an imported binding, an override
-    /// — shows in both modes and enhances the simple one. Simple
-    /// withholds only the OFFER to create, never an existing
-    /// thing. So an `.immediate` row is at rest once its gate
-    /// says the thing exists, and behind the offer's disclosure
-    /// before that; it is NOT a `.showMore` row, and reading it
-    /// as one hides a user's own configuration from them.
+    /// Surfaces without disclosure when its configuration exists.
     case immediate
-    /// No row of its own — reachable from Lua (`init.lua`) by
-    /// design. The tier is about the ROW, not about who may
-    /// write the value; `SettingPlacement.luaOnly` carries the
-    /// carve-out a master row creates.
+    /// Reachable from Lua without a dedicated GUI row.
     case luaOnly
-    /// App-internal storage (picker recents) — no surface.
+    /// App-internal storage without a settings surface.
     case internalOnly
-    /// Lives outside the Settings window (onboarding wizard).
+    /// Surfaced outside Settings (e.g. onboarding wizard).
     case outsideSettings
 }
 
-/// How a row is titled: a stable `L()` key, or text the GUI
-/// composes at runtime — space names, per-instance keybinding
-/// rows (their family keys carry positional specifiers and are
-/// only ever formatted per instance), the orientation-swapped
-/// slot-size label.
+/// How a row is titled: a static `L()` key or dynamic runtime text.
 enum SettingLabel: Hashable {
     case key(String)
     case dynamic
 }
 
-/// The localized text a row carries — label, optional grey
-/// caption, optional `?` help popover. Key-only on purpose: the
-/// English lives at the live views' `L()` call sites, which is
-/// what `scripts/extract-keys` scans, so the census never
-/// becomes a second authoring surface for `en.json`. Before a
-/// Phase 2+ change deletes a view, the renderer must author
-/// each key through a scanner-recognized `L(key, english)`
-/// shape in the same change, or the key is pruned from every
-/// locale (`SettingKeyLocaleTests` reds at that moment). Tiers
-/// the GUI never renders (`.luaOnly`, `.internalOnly`,
-/// `.outsideSettings`) carry `.none`.
+/// Localized text for a setting row (`SettingKeyLocaleTests`).
 struct SettingRowText: Hashable {
     var label: SettingLabel?
     var captionKey: String?
@@ -168,32 +95,16 @@ struct SettingRowText: Hashable {
     }
 }
 
-/// Where one setting lives (item 12): area card, container,
-/// tier, and — for a row that greys behind something — its
-/// gate, composing with `SettingsContainer.gate`.
-/// `area`/`container` are nil exactly for the tiers that have
-/// no Settings surface.
+/// Setting location: area card, container, tier, and optional gate.
 struct SettingPlacement: Hashable {
     var area: SettingsArea?
     var container: SettingsContainer?
     var tier: SettingTier
     var gate: SettingGate?
-    /// True for the rare row the live wiring deliberately
-    /// keeps OUTSIDE its container's block gate (the icon
-    /// source picker also feeds the ⌃⌥K panel's Apps band, so
-    /// it stays live while the App Bar editor greys).
+    /// True if exempt from container-level gate.
     var exemptFromContainerGate = false
 
-    /// No Settings surface of its own — which is NOT the same
-    /// as "the GUI never writes it". A MASTER row is one
-    /// control over several stored leaves, and those leaves
-    /// have no row: the shared Width and Corners controls
-    /// overwrite five of them on every edit (#754), and a
-    /// reader who took `.luaOnly` to mean untouched could
-    /// retune or drop one and break the control silently. So
-    /// read this as "nothing in the GUI asks about this value
-    /// on its own", and take `SettingKey.masterWrites` as the
-    /// register of which leaves a master writes anyway.
+    /// No individual GUI row (#754; see `SettingKey.masterWrites`).
     static let luaOnly = SettingPlacement(
         area: nil,
         container: nil,

--- a/Sources/KiwiDesk/Settings/Census/SettingsContainer.swift
+++ b/Sources/KiwiDesk/Settings/Census/SettingsContainer.swift
@@ -1,10 +1,4 @@
-/// A titled card or group within an area. Several containers
-/// deliberately span TWO areas (`.appBar`, `.spaceBar`,
-/// `.borders`, `.dragAndDrop`, `.scrolling` appear in both a
-/// home area and Advanced Colours / Layout Defaults), and the
-/// spanning is load-bearing: it is what carries a container
-/// gate onto both surfaces. Never normalize to per-area
-/// containers.
+/// Titled card or group within an area. Spans multiple areas where relevant.
 enum SettingsContainer: CaseIterable, Hashable {
     case about
     case advanced
@@ -45,20 +39,7 @@ enum SettingsContainer: CaseIterable, Hashable {
     case stickyWindows
     case track
 
-    /// The gate that greys this container's rows AS A UNIT,
-    /// where the live editor greys wholesale (the App Bar and
-    /// Space Bar editors off their bar-shown switches, Focus
-    /// border off its enable toggle, the animations card under
-    /// macOS Reduce Motion). Composes with each row's own
-    /// `SettingPlacement.gate` (both apply). There is ONE
-    /// escape and it is data, never prose: any row that must
-    /// stay live while its container greys — the gate's own
-    /// owner toggles included, or a lockout follows — sets
-    /// `exemptFromContainerGate`, and the census guards pin
-    /// that every in-container owner does. Containers whose
-    /// greys have no single owning switch (Drag & drop's two
-    /// halves) record nothing here — the row gates carry the
-    /// owners.
+    /// Container-level gate that greys member rows as a unit.
     var gate: SettingGate? {
         switch self {
         case .appBar:

--- a/Sources/KiwiDesk/Settings/Chips.swift
+++ b/Sources/KiwiDesk/Settings/Chips.swift
@@ -1,11 +1,8 @@
 import SwiftUI
 
-/// Reusable chip primitives shared across the settings tabs: the
-/// space palette and assignment rows (#6) and the profile palette
-/// (#7). Kept in a neutral home so no feature file owns them.
+/// Reusable chip primitives shared across settings views (#6, #7).
 
-/// A pill rendering a space name, shared by the palette and the
-/// assignment rows.
+/// A pill rendering a space name.
 struct SpaceChip: View {
     let label: String
 
@@ -24,9 +21,7 @@ struct SpaceChip: View {
     }
 }
 
-/// The small status capsule used across the settings sections
-/// ("active", "default", "Fallback", …) — one chip language
-/// everywhere a row carries a state marker.
+/// Small status capsule used across settings sections.
 struct BadgeChip: View {
     let label: String
 
@@ -47,21 +42,7 @@ struct BadgeChip: View {
 }
 
 extension View {
-    /// The filled chip surface (#678 turn 16b): `sunken` fill and
-    /// a hairline on `ChipMetrics.shape`.
-    ///
-    /// Owned here beside the other chip primitives rather than in
-    /// the header, because it is what a chip IS — the header is
-    /// one consumer.
-    ///
-    /// The hairline is not decoration. `sunken` on `card` is
-    /// **1.08:1 in both appearances**, so a fill-only chip is a
-    /// rectangle very nearly the colour of the bar behind it — and
-    /// the search field, which is the header's central affordance,
-    /// is one of these. The section container carries a hairline
-    /// one level up for exactly this reason: in a palette spaced
-    /// this closely, the border is what does the separating and
-    /// the fill only sets the mood.
+    /// Filled chip surface with sunken fill and hairline border (#678).
     func chipSurface() -> some View {
         padding(.horizontal, ChipMetrics.padH)
             .padding(.vertical, ChipMetrics.padV)
@@ -77,43 +58,21 @@ extension View {
     }
 }
 
-/// Geometry every chip list shares.
-///
-/// Owned HERE, at the shared widget, not in one area's component:
-/// `WrapChips` is used by Monitors, App Rules and Layout
-/// Defaults, so taking its gap from `MonitorCardChips` let a
-/// Monitors retune silently move the other two. The card-capacity
-/// arithmetic is this constant's consumer, not its owner
-/// (architect review, 2026-08-04).
+/// Shared layout metrics for chip views.
 enum ChipMetrics {
     static let spacing: CGFloat = 6
 
-    /// A rounded rect, never a `Capsule` like the two chips
-    /// above. The prototype draws these as square-ish tokens, and
-    /// a capsule beside the Simple|Power User segmented control
-    /// reads as a second control rather than as a label.
+    /// Rounded rect matching `SettingsTheme.chipRadius`.
     static var shape: RoundedRectangle {
         RoundedRectangle(cornerRadius: SettingsTheme.chipRadius)
     }
 
-    /// The padding inside a header chip — and inside the search
-    /// field, which is a chip that happens to take text. ONE pair
-    /// for both, because they sit in the same row and a chip a few
-    /// points shorter than the field beside it reads as
-    /// misaligned rather than as smaller. Sized up from 10/4 when
-    /// the chips read as cramped against the taller bar (owner,
-    /// 2026-08-04).
+    /// Internal padding for chips and search field.
     static let padH: CGFloat = 12
     static let padV: CGFloat = 7
 }
 
-/// A simple left-to-right flowing row of chips that wraps to the
-/// next line when it runs out of width.
-///
-/// `Item: Hashable` and identity by VALUE, not by index: a chip
-/// list that re-identified its children by position handed the
-/// wrong view state to the wrong chip whenever membership changed
-/// mid-drag, which is exactly what these lists do.
+/// Flowing horizontal chip row wrapping across lines.
 struct WrapChips<Item: Hashable, Chip: View>: View {
     private let items: [Item]
     private let chip: (Item) -> Chip

--- a/Sources/KiwiDesk/Settings/ClickAwayResignsFocus.swift
+++ b/Sources/KiwiDesk/Settings/ClickAwayResignsFocus.swift
@@ -1,23 +1,8 @@
 import AppKit
 import SwiftUI
 
-/// Resigns the settings window's first responder when the user
-/// clicks outside the currently-edited text field (#93).
-///
-/// Several settings fields (`StepperRow`, `ColorSwatch`'s hex
-/// field, `SpaceNameField`) use `@FocusState` and commit on focus
-/// loss — but on macOS, clicking empty/non-focusable space does
-/// NOT resign a `TextField`'s first responder the way it does on
-/// iOS, so a typed value can stick uncommitted until Return or a
-/// click into another field.
-///
-/// A transparent tap layer can't fix this: the section
-/// `ScrollView`s and every control claim the mouse-down before it
-/// reaches a sibling behind them. So this installs a window-scoped
-/// `NSEvent` local monitor, independent of SwiftUI hit-testing: on
-/// a left mouse-down, if a field editor holds focus and the click
-/// landed outside it, resign — which fires each field's
-/// commit-on-focus-loss path.
+/// Resigns first responder when clicking outside an active text field (#93).
+/// Uses an `NSEvent` local monitor so unfocusable clicks trigger commits.
 struct ClickAwayResignsFocus: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         FocusResignMonitorView()
@@ -26,13 +11,7 @@ struct ClickAwayResignsFocus: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
-/// Owns a left-mouse-down monitor scoped to its own window. The
-/// monitor is torn down (and re-installed) in `viewDidMoveToWindow`
-/// whenever the view's window changes — including leaving the
-/// window (`window == nil`), which is the teardown path — so no
-/// `deinit` is needed (a nonisolated `deinit` can't touch the
-/// `@MainActor` monitor state anyway). Never intercepts clicks
-/// itself (`hitTest` returns nil).
+/// Window-scoped monitor view for resigning text field focus.
 private final class FocusResignMonitorView: NSView {
     private var monitor: Any?
 
@@ -51,10 +30,7 @@ private final class FocusResignMonitorView: NSView {
         }
     }
 
-    /// Keep editing when the click lands inside the focused field
-    /// editor; otherwise resign so the field commits. A no-op
-    /// unless a text field editor currently holds focus, so plain
-    /// clicks never disturb button/menu behaviour.
+    /// Resigns focus when a click occurs outside the active field editor.
     private static func resignIfClickOutsideEditor(
         _ window: NSWindow,
         _ event: NSEvent

--- a/Sources/KiwiDesk/Settings/Components/AppRules/AppRuleMatchPreview.swift
+++ b/Sources/KiwiDesk/Settings/Components/AppRules/AppRuleMatchPreview.swift
@@ -2,7 +2,8 @@ import KiwiDeskCore
 import SwiftUI
 
 /// Previews what an app rule matches against open windows as the user types
-/// (#123, `FloatRules.matches`).
+/// (#123, `FloatRules.matches`). Title patterns are the one part whose effect
+/// cannot be read off the rule text alone.
 struct AppRuleMatchPreview: View {
     @ObservedObject var model: SettingsModel
     let app: String

--- a/Sources/KiwiDesk/Settings/Components/AppRules/AppRuleMatchPreview.swift
+++ b/Sources/KiwiDesk/Settings/Components/AppRules/AppRuleMatchPreview.swift
@@ -1,56 +1,12 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// "What this rule matches" (turn 14a): the app's currently
-/// open windows, each labelled with what the rule being edited
-/// would do to it — **as you type**, so a rule is verified
-/// before it is saved rather than after it misfires.
-///
-/// A title pattern is the one part of an app rule whose effect
-/// you cannot read off the rule itself. "Windows titled Info"
-/// looks obviously right until it also catches "Information",
-/// or misses "Get Info" because the match is case-sensitive.
-/// The rule's own text can never answer that; the user's actual
-/// window titles can.
-///
-/// **The verdict comes from the engine, never from a rule
-/// re-derived here** (gui.md: a preview that claims to show
-/// engine behavior asks the engine). Two engines answer, and
-/// using only one is how the first cut of this view lied:
-/// `FloatRules.matches` decides whether the RULE catches a
-/// window — lowercasing bundle ids, comparing title fragments
-/// case-SENSITIVELY — while `WindowModel.isFloating` carries the
-/// settled answer, which includes the dialogs and panels
-/// `FloatDetection` floats with no rule at all. Asking only the
-/// first labelled Finder's "Get Info" **tiles** while the
-/// running app floats it, contradicting the user guide on the
-/// same screen.
-///
-/// So a window floating for a reason other than this rule says
-/// so, rather than being folded into the rule's verdict: the
-/// reader is deciding whether their rule is right, and "it
-/// floats anyway" is the answer that stops them writing a rule
-/// they do not need.
-///
-/// One limit, stated rather than hidden: `isFloating` is the
-/// LIVE session's verdict and the rules here are a DRAFT. Delete
-/// a saved rule without saving and its windows still read
-/// "floats anyway", because in the running app they still do.
-/// That is the honest reading of two different clocks, and the
-/// alternative — recomputing `FloatDetection` over staged
-/// config — needs the AX role and layer of each window, which
-/// is the live-apply coupling #123 rejects.
-///
-/// Live window state, not AX: `state.windows` is the snapshot
-/// the app already keeps, and the same one this row's
-/// open-window picker reads. Nothing here reaches the
-/// accessibility layer, so typing a character costs a filter
-/// over an array the GUI already holds.
+/// Previews what an app rule matches against open windows as the user types
+/// (#123, `FloatRules.matches`).
 struct AppRuleMatchPreview: View {
     @ObservedObject var model: SettingsModel
     let app: String
-    /// The pattern being typed but not yet committed, so the
-    /// list answers the question while it is still being asked.
+    /// Uncommitted pending pattern.
     var pending: String = ""
 
     var body: some View {
@@ -102,15 +58,11 @@ struct AppRuleMatchPreview: View {
         }
     }
 
-    /// What happens to a window, in the three states that are
-    /// actually distinguishable — collapsing the third into
-    /// "floats" is what made the first cut disagree with the app.
+    /// Result state for a window under the draft rule.
     enum Verdict: Hashable {
         /// This rule catches it.
         case floatsByRule
-        /// It floats regardless — a dialog, a panel, an
-        /// accessory app's window — so the rule is not what is
-        /// doing it, and removing the rule will not tile it.
+        /// Window floats due to system/dialog detection independently of rule.
         case floatsAnyway
         case tiles
     }
@@ -129,18 +81,13 @@ struct AppRuleMatchPreview: View {
         }
     }
 
-    /// One open window as the preview needs it: the title the
-    /// rule matches on, and the engine's settled float verdict.
+    /// Open window title and engine floating status.
     struct PreviewWindow: Hashable {
         let title: String
         let isFloating: Bool
     }
 
-    /// The app's open windows, deduped by title and in a stable
-    /// order so the list does not reshuffle under the reader
-    /// between keystrokes. A title open twice keeps the floating
-    /// reading if either copy floats — the reader is asking
-    /// about the title, which is all a rule can name.
+    /// Open windows deduped by title in stable alphabetical order.
     var windows: [PreviewWindow] {
         var byTitle: [String: Bool] = [:]
         for window in model.core.state.windows.all
@@ -153,16 +100,7 @@ struct AppRuleMatchPreview: View {
         }
     }
 
-    /// The verdict for one window: the rule first, then the
-    /// engine's settled answer for everything the rule does not
-    /// claim.
-    ///
-    /// Internal rather than private so the guard can assert the
-    /// PREVIEW's verdict rather than only scanning for the call:
-    /// a scan is one spelling deep, and guard-prover slipped a
-    /// plausible "fast path while typing" (`title.range(of:)`)
-    /// past it — which disagrees with the engine on exactly the
-    /// pending pattern the user is watching.
+    /// Resolves rule match first, falling back to engine floating status.
     func verdict(for window: PreviewWindow) -> Verdict {
         var staged = model.config.floatRules
         let typed = pending.trimmed

--- a/Sources/KiwiDesk/Settings/Components/AppRules/AppRulesRowOrder.swift
+++ b/Sources/KiwiDesk/Settings/Components/AppRules/AppRulesRowOrder.swift
@@ -1,6 +1,7 @@
 import KiwiDeskCore
 
-/// Rendering declarations for the App Rules area (#678).
+/// Rendering declarations for the App Rules area (#678); the census is the
+/// sole record of row placement and search ordering.
 enum AppRulesRowOrder {
     /// Containers drawn via bespoke views rather than static order lists
     /// (`AppRulesCensusRenderTests`, `ShortcutsRowOrder.bespokeContainers`).

--- a/Sources/KiwiDesk/Settings/Components/AppRules/AppRulesRowOrder.swift
+++ b/Sources/KiwiDesk/Settings/Components/AppRules/AppRulesRowOrder.swift
@@ -1,35 +1,9 @@
 import KiwiDeskCore
 
-/// What the App Rules area declares about its own rendering
-/// (turn 14a of the redesign, #678 Phase 3).
-///
-/// **It declares one thing, and deliberately not an order
-/// list.** The other census-rendered areas hold `[SettingKey]`
-/// lists because the census records placement but not display
-/// order, so a `ForEach` needs somewhere to read the order from.
-/// This area has no such `ForEach`: its repeating unit is the
-/// user's app list, not a static set of settings, and one census
-/// setting draws a row per app. An order list here would be a
-/// second copy of `SettingKey.allCases.filter { area ==
-/// .appRules && tier == … }` — derivable from the census, read
-/// by nothing but its own parity test, and maintained so that
-/// test could compare the copy against what it was copied from.
-///
-/// So the census is the sole record of these rows for the
-/// placement table and for search, and what stays here is the
-/// fact a reader of `gui.md`'s census promise needs: editing the
-/// census moves nothing on this screen.
+/// Rendering declarations for the App Rules area (#678).
 enum AppRulesRowOrder {
-    /// Containers this area draws with a bespoke view rather
-    /// than a `ForEach` over an order list. Data, not prose, so
-    /// a second container going bespoke has to edit this set —
-    /// which `AppRulesCensusRenderTests` asserts against the
-    /// tree rather than against a restatement of it, so a
-    /// container that *stops* being bespoke reds too.
-    ///
-    /// The same shape, and the same stated weakness, as the
-    /// Shortcuts area's app list, layer strip and raw-Lua drawer
-    /// (`ShortcutsRowOrder.bespokeContainers`).
+    /// Containers drawn via bespoke views rather than static order lists
+    /// (`AppRulesCensusRenderTests`, `ShortcutsRowOrder.bespokeContainers`).
     static let bespokeContainers: Set<SettingsContainer> = [
         .rulesPerApp
     ]

--- a/Sources/KiwiDesk/Settings/Components/AppRules/SentenceFrame.swift
+++ b/Sources/KiwiDesk/Settings/Components/AppRules/SentenceFrame.swift
@@ -1,35 +1,8 @@
 import Foundation
 
-/// A localized sentence whose arguments are CONTROLS, split
-/// into the pieces a view lays out in the translation's own
-/// order.
-///
-/// `L(key, english, args…)` covers the ordinary case: the
-/// arguments are strings, `String(format:)` places them, and a
-/// translator moves `%2$@` before `%1$@` freely. A menu is not
-/// a string, so a row that wants "Spotify opens in media ▾ and
-/// floats ▾" cannot format its way there — and the tempting
-/// alternative, emitting the connectives as their own keys
-/// between fixed stack positions, is exactly what
-/// `.claude/rules/localization.md` bans: a translation cannot
-/// reorder pieces stitched together in Swift, and this app
-/// ships ja, ko, zh-Hans and zh-Hant, where a verb-final
-/// language cannot render "opens in" as anything that sits
-/// where an English stack puts it.
-///
-/// So the frame stays one key with positional specifiers, and
-/// this splits it into literal text and argument slots **in the
-/// order the translation wrote them**. The view then draws its
-/// controls at the slots, which is the same contract
-/// `String(format:)` offers, with views instead of strings.
-///
-/// Unrecognized specifiers are kept as literal text rather than
-/// dropped: a catalog carrying `%4$@` for a frame with three
-/// arguments is a translation bug, and showing it is how it gets
-/// noticed instead of silently losing a word.
+/// Localized format string parsed into interleaved text and control slots.
 struct SentenceFrame {
-    /// One piece of the sentence: literal words, or the slot
-    /// where argument *n* goes.
+    /// Literal text chunk or argument position.
     enum Slot: Hashable {
         case text(String)
         case argument(Int)
@@ -58,8 +31,6 @@ struct SentenceFrame {
         while let percent = rest.firstIndex(of: "%") {
             literal += rest[rest.startIndex..<percent]
             rest = rest[rest.index(after: percent)...]
-            // `%n$@` — the only shape the localization rules
-            // allow, so anything else is literal text.
             let digits = rest.prefix { $0.isNumber }
             let after = rest.dropFirst(digits.count)
             if let index = Int(digits), after.hasPrefix("$@") {
@@ -80,22 +51,14 @@ struct SentenceFrame {
         self.segments = segments
     }
 
-    /// Which control an argument slot draws. A pure function so
-    /// a guard can assert it: the row's own `switch` cannot be,
-    /// and a `default:` arm there silently gave every
-    /// unrecognized position the float menu — so a catalog
-    /// carrying `%4$@` drew a SECOND float menu rather than
-    /// anything a reader would spot as a translation bug,
-    /// defeating the preservation promise above at its only
-    /// consumer.
+    /// Supported control types mapped to argument positions.
     enum Control: Hashable {
         case appName
         case space
         case float
     }
 
-    /// `nil` for a position the row has no control for — which
-    /// the row must draw as nothing, never as its last case.
+    /// Resolves argument index to control type, returning nil if unmapped.
     static func control(at position: Int) -> Control? {
         switch position {
         case 1: return .appName
@@ -110,9 +73,7 @@ struct SentenceFrame {
         argumentPositions.compactMap(Self.control(at:))
     }
 
-    /// The argument positions the frame actually uses, so a
-    /// guard can hold a translation to the slots its view draws
-    /// rather than trusting the catalog.
+    /// Argument slot indices referenced by the format string.
     var argumentPositions: [Int] {
         segments.compactMap {
             if case .argument(let index) = $0.slot { return index }

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard+ContentRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard+ContentRows.swift
@@ -1,18 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The App Bar card's three content rows: what an item draws
-/// (`contentRow`), how much of a title it may draw
-/// (`titleCapRow`), and how its icon is drawn
-/// (`iconSourceRow`). Split from AppBarCard+Rows.swift at the
-/// §2.1 ceiling — the shape `SpaceBarCard+RowHelpers.swift`
-/// already uses on the other card.
-///
-/// The three travel together rather than by line count: each one
-/// greys on a gate the other two decide. Icon-only content
-/// silences the title cap; title-only content silences the icon
-/// style; and a vertical bar, which renders icon-only whatever
-/// is stored, silences both.
+/// Content configuration rows for AppBarCard: content, title cap, icon style.
 extension AppBarCard {
     var contentRow: some View {
         SegmentedPicker(
@@ -22,9 +11,6 @@ extension AppBarCard {
         )
         .modifier(
             GreyOut(
-                // Vertical bars render icon-only (names would
-                // need stacked or rotated text) — the stored
-                // preference survives an edge round-trip.
                 active: gates.everyShownBarVertical,
                 help: L(
                     "app_bar.content.vertical_only",
@@ -35,15 +21,7 @@ extension AppBarCard {
         )
     }
 
-    /// How much of a window title an item shows, directly
-    /// below the Content control it depends on. Deliberately
-    /// NOT greyed under icon-only content (#937): an icon-only
-    /// or vertical bar draws no title but its items still
-    /// ANNOUNCE the capped title (`AppBarItemView`'s
-    /// accessibility label), so the knob is live on every
-    /// content — the same reasoning the Space Bar twin's
-    /// asymmetry note reserved for the day #901 gave items an
-    /// accessible name, which it since has.
+    /// Window title character length cap (#901, #937).
     var titleCapRow: some View {
         StepperRow(
             label: L("app_bar.title_cap", "Title length"),
@@ -59,25 +37,13 @@ extension AppBarCard {
         )
     }
 
-    /// #294 icon rendering, directly below the Content control
-    /// it depends on; greyed (never hidden, #171) when
-    /// title-only content shows no icons at all. Census-exempt from the
-    /// container gate: the ⌃⌥K panel's Apps band reads this
-    /// whether or not any bar renders.
+    /// App icon rendering dropdown (#171, #294, #818).
     var iconSourceRow: some View {
         DropdownRow(
             label: L("app_bar.icon_source.label", "App symbol style"),
             spokenValue: AppBarOptions.iconSourceTitle(
                 style.iconSource.wrappedValue
             ),
-            // Five labels INTERPOLATED from their own keys, not
-            // re-typed (#818): the mode, the three colour rows
-            // this sentence sends the reader to, and the page
-            // they are on. The rows are NOT below — they render
-            // at `.row(.advancedColours, .appBar, .showMore)`,
-            // all three Power-User-only — so the sentence
-            // names the destination instead of saying "below",
-            // which sent the reader looking down this card.
             help: L(
                 "app_bar.icon_source.help",
                 "How app icons are drawn. "
@@ -109,12 +75,7 @@ extension AppBarCard {
         }
         .modifier(
             GreyOut(
-                // Gate on the RENDERED content: a vertical bar
-                // collapses Title to icon-only, so icons are on
-                // screen and this control must stay live.
                 active: gates.everyShownBarTitleOnly,
-                // Both labels INTERPOLATED from their own keys,
-                // not re-typed (#818).
                 help: L(
                     "app_bar.icon_source.title_only",
                     "Icons are hidden while \u{201C}%1$@\u{201D} "

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard+Rows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard+Rows.swift
@@ -42,9 +42,7 @@ extension AppBarCard {
                     .map { ($0.1, $0.0) }
             )
         case .appBarLiquidGlass:
-            // Hidden, not greyed, below macOS 26 — matching the
-            // OS-capability gate (#390) and the census's
-            // `.liquidGlassUnavailable` runtime tag.
+            // Hidden below macOS 26 (#390).
             if AppBarStyle.glassAvailable {
                 ToggleRow(
                     label: L(
@@ -69,15 +67,6 @@ extension AppBarCard {
                 selection: style.alignment,
                 options: AppBarOptions.alignment
                     .map { ($0.1, $0.0) },
-                // The two option names are INTERPOLATED from the
-                // picker's own keys rather than re-typed (#818).
-                // Each appears ONCE: `placeholder_drift` compares
-                // a multiset, so a repeated specifier would make
-                // a stylistic second mention mandatory in every
-                // language and fail a translation that
-                // pronominalises it — correct copy, hard failure.
-                // The mapping is carried by the common noun
-                // instead, which no locale has to match.
                 help: L(
                     "app_bar.alignment.label.help",
                     "Where the item group sits along the bar "
@@ -107,11 +96,6 @@ extension AppBarCard {
         case .appBarIconSource:
             iconSourceRow
         case .appBarCornerRoundness:
-            // Never greyed since background_fit: roundness
-            // shapes the Boxed items, the glass plate, AND
-            // Plain's own shared plate (BarPlate) — the old
-            // Plain grey predated Plain getting a plate
-            // (QA 2026-07-19).
             PtSlider(
                 label: L(
                     "app_bar.corner_roundness",
@@ -158,20 +142,12 @@ extension AppBarCard {
                 )
             }
         case .appBarItemSize, .appBarFontSize:
-            // Rendered by their Auto toggles' `AutoGatedGroup`
-            // above — the census keeps them as their own gated
-            // rows, the GUI composes the pair.
             EmptyView()
         case .appBarDimFactor, .appBarFillColor,
             .appBarHighlightColor, .appBarItemColor,
             .appBarActiveItemColor, .appBarHoverFillColor,
             .appBarHoverItemColor, .appBarGroupBadgeColor,
             .appBarGroupBadgeTextColor:
-            // Lua-only or colour-card rows today. If a census
-            // move places one in this card, the render-parity
-            // guard forces it into the order lists and it lands
-            // here — fail loud in debug rather than render
-            // nothing.
             let _ = assertionFailure(
                 "unrendered App Bar census key: \(key.rawValue)"
             )
@@ -179,8 +155,7 @@ extension AppBarCard {
         }
     }
 
-    /// Position plus the shared-edge info row directly under it
-    /// (#374) — the Space Bar card shows the same row.
+    /// Position plus the shared-edge info row directly under it (#374).
     @ViewBuilder private var edgeRow: some View {
         SegmentedPicker(
             L("app_bar.edge.label", "Position"),
@@ -212,21 +187,8 @@ extension AppBarCard {
         )
         .modifier(
             GreyOut(
-                // Boxed never draws a shared plate to size — so
-                // fit is inert for Boxed regardless of the glass
-                // finish; Plain (the shipped default, #660)
-                // un-greys it. Asked of the bars actually SHOWN,
-                // not the global value: a layout overriding to
-                // Plain via Lua still reads this global fit, and
-                // greying it hid the only editor for a value in
-                // use.
+                // Inert when Boxed (#660, #818).
                 active: gates.everyShownBarBoxed,
-                // Style name INTERPOLATED from the picker entry's
-                // own key, not re-typed (#818) — and it must move
-                // with its Space Bar twin, which carries the
-                // identical English: one anchored and one typed
-                // is worse than either end, since the two then
-                // disagree per locale with nothing checking.
                 help: L(
                     "app_bar.background_fit.boxed_only",
                     "\u{201C}%1$@\u{201D} draws a box per item, "

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarCard.swift
@@ -1,21 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The App Bar card (turn 7a): Position, Thickness and the
-/// grouping toggle at rest, one Style disclosure, then the
-/// "Show it in" block — the two per-layout switches that
-/// replaced the per-layout override sub-editors
-/// (GUI_REMOVED_2026-08; styling stays fully available in Lua).
-/// There is no global on/off row because the bar doesn't have
-/// one — visibility is per layout.
-///
-/// Census-rendered like `SpaceBarCard`: `BarsRowOrder` gives
-/// the order, the `.appBar` container's gate greys the card
-/// wholesale, and `exemptFromContainerGate` names the rows that
-/// stay live — the two Show-it-in switches (which own the
-/// gate), the symbol-style picker (it also feeds the ⌃⌥K
-/// panel's Apps band) and the copy-appearance action (gated on
-/// the Space Bar instead).
+/// Settings card for App Bar configuration and layout toggles.
 struct AppBarCard: View {
     @ObservedObject var model: SettingsModel
     @State private var styleExpanded = false
@@ -33,23 +19,20 @@ struct AppBarCard: View {
     private var allows: Bool { reason == nil }
 
     var body: some View {
-        // The header `?` is the gate's live anchor (#527).
+        // Section header help provides the gate anchor (#527).
         SettingsSection(
             SettingsCatalog.bars.appBarCard,
             caption: cardCaption,
             help: reason.map(BarsGateHelp.sentence)
         ) {
-            // The strip moved to the detail PANEL
-            // (`BarsPanelPreview`, #678 redesign spec); the palette
-            // mirror keeps its own mount.
+            // Preview strip renders in BarsPanelPreview (#678).
             rows(BarsRowOrder.appBarAtRest)
             styleDisclosure
             showInBlock
         }
     }
 
-    /// Parallel per-row gates, never nested (#520): each row
-    /// carries the container gate unless the census exempts it.
+    /// Parallel per-row gates (#520), respecting census exemptions.
     private func rows(_ keys: [SettingKey]) -> some View {
         ForEach(keys, id: \.id) { key in
             row(for: key)
@@ -73,10 +56,6 @@ struct AppBarCard: View {
         case .layoutAppBar(let k):
             showInRow(k)
         default:
-            // The render-parity guard forces every census row
-            // of this container into the order lists — an
-            // unhandled key reaching this arm must fail loud
-            // in debug, not vanish.
             let _ = assertionFailure(
                 "unrendered Bars census key: \(key.id)"
             )
@@ -96,10 +75,7 @@ struct AppBarCard: View {
         }
     }
 
-    /// "Show it in", after the Style disclosure: the only
-    /// layouts that can carry an App Bar. Live while the card
-    /// greys — these own the gate, or the lockout would be
-    /// permanent.
+    /// "Show it in" block for layout-specific toggles.
     @ViewBuilder private var showInBlock: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(L("bars.show_in.title", "Show it in"))
@@ -112,8 +88,6 @@ struct AppBarCard: View {
         rows(BarsRowOrder.appBarShowIn)
     }
 
-    /// One switch per bar-hosting layout, search-anchored so
-    /// "Monocle" finds the row that decides its bar.
     @ViewBuilder private func showInRow(
         _ key: LayoutAppBarKey
     ) -> some View {
@@ -139,17 +113,7 @@ struct AppBarCard: View {
         }
     }
 
-    /// One-shot copy, then fully independent — never a live
-    /// link. Owner flipped the DIRECTION (2026-08-10): a
-    /// button on THIS card fills in THIS bar from the Space
-    /// Bar the user already configured — pushing outward
-    /// surprised on sight — and it rides at rest, always
-    /// visible (the adjust-gaps precedent). It
-    /// needs the SOURCE (Space Bar) on, not the App Bar
-    /// shown. Sizes and style ONLY — colours are the Advanced
-    /// Colours area's concern (owner ruling 2026-08-02; a
-    /// colours-copy, if it ships, lives there). The one-shot
-    /// caveat rides a persistent caption, never hover alone.
+    /// One-shot copy of size and style from Space Bar to App Bar.
     private var copyAppearanceRow: some View {
         VStack(alignment: .leading, spacing: 4) {
             VStack(alignment: .leading, spacing: 4) {
@@ -188,22 +152,8 @@ struct AppBarCard: View {
                     help: BarsGateHelp.sentence(for: .spaceBarOff)
                 )
             )
-            // The gate's reason, INLINE and OUTSIDE the dimmed
-            // subtree (#815): a dim says an answer exists, and
-            // this row's answer is on another card of this same
-            // page, so nothing beside the button connects the
-            // two. The caption above says what the verb does,
-            // never why it is dead — which is exactly the
-            // distinction that let this ship with the reason in
-            // a tooltip.
-            //
-            // The census is ASKED rather than quoted: a comment
-            // claiming `GateReasonPlacement` puts this row in
-            // that class, over an `if` that re-derives it, is
-            // the dead-resolver shape gui.md names — the type
-            // would then answer for nobody and a row whose
-            // adjacency changed would keep drawing this
-            // (architect review, 2026-08-12).
+            // Inline gate reason outside the dimmed subtree
+            // (#815, GateReasonPlacement).
             if sourceBarOff, owesInlineGateReason {
                 Text(BarsGateHelp.sentence(for: .spaceBarOff))
                     .font(.caption)
@@ -212,16 +162,10 @@ struct AppBarCard: View {
         }
     }
 
-    /// The source bar being off is what kills the copy — read
-    /// once, so the dim and the sentence cannot disagree.
     private var sourceBarOff: Bool {
         !model.config.settings.spaceBarStyle.enabled
     }
 
-    /// Whether this row's reason travels inline, per the census.
-    /// Nothing here decides it: give the copy action a gating
-    /// control on this card and the derivation answers
-    /// `.adjacent`, and this sentence retires itself.
     private var owesInlineGateReason: Bool {
         GateReasonPlacement.owesInlineReason(
             .spaceBar(.copyAppearance)

--- a/Sources/KiwiDesk/Settings/Components/Bars/AppBarOptions.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/AppBarOptions.swift
@@ -1,17 +1,7 @@
 import KiwiDeskCore
 
-/// The shared App Bar option lists so the global editor and the
-/// per-layout override pickers stay in sync — one source of the
-/// value/label pairs both surfaces render (as segments now, #291).
-/// Split out of the per-space override chrome
-/// (`SpaceOverrides/OverrideControls.swift`) to keep that file
-/// under the line ceiling. It stays here because these ARE bar
-/// data — the edges and alignments the App Bar editor renders —
-/// while the chrome that once wrapped them moved to the one
-/// surface that still draws it (#819).
+/// Shared App Bar option value/label pairs (#291, #819).
 enum AppBarOptions {
-    /// Built from `allCases` through an exhaustive switch, so a
-    /// new edge case can't silently vanish from the pickers.
     @MainActor
     static let edge: [(AppBarEdge, String)] =
         AppBarEdge.allCases.map { ($0, label($0)) }
@@ -25,7 +15,7 @@ enum AppBarOptions {
         case .right: return L("app_bar.edge.right", "Right")
         }
     }
-    /// Same exhaustive-switch guard as `edge`.
+
     @MainActor
     static let alignment: [(AppBarStyle.BarAlignment, String)] =
         AppBarStyle.BarAlignment.allCases.map {
@@ -46,17 +36,14 @@ enum AppBarOptions {
         }
     }
 
-    /// WHERE the background is drawn — per item, or one plate
-    /// behind all of them. Liquid Glass is no longer an option
-    /// here — it is a separate `liquidGlass` finish toggle (#390),
-    /// offered only where it can render (macOS 26+).
+    /// Background plate drawing style (#390).
     @MainActor
     static let backgroundStyle: [(AppBarStyle.BackgroundStyle, String)] = [
         (.boxed, L("app_bar.background_style.boxed", "Boxed")),
         (.plain, L("app_bar.background_style.plain", "Plain")),
     ]
-    /// How far the shared plate reaches (QA 2026-07-19).
-    /// Default (hug) first, like every options list here.
+
+    /// Background reach options.
     @MainActor
     static let backgroundFit: [(AppBarStyle.BackgroundFit, String)] = [
         (
@@ -74,6 +61,7 @@ enum AppBarOptions {
             )
         ),
     ]
+
     @MainActor
     static let activeIndicator: [(AppBarStyle.ActiveIndicator, String)] = [
         (.outline, L("app_bar.active_indicator.outline", "Outline")),
@@ -86,10 +74,8 @@ enum AppBarOptions {
         ),
         (.gap, L("app_bar.active_indicator.gap", "Gap")),
     ]
-    /// #294 icon rendering. "System default" = the icon as
-    /// macOS hands it out (the system-wide Icon & widget
-    /// style already covers tinting wants); styled variants
-    /// are not obtainable via public API (#362).
+
+    /// App icon rendering options (#294, #362).
     @MainActor
     static let iconSource: [(BarAppIconSource, String)] = [
         (
@@ -101,8 +87,8 @@ enum AppBarOptions {
             L("app_bar.icon_source.app_font", "Glyphs")
         ),
     ]
-    /// The icon-source entry's title, for a row to speak as its
-    /// value — the same strings the picker draws.
+
+    /// Localized title for a given icon source option.
     @MainActor
     static func iconSourceTitle(_ source: BarAppIconSource) -> String {
         iconSource.first { $0.0 == source }?.1 ?? ""

--- a/Sources/KiwiDesk/Settings/Components/Bars/BarCanvasAlignment.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/BarCanvasAlignment.swift
@@ -1,14 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Maps a bar's absolute edge plus its along-axis alignment
-/// onto the composite SwiftUI `Alignment` a preview canvas
-/// uses (#293 QA): the edge supplies the cross-axis component
-/// (the strip hugs its matching side; the off-axis emptiness
-/// mirrors the bar's real relationship to the desktop), the
-/// alignment the along-axis one. Both preview strips share
-/// this one mapping. GUI-side on purpose — SwiftUI's
-/// `Alignment` must never leak into KiwiDeskCore.
+/// Maps bar edge and along-axis alignment to SwiftUI `Alignment` (#293).
 extension AppBarEdge {
     func canvasAlignment(
         _ alignment: AppBarStyle.BarAlignment

--- a/Sources/KiwiDesk/Settings/Components/Bars/BarSameEdgeRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/BarSameEdgeRow.swift
@@ -1,18 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The neutral both-bars-share-an-edge explainer (#293/#374),
-/// shown under each bar editor's Position row when both
-/// *enabled* bars resolve to the same edge
-/// (`TilingSettings.spaceBarSharesEdgeWithAppBar`). Never a
-/// warning, never a popup.
-///
-/// Renders the **Space Bar's** edge, never the App Bar's
-/// global one: the predicate matches per-layout *resolved*
-/// App Bar edges, so the shared edge can legitimately differ
-/// from the App Bar's global Position control sitting right
-/// above this row (global top, monocle override bottom,
-/// Space Bar bottom → the shared edge is bottom).
+/// Explainer row when both enabled bars share an edge (#293, #374,
+/// `TilingSettings.spaceBarSharesEdgeWithAppBar`).
 struct BarSameEdgeRow: View {
     let edge: AppBarEdge
 

--- a/Sources/KiwiDesk/Settings/Components/Bars/BarsGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/BarsGates.swift
@@ -2,7 +2,8 @@ import KiwiDeskCore
 
 /// Resolves Bars area gating states to structured reason codes (#520, #678,
 /// `GapsBordersGates`, `GeneralGates`, `LayoutDefaultsGates`,
-/// `BarsGateHelp.sentence`).
+/// `BarsGateHelp.sentence`). The census is the one copy of container
+/// exemptions.
 struct BarsGates {
     let settings: TilingSettings
 

--- a/Sources/KiwiDesk/Settings/Components/Bars/BarsGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/BarsGates.swift
@@ -1,49 +1,22 @@
 import KiwiDeskCore
 
-/// The Bars area's greying, resolved from the census (#678
-/// Phase 2), folded onto the reason-case shape the redesigned
-/// areas share (`GapsBordersGates`, `GeneralGates`,
-/// `LayoutDefaultsGates`, 2026-08-03 convergence): the block gate
-/// returns a REASON case rather than a Bool, so the grey and the
-/// sentence explaining it are one decision (`BarsGateHelp.sentence`
-/// renders it), never two that can disagree.
-///
-/// Each card's block gate is its census container's own greying
-/// condition, and a row escapes it exactly when its
-/// `SettingPlacement.exemptFromContainerGate` says so — the census
-/// is the one copy of who may. Row-specific gates keep their
-/// predicates here as WIRING (the census names the owning setting;
-/// the exact predicate lives with the wiring), because they read
-/// the bars actually SHOWN, which a per-layout Lua override can
-/// change and no single declared owner can answer.
-///
-/// Every "shown bar" predicate asks about the bars actually SHOWN
-/// rather than the global value (#520): per-layout overrides are
-/// Lua-only now (GUI_REMOVED_2026-08) but still resolve, so a gate
-/// keyed on the global would grey the only editor for a value an
-/// overriding layout still reads.
+/// Resolves Bars area gating states to structured reason codes (#520, #678,
+/// `GapsBordersGates`, `GeneralGates`, `LayoutDefaultsGates`,
+/// `BarsGateHelp.sentence`).
 struct BarsGates {
     let settings: TilingSettings
 
-    /// Why a bar block — or a shown-bar-gated colour row — is
-    /// inert. The two block reasons plus `.gapOnly`, whose
-    /// PREDICATE is wiring (a resolved shown-bar value) but whose
-    /// sentence belongs with the rest, authored once.
+    /// Why a bar block or shown-bar-gated row is inert.
     enum InertReason: Hashable {
         /// No layout shows an App Bar.
         case noBarShown
         /// The Space Bar is switched off.
         case spaceBarOff
-        /// The active indicator is Gap — it hides the active item
-        /// instead of marking it, so the highlight/active colours
-        /// are never painted.
+        /// The active indicator is Gap — active items are hidden.
         case gapOnly
     }
 
-    /// Resolves a bar container's block gate to a reason, or nil
-    /// while it is live. The two bar containers are the only ones
-    /// this area renders; a Bars row placed in a new container
-    /// fails the render-parity guard before this is reached.
+    /// Resolves container gate to an inert reason, or nil if active.
     func containerReason(
         for container: SettingsContainer
     ) -> InertReason? {
@@ -75,8 +48,7 @@ struct BarsGates {
             }
     }
 
-    /// True when EVERY shown bar renders on a vertical edge,
-    /// where titles would need stacked or rotated text.
+    /// True when EVERY shown bar renders on a vertical edge.
     var everyShownBarVertical: Bool {
         anyBarShown
             && shownBars.allSatisfy {
@@ -94,10 +66,8 @@ struct BarsGates {
             }
     }
 
-    /// Under `activeIndicator = .gap` the active item's view is
-    /// hidden outright (`AppBarOverlay`) and `accentMode`
-    /// returns `.none` (`AppBarItemView`), so neither the
-    /// highlight nor the active-item ink is ever painted.
+    /// True when active indicator hides active items outright
+    /// (`AppBarOverlay`, `AppBarItemView`).
     var gapOnly: Bool {
         anyBarShown
             && shownBars.allSatisfy {
@@ -107,31 +77,13 @@ struct BarsGates {
     }
 }
 
-/// The inline sentence each `BarsGates.InertReason` renders — the
-/// "why you can't edit this" a greyed block or row shows on hover.
-/// Split from the resolver so the resolver stays assertable off the
-/// main actor; the reason and its sentence are one decision, never
-/// two that can disagree (#678, gui.md). Every key here is reused
-/// from the hand-wired gate this conversion replaced, so the
-/// English is unchanged and no translation is dropped.
-///
-/// Advanced Colours needs the two block conditions worded
-/// differently — its sentences must say WHICH page to go to — so it
-/// authors its own in `AdvancedColorsHelp` and shares only the
-/// `.gapOnly` sentence, whose wording is about the indicator
-/// rather than a place.
+/// Explanatory hover/help text for bar gate reasons (#678).
 @MainActor
 enum BarsGateHelp {
     static func sentence(for reason: BarsGates.InertReason) -> String {
         switch reason {
         case .noBarShown:
-            // The near-twin of `colors.app_bar_off.help`, and
-            // reworded with it (#705): "turn one on below" left
-            // the reader to decide whether "one" was the bar or
-            // the layout. Names the block that holds the switch,
-            // through its own key rather than as quoted text
-            // (#818) — which also drops "below", the block being
-            // what the sentence now points at.
+            // Points to the block holding the switches (#705, #818).
             return L(
                 "app_bar.no_layout.help",
                 "No layout shows an App Bar — turn a layout's "
@@ -145,11 +97,7 @@ enum BarsGateHelp {
                 L("space_bar.enabled", "Show Space Bar")
             )
         case .gapOnly:
-            // The indicator style is INTERPOLATED from the picker
-            // entry's own key rather than named as text (#818):
-            // a sentence quoting a label is a hand-kept mirror
-            // every locale must keep in step with nothing
-            // checking that it does.
+            // Interpolated from picker entry (#818).
             return L(
                 "app_bar.color.gap_only",
                 "The \u{201C}%1$@\u{201D} indicator hides the "

--- a/Sources/KiwiDesk/Settings/Components/Bars/BarsPanelPreview.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/BarsPanelPreview.swift
@@ -1,13 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Bars panel content (#678 redesign spec, turn 7a): ONE desktop
-/// scene with both bars in place — the fused view the owner
-/// asked for (2026-08-10), so "both on top" coexistence is
-/// seen, not described. The scene is `HomeCardBarsTile`, the
-/// Home plate's own renderer, mounted larger with the same
-/// palette fold — one renderer, two sizes, never a second
-/// drawing. Space pips are the draft's real space count.
+/// Desktop preview scene for the Bars panel (#678, `HomeCardBarsTile`).
 struct BarsPanelPreview: View {
     @ObservedObject var model: SettingsModel
 

--- a/Sources/KiwiDesk/Settings/Components/Bars/BarsRowOrder.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/BarsRowOrder.swift
@@ -1,16 +1,6 @@
-/// The Bars area's display order (turn 7a of the redesign,
-/// #678 Phase 2). The census owns *placement* — which container
-/// and tier each row sits in — but records no display order, so
-/// the renderer declares it here as data.
-///
-/// `BarsCensusRenderTests` pins each list against the census:
-/// every `.bars`-area key must appear in exactly the list its
-/// placement names, so a census row added or moved without a
-/// renderer update is a red test, not a silently missing
-/// control.
+/// Display order for the Bars settings area (#678, `BarsCensusRenderTests`).
 enum BarsRowOrder {
-    /// Space Bar card, at rest: does the bar exist, where, how
-    /// thick, and the two content toggles.
+    /// Space Bar card, at rest.
     static let spaceBarAtRest: [SettingKey] = [
         .spaceBar(.spaceBarEnabled),
         .spaceBar(.spaceBarEdge),
@@ -19,9 +9,7 @@ enum BarsRowOrder {
         .spaceBar(.spaceBarHideEmpty),
     ]
 
-    /// Space Bar card, behind the Style disclosure. The
-    /// Auto/value pairs are two census rows rendered as one
-    /// `AutoGatedGroup`; the value key follows its toggle.
+    /// Space Bar card, behind the Style disclosure.
     static let spaceBarStyle: [SettingKey] = [
         .spaceBar(.spaceBarBackground),
         .spaceBar(.spaceBarLiquidGlass),
@@ -40,15 +28,11 @@ enum BarsRowOrder {
         .spaceBar(.spaceBarSpringDelay),
     ]
 
-    /// App Bar card, at rest. No global on/off row — visibility
-    /// is per layout, in `appBarShowIn` below.
+    /// App Bar card, at rest.
     static let appBarAtRest: [SettingKey] = [
         .appBar(.appBarEdge),
         .appBar(.appBarThickness),
         .appBar(.appBarGroupAdjacentWindows),
-        // The copy verb rides at rest, the adjust-gaps
-        // precedent (owner 2026-08-10) — a one-shot action
-        // nearly nobody found behind the drawer.
         .spaceBar(.copyAppearance),
     ]
 
@@ -70,10 +54,7 @@ enum BarsRowOrder {
         .appBar(.appBarFontSize),
     ]
 
-    /// The "Show it in" block, after the Style disclosure: the
-    /// only layouts that can carry an App Bar. These own the
-    /// `.appBar` container gate, so they stay live while the
-    /// rows above grey.
+    /// App Bar layout toggles ("Show it in").
     static let appBarShowIn: [SettingKey] = [
         .layoutAppBar(.monocleAppBarEnabled),
         .layoutAppBar(.scrollingAppBarEnabled),

--- a/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarCard+RowHelpers.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarCard+RowHelpers.swift
@@ -104,7 +104,8 @@ extension SpaceBarCard {
     }
 
     /// Front segment title length cap (#171, #818, #901, #937,
-    /// `SettingKey+SpaceBar`, `SpaceBarOverlay+FrontApp`).
+    /// `SettingKey+SpaceBar`, `SpaceBarOverlay+FrontApp`). Greys on the toggle
+    /// alone: vertical bars announce the name via AX even when not drawn.
     @ViewBuilder var titleCapRow: some View {
         StepperRow(
             label: L("space_bar.title_cap", "Title length"),

--- a/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarCard+RowHelpers.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/SpaceBarCard+RowHelpers.swift
@@ -6,11 +6,7 @@ import SwiftUI
 /// (not private) only because the `row(for:)` switch lives in
 /// the sibling extension file.
 extension SpaceBarCard {
-    /// A plain binding. It wrote `stickyStyle.mark = true`
-    /// through on the way off until #678 Phase 3, to back the
-    /// sticky-mark toggle's forced-ON greying; that gate is gone
-    /// (`StickyMarkEditor`), and with it the only reason this
-    /// switch had to reach into another setting.
+    /// Space Bar enable toggle (#678, `StickyMarkEditor`).
     var showToggle: some View {
         ToggleRow(
             label: L("space_bar.enabled", "Show Space Bar"),
@@ -25,8 +21,7 @@ extension SpaceBarCard {
         )
     }
 
-    /// Position plus the shared-edge info row directly under it
-    /// (#374) — the App Bar card shows the same row.
+    /// Position plus the shared-edge info row directly under it (#374).
     @ViewBuilder var edgeRow: some View {
         SegmentedPicker(
             L("space_bar.edge.label", "Position"),
@@ -56,15 +51,9 @@ extension SpaceBarCard {
         )
         .modifier(
             GreyOut(
-                // Boxed never draws a shared plate to size —
-                // glass hugs each box, solid draws each box — so
-                // fit is inert for Boxed regardless of the glass
-                // finish. Plain (the shipped default, #660)
-                // un-greys it.
+                // Inert when Boxed (#660, #818).
                 active: style.wrappedValue.backgroundStyle
                     == .boxed,
-                // Style name INTERPOLATED from the picker entry's
-                // own key, not re-typed (#818).
                 help: L(
                     "space_bar.background_fit.boxed_only",
                     "\u{201C}%1$@\u{201D} draws a box per item, "
@@ -85,12 +74,7 @@ extension SpaceBarCard {
             spokenValue: AppBarOptions.iconSourceTitle(
                 style.iconSource.wrappedValue
             ),
-            // Two labels INTERPOLATED from their own keys, not
-            // re-typed (#818): the picker entry, and the page
-            // the item colours this sentence names are edited
-            // on. The App Bar twin already named that page; this
-            // one said "the bar's item colors" and pointed
-            // nowhere, so the reader had no way to reach them.
+            // Interpolated labels (#818).
             help: L(
                 "space_bar.icon_source.help",
                 "How app glyphs are drawn. "
@@ -119,24 +103,8 @@ extension SpaceBarCard {
         }
     }
 
-    /// The front segment's title length — the only text the
-    /// Space Bar draws, so the knob is inert while that segment
-    /// is off. Greyed rather than hidden (#171), pairing the
-    /// census gate `SettingKey+SpaceBar` declares with a live
-    /// `GreyOut`, as `backgroundFitRow` above does.
-    ///
-    /// Gated on the toggle ALONE: with the front segment off
-    /// the title is truly nowhere — not drawn, not announced.
-    /// A vertical Space Bar draws no front name but still
-    /// ANNOUNCES one — the segment's accessibility label is
-    /// built from the capped title on every edge
-    /// (`SpaceBarOverlay+FrontApp`) — so the cap is live there
-    /// and greying it would lie. The App Bar twin now follows
-    /// the same reasoning (#937): #901 gave its items an
-    /// accessible name, which is the condition the 2026-08-20
-    /// review ruling attached to retiring that twin's
-    /// icon-only grey, so both caps now grey only where the
-    /// title reaches NEITHER channel.
+    /// Front segment title length cap (#171, #818, #901, #937,
+    /// `SettingKey+SpaceBar`, `SpaceBarOverlay+FrontApp`).
     @ViewBuilder var titleCapRow: some View {
         StepperRow(
             label: L("space_bar.title_cap", "Title length"),
@@ -152,8 +120,6 @@ extension SpaceBarCard {
         .modifier(
             GreyOut(
                 active: !style.wrappedValue.showFrontApp,
-                // Toggle name INTERPOLATED from its own key,
-                // not re-typed (#818).
                 help: L(
                     "space_bar.title_cap.front_app_only",
                     "Only \u{201C}%1$@\u{201D} draws a title.",
@@ -166,11 +132,7 @@ extension SpaceBarCard {
         )
     }
 
-    /// The stepper plus a neutral live summary of the current
-    /// cap — a caption that states what shows, not why (#94
-    /// defers the why to `help`). The preview strip is a fixed
-    /// stand-in and cannot honestly render N synthetic glyphs,
-    /// so the fact lives here.
+    /// Glyphs per Space stepper and live summary (#94).
     @ViewBuilder var glyphCapRow: some View {
         StepperRow(
             label: L("space_bar.glyph_cap", "Glyphs per Space"),


### PR DESCRIPTION
## Summary
Batch 3 of comment diet covering files 51–75 from worklist (Settings census and components):

- Trimmed comments to §2.8 budget (1–3 lines for constraints, 1–4 lines for docstrings).
- Removed design histories, rejected alternatives, and redundant code restatements.
- Preserved all `#NNN` issue references (`#6`, `#7`, `#94`, `#123`, `#171`, `#291`, `#293`, `#294`, `#362`, `#374`, `#390`, `#520`, `#527`, `#660`, `#678`, `#705`, `#754`, `#815`, `#818`, `#819`, `#859`, `#888`, `#901`, `#937`).
- Preserved all single-home, single-truth, and obligation claims in compressed form.
- Preserved all test suite and type references (`SettingKeyLocaleTests`, `SettingsDraftDiffTests`, `BorderMastersFanOutTests`, `AppRulesCensusRenderTests`, `BarsCensusRenderTests`, etc.).

## Verification
- `scripts/lint.sh`: green (exit code 0)
- Zero lines > 79 characters
- Automated issue reference check: ALL REFS PRESERVED (0 lost refs)
