### PR TITLE
fix(core): pay the wake restore's focus for real

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiCore+BootSeams.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+BootSeams.swift
@@ -22,6 +22,11 @@ extension KiwiCore {
             NSWorkspace.shared.frontmostApplication?
                 .processIdentifier
         }
+        // The wake payment's fallback seed reads the one trusted
+        // frontmost chain (#442/#1130).
+        trustedFrontmostProvider = { [weak self] in
+            self?.trustedFrontmostFocusedWindowID()
+        }
         // Arm the raise-echo revert's click-provenance check
         // (#687): the press stamp below resolves which window
         // each click reached.

--- a/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
@@ -153,8 +153,10 @@ extension KiwiCore {
         sleepWake.captureState = { [weak self] in
             self?.state.snapshot()
         }
+        // The wake leg pays the adopted focus for real (#1130);
+        // the crash leg above keeps the bare replay.
         sleepWake.restoreState = { [weak self] snapshot in
-            self?.restoreAndSettle(snapshot)
+            self?.restoreAndSettleAfterWake(snapshot)
         }
         sleepWake.displayFingerprints = { [weak self] in
             self?.state.workspaces.allDisplays

--- a/Sources/KiwiDeskCore/App/KiwiCore+FocusEvents.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+FocusEvents.swift
@@ -214,16 +214,11 @@ extension KiwiCore {
         // would revert to the stale target. Re-assert the
         // intended focus and drop the echo. Consume the id
         // from the outstanding set either way.
-        // An outstanding entry is our raise's echo only while
-        // the raise is RECENT (`selfRaiseStamps`, stamped at
-        // raise time, age-pruned): raising an already-key
-        // window emits no echo at all — the restore's closing
-        // re-assert does exactly that — so its entry sat
-        // unconsumed forever and classified the user's NEXT
-        // click on that window as our echo, eating it (device
-        // QA 2026-08-03). `outstandingSelfRaises` was the last
-        // unbounded ledger — the `zOrderRaiseEchoWindow`
-        // lesson again. The entry is consumed either way.
+        // An outstanding entry is our echo only while the raise
+        // is RECENT (`selfRaiseStamps`): an already-key raise
+        // never echoes, so an unbounded entry classified the
+        // user's NEXT click on that window as our echo, eating
+        // it (#687). The entry is consumed either way.
         let selfEcho = freshSelfRaise(id, now: now)
         outstandingSelfRaises.remove(id)
         // And even a FRESH entry stands down for a report with
@@ -272,6 +267,8 @@ extension KiwiCore {
         // the user reached, and a stale raise firing after the
         // pan would steal focus back.
         pendingFocusRaise = nil
+        // State and the OS agree again (#1130).
+        disarmWakeFocusHeal()
         let honoredApp: String =
             state.windows[id]?.appName ?? "?"
         let honoredBefore: String = describe(

--- a/Sources/KiwiDeskCore/App/KiwiCore+FocusEvents.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+FocusEvents.swift
@@ -216,9 +216,9 @@ extension KiwiCore {
         // from the outstanding set either way.
         // An outstanding entry is our echo only while the raise
         // is RECENT (`selfRaiseStamps`): an already-key raise
-        // never echoes, so an unbounded entry classified the
-        // user's NEXT click on that window as our echo, eating
-        // it (#687). The entry is consumed either way.
+        // never echoes (device QA 2026-08-03), so an unbounded
+        // entry classified the user's NEXT click on that window
+        // as our echo, eating it (#687). Consumed either way.
         let selfEcho = freshSelfRaise(id, now: now)
         outstandingSelfRaises.remove(id)
         // And even a FRESH entry stands down for a report with

--- a/Sources/KiwiDeskCore/App/KiwiCore+FocusSeed.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+FocusSeed.swift
@@ -16,11 +16,10 @@ extension KiwiCore {
     /// Seeds internal focus state after the startup landing
     /// (session restore and the delayed startup sweep). State
     /// only — never raises or AX-focuses anything, so launch
-    /// steals no OS focus.
+    /// steals no OS focus. The frontmost read is the one
+    /// `trustedFrontmostTracked` copy (#1130).
     func seedStartupFocus() {
-        let frontmost = trustedFrontmostFocusedWindowID()
-            .flatMap { state.windows[$0] != nil ? $0 : nil }
-        seedStartupFocus(frontmost: frontmost)
+        seedStartupFocus(frontmost: trustedFrontmostTracked())
     }
 
     /// Testable core, the OS-frontmost managed window injected.

--- a/Sources/KiwiDeskCore/App/KiwiCore+Restore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Restore.swift
@@ -46,19 +46,15 @@ extension KiwiCore {
         }
     }
 
-    /// The full restore contract for the wake/unlock and crash
-    /// paths: replay, then settle like any other space switch —
-    /// force past the ±2 pt tolerance and tell bus subscribers
-    /// (the bar) where we landed. Both paths used to stop at
-    /// the bare replay (#633), which left everything un-retiled
-    /// with stale bars. The launch-time session restore keeps
-    /// its own sequence in `KiwiCore+Lifecycle` — it seeds
-    /// focus between the replay and the settle. Crash restore
-    /// gets no focus seeding here on purpose: it runs inside
-    /// `start()`, whose 1 s startup sweep
-    /// (`scheduleStartupSweep`) re-runs the landing choice and
-    /// `seedStartupFocus` — that sweep is the focus half of
-    /// this path's contract.
+    /// The crash leg's restore contract: replay, then settle
+    /// like any other space switch — force past the ±2 pt
+    /// tolerance and tell bus subscribers (the bar) where we
+    /// landed (#633). No focus seeding on purpose: it runs
+    /// inside `start()`, whose startup sweep re-runs the
+    /// landing choice and `seedStartupFocus`. The launch-time
+    /// session restore seeds focus itself (`KiwiCore+Lifecycle`)
+    /// and the wake/unlock leg pays the adopted focus for real
+    /// (`restoreAndSettleAfterWake`, #1130).
     func restoreAndSettle(_ snapshot: StateSnapshot) {
         restore(snapshot)
         spaceSwitchRetile()

--- a/Sources/KiwiDeskCore/App/KiwiCore+WakeFocus.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+WakeFocus.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// The wake/unlock restore's focus payment (#1130). The replay
+/// adopts the snapshot's focus, so it must PERFORM that focus —
+/// activate and raise, never a bare state stamp — or state and
+/// the OS key app diverge and the #292 preflight refuses every
+/// shortcut until a click.
+extension KiwiCore {
+    /// The wake/unlock leg of the restore contract: replay and
+    /// settle, then pay the remembered focus for real. The crash
+    /// leg keeps `restoreAndSettle` — its startup sweep seeds
+    /// focus, and a launch must not steal the OS focus.
+    func restoreAndSettleAfterWake(_ snapshot: StateSnapshot) {
+        restoreAndSettle(snapshot)
+        performWakeFocusPayment()
+    }
+
+    /// Pays the adopted focus as a real focus, and arms the
+    /// one-shot #292 heal for the case where the app refuses the
+    /// activation. `warp: false`: the pointer is wherever the
+    /// user unlocked, not ours to move.
+    func performWakeFocusPayment() {
+        wakeFocusHealArmed = true
+        guard let id = focusedWindowID,
+            state.windows[id] != nil
+        else {
+            seedFocusFromFrontmost()
+            return
+        }
+        focusWindow(id, refocusRetile: false, warp: false)
+    }
+
+    /// Re-seeds state focus from the OS frontmost — the #442
+    /// seed, through the injectable provider — when the
+    /// remembered focus is gone, or when the #292 heal fires.
+    func seedFocusFromFrontmost() {
+        let frontmost = trustedFrontmostProvider?()
+            .flatMap { state.windows[$0] != nil ? $0 : nil }
+        seedStartupFocus(frontmost: frontmost)
+    }
+
+    /// One-shot consume for the #292 preflight: true while the
+    /// wake payment awaits its confirming focus event.
+    func consumeWakeFocusHeal() -> Bool {
+        guard wakeFocusHealArmed else { return false }
+        wakeFocusHealArmed = false
+        return true
+    }
+
+    /// An honored focus event proves state and the OS agree
+    /// again — the heal has nothing left to fix.
+    func disarmWakeFocusHeal() {
+        wakeFocusHealArmed = false
+    }
+}

--- a/Sources/KiwiDeskCore/App/KiwiCore+WakeFocus.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+WakeFocus.swift
@@ -4,52 +4,83 @@ import Foundation
 /// adopts the snapshot's focus, so it must PERFORM that focus —
 /// activate and raise, never a bare state stamp — or state and
 /// the OS key app diverge and the #292 preflight refuses every
-/// shortcut until a click.
+/// shortcut until a click. This file is the one machine mutating
+/// `wakeFocusHealArmedAt`.
 extension KiwiCore {
-    /// The wake/unlock leg of the restore contract: replay and
-    /// settle, then pay the remembered focus for real. The crash
-    /// leg keeps `restoreAndSettle` — its startup sweep seeds
-    /// focus, and a launch must not steal the OS focus.
+    /// How long an arm may spend its heal: generous against a
+    /// slow unlock, bounded so an ordinary #292 activation race
+    /// hours later cannot spend it (an already-key raise never
+    /// echoes, so a successful payment often leaves the arm).
+    static let wakeFocusHealWindow: TimeInterval = 30
+
+    /// The wake/unlock leg of the restore contract — the crash
+    /// leg keeps `restoreAndSettle`, whose settle trio this
+    /// inlines: a GONE remembered focus is re-seeded BEFORE the
+    /// settle (the #442 launch shape), so the retile and bars
+    /// lay out for the focus that stays; a tracked one is paid
+    /// as a real focus after it.
     func restoreAndSettleAfterWake(_ snapshot: StateSnapshot) {
-        restoreAndSettle(snapshot)
-        performWakeFocusPayment()
-    }
-
-    /// Pays the adopted focus as a real focus, and arms the
-    /// one-shot #292 heal for the case where the app refuses the
-    /// activation. `warp: false`: the pointer is wherever the
-    /// user unlocked, not ours to move.
-    func performWakeFocusPayment() {
-        wakeFocusHealArmed = true
-        guard let id = focusedWindowID,
-            state.windows[id] != nil
-        else {
-            seedFocusFromFrontmost()
-            return
+        restore(snapshot)
+        let remembered = focusedWindowID.flatMap {
+            state.windows[$0] != nil ? $0 : nil
         }
-        focusWindow(id, refocusRetile: false, warp: false)
+        if remembered == nil {
+            seedStartupFocus(frontmost: trustedFrontmostTracked())
+        }
+        spaceSwitchRetile()
+        emitSpaceChange()
+        if let remembered {
+            // `warp: false`: the pointer is wherever the user
+            // unlocked, not ours to move.
+            focusWindow(remembered, refocusRetile: false, warp: false)
+        }
+        armWakeFocusHeal()
     }
 
-    /// Re-seeds state focus from the OS frontmost — the #442
-    /// seed, through the injectable provider — when the
-    /// remembered focus is gone, or when the #292 heal fires.
-    func seedFocusFromFrontmost() {
-        let frontmost = trustedFrontmostProvider?()
-            .flatMap { state.windows[$0] != nil ? $0 : nil }
+    /// The one copy of the #442 trusted-frontmost tail: the
+    /// injectable provider where wired (nil in unit tests),
+    /// the live chain otherwise, filtered to tracked windows.
+    /// A blocking AX round trip against an unresponsive app —
+    /// callers on a press path pay it at most once per arm.
+    func trustedFrontmostTracked() -> WindowID? {
+        let raw: WindowID?
+        if let provider = trustedFrontmostProvider {
+            raw = provider()
+        } else {
+            raw = trustedFrontmostFocusedWindowID()
+        }
+        return raw.flatMap { state.windows[$0] != nil ? $0 : nil }
+    }
+
+    /// Re-seeds state focus from the OS frontmost when the #292
+    /// heal fires. Frontmost arm ONLY — never `seedStartupFocus`'s
+    /// guess arm, which could bless a window macOS never reported
+    /// focused, the case #292 exists to refuse.
+    func reseedFromFrontmostForHeal() -> Bool {
+        guard let frontmost = trustedFrontmostTracked() else {
+            return false
+        }
         seedStartupFocus(frontmost: frontmost)
+        return true
     }
 
-    /// One-shot consume for the #292 preflight: true while the
-    /// wake payment awaits its confirming focus event.
-    func consumeWakeFocusHeal() -> Bool {
-        guard wakeFocusHealArmed else { return false }
-        wakeFocusHealArmed = false
-        return true
+    func armWakeFocusHeal() {
+        wakeFocusHealArmedAt = Date()
+    }
+
+    /// One-shot consume for the #292 preflight: clears the arm
+    /// either way, and spends it only inside
+    /// `wakeFocusHealWindow` of the payment.
+    func consumeWakeFocusHeal(now: Date = Date()) -> Bool {
+        guard let armed = wakeFocusHealArmedAt else { return false }
+        wakeFocusHealArmedAt = nil
+        return now.timeIntervalSince(armed)
+            < Self.wakeFocusHealWindow
     }
 
     /// An honored focus event proves state and the OS agree
     /// again — the heal has nothing left to fix.
     func disarmWakeFocusHeal() {
-        wakeFocusHealArmed = false
+        wakeFocusHealArmedAt = nil
     }
 }

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -162,13 +162,15 @@ public final class KiwiCore {
     /// provenance.
     var stackingOrderProvider: (@MainActor () -> [WindowID])?
 
-    /// Z-order raises' stamps (#418/#425). Their focus echoes
+    /// Windows raised purely for z-order (#418 floats, #425 pile
+    /// restores), stamped per raise sequence. Their focus echoes
     /// carry no self-raise provenance (#152), so a fresh stamped
     /// report that is not the intended focus is reverted unless
-    /// it carries click provenance (#687). Age-pruned, cleaned
-    /// on destroy/rekey, and NEVER consumed by an echo — lazy
-    /// apps re-report, and the unstamped duplicate was honored
-    /// as deliberate focus (#689).
+    /// it carries click provenance (#687 — the design-decisions
+    /// entry owns the ruling). Age-pruned, cleaned on
+    /// destroy/rekey, and NEVER consumed by an echo: lazy apps
+    /// re-report, and the unstamped duplicate was honored as
+    /// deliberate focus (#689).
     var zOrderRaiseEchoes: [WindowID: Date] = [:]
 
     /// Bumped per z-order raise sequence (float raise or pile
@@ -195,9 +197,9 @@ public final class KiwiCore {
     /// pattern), so unit tests never read the host's focus.
     var trustedFrontmostProvider: (@MainActor () -> WindowID?)?
 
-    /// The wake heal latch (#1130) — `KiwiCore+WakeFocus.swift`
-    /// is the one machine mutating it.
-    var wakeFocusHealArmed = false
+    /// The wake heal arm's timestamp (#1130) —
+    /// `KiwiCore+WakeFocus.swift` is the one machine mutating it.
+    var wakeFocusHealArmedAt: Date?
 
     /// Hands key focus to the desktop (Finder) when a move without
     /// follow empties the focused display's space (#446). macOS has

--- a/Sources/KiwiDeskCore/App/KiwiCore.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore.swift
@@ -162,18 +162,13 @@ public final class KiwiCore {
     /// provenance.
     var stackingOrderProvider: (@MainActor () -> [WindowID])?
 
-    /// Windows raised purely for z-order, stamped with the
-    /// raise time — floats promoted above the tiled plane
-    /// (#418) and the pile members a restore re-raises (#425).
-    /// A raise couples with app activation and echoes a focus
-    /// report with no self-raise provenance (#152); a fresh
-    /// stamped report that is not the intended focus is that
-    /// echo — reverted, unless it carries click provenance
-    /// (#687; the design-decisions entry owns the ruling).
-    /// Stamped per sequence, age-pruned, cleaned on
-    /// destroy/rekey — and NEVER consumed by an echo: lazy
-    /// apps re-report a raised window, and the unstamped
-    /// duplicate was honored as deliberate focus (#689 QA).
+    /// Z-order raises' stamps (#418/#425). Their focus echoes
+    /// carry no self-raise provenance (#152), so a fresh stamped
+    /// report that is not the intended focus is reverted unless
+    /// it carries click provenance (#687). Age-pruned, cleaned
+    /// on destroy/rekey, and NEVER consumed by an echo — lazy
+    /// apps re-report, and the unstamped duplicate was honored
+    /// as deliberate focus (#689).
     var zOrderRaiseEchoes: [WindowID: Date] = [:]
 
     /// Bumped per z-order raise sequence (float raise or pile
@@ -194,6 +189,15 @@ public final class KiwiCore {
     /// inject a stub. When wired, a `nil` *return* means foreground
     /// ownership is unknown, which fails the command closed.
     var frontmostPIDProvider: (@MainActor () -> pid_t?)?
+
+    /// Trusted OS-frontmost focused window id (#1130); nil until
+    /// `start()` wires the #442 chain (the `frontmostPIDProvider`
+    /// pattern), so unit tests never read the host's focus.
+    var trustedFrontmostProvider: (@MainActor () -> WindowID?)?
+
+    /// The wake heal latch (#1130) — `KiwiCore+WakeFocus.swift`
+    /// is the one machine mutating it.
+    var wakeFocusHealArmed = false
 
     /// Hands key focus to the desktop (Finder) when a move without
     /// follow empties the focused display's space (#446). macOS has
@@ -218,18 +222,12 @@ public final class KiwiCore {
     /// #958 steal debt; `KiwiCore+AccessibilityReturn.swift`.
     var accessibilityReturn: AccessibilityReturnDebt?
 
-    /// Z-order restores whose raise sequence has not re-asserted
-    /// focus yet (#186). The pile raises steal focus window by
-    /// window and those echoes are not in `outstandingSelfRaises`
-    /// (#152's provenance gap), so mouse-follows-focus holds its
-    /// warp while any restore is in flight. A count, not a flag:
-    /// back-to-back restores overlap on the serial raise queue.
-    /// WARP-scoped by design, and again in fact since #689
-    /// retired the monocle arm's read: the hold in
-    /// `warpMouseToFocused` and its release
-    /// (`runPendingMouseWarp`) are the only readers. A consumer
-    /// outside the warp is the signal to close #152's gap
-    /// properly, not to extend this.
+    /// Z-order restores whose raises have not re-asserted focus
+    /// yet (#186); their echoes lack provenance (#152), so the
+    /// mouse warp holds while any restore is in flight. A count —
+    /// restores overlap. WARP-scoped (#689): `warpMouseToFocused`
+    /// and `runPendingMouseWarp` are the only readers; a consumer
+    /// outside the warp closes #152's gap properly instead.
     var zOrderRestoresInFlight = 0
 
     /// The warp a draining restore held (#689): recorded while

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+FocusedCommandGuard.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+FocusedCommandGuard.swift
@@ -2,10 +2,11 @@ import Foundation
 
 extension KiwiCore {
     /// Fail-closed preflight for implicit-focused commands (#292).
-    /// Returns a failed `CommandResponse` — and blocks the command
-    /// before any state mutation — when the command acts on the
-    /// focused window but the OS foreground is not that managed
-    /// window. Returns `nil` (allow) otherwise.
+    /// Returns a failed `CommandResponse` — blocking the command —
+    /// when the command acts on the focused window but the OS
+    /// foreground is not that managed window. Returns `nil`
+    /// (allow) otherwise. The one mutation it may make: a fresh
+    /// wake heal (#1130) re-seeds state focus from the frontmost.
     ///
     /// The guard is inert until `frontmostPIDProvider` is wired
     /// (`start()` installs it; unit tests leave it `nil`), so it
@@ -37,11 +38,11 @@ extension KiwiCore {
         // window this seam diagnoses.
         let front = frontmostPID()
         if foregroundOwned(front: front) { return nil }
-        // The wake heal (#1130), one-shot: the wake payment's
-        // activation can be refused, so re-seed from the real
-        // frontmost and re-ask before failing the press.
-        if consumeWakeFocusHeal() {
-            seedFocusFromFrontmost()
+        // The wake heal (#1130), one-shot and time-bounded: the
+        // wake payment's activation can be refused, so re-seed
+        // from the real frontmost (a blocking AX read, paid at
+        // most once per arm) and re-ask before failing the press.
+        if consumeWakeFocusHeal(), reseedFromFrontmostForHeal() {
             if foregroundOwned(front: front) {
                 onLog(
                     "wake focus heal: reseeded from frontmost, "

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+FocusedCommandGuard.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+FocusedCommandGuard.swift
@@ -36,25 +36,43 @@ extension KiwiCore {
         // that may have changed in exactly the racy activation
         // window this seam diagnoses.
         let front = frontmostPID()
+        if foregroundOwned(front: front) { return nil }
+        // The wake heal (#1130), one-shot: the wake payment's
+        // activation can be refused, so re-seed from the real
+        // frontmost and re-ask before failing the press.
+        if consumeWakeFocusHeal() {
+            seedFocusFromFrontmost()
+            if foregroundOwned(front: front) {
+                onLog(
+                    "wake focus heal: reseeded from frontmost, "
+                        + "allowed \(command)"
+                )
+                return nil
+            }
+        }
+        // The hotkey path discards the response, so a denial
+        // is otherwise invisible — the "#483 `_and_follow`
+        // does nothing" trap. Log which clause denied: the
+        // anchor/frontmost divergence is usually a dropped
+        // cooperative activate (#463).
+        logFocusedCommandDenial(
+            command,
+            focused: focusedWindow,
+            front: front
+        )
+        return .fail("no managed window is currently focused")
+    }
+
+    /// The #292 ownership clauses in one place, so the wake heal
+    /// (#1130) re-asks the same question after its reseed.
+    private func foregroundOwned(front: pid_t?) -> Bool {
         guard let focused = focusedWindow,
             let front,
             front == focused.pid,
             eventLoop.observes(pid: focused.pid),
             !ignoredPanel.active.contains(focused.pid)
-        else {
-            // The hotkey path discards the response, so a denial
-            // is otherwise invisible — the "#483 `_and_follow`
-            // does nothing" trap. Log which clause denied: the
-            // anchor/frontmost divergence is usually a dropped
-            // cooperative activate (#463).
-            logFocusedCommandDenial(
-                command,
-                focused: focusedWindow,
-                front: front
-            )
-            return .fail("no managed window is currently focused")
-        }
-        return nil
+        else { return false }
+        return true
     }
 
     /// One line naming the denied command, both sides of the

--- a/Tests/KiwiDeskCoreTests/FocusedCommandGuardTests.swift
+++ b/Tests/KiwiDeskCoreTests/FocusedCommandGuardTests.swift
@@ -5,9 +5,10 @@ import Testing
 @testable import KiwiDeskCore
 
 /// The foreground-ownership preflight (#292): an implicit-focused
-/// command fails closed — with no state mutation — unless the OS
-/// frontmost app is KiwiDesk's focused managed window. The guard is
-/// inert until `frontmostPIDProvider` is wired, so these tests
+/// command fails closed — the command itself never mutates — unless
+/// the OS frontmost app is KiwiDesk's focused managed window (a
+/// fresh wake heal may re-seed state focus first, #1130). The guard
+/// is inert until `frontmostPIDProvider` is wired, so these tests
 /// inject a stub (and, for the allow path, a real self observer).
 @Suite("Focused-command foreground guard", .serialized)
 @MainActor

--- a/Tests/KiwiDeskCoreTests/WakeFocusRestoreTests.swift
+++ b/Tests/KiwiDeskCoreTests/WakeFocusRestoreTests.swift
@@ -1,0 +1,194 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The wake/unlock focus payment and its #292 heal (#1130): the
+/// replay must pay the adopted focus for real, and a denial while
+/// the payment is unconfirmed re-seeds from the OS frontmost once
+/// instead of dying on every press until a click.
+@Suite("Wake focus payment (#1130)", .serialized)
+@MainActor
+struct WakeFocusRestoreTests {
+    private func makeCore() -> KiwiCore {
+        let core = makeTestCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-wake-focus-\(UUID().uuidString)"
+                )
+        )
+        core.tiler.visibleBounds = { _ in
+            CGRect(x: 0, y: 0, width: 1600, height: 1000)
+        }
+        return core
+    }
+
+    private func addWindow(
+        _ core: KiwiCore,
+        _ raw: UInt32,
+        pid: pid_t = 1
+    ) {
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(
+                    id: WindowID(raw),
+                    pid: pid,
+                    appName: "App\(raw)"
+                )
+            )
+        )
+    }
+
+    /// A real self observer so `observes(pid)` is true — the
+    /// `FocusedCommandGuardTests` idiom.
+    private func observe(_ core: KiwiCore, pid: pid_t) {
+        guard let observer = AXApplicationObserver(pid: pid)
+        else {
+            Issue.record("could not create a self AX observer")
+            return
+        }
+        core.eventLoop.observers[pid] = observer
+    }
+
+    @Test(
+        """
+        The wake leg re-focuses the snapshot's window over a \
+        fresher OS focus, and arms the one-shot heal
+        """
+    )
+    func wakeLegPaysTheRememberedFocus() {
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        guard let space = core.state.workspaces.activeSpace
+        else {
+            Issue.record("no active space")
+            return
+        }
+        core.state.workspaces.focus(WindowID(1), in: space)
+        let snapshot = core.state.snapshot()
+        // macOS restores its own key app after unlock (#1130's
+        // log: Claude honored one second before the replay).
+        core.state.workspaces.focus(WindowID(2), in: space)
+        core.sleepWake.restoreState(snapshot)
+        #expect(core.focusedWindowID == WindowID(1))
+        #expect(core.wakeFocusHealArmed)
+    }
+
+    @Test("The crash leg stays a bare replay: no heal armed")
+    func crashLegDoesNotArm() {
+        let core = makeCore()
+        addWindow(core, 1)
+        let snapshot = core.state.snapshot()
+        core.crash.restoreState(snapshot)
+        #expect(!core.wakeFocusHealArmed)
+    }
+
+    @Test(
+        """
+        A remembered focus that is gone falls back to seeding \
+        from the OS frontmost instead of a dead stamp
+        """
+    )
+    func goneFocusSeedsFromFrontmost() {
+        let core = makeCore()
+        addWindow(core, 1)
+        guard let space = core.state.workspaces.activeSpace
+        else {
+            Issue.record("no active space")
+            return
+        }
+        core.state.workspaces.focus(WindowID(1), in: space)
+        let snapshot = core.state.snapshot()
+        core.state.apply(
+            .windowDestroyed(WindowID(1), wasMinimized: false)
+        )
+        addWindow(core, 2)
+        // Clear the spawn grant so only the payment's seed can
+        // put the focus back.
+        core.state.workspaces.withSpace(space) {
+            $0.focused = nil
+        }
+        core.trustedFrontmostProvider = { WindowID(2) }
+        core.restoreAndSettleAfterWake(snapshot)
+        #expect(core.focusedWindowID == WindowID(2))
+    }
+
+    @Test(
+        """
+        An armed heal re-seeds from the frontmost and allows \
+        the press the stale anchor would have denied
+        """
+    )
+    func armedHealAllowsThePress() {
+        let core = makeCore()
+        let own = getpid()
+        addWindow(core, 2, pid: own)
+        addWindow(core, 1, pid: 1)
+        guard let space = core.state.workspaces.activeSpace
+        else {
+            Issue.record("no active space")
+            return
+        }
+        // The stale wake anchor: w1, while the OS front is w2.
+        core.state.workspaces.focus(WindowID(1), in: space)
+        observe(core, pid: own)
+        core.frontmostPIDProvider = { own }
+        core.trustedFrontmostProvider = { WindowID(2) }
+        core.wakeFocusHealArmed = true
+        let response = core.execute("make_floating")
+        #expect(response.isSuccess)
+        #expect(core.focusedWindowID == WindowID(2))
+        #expect(!core.wakeFocusHealArmed)
+    }
+
+    @Test("Unarmed, the same divergence still fails closed")
+    func unarmedDenialStands() {
+        let core = makeCore()
+        let own = getpid()
+        addWindow(core, 2, pid: own)
+        addWindow(core, 1, pid: 1)
+        guard let space = core.state.workspaces.activeSpace
+        else {
+            Issue.record("no active space")
+            return
+        }
+        core.state.workspaces.focus(WindowID(1), in: space)
+        observe(core, pid: own)
+        core.frontmostPIDProvider = { own }
+        core.trustedFrontmostProvider = { WindowID(2) }
+        let response = core.execute("make_floating")
+        #expect(!response.isSuccess)
+        #expect(core.focusedWindowID == WindowID(1))
+    }
+
+    @Test(
+        """
+        The heal is one-shot: a reseed that cannot own the \
+        foreground consumes the arm and fails closed
+        """
+    )
+    func healConsumesEvenWhenItCannotFix() {
+        let core = makeCore()
+        addWindow(core, 1, pid: 1)
+        core.frontmostPIDProvider = { 999 }
+        core.trustedFrontmostProvider = { nil }
+        core.wakeFocusHealArmed = true
+        let response = core.execute("make_floating")
+        #expect(!response.isSuccess)
+        #expect(!core.wakeFocusHealArmed)
+    }
+
+    @Test("An honored focus event disarms the heal")
+    func honoredFocusDisarms() {
+        let core = makeCore()
+        addWindow(core, 1)
+        addWindow(core, 2)
+        core.wakeFocusHealArmed = true
+        core.handle(.windowFocused(WindowID(1)))
+        #expect(!core.wakeFocusHealArmed)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/WakeFocusRestoreTests.swift
+++ b/Tests/KiwiDeskCoreTests/WakeFocusRestoreTests.swift
@@ -75,7 +75,7 @@ struct WakeFocusRestoreTests {
         core.state.workspaces.focus(WindowID(2), in: space)
         core.sleepWake.restoreState(snapshot)
         #expect(core.focusedWindowID == WindowID(1))
-        #expect(core.wakeFocusHealArmed)
+        #expect(core.wakeFocusHealArmedAt != nil)
     }
 
     @Test("The crash leg stays a bare replay: no heal armed")
@@ -84,7 +84,7 @@ struct WakeFocusRestoreTests {
         addWindow(core, 1)
         let snapshot = core.state.snapshot()
         core.crash.restoreState(snapshot)
-        #expect(!core.wakeFocusHealArmed)
+        #expect(core.wakeFocusHealArmedAt == nil)
     }
 
     @Test(
@@ -138,11 +138,11 @@ struct WakeFocusRestoreTests {
         observe(core, pid: own)
         core.frontmostPIDProvider = { own }
         core.trustedFrontmostProvider = { WindowID(2) }
-        core.wakeFocusHealArmed = true
+        core.wakeFocusHealArmedAt = Date()
         let response = core.execute("make_floating")
         #expect(response.isSuccess)
         #expect(core.focusedWindowID == WindowID(2))
-        #expect(!core.wakeFocusHealArmed)
+        #expect(core.wakeFocusHealArmedAt == nil)
     }
 
     @Test("Unarmed, the same divergence still fails closed")
@@ -176,10 +176,41 @@ struct WakeFocusRestoreTests {
         addWindow(core, 1, pid: 1)
         core.frontmostPIDProvider = { 999 }
         core.trustedFrontmostProvider = { nil }
-        core.wakeFocusHealArmed = true
+        core.wakeFocusHealArmedAt = Date()
         let response = core.execute("make_floating")
         #expect(!response.isSuccess)
-        #expect(!core.wakeFocusHealArmed)
+        #expect(core.wakeFocusHealArmedAt == nil)
+    }
+
+    @Test(
+        """
+        An expired arm cannot spend the heal: hours later an \
+        ordinary #292 race is still refused, latch cleared
+        """
+    )
+    func expiredArmDoesNotHeal() {
+        let core = makeCore()
+        let own = getpid()
+        addWindow(core, 2, pid: own)
+        addWindow(core, 1, pid: 1)
+        guard let space = core.state.workspaces.activeSpace
+        else {
+            Issue.record("no active space")
+            return
+        }
+        core.state.workspaces.focus(WindowID(1), in: space)
+        observe(core, pid: own)
+        core.frontmostPIDProvider = { own }
+        core.trustedFrontmostProvider = { WindowID(2) }
+        // Just past the window, derived from the shipped bound
+        // rather than restating it (tests.md — number pins).
+        core.wakeFocusHealArmedAt = Date(
+            timeIntervalSinceNow: -KiwiCore.wakeFocusHealWindow - 1
+        )
+        let response = core.execute("make_floating")
+        #expect(!response.isSuccess)
+        #expect(core.focusedWindowID == WindowID(1))
+        #expect(core.wakeFocusHealArmedAt == nil)
     }
 
     @Test("An honored focus event disarms the heal")
@@ -187,8 +218,8 @@ struct WakeFocusRestoreTests {
         let core = makeCore()
         addWindow(core, 1)
         addWindow(core, 2)
-        core.wakeFocusHealArmed = true
+        core.wakeFocusHealArmedAt = Date()
         core.handle(.windowFocused(WindowID(1)))
-        #expect(!core.wakeFocusHealArmed)
+        #expect(core.wakeFocusHealArmedAt == nil)
     }
 }

--- a/Tests/KiwiDeskGuiTests/WakeFocusSeamTests.swift
+++ b/Tests/KiwiDeskGuiTests/WakeFocusSeamTests.swift
@@ -6,7 +6,7 @@ import Testing
 /// a bare `workspaces.focus` stamp leave identical state — no AX
 /// element, so no raise — and the bare stamp IS the shipped
 /// defect. `WakeFocusRestoreTests` holds what the payment does;
-/// this holds that it stays a payment.
+/// this holds that it stays a payment, singly wired.
 @Suite("The wake focus payment stays wired (#1130)")
 struct WakeFocusSeamTests {
     private static let root = SourceScan.repoRoot(
@@ -34,6 +34,14 @@ struct WakeFocusSeamTests {
             "KiwiCore+WakeFocus.swift",
             "KiwiCore+FocusEvents.swift"
         ),
+        // The consume is one-shot, so a second consumer would
+        // silently eat the arm before the press it exists to
+        // heal — with every behavioral test green.
+        (
+            "consumeWakeFocusHeal(",
+            "KiwiCore+WakeFocus.swift",
+            "KiwiCore+FocusedCommandGuard.swift"
+        ),
     ]
 
     @Test("each wiring is declared once and wired once")
@@ -44,15 +52,65 @@ struct WakeFocusSeamTests {
                 under: Self.core
             )
             let files = sites.map(\.file.lastPathComponent)
+            let expected =
+                declared == wired
+                ? [declared] : [declared, wired].sorted()
             #expect(
-                files.sorted() == [declared, wired].sorted(),
+                files.sorted() == expected,
                 """
-                expected `\(needle)` exactly twice — declared \
-                in \(declared), wired in \(wired) — found: \
+                expected `\(needle)` only as declared in \
+                \(declared) and wired in \(wired) — found: \
                 \(sites.map(\.site).joined(separator: ", "))
                 """
             )
         }
+    }
+
+    /// No behavior test can red on the wiring — every test
+    /// injects the provider — so this pins it (tests.md:
+    /// forget-proof the injection). Declaration, `armMachineSeams`
+    /// wiring, and the one `trustedFrontmostTracked` read.
+    @Test("the frontmost provider is wired and read once each")
+    func providerIsWiredAndReadOnce() throws {
+        let sites = try SourceScan.identifierSites(
+            of: "trustedFrontmostProvider",
+            under: Self.core
+        )
+        let files = sites.map(\.file.lastPathComponent).sorted()
+        #expect(
+            files
+                == [
+                    "KiwiCore.swift",
+                    "KiwiCore+BootSeams.swift",
+                    "KiwiCore+WakeFocus.swift",
+                ].sorted(),
+            """
+            expected the provider declared in KiwiCore.swift, \
+            wired in KiwiCore+BootSeams.swift, read in \
+            KiwiCore+WakeFocus.swift — found: \
+            \(sites.map(\.site).joined(separator: ", "))
+            """
+        )
+    }
+
+    @Test("the latch mutates only through its one machine")
+    func latchHasOneHome() throws {
+        let sites = try SourceScan.identifierSites(
+            of: "wakeFocusHealArmedAt",
+            under: Self.core
+        )
+        let files = Set(sites.map(\.file.lastPathComponent))
+        #expect(
+            files == [
+                "KiwiCore.swift", "KiwiCore+WakeFocus.swift",
+            ],
+            """
+            `wakeFocusHealArmedAt` may appear only in its \
+            declaration and its one machine — an inline write \
+            beside a call site is the #951 disarm-race shape. \
+            Found: \(sites.map(\.site).joined(separator: ", "))
+            """
+        )
     }
 
     @Test("the payment performs a focus, never a bare stamp")
@@ -66,11 +124,11 @@ struct WakeFocusSeamTests {
         )
         guard
             let payer = SourceScan.declarationBody(
-                after: "func performWakeFocusPayment",
+                after: "func restoreAndSettleAfterWake",
                 in: source
             )
         else {
-            Issue.record("performWakeFocusPayment missing")
+            Issue.record("restoreAndSettleAfterWake missing")
             return
         }
         #expect(

--- a/Tests/KiwiDeskGuiTests/WakeFocusSeamTests.swift
+++ b/Tests/KiwiDeskGuiTests/WakeFocusSeamTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+/// The wake focus payment's shape (#1130), which its behavior
+/// suite cannot see: on a unit fixture a real `focusWindow` and
+/// a bare `workspaces.focus` stamp leave identical state — no AX
+/// element, so no raise — and the bare stamp IS the shipped
+/// defect. `WakeFocusRestoreTests` holds what the payment does;
+/// this holds that it stays a payment.
+@Suite("The wake focus payment stays wired (#1130)")
+struct WakeFocusSeamTests {
+    private static let root = SourceScan.repoRoot(
+        from: #filePath
+    )
+    private static let core = root.appendingPathComponent(
+        "Sources/KiwiDeskCore"
+    )
+
+    /// needle → its declaring file and its ONE wiring file. Two
+    /// sites exactly: the `func` and the call — a second caller
+    /// reds as loudly as a deleted one.
+    private static let wirings: [(String, String, String)] = [
+        // The wake leg's wiring: only the sleep/wake restore
+        // pays; the crash leg keeps the bare replay.
+        (
+            "restoreAndSettleAfterWake(",
+            "KiwiCore+WakeFocus.swift",
+            "KiwiCore+Bootstrap.swift"
+        ),
+        // The disarm: an honored focus event is the payment's
+        // confirmation, read at the one honored site.
+        (
+            "disarmWakeFocusHeal(",
+            "KiwiCore+WakeFocus.swift",
+            "KiwiCore+FocusEvents.swift"
+        ),
+    ]
+
+    @Test("each wiring is declared once and wired once")
+    func wiringsAreSingular() throws {
+        for (needle, declared, wired) in Self.wirings {
+            let sites = try SourceScan.identifierSites(
+                of: needle,
+                under: Self.core
+            )
+            let files = sites.map(\.file.lastPathComponent)
+            #expect(
+                files.sorted() == [declared, wired].sorted(),
+                """
+                expected `\(needle)` exactly twice — declared \
+                in \(declared), wired in \(wired) — found: \
+                \(sites.map(\.site).joined(separator: ", "))
+                """
+            )
+        }
+    }
+
+    @Test("the payment performs a focus, never a bare stamp")
+    func paymentPerformsAFocus() throws {
+        let source = try SourceScan.strippedSource(
+            at: Self.core
+                .appendingPathComponent("App")
+                .appendingPathComponent(
+                    "KiwiCore+WakeFocus.swift"
+                )
+        )
+        guard
+            let payer = SourceScan.declarationBody(
+                after: "func performWakeFocusPayment",
+                in: source
+            )
+        else {
+            Issue.record("performWakeFocusPayment missing")
+            return
+        }
+        #expect(
+            payer.contains("focusWindow("),
+            """
+            the payment must route through `focusWindow` — a \
+            bare `workspaces.focus` stamp is the #1130 defect: \
+            state and the OS key app diverge and the #292 \
+            preflight refuses every shortcut until a click
+            """
+        )
+        #expect(
+            !payer.contains("workspaces.focus("),
+            "the payment may not stamp state beside the payer"
+        )
+    }
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1565,6 +1565,64 @@ panel blip-keys another own window, whose clickless AX
 re-report trails the close's activation yield (#952 — the
 yield itself is a Shortcuts-section ruling). (#951)
 
+### A wake restore pays the focus it adopts; a launch never steals one
+
+**[Principle]**
+
+A state snapshot carries each space's focused window, and a
+restore adopts it. But state is only half of what "focused"
+means: macOS keeps its own key app, and the command preflight
+compares the two before any implicit-focused shortcut runs
+([#292](https://github.com/KiwiCanopy/KiwiDesk/issues/292)). A
+restore that stamps state and performs nothing leaves them
+diverged, so every shortcut fails "no managed window is
+currently focused" until the first click — which is exactly what
+the wake/unlock restore did
+([#1130](https://github.com/KiwiCanopy/KiwiDesk/issues/1130)):
+the arrangement came back, and the window the user went to rest
+in did not.
+
+So the wake leg **performs** the focus it adopted — raise plus
+app activation, the same act a focus command pays. It is
+[#1007](https://github.com/KiwiCanopy/KiwiDesk/issues/1007)'s
+principle extended one leg over: an operation that names a
+window owes the user the window, never a bookkeeping entry about
+it, and a wake restore names the window the user was standing in
+when the machine went to rest. Fronting it again is restoring,
+not stealing — the user is at the machine, mid-return, and the
+feature's whole promise is "as you left it". Two boundaries keep
+the payment honest. When the remembered window is gone, the
+payment inverts: macOS already fronted something at unlock, so
+state follows the OS (the
+[#442](https://github.com/KiwiCanopy/KiwiDesk/issues/442)
+frontmost seed) rather than raising a stand-in nobody chose. And
+the pointer is no part of it: it sits wherever the user
+unlocked, so the focus is paid without the mouse-follows-focus
+warp.
+
+The launch and crash-relaunch legs answer the same question the
+other way, deliberately: they seed state only, from the OS
+frontmost ([#442](https://github.com/KiwiCanopy/KiwiDesk/issues/442)),
+because a starting app must never yank key focus from whatever
+the user is doing while it boots. The asymmetry is the ruling —
+unifying the legs in either direction re-breaks one of them: a
+state-only wake restore is #1130 again, and a performed launch
+focus is a focus steal.
+
+Activation is cooperative and macOS may decline it, so the
+payment can silently fail to land. The escape is a one-shot heal
+on the preflight itself: armed at the wake payment, the first
+shortcut press that would otherwise fail re-seeds from the real
+frontmost and asks again — so the press acts on the window the
+user is genuinely looking at — and any honored focus event
+disarms it, the divergence being over. The accepted residue:
+after a declined activation, that first press acts on macOS's
+front window rather than the remembered one, which is strictly
+better than a press that does nothing. `WakeFocusRestoreTests`
+pins the wake leg's payment, the crash leg's stand-down, the
+gone-window seed and the heal; `WakeFocusSeamTests` pins the
+wiring no unit fixture can see.
+
 ### Layout and resize behavior
 
 **[Rationale]**

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -4735,7 +4735,10 @@ delay (default 1500 ms). The restore is skipped when the display set
 changed while the machine was away (undock, monitor power-off): the
 captured frames belong to the old displays, so the monitor-change
 profile resolution wins instead. A restore that does run finishes
-with a full retile, like any space switch.
+with a full retile, like any space switch, and actually focuses the
+remembered window — raises it and activates its app — so shortcuts
+act on it immediately. If that window is gone, focus follows
+whatever macOS brought to the front at unlock.
 
 **Example:**
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2009,7 +2009,9 @@ the [Lua reference](lua-reference.md)); there is no GUI control:
 
 - **Restore on wake**: when your Mac wakes from sleep or the
   screen unlocks, restore the window arrangement captured when
-  it went to rest (on by default).
+  it went to rest (on by default), and put the keyboard focus
+  back on the window you were in — so your shortcuts work right
+  away, without a click first.
 - **Wake restore delay** (ms): how long to wait after wake before
   restoring (default 1500 ms, giving displays time to settle).
 


### PR DESCRIPTION
## Description

The wake/unlock replay adopted the snapshot's focus as a bare
state stamp: KiwiDesk believed (and bordered, and raised) one
window while macOS kept another key, so every shortcut died in
the #292 preflight until a mouse click produced a genuine focus
event. Observed live 2026-08-30 17:49 — five presses denied
over 2 s (`preflight (#292): denied focus — anchor window
113844 pid 93224, frontmost pid 86199 is another app`), healed
only by a rescue click.

The wake leg now PAYS the adopted focus — `focusWindow`
(raise + app activation) — instead of stamping it; a remembered
window that is gone falls back to seeding from the OS frontmost
BEFORE the settle (the #442 launch shape), so the retile and
bars lay out for the focus that stays. A one-shot, time-bounded
heal covers a refused activation: the first #292 denial within
`wakeFocusHealWindow` of the payment re-seeds state focus from
the real frontmost (frontmost arm only, never the seed's guess
arm) and re-asks, so the first press works instead of none. Any
honored focus event disarms the heal. The crash leg keeps the
bare replay — its startup sweep owns focus seeding.

New seam: `trustedFrontmostProvider` (nil in unit tests, armed
in `armMachineSeams`, routing the one #442 trusted chain, which
`seedStartupFocus` now shares via `trustedFrontmostTracked`).
`KiwiCore+WakeFocus.swift` is the one machine mutating the heal
latch, pinned by `WakeFocusSeamTests`.

Review round: code-reviewer, architect-reviewer, docs-steward,
and two guard-prover rounds (14 mutations, all red-proofed, 0
inert). One architect finding consciously dismissed: a
state-and-layout.md row for the new latch — the seam suite's
one-home scan pins mechanically what the row would describe,
and the leg contract lives at the restore seam's docstring
(`KiwiCore+Restore.swift`); the product argument is the new
design-decisions entry.

## Related Issue(s)

Closes #1130

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] Release build green — CI's `Release Build` job (read it
  before merging; it reports, it does not block), or locally
  for concurrency / `@Sendable` changes — also built locally
- [x] PR is focused; refactors separated from features

## How I verified

- Diagnosed from the live incident's unified log (the #1130
  issue body carries the excerpt): the replay stamped a 3.4 h
  stale focus one second after macOS honored a fresher one,
  then five denials with the exact anchor/frontmost divergence
  this fix removes.
- `swift build`, full `swift test` (4289 tests green; one
  unrelated red in a first run was the documented live-mouse
  flake and passed on re-run), `scripts/lint.sh` exit 0,
  `swift build -c release`, and the site build (docs touched).
- Two isolated guard-prover rounds mutated the payment, the
  wiring, the heal, the disarm and the seam pins — 14
  designed mutations, every one red where predicted. Notably:
  under the exact shipped-defect shape (bare stamp instead of
  `focusWindow`) all behavior tests stay green and only the
  seam scan reds, which is why that scan exists.
- The end-to-end wake path (real sleep → unlock → replay on
  hardware) cannot be exercised from this session; the wake
  leg was driven through its production wiring
  (`sleepWake.restoreState`) on live cores in the suite.
  Owner QA suggestion: rebuild, relaunch, one sleep/unlock
  cycle, then press a shortcut before touching the mouse.

## Notes for Reviewer

The heal is deliberately conservative: strictly one-shot per
arm, spendable only within 30 s of the payment (an already-key
raise never echoes, so a successful payment often leaves the
arm standing — unbounded, it would convert an ordinary #292
activation race hours later into an allow), and it re-syncs to
the OS frontmost, never to a guess. "screen lock not reported"
staleness (the capture leg never armed on an auto-sleep) is a
separate follow-up noted on #1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
