### PR TITLE
docs(agents): land PRs through the merge queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,13 @@ Use the GitHub [issue templates](.github/ISSUE_TEMPLATE/) and
 [PR template](.github/pull_request_template.md). Reference issues
 with `fixes #123`.
 
+**Merge through the queue** (owner ruling 2026-08-30): `main`
+carries a merge-queue ruleset, so land a green PR with "Merge
+when ready" (`gh pr merge <n> --auto --squash`) and let the
+queue validate it against whatever is queued ahead — never merge
+directly, and never hand-rebase a branch just to satisfy
+staleness, which the queue now owns.
+
 **An agent drafting an issue renders the template, rather than
 writing whatever shape it likes.** GitHub applies a `.yml` form
 only when a human opens the *New issue* page (observed


### PR DESCRIPTION
## Description

Documents the new merge flow in AGENTS.md §3: main carries a
merge-queue ruleset (squash, ALLGREEN, max 5 entries), so a
green PR lands via "Merge when ready" and the queue validates
it against everything queued ahead. The classic protection's
strict up-to-date requirement was turned off at the same time —
the queue supersedes it, so hand-rebasing for staleness is
retired.

## Checklist

- [x] Commits follow Conventional Commits format
- [x] No contradictions between code and docs
- [x] PR is focused

## How I verified

Ruleset confirmed active via `gh api repos/{owner}/{repo}/rules/branches/main`
(merge_queue listed); strict confirmed false. Docs-only change;
this PR itself rides the queue as the first live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)