### PR TITLE
ci: run the required checks on merge-group refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The merge queue validates entries on its own merge-group
+  # refs; without this trigger the required checks never start
+  # there and every queued PR waits out the queue's timeout.
+  merge_group:
   # Manual "Run workflow" button in the Actions tab. Additive — the
   # automatic triggers above still fire. Useful while the repo is
   # private, where macOS runners bill at a 10x multiplier against a


### PR DESCRIPTION
## Description

Adds the `merge_group:` trigger to ci.yml. The new merge-queue
ruleset validates entries on merge-group refs; without this
trigger the two required checks never start there, so every
queued PR sits until the queue's 60-minute timeout kicks it.
The `changes` job needs no change: an unknown event resolves to
"no usable base — running everything", which is exactly right
for a merge group.

## Checklist

- [x] Commits follow Conventional Commits format
- [x] PR is focused

## How I verified

Queue observed stuck with four green PRs enqueued and no check
runs on their merge groups; ci.yml's `on:` block confirmed to
lack `merge_group`. The proof is this PR's own landing plus the
backlog draining once the trigger is on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)