### PR TITLE
chore(comments): trim settings components to §2.8 budget (batch 5)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/AppRules/SentenceFrame.swift
+++ b/Sources/KiwiDesk/Settings/Components/AppRules/SentenceFrame.swift
@@ -68,7 +68,7 @@ struct SentenceFrame {
         }
     }
 
-    /// The controls this frame draws, in its own order.
+    /// Controls referenced by frame in parsed appearance order.
     var controls: [Control] {
         argumentPositions.compactMap(Self.control(at:))
     }

--- a/Sources/KiwiDesk/Settings/Components/Bars/BarsPanelPreview.swift
+++ b/Sources/KiwiDesk/Settings/Components/Bars/BarsPanelPreview.swift
@@ -20,7 +20,6 @@ struct BarsPanelPreview: View {
                 RoundedRectangle(cornerRadius: 12)
                     .fill(SettingsTheme.previewPlate)
             )
-            // 16b dark seam — see `SettingsTheme.planeRing`.
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
                     .strokeBorder(
@@ -45,8 +44,7 @@ struct BarsPanelPreview: View {
         }
     }
 
-    /// Each declared space's identifier, the real bar's rule:
-    /// the stored icon, else the space's ordinal.
+    /// Space label identifiers (icon or ordinal).
     private var spaceLabels: [String] {
         let icons = model.config.settings.spaceIcons
         return model.config.spaces.enumerated().map {

--- a/Sources/KiwiDesk/Settings/Components/Colors/MotionCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Colors/MotionCard.swift
@@ -1,7 +1,14 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Settings card for window animations (#171, #678, #1017).
+/// Animations settings card (#678). Moved whole from Behavior —
+/// the census places every row in `.coloursAndMotion`, and a
+/// card split across two destinations is a half-rendered area
+/// the parity guard cannot see. "Motion" in this type's NAME is
+/// frozen while the noun is "animation" (#1017, scoped to
+/// labels — a census re-key has its own blast radius): prose
+/// naming what is on screen says "the Animations card", and
+/// *motion* survives only quoting Apple's "Reduce Motion".
 struct MotionCard: View {
     @ObservedObject var model: SettingsModel
     /// macOS Reduce Motion forces animations off system-wide (#171).
@@ -20,6 +27,10 @@ struct MotionCard: View {
                     rows(ColorsRowOrder.motionAtRest)
                     disclosure
                 }
+                // Reduce Motion greys the CONTENT, never the
+                // header, so the `?` stays a live #527 anchor —
+                // the `.motion` container's `.runtime` census
+                // gate (#171).
                 .modifier(GreyOut(active: reduceMotion))
                 // Signpost stays outside the Reduce Motion gate
                 // (#171; `LinkedCaption`).

--- a/Sources/KiwiDesk/Settings/Components/Common/FocusBorderPreview.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/FocusBorderPreview.swift
@@ -1,60 +1,21 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Shared by the Gaps & Borders editor (which owns the ring's
-/// structure) and the Advanced Colours Borders group (which owns
-/// its tints) — `Common/` admits a primitive once a second
-/// component area needs it. The redesign rule is that a preview is
-/// RECYCLED, never rebuilt from a mock, so the colour page leads
-/// with this exact view rather than a scene of its own.
-///
-/// Two mock windows on a neutral desktop: the focused one always
-/// ringed, the other ringed only when unfocused borders are on.
-/// Reflects width and corner style live so the editor's controls
-/// preview before they hit real windows.
+/// Preview of focused and unfocused window borders (#678).
 struct FocusBorderPreview: View {
     let style: BorderStyle
-    /// The sticky mark, drawn on the focused window when the
-    /// area that owns the mark is the one previewing (owner,
-    /// 2026-08-16). `nil` in a mount whose subject is only the
-    /// ring — the parameter is what keeps this ONE renderer
-    /// instead of a second window mock beside it.
-    ///
-    /// It belongs on this picture rather than on the gap
-    /// diagram: the mark is an overlay on a WINDOW, and this is
-    /// the only preview here that draws one. Gaps are about the
-    /// space between windows and have nothing to hang it on.
     var sticky: StickyStyle? = nil
 
     var body: some View {
         picture
-            // One element with one summary, never a tour of the
-            // shapes (#678 Phase 4 pass 10, turn 20a rule 2):
-            // it is a picture of the result, so tabbing through
-            // its two windows would be tabbing through nothing
-            // actionable. Every other preview in the tree already
-            // reads aloud through text it happens to contain — a
-            // legend, a caption, a chip — and this one is the pure
-            // drawing that had nothing, so it announced nothing at
-            // all.
             .accessibilityElement()
             .accessibilityLabel(axLabel)
     }
 
-    /// Conditional on what is actually drawn, for the reason
-    /// #708 made explicit: a spoken label may no more assert a
-    /// mark the frame omits than a written caption may. The
-    /// mark arm is reached only where a mount passes `sticky`
-    /// AND the toggle is on. Both scopes are drawn together, so
-    /// one sentence covers the pair.
+    /// Spoken description based on active border and sticky states (#708).
     private var axLabel: String {
         stickyMark == nil
             ? L(
-                // Names its subject, as the sibling preview keys
-                // do (`app_bar.preview.ax`, `space_bar.preview.ax`):
-                // in the VoiceOver rotor there is no visual
-                // context, and a bare "Preview:" announces a
-                // preview of nothing (l10n audit, 2026-08-11).
                 "border.preview.ax",
                 "Border preview: a focused window with its "
                     + "ring, beside an unfocused one."
@@ -75,7 +36,6 @@ struct FocusBorderPreview: View {
                 window(
                     color: style.focusedColor,
                     ringed: true,
-                    // Glow is focused-ring-only (#358).
                     glow: style.glow,
                     mark: stickyMark
                 )
@@ -83,15 +43,6 @@ struct FocusBorderPreview: View {
                     color: style.unfocusedColor,
                     ringed: style.unfocusedEnabled,
                     glow: false,
-                    // The DISPLAY-sticky scope on the second
-                    // window (owner, on device, 2026-08-16).
-                    // One window showing one scope taught only
-                    // half the family: `StickyStyle` draws two
-                    // glyphs — `infinity` for a window on every
-                    // Space of every monitor, `pin.fill` for one
-                    // tacked to a single display (#445) — they
-                    // share one tint, and the pair is the thing
-                    // a reader needs to tell apart.
                     mark: displayStickyMark
                 )
             }
@@ -102,27 +53,17 @@ struct FocusBorderPreview: View {
         .opacity(style.enabled ? 1 : 0.4)
     }
 
-    /// The mark to draw, or nil. Gated on the style's own
-    /// `mark` toggle, so turning the glyph off turns it off here
-    /// — which is the whole point of showing it: the reader can
-    /// see what the switch does before saving.
-    /// Internal so `GapsBordersPanelTests` can read the
-    /// decision: whether a mark is drawn is a BRANCH, and a
-    /// branch that stops being written passes every source
-    /// needle above it (the Monitors lesson, `gui.md`).
+    /// Everywhere-sticky mark for focused window (`GapsBordersPanelTests`).
     var stickyMark: (symbol: String, tint: Color)? {
         mark(for: .global)
     }
 
-    /// The display-sticky twin, drawn on the unfocused window so
-    /// the two scopes sit side by side.
+    /// Display-sticky mark for unfocused window (#445).
     var displayStickyMark: (symbol: String, tint: Color)? {
         mark(for: .display)
     }
 
-    /// Both scopes read ONE toggle and ONE tint — that is the
-    /// "one glyph everywhere" family (#414), and the preview
-    /// would be lying if it let them diverge.
+    /// Resolves sticky symbol and tint for scope (#414).
     private func mark(
         for scope: StickyScope
     ) -> (symbol: String, tint: Color)? {
@@ -138,25 +79,10 @@ struct FocusBorderPreview: View {
         glow: Bool,
         mark: (symbol: String, tint: Color)?
     ) -> some View {
-        // Remap the 1–20 pt width onto the preview's smaller span
-        // so a thick border reads without swamping the mock —
-        // through the ONE remap the Home tile also reads
-        // (`BorderPreviewScale`, #786 review).
         let width = BorderPreviewScale.width(
             style.clampedWidth,
             to: 1...7
         )
-        // Remap the RESOLVED glow blur (auto formula or the
-        // explicit glow_size, #533/#551) the same way — the
-        // literal pt value would swamp this 96 pt mock and
-        // read as a smear, not a halo (#358). A proportional
-        // approximation, like width and corners here.
-        // The source band is derived from the formula's own
-        // clamp, so a retuned floor/cap cannot leave this remap
-        // silently stale (the numbers live in
-        // `BorderGeometryTests`, nowhere else); an explicit
-        // size past the band clamps at the mock's top, which
-        // is honest enough for a schematic.
         let glowRadius = scale(
             style.resolvedGlowBlur,
             from: BorderStyle.glowBlur(
@@ -170,17 +96,12 @@ struct FocusBorderPreview: View {
             .fill(Color.secondary.opacity(0.25))
             .overlay {
                 if ringed {
-                    // Preview the configured visible width. The real
-                    // renderer adds a hidden overlap behind the
-                    // window, which does not change this weight.
                     RoundedRectangle(cornerRadius: radius)
                         .stroke(
                             Color(kiwiHex: color),
                             lineWidth: width
                         )
                         .shadow(
-                            // Bloom uses the brightened derivative,
-                            // matching the real renderer (#358).
                             color: glow
                                 ? Color(
                                     kiwiHex: BorderStyle.glowColor(

--- a/Sources/KiwiDesk/Settings/Components/Common/FocusBorderPreview.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/FocusBorderPreview.swift
@@ -83,6 +83,12 @@ struct FocusBorderPreview: View {
             style.clampedWidth,
             to: 1...7
         )
+        // Remap the RESOLVED glow blur (auto or explicit
+        // glow_size, #533/#551): the literal pt value would read
+        // as a smear on this 96 pt mock, not a halo (#358). The
+        // source band derives from the formula's own clamp, so a
+        // retuned floor/cap cannot leave the remap stale — the
+        // numbers live in `BorderGeometryTests`, nowhere else.
         let glowRadius = scale(
             style.resolvedGlowBlur,
             from: BorderStyle.glowBlur(
@@ -102,6 +108,9 @@ struct FocusBorderPreview: View {
                             lineWidth: width
                         )
                         .shadow(
+                            // Focused-ring-only, brightened
+                            // derivative — the real renderer's
+                            // rule (#358).
                             color: glow
                                 ? Color(
                                     kiwiHex: BorderStyle.glowColor(

--- a/Sources/KiwiDesk/Settings/Components/Common/GapsDiagram.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/GapsDiagram.swift
@@ -1,15 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Pure math for the gap preview: maps real 0–100 pt gap
-/// values onto the miniature's 1–14 pt span. The square root
-/// exaggerates the 0–20 pt range users actually live in and
-/// compresses 60–100 pt, so slider drags stay perceptible
-/// without the miniature blowing out. The 1 pt floor is
-/// deliberate: even a real gap of 0 keeps a hairline seam so
-/// the miniature's windows stay countable. The enum itself
-/// touches no AppKit/SwiftUI API (`GapPreviewScaleTests`);
-/// it lives here only until it grows more math.
+/// Pure scaling math mapping 0–100 pt gaps onto 1–14 pt preview span
+/// (`GapPreviewScaleTests`).
 enum GapPreviewScale {
     static let realMax: CGFloat = 100
     static let miniMin: CGFloat = 1
@@ -21,34 +14,14 @@ enum GapPreviewScale {
     }
 }
 
-/// The live gap preview beside the legend (#68 §3.14): a
-/// screen outline holding a 2×2 window grid, so both gap
-/// kinds show on both axes — outer as the margin to the
-/// screen edge, inner as the seams between the windows. Every
-/// stored value maps through `GapPreviewScale` independently,
-/// so per-edge asymmetry renders honestly as uneven margins.
-/// It teaches the outer/inner vocabulary; it is deliberately
-/// not a layout preview.
-///
-/// Left-aligned beside its legend (not centered like a
-/// `SchematicCanvas`): this preview is **paired with the exact
-/// controls in its card**, so it lines up flush with them as one
-/// stack rather than reading as a standalone figure (see
-/// design-decisions "Preview alignment splits on
-/// standalone-vs-paired").
+/// Visual 2×2 grid diagram demonstrating inner and outer gaps (#68, #812).
 struct GapsDiagram: View {
     let outer: Gaps.Outer
     let inner: Gaps.Inner
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// The schematics' damping, gated (#1069) — the diagram
-    /// still redraws at the staged gaps, it just stops
-    /// travelling there. READ from `LayoutSchematic`, not
-    /// re-spelled: the gate rule asks only that the ternary be
-    /// local, and this diagram is one of that family's pictures,
-    /// so a second copy of the duration is two tunings nothing
-    /// holds equal (code review, #1069).
+    /// Shared damping animation gated by reduce motion (#1069).
     private var damping: Animation? {
         reduceMotion ? nil : LayoutSchematic.damping
     }
@@ -56,10 +29,6 @@ struct GapsDiagram: View {
     var body: some View {
         HStack(spacing: 12) {
             miniScreen
-                // A picture of the sliders' values; the legend
-                // beside it and the sliders themselves speak
-                // them, so the shapes say nothing (#812, as
-                // `BarsPanelPreview` is treated).
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 4) {
                 legend(

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsDisclosure.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsDisclosure.swift
@@ -1,109 +1,28 @@
 import SwiftUI
 
-/// The one way a Settings drawer renders (#277): a
-/// `DisclosureGroup` that owns the anchor pairing part 1 left as
-/// a call-site convention — `searchFlashHeader` on the label,
-/// `searchAnchorCard` on the whole group, OUTSIDE any card chrome —
-/// plus expansion, so a reveal targeting a control *inside* a
-/// collapsed drawer opens it before the scroll lands.
+/// Settings drawer with search reveal anchoring and auto-expansion (#277).
 ///
-/// The containment question ("is the reveal target one of
-/// mine?") is answered by the `SettingsDrawer` value the call
-/// site already mounts — its nested children declarations —
-/// never a parent column in the catalog. A direct hit on the
-/// drawer's own label does NOT auto-expand: the header is
-/// visible and highlighted, and opening it is one honest click
-/// (part-1 design call).
-///
-/// Two chromes, matching the two shapes the tree uses: `.inline`
-/// for a drawer inside a `SettingsSection` card (Gaps, the bar
-/// colour drawers), `.card` for a standalone drawer that paints
-/// its own card (the three "Advanced" drawers). The card chrome
-/// anchors outside its padding so `scrollTo(anchor: .top)` lands
-/// on the card's edge, not 12 pt inside it — the mistake the
-/// part-1 comment block in `SettingsReveal` existed to spell
-/// out.
-///
-/// An `.inline` drawer sits *below* its section's heading, so
-/// anchoring its own body would scroll that heading off screen
-/// (#610). Such a drawer sets `scrollHoisted`: it gives up its
-/// scroll id and publishes its control through
-/// `HoistedRevealAnchorsKey`, which its enclosing `SettingsSection`
-/// turns into a top-of-section `searchScrollAnchor` marker, so the
-/// reveal lands the section — heading first — while the drawer
-/// keeps its own wash.
+/// Anchors via `SettingsReveal`, auto-expanding when an interior
+/// child is targeted (#610, #760).
 struct SettingsDisclosure<Content: View, Accessory: View>: View {
-    /// What SURROUNDS the header — never how it is drawn (#1021).
-    ///
-    /// It used to carry a `font:` payload, and that is what the
-    /// owner was looking at: one component drew its title at
-    /// four tiers, and SEVEN of the fifteen drawers were drawn
-    /// SMALLER than the rows they head. A header quieter than
-    /// its own contents is an inverted hierarchy, and pushing
-    /// the choice out to each call site is what let it drift
-    /// that far. Both chromes now draw ONE tier, which is the
-    /// part that must not drift back —
-    /// `SettingsDisclosureSizeTests` holds it.
-    ///
-    /// That tier is `.callout` at semibold: 12 pt, a point
-    /// UNDER the `.body` rows it heads, carrying the header on
-    /// weight rather than on size. It went to `.headline` (13
-    /// pt semibold) first, and the owner read the result as
-    /// heavy on the two pages that carry seven of the fifteen
-    /// drawers between them. Note there is no "bigger"
-    /// available above either: macOS's ramp goes body 13 →
-    /// headline 13 at weight 0.4 → title3 15, so below 15
-    /// "bigger" and "weightier" are the SAME edit, and the only
-    /// genuine size step is `title3` — `SettingsGroupHeader`'s
-    /// tier, which would outrank the section title an inline
-    /// drawer sits INSIDE (owner, 2026-08-26).
+    /// Container chrome variant (`SettingsDisclosureSizeTests`, #1021).
     enum Chrome {
-        /// Inside a section card, under a hairline rule.
+        /// Inside a section card under a hairline rule.
         case inline
-        /// Standalone: 12 pt padding and its own card
-        /// background.
+        /// Standalone card with background and padding.
         case card
     }
 
     private let control: SettingsControl
     private let childIDs: Set<String>
     private let chrome: Chrome
-    /// `.inline` only: the scroll id is hoisted to the enclosing
-    /// section's top (#610), so this drawer keeps its wash but
-    /// gives up its own `searchAnchorCard`, publishing its control
-    /// through `HoistedRevealAnchorsKey` for the section to anchor.
-    /// A `.card` drawer paints its own card and anchors it, so it
-    /// ignores this.
+    /// Hoists scroll anchor to enclosing section top (#610).
     private let scrollHoisted: Bool
-    /// The drawer's presence is mode-gated — it would leave the
-    /// page in Simple (#760). Heavier `.card` stroke, and the
-    /// mode-reveal wash marks the label; call sites derive it
-    /// from their own offer predicate evaluated at `.simple`.
+    /// Mode-gated presence (#760).
     private let modeGated: Bool
-    /// Call-site expansion state, for a drawer with its own
-    /// rules (Gaps force-expands while its values are mixed);
-    /// nil means this view owns it.
     private let externalExpansion: Binding<Bool>?
     @State private var internalExpansion = false
-    /// What the drawer hides, drawn beside the header while it
-    /// is shut. `SettingsDisclosureStyle.summaryText` owns the
-    /// tier and the shut-only rule; a call site hands it the
-    /// words and nothing else.
-    ///
-    /// **Those words are user-facing**, so a call site passes an
-    /// `L()` result.
-    ///
-    /// **A summary is a PHRASE saying what is inside, never a
-    /// bare count (#1028).** Since #1021 it renders inside the
-    /// header button, so its text composes into that button's
-    /// accessibility NAME and therefore into its headings-rotor
-    /// entry: a lone number announces as an unlabelled digit
-    /// ("Other setups 12, collapsed, heading") where its
-    /// siblings announce "Background, content, indicator, sizes,
-    /// symbol style". The placement is correct and is not what
-    /// should change — the string is. `PresetsSection` was the
-    /// one call site that passed a count; it now passes nothing,
-    /// which is the other legal answer.
+    /// Summary phrase displayed while collapsed (#1028).
     private let summary: String?
     @ViewBuilder private let content: () -> Content
     @ViewBuilder private let accessory: () -> Accessory
@@ -155,13 +74,6 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
     var body: some View {
         switch chrome {
         case .inline:
-            // Hoisted (#610): publish this control so the enclosing
-            // section mounts the scroll marker at its top, and DON'T
-            // anchor here — a second candidate would let `scrollTo`
-            // land the bare drawer at the top, the very bug. The
-            // wash stays, on the label inside `group`. Emitting only
-            // from `.inline` also means `scrollHoisted` on a `.card`
-            // drawer is inert rather than a double anchor.
             if scrollHoisted {
                 inlineRuled.preference(
                     key: HoistedRevealAnchorsKey.self,
@@ -201,13 +113,6 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
         }
     }
 
-    /// The inline form leads with a thin rule (owner
-    /// 2026-08-10: the App Bar's Style accordion was nearly
-    /// overlooked among plain rows) — the prototype draws
-    /// every inline disclosure row with a top border, so the
-    /// rule is the row's "I am a different kind of row"
-    /// signal, matching the card rows around it without
-    /// promoting the drawer to a card.
     private var inlineRuled: some View {
         VStack(alignment: .leading, spacing: 10) {
             SettingsTheme.hairline.frame(height: 1)
@@ -218,18 +123,6 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
 
     private var group: some View {
         DisclosureGroup(isExpanded: expansion) {
-            // The Sunken interior: an expanded drawer's contents
-            // sit in a well one step inside the card, so what the
-            // disclosure REVEALS is legible as a nested thing
-            // rather than as more of the card it opened from.
-            //
-            // The `VStack` is load-bearing, not layout taste: a
-            // caller may hand this a bare `ForEach`, and SwiftUI
-            // applies modifiers on a `ForEach` PER CHILD — the
-            // Motion drawer shipped every toggle, a caption and
-            // a lone `Divider` each in its own well before this
-            // wrapper made the well one (owner caught it on
-            // screen, 2026-08-10).
             VStack(alignment: .leading, spacing: 8) {
                 content()
             }
@@ -238,9 +131,6 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
                 alignment: .leading
             )
             .padding(10)
-            // Fill AND hairline: `sunken` on `card` is
-            // 1.08:1, so a fill-only well says nothing about
-            // being nested — which is the well's whole job.
             .background(
                 RoundedRectangle(
                     cornerRadius:
@@ -256,37 +146,17 @@ struct SettingsDisclosure<Content: View, Accessory: View>: View {
                 )
             )
         } label: {
-            // The wash goes on the label alone; flashing the
-            // group would tint the expanded contents too — the
-            // whole-card wash the treatment exists to avoid.
-            //
-            // The accessory is NOT in here (#956): the style
-            // makes this label the content of the header's
-            // button, and an accessory may be a control —
-            // `DesktopsGroup`'s `?` is. It travels to the
-            // style separately and is drawn beside the button.
             Text(control.text)
                 .font(SettingsDrawerHeader.tier.weight(.semibold))
                 .searchFlashHeader(control)
-                // The mode-reveal wash shares the label band the
-                // search wash uses (#760), for the same reason:
-                // a whole-group wash would tint the interior.
                 .modeRevealWash(modeGated)
         }
-        // The header is a full-row button with a resting cue
-        // and its own expanded/collapsed announcement (#956) —
-        // `SettingsDisclosureStyle` carries the argument. Every
-        // drawer takes it, in both chromes.
         .disclosureGroupStyle(
             SettingsDisclosureStyle(
                 summary: summary,
                 accessory: accessory
             )
         )
-        // Reads only — the reveal fields keep one writer and
-        // one clearer (`SettingsView`); an observer that also
-        // cleared could blank a request before the scroll
-        // driver ran (the part-1 #326 bug).
         .onChange(of: revealTarget) { _, target in
             expand(revealing: target)
         }

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsDisclosureStyle.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsDisclosureStyle.swift
@@ -1,62 +1,21 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// **The one tier a drawer header row draws at**, so the
-/// title and the summary beside it cannot drift apart
-/// (architect review, 2026-08-26). #1021 took the tier out
-/// of fifteen call sites and the summary out of the call sites
-/// that pass one, and
-/// then left the two literals in two types — retune the
-/// header and the summary silently stays behind, which is
-/// the same drift one level up. The title takes this at
-/// semibold, the summary takes it plain; neither spells a
-/// size of its own, and `SettingsDisclosureSizeTests`
-/// reds on either doing so.
-///
-/// `.callout` is 12 pt: a point UNDER the `.body` rows a
-/// drawer heads, carrying the header on weight rather than
-/// on size. The argument for that number, and for there
-/// being nothing bigger available, is
-/// `SettingsDisclosure.Chrome`'s.
+/// Font tier for drawer header row (`SettingsDisclosureSizeTests`, #1021).
 enum SettingsDrawerHeader {
     static let tier: Font = .callout
 }
 
-/// How every Settings drawer's header renders (#956).
+/// Settings drawer header render style (#956).
 ///
-/// One full-width `.plain` `Button` over the row — chevron,
-/// label, Spacer — carrying the house hover cue and a chevron
-/// that rotates on expand, with the drawer's `accessory` laid
-/// out BESIDE that button rather than inside it. The argument
-/// for each of those choices is `docs/design-decisions.md`'s,
-/// beside the inline-hairline ruling it follows; what belongs
-/// here is the seam.
-///
-/// **The accessory is a sibling of the button, never its
-/// child** — the one thing about this file that is not obvious
-/// and the one that broke. `SettingsDisclosure` used to hand
-/// the accessory to the `DisclosureGroup` label, which the
-/// first draft of this style then wrapped whole in the header
-/// button: `DesktopsGroup`'s `?` became a control inside a
-/// control, so its click toggled the drawer and its name and
-/// hint collapsed into the header's one element (code +
-/// architect review, 2026-08-24). An accessory slot that may
-/// hold a control cannot travel inside `configuration.label`,
-/// which is why the style takes it as its own parameter and
-/// the row's hit shape stops where it begins.
-///
-/// The style deliberately takes no CHROME argument: `.inline`
-/// and `.card` differ in what surrounds the header, never in
-/// how the header behaves, and a drawer that reads as openable
-/// in one chrome and not the other is the defect this fixes.
-
+/// Header button is a full-width `.plain` Button with chevron, label, and
+/// summary. Accessory view is laid out as a sibling outside the button.
 struct SettingsDisclosureStyle<Accessory: View>:
     DisclosureGroupStyle
 {
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
-    /// What the drawer hides, stated on the row while it is
-    /// SHUT — see `summaryText`.
+    /// What the drawer hides, shown trailing while shut.
     private let summary: String?
     @ViewBuilder private let accessory: () -> Accessory
 
@@ -92,40 +51,17 @@ struct SettingsDisclosureStyle<Accessory: View>:
                 HStack(spacing: 6) {
                     chevron(expanded: configuration.isExpanded)
                     configuration.label
-                    // The row is the hit target, so it claims
-                    // the width the accessory does not.
+                        .font(SettingsDrawerHeader.tier)
+                        .foregroundStyle(SettingsTheme.ink)
                     Spacer(minLength: 0)
-                    // INSIDE the button, unlike the accessory
-                    // beside it. The #956 ruling puts that slot
-                    // outside because it may hold a CONTROL, and
-                    // a control inside a control loses its click
-                    // and its name — a summary is plain text, so
-                    // that reason does not reach it. Drawn
-                    // outside, the hover pill stopped where the
-                    // summary began and those words did not
-                    // toggle the drawer they describe (owner,
-                    // 2026-08-26).
-                    if !configuration.isExpanded { summaryText }
+                    if !configuration.isExpanded {
+                        summaryText
+                    }
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            // The FULL-ROW ladder (0 → 0.06), not the icon
-            // chip's (0.06 → 0.12). A resting fill that works
-            // on all three of this style's grounds has to be
-            // `Color.primary`-based, and that is achromatic —
-            // invisible at a glyph's size, and at row width the
-            // one exactly-neutral band in a green-tinted
-            // window. The header rests on its chevron and, in
-            // `.inline`, on the hairline rule.
             .rowHoverHighlight(cornerRadius: 6, padding: 4)
-            // On the BUTTON, not on the `Text` inside it: the
-            // button swallows its label's traits, and putting it
-            // here is also what reaches the one drawer whose
-            // title is not a plain `Text`. Every drawer was
-            // absent from the headings rotor until #1021 — the
-            // same "too small to find as one" complaint, on the
-            // channel no amount of points can answer.
             .accessibilityAddTraits(.isHeader)
             .accessibilityValue(
                 configuration.isExpanded
@@ -139,56 +75,7 @@ struct SettingsDisclosureStyle<Accessory: View>:
         }
     }
 
-    /// **What the drawer hides, at the size of the header it
-    /// sits beside.** Five call sites drew this by hand at
-    /// `.font(.caption)` — 10 pt, two steps under a 12 pt
-    /// header — which is the same drift the header's own tier
-    /// came out of in #1021, and it read as an afterthought
-    /// rather than as the row's value (owner, 2026-08-26).
-    ///
-    /// **It stays BESIDE the header rather than becoming a
-    /// caption under it**, and that is the ruling rather than
-    /// the layout that fell out: this states the drawer's
-    /// current VALUE and is gone the moment the drawer opens,
-    /// where a caption explains what a thing IS and stays.
-    /// Under the header it would add and remove a line on every
-    /// toggle, shoving the rows below it, and it would sit
-    /// exactly where the drawer's own contents go — reading as
-    /// content that failed to hide. macOS states a shut row's
-    /// value trailing on the row, which is where it already
-    /// was; only the size was wrong.
-    ///
-    /// SHUT only, here rather than at each call site: four of
-    /// the five wrapped their own `if`, and the fifth
-    /// (Presets' count) did not, so the rule was a call-site
-    /// decision too. Expanded, the summary restates what the
-    /// rows below it now say in full.
-    ///
-    /// `ink3`, NOT the chevron's `ink2` beside it, and the
-    /// distinction is the chevron's own argument read the right
-    /// way round. That one takes `ink2` because with no resting
-    /// fill the chevron IS the row's affordance, and an
-    /// affordance outranks the caption tier. This is not an
-    /// affordance — it is description, which is exactly what
-    /// `ink3` is for, and a whole phrase of it at the chevron's
-    /// darkness competes with the title it supports (owner,
-    /// 2026-08-26: "too strong"). Nothing new is drawn on this
-    /// ground either way, so `SettingsThemeContrastTests`'
-    /// pairings are unchanged.
-    ///
-    /// **Not `.accessibilityHidden`.** It rides inside the
-    /// button, so its words compose into the header's NAME —
-    /// "Style, Background, Content …" — where before they were
-    /// a static text stop of their own. Read aloud the
-    /// information survives the move; hidden it would not, and
-    /// the button's `.accessibilityValue` is already spent on
-    /// expanded/collapsed.
-    ///
-    /// **No `layoutPriority`.** The label's `Spacer` is greedy,
-    /// so a lower priority here starves the summary to zero
-    /// width at every size rather than only at narrow ones.
-    /// Sharing the squeeze is what `lineLimit(1)` is for: the
-    /// summary loses its tail, the title keeps wrapping.
+    /// Summary text shown when shut (`SettingsThemeContrastTests`, #1021).
     @ViewBuilder private var summaryText: some View {
         if let summary {
             Text(summary)
@@ -198,51 +85,12 @@ struct SettingsDisclosureStyle<Accessory: View>:
         }
     }
 
-    /// **Sized by the header it marks, never by a number of its
-    /// own** (#1021). It takes no `.font` and no scale step, so
-    /// it inherits the header's size outright and moves whenever
-    /// the header does: about 12 pt against a 12 pt title, and
-    /// about 10 pt on the one deliberately-quiet drawer, which
-    /// stays quiet. Proportional by construction rather than a
-    /// constant that has to be re-tuned every time a header
-    /// moves.
-    ///
-    /// **Weight is the only step it takes.** It wore
-    /// `.imageScale(.large)` on top of the inheritance for one
-    /// round, which drew the indicator LARGER than the title it
-    /// marks — the biggest thing in the row — and that is what
-    /// the owner then read as a heavy header (owner,
-    /// 2026-08-26). A scale step here is that regression;
-    /// `SettingsDisclosureSizeTests` reds on either it or a
-    /// `.font(`.
-    ///
-    /// That is what #956 claimed and did not do. It replaced the
-    /// native triangle *because* the system drew it small, then
-    /// pinned the replacement at `.footnote` — the smallest step
-    /// on the ramp. It bought a hit target, an announcement and
-    /// one notch of weight; it never made the indicator bigger,
-    /// which is why the complaint came back (ui-designer,
-    /// 2026-08-26).
-    ///
-    /// A concrete ink rather than `.secondary`: the Overrides
-    /// footer sets `.foregroundStyle(.secondary)` on the whole
-    /// group, and hierarchical styles compound — that one
-    /// header drew its cue at secondary-of-secondary (code
-    /// review, 2026-08-24).
-    ///
-    /// `ink2`, not the quieter `ink3` it first took: with no
-    /// resting fill the chevron IS the row's resting
-    /// affordance, and `ink3` is the caption tier — body copy,
-    /// by its own docstring. Row detail outranks a caption
-    /// (ui-designer, 2026-08-24).
+    /// Rotating chevron (`SettingsDisclosureSizeTests`, #956, #1021).
     private func chevron(expanded: Bool) -> some View {
         Image(systemName: "chevron.right")
             .fontWeight(.bold)
             .foregroundStyle(SettingsTheme.ink2)
             .rotationEffect(.degrees(expanded ? 90 : 0))
-            // The state it encodes is on the button's value, in
-            // words; a second reading of the same fact as
-            // "chevron.right" is noise.
             .accessibilityHidden(true)
     }
 }

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersPanelPreview.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersPanelPreview.swift
@@ -1,35 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Gaps & Borders panel content (#678 redesign spec): the
-/// pictures this area always had, recycled whole — the gap
-/// miniature with its legend, the focus-ring pair, and the drag
-/// visuals — now stacked in the panel column instead of leading
-/// their cards. Deliberately NOT a new fused desktop scene: each
-/// picture is an existing renderer with its own guard surface,
-/// and the redesign rule is recycle, never rebuild beside one.
-///
-/// Three things it did not do until the owner looked at it on
-/// screen (2026-08-16), all of them the same failure — a panel
-/// that answers for a whole area has to answer for the WHOLE
-/// area:
-///
-/// 1. **The drag visuals are a pair.** It drew the ghost alone,
-///    while the area's own editor draws ghost and drop zone in
-///    twin columns because #231 says they are edited by
-///    comparison. One of a pair is the half that cannot be
-///    compared.
-/// 2. **The sticky mark was nowhere**, though this area owns the
-///    Sticky windows card and its toggle. A switch whose effect
-///    the preview never shows is a switch the reader has to save
-///    and go look for.
-/// 3. **Nothing was labelled.** Three pictures stacked without
-///    headers read as one run-on illustration; with them, each
-///    is an answer to a card below.
-///
-/// The headers reuse the area's own catalog declarations rather
-/// than minting titles, so a picture and the card it answers for
-/// can never come to disagree about what they are called.
+/// Gaps & Borders visual preview panel (#678).
 struct GapsBordersPanelPreview: View {
     @ObservedObject var model: SettingsModel
 
@@ -46,8 +18,6 @@ struct GapsBordersPanelPreview: View {
             group(SettingsCatalog.gapsAndBorders.focusBorder) {
                 FocusBorderPreview(
                     style: settings.borderStyle,
-                    // This area owns the mark's switch, so this
-                    // is the mount that shows it.
                     sticky: settings.stickyStyle
                 )
             }
@@ -65,11 +35,7 @@ struct GapsBordersPanelPreview: View {
         }
     }
 
-    /// Ghost beside drop zone, each under its own subheading —
-    /// the #231 twin columns, at panel width. Stacked rather
-    /// than side by side: the panel is 392 pt less its insets,
-    /// and two drag mocks side by side there are too small to
-    /// compare, which is the one thing the pairing is for.
+    /// Ghost and drop zone drag previews (#231).
     private var dragPair: some View {
         VStack(alignment: .leading, spacing: 10) {
             labelled(SettingsCatalog.gapsAndBorders.dragGhost) {
@@ -87,7 +53,6 @@ struct GapsBordersPanelPreview: View {
         }
     }
 
-    /// A picture under the name of the card it answers for.
     private func group<C: View>(
         _ control: SettingsControl,
         @ViewBuilder content: () -> C
@@ -105,9 +70,6 @@ struct GapsBordersPanelPreview: View {
         }
     }
 
-    /// The quieter inner heading, for the two halves of one
-    /// picture — a second mono-caps line would compete with the
-    /// group header above it.
     private func labelled<C: View>(
         _ control: SettingsControl,
         @ViewBuilder content: () -> C

--- a/Sources/KiwiDesk/Settings/Components/General/LoginItemCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/General/LoginItemCard.swift
@@ -50,7 +50,11 @@ struct LoginItemCard: View {
         )
     }
 
-    /// Toggle greyed state: unregisterable gate or loading state (#171, #342).
+    /// Toggle greyed state (#171, #342): the durable reason (an
+    /// unregisterable copy) comes from the gate resolver, never a
+    /// predicate re-derived here — so the grey and the
+    /// census-declared gate cannot drift; the transient
+    /// load/write block is added on top.
     private var loginInert: Bool {
         model.autoStartLoading
             || model.generalGates

--- a/Sources/KiwiDesk/Settings/Components/General/LoginItemCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/General/LoginItemCard.swift
@@ -2,40 +2,12 @@ import AppKit
 import KiwiDeskCore
 import SwiftUI
 
-/// The login-item row — `general.login_item.start` (#576,
-/// resplit for #678 item 16).
+/// Login item row (`general.login_item.start`, #576, #678, #864, #1071).
 ///
-/// Named by its KEY rather than by its text: this header quoted
-/// the label verbatim until #864 shortened it, at which point
-/// the comment described a string no catalog carried. Quoting a
-/// label in prose is the defect this branch closed one altitude
-/// down (#818); it is the same defect in a doc comment.
-///
-/// #576 folded #342's login toggle and the `kiwidesk service`
-/// LaunchAgent into ONE 3-level picker; turn 14b split it into
-/// two rows; **#1071 removed the second one.** The two are two
-/// LAUNCHERS, and one switch installing both meant they raced
-/// for the instance lock at every login — which is what stole
-/// focus every ten seconds in #1068 and left supervision
-/// silently idle in #1071. So this card owns the `SMAppService`
-/// login item and nothing else, and crash restart is
-/// `kiwidesk service`. Read `AutoStartManager`'s header for the
-/// level ladder the CLI still uses, and `SettingsModel
-/// +AutoStart` for why the status does not live in this view.
-///
-/// A **read-through**, **async** control: it stores no preference,
-/// it reads `AutoStartManager.current()` off the main actor on
-/// appear and on every `didBecomeActive`, and a change writes
-/// through `AutoStartManager.set(_:)` and adopts the state it reads
-/// back. launchctl is a blocking spawn, so the read/write happen on
-/// a detached task and publish on main; `autoStartLoaded` gates the
-/// pending window before the first read lands.
-///
-/// Core hands us structure (`AutoStartStatus`); the labels and
-/// captions are rendered here (#96). The toggle greys (grey, don't
-/// hide, #171) when the running copy can't register — a bare
-/// binary or a translocated download — which is the shape #342's
-/// whole-toggle grey took.
+/// Controls `SMAppService` login item; crash restart is handled by CLI
+/// `kiwidesk service` (#1068). Reads and writes async via `AutoStartManager`.
+/// Core returns `AutoStartStatus`, GUI renders copy (#96); greys when
+/// unregisterable (#171, #342).
 struct LoginItemCard: View {
     @ObservedObject var model: SettingsModel
     @EnvironmentObject private var localization: LocalizationManager
@@ -45,32 +17,12 @@ struct LoginItemCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             DropdownRow(
-                // Card heading is the noun "Login"; the row
-                // carries the verb.
                 label: startLabel,
-                // A toggle's on/off is its value and survives
-                // the row's label; nothing to give back.
                 spokenValue: nil,
                 help: startHelp
             ) {
-                // A Toggle, not the #576 Picker: this row now
-                // asks ONE yes/no question, and the second
-                // question (restart on crash) is its own row
-                // among Advanced's five. `gui.md` gives a
-                // toggle the binary case.
                 Toggle("", isOn: loginBinding)
                     .labelsHidden()
-                    // Grey the control only, never the row —
-                    // the label's `?` stays live because that
-                    // help is useful whether or not the
-                    // toggle can be driven right now. The
-                    // durable reason (an unregisterable copy —
-                    // bare binary or translocated download)
-                    // comes from the gate resolver, not a
-                    // predicate re-derived here, so the grey and
-                    // the census-declared gate cannot drift; the
-                    // transient load/write block is added on top
-                    // (#342, #171).
                     .disabled(loginInert)
             }
             confirmation
@@ -84,31 +36,12 @@ struct LoginItemCard: View {
         ) { _ in model.refreshAutoStart() }
     }
 
-    /// It deliberately does NOT say "and keep it running": that
-    /// becomes false the moment the Advanced row is switched
-    /// off, and item 16 rules that "a label that rewrites itself
-    /// is worse than one that is simply always true".
-    ///
-    /// Shortened from "Start KiwiDesk when I log in" for #864,
-    /// which is the ROW-label sibling of `localization.md`'s
-    /// action-label rule: the English is the guardable half, and
-    /// a clause here hands every translator a clause. The old
-    /// one left 8 pt of headroom in this row's label column, so
-    /// five locales overflowed by construction and French lost
-    /// the object of its phrase. The app's own name is carried
-    /// by the window this row is in; the help beside it still
-    /// spells it out. Nothing guards the fit — `SettingsMetrics
-    /// .labelColumn`'s docstring rules that a label past its
-    /// width is SHORTENED rather than accommodated, the column
-    /// being the shared alignment axis for every section.
+    /// Row label key (`SettingsMetrics.labelColumn`, #818, #864).
     private var startLabel: String {
         L("general.login_item.start", "Start at login")
     }
 
-    /// The one field-level `?` (#94). Since #1071 this switch
-    /// is the login item and nothing else, so the help no longer
-    /// promises supervision or points at an Advanced row that
-    /// does not exist — a new key, the meaning having changed.
+    /// Field-level help (#94, #1071).
     private var startHelp: String {
         L(
             "general.login_item.start_help_login_only",
@@ -117,68 +50,18 @@ struct LoginItemCard: View {
         )
     }
 
-    /// This row's half of the folded level: does KiwiDesk start
-    /// itself at all.
-    ///
-    /// **It drives the login item alone (#1071).** Crash
-    /// supervision is the CLI's — the north star's "the GUI
-    /// curates, Lua is open" applied to a knob that is risky
-    /// (it races the login item, and `KeepAlive` on a
-    /// deterministic crash loops with no breaker) and valid
-    /// (someone running KiwiDesk as infrastructure wants it).
-    /// A user who loses the app reopens it from Spotlight; the
-    /// menu bar item vanishing is not a silent failure.
-    ///
-    /// **A login-without-restart choice does not survive being
-    /// switched off and on again**, and it cannot: the level is
-    /// read through from the OS with nothing cached, and `.off`
-    /// erases the distinction — a copy that never wanted restart
-    /// and a copy that was simply never started both read as
-    /// `.off`. So turning login back on has no prior answer to
-    /// restore and takes the default. Storing one would mean a
-    /// preference the OS does not have, which is the drift
-    /// read-through exists to prevent.
-    ///
-    /// The refusal on an unregisterable copy lives in
-    /// `SettingsModel.setAutoStart`, not here: the harm is a
-    /// filesystem/launchd side effect (a LaunchAgent written
-    /// against an ephemeral `.build` or translocated path, which
-    /// read-through cannot undo), so it must not depend on a view
-    /// having disabled the control.
-    /// The toggle's greyed state: the resolver's durable reason
-    /// for this row (an unregisterable copy), or the transient
-    /// load/write block that is not a gate reason.
+    /// Toggle greyed state: unregisterable gate or loading state (#171, #342).
     private var loginInert: Bool {
         model.autoStartLoading
             || model.generalGates
                 .inertReason(for: .general(.startAtLogin)) != nil
     }
 
-    /// The switch owns the LOGIN ITEM and nothing else (#1071).
-    ///
-    /// It used to pass `restartOnCrash: on` alongside, which made
-    /// one flip install a LaunchAgent as well — two launchers
-    /// racing for the instance lock at every login, which is the
-    /// whole of #1068/#1071. Crash supervision is now the CLI's
-    /// (`kiwidesk service`), so this drives `.off` ↔ `.atLogin`
-    /// and never touches the agent.
-    ///
-    /// **Reading the folded level is deliberate.** While the
-    /// service is loaded the level is `.atLoginWithAutoRestart`,
-    /// so the switch reads ON — which is TRUE, KiwiDesk does
-    /// start at login — and the gate above makes it inert with
-    /// the reason inline. The getter answers "does it start at
-    /// login", not "which mechanism does it".
+    /// Drives `.off` ↔ `.atLogin` without modifying service agent (#1071).
     private var loginBinding: Binding<Bool> {
         Binding(
             get: { model.autoStart.level.opensAtLogin },
             set: { on in
-                // The refusal that matters is in the model —
-                // gui.md bans a grey as the sole gate on a side
-                // effect — and the path from there reaches no
-                // `ServiceManager` call at all, so the agent is
-                // safe from this switch by construction rather
-                // than by this guard.
                 guard
                     model.autoStart.level != .atLoginWithAutoRestart
                 else { return }
@@ -200,8 +83,6 @@ struct LoginItemCard: View {
                 .font(.caption)
                 .foregroundStyle(SettingsTheme.ink2)
         } else if let applied = model.autoStartApplied {
-            // Green-emphasis text token, not `.green` — the
-            // diff rows' precedent (dark pass).
             HStack(spacing: 4) {
                 Image(systemName: "checkmark.circle.fill")
                 Text(confirmationText(applied))
@@ -212,9 +93,7 @@ struct LoginItemCard: View {
         }
     }
 
-    /// The line each applied level confirms — present tense, naming
-    /// what will now happen, never a "saved" past tense (nothing was
-    /// staged).
+    /// Confirmation text for applied auto-start level.
     private func confirmationText(_ level: AutoStartLevel) -> String {
         switch level {
         case .off:
@@ -236,13 +115,7 @@ struct LoginItemCard: View {
         }
     }
 
-    /// The row's standing caption, from the design's own words
-    /// (digest 14b): it says where the setting LIVES, which is
-    /// what makes the read-through behaviour legible — flip it in
-    /// System Settings and this row follows, because there is no
-    /// second copy here. The conditional captions below add to
-    /// it rather than replace it; approval and unavailability are
-    /// states of the same fact.
+    /// Read-through caption and state notices.
     @ViewBuilder private var caption: some View {
         Text(
             L(
@@ -275,19 +148,10 @@ struct LoginItemCard: View {
                 .settingsActionButton()
             }
         }
-        // NOT an `else if` on the approval branch (#1071): while
-        // `cannotRegister` and `requiresApproval` are exclusive
-        // arms of one `LoginItemState`, `managedByService` is
-        // read from launchd and is independent of both. Chained,
-        // it would be swallowed for an approval-pending copy
-        // whose service is loaded — precisely the user upgrading
-        // from the old coupled switch — leaving a dimmed switch
-        // with no sentence and a button that cannot unblock it.
+        // Checked independently from requiresApproval branch (#1071).
         if let reason = model.generalGates.inertReason(
             for: .general(.startAtLogin)
         ) {
-            // The sentence is named once by the gate help, so
-            // the grey and its reason cannot disagree.
             unavailableCaption(GeneralGateHelp.sentence(for: reason))
         }
     }

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Desktops.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Desktops.swift
@@ -1,31 +1,10 @@
 import KiwiDeskCore
 
-/// The macOS **Desktop** rows (#884's verbs, GUI half): the
-/// Desktop-side twins of the per-Space families, split into
-/// their own file so `KeybindingCatalog.swift` stays inside the
-/// §2.1 target.
+/// macOS Desktop keybinding catalog rows (#884).
 ///
-/// A Desktop is Mission Control's, a Space is KiwiDesk's own
-/// (config-vocabulary.md), so these rows say **Desktop** and
-/// carry the same `square.on.square` glyph the Profiles card
-/// draws beside a Desktop — one word and one picture for the
-/// concept, wherever the app names it.
-///
-/// **The Lua argument is a bare NUMBER**, not a quoted string —
-/// `spaceArg`'s twin, one type over, and `desktopArg` is the
-/// one place that form is authored.
-///
-/// Not because a quoted one would refuse: `JSONValue.intValue`
-/// coerces a numeric string, so `focus_desktop("3")` reaches
-/// the verb intact. The cost is IDENTITY. A `NavCommand` is
-/// keyed by its Lua body, the import classifier matches that
-/// body byte-for-byte (#4), and `docs/lua-reference.md` teaches
-/// the bare form — so a quoted catalog would file a
-/// hand-written `focus_desktop(3)` as Custom while the row it
-/// belongs in sat right there, and `desktopNumber(from:)`, which
-/// parses an Int, would stop recognising the catalog's own rows.
+/// Uses bare integer arguments for Lua bindings (`desktopArg`, #4).
 extension KeybindingCatalog {
-    /// One "Go to Desktop …" row per Desktop (#26).
+    /// "Go to Desktop …" command rows (#26).
     static func goToDesktop(
         _ desktops: [Int],
         absent: Set<Int> = []
@@ -48,12 +27,7 @@ extension KeybindingCatalog {
         }
     }
 
-    /// The per-Desktop "Move to …" / "… & follow" pairs,
-    /// interleaved per Desktop — composed from the two
-    /// half-builders below rather than repeating their Lua, for
-    /// the reason `moveToSpace` gives: a second copy of either
-    /// body is the byte-for-byte drift that silently demotes an
-    /// import to Custom (#4).
+    /// Interleaved "Move to Desktop" and "Move & follow" rows (#4, #25).
     static func moveToDesktop(
         _ desktops: [Int],
         absent: Set<Int> = []
@@ -65,9 +39,7 @@ extension KeybindingCatalog {
         .flatMap { [$0, $1] }
     }
 
-    /// One "Move to Desktop …" row per Desktop (#25). No follow:
-    /// the window leaves and you stay, which is why the pair is
-    /// two rows rather than one row with a modifier.
+    /// "Move to Desktop …" command rows (#25).
     static func moveToDesktopRows(
         _ desktops: [Int],
         absent: Set<Int> = []
@@ -90,7 +62,7 @@ extension KeybindingCatalog {
         }
     }
 
-    /// One "Move to Desktop … & follow" row per Desktop.
+    /// "Move to Desktop … & follow" command rows.
     static func moveToDesktopFollowRows(
         _ desktops: [Int],
         absent: Set<Int> = []
@@ -114,15 +86,7 @@ extension KeybindingCatalog {
         }
     }
 
-    /// The short spoken mark for a row whose Desktop is not on
-    /// any screen right now, or nil when it is.
-    ///
-    /// Short on purpose: it is the row's `.accessibilityHint`,
-    /// read after the row's own name and combo, and the family's
-    /// block sentence carries the explanation. `absent` is
-    /// EMPTY for every caller with no machine in its question —
-    /// the diff readout, the conflict roster, the import
-    /// classifier — which is why it defaults so.
+    /// Accessibility hint for disconnected desktop row.
     private static func awayMark(
         _ number: Int,
         in absent: Set<Int>
@@ -136,64 +100,15 @@ extension KeybindingCatalog {
         }
     }
 
-    /// Which Desktops get a row, and which of those are not
-    /// attached right now.
-    ///
-    /// **A Desktop keeps its rows for as long as ANY shortcut
-    /// names it** — all three families, together, dimmed. One
-    /// rule, and the alternative was tried and withdrawn: a
-    /// per-family offer (each family widened only by bindings
-    /// for its OWN verb) is defensible in the abstract and reads
-    /// as broken on screen, because the three rows for one
-    /// Desktop then appear and vanish independently — you bind
-    /// "move & follow" and the plain move row disappears from
-    /// under it (owner, on device, 2026-08-26).
-    ///
-    /// It also keeps the interleaved move pair honest for free.
-    /// Its two families render zipped by index and truncated to
-    /// the shorter column, so halves offering different Desktops
-    /// would drop rows off the end of BOTH — including rows for
-    /// Desktops that are perfectly fine.
-    ///
-    /// And it is the more useful rule: a Desktop you still have
-    /// shortcuts for stays fully editable while its screen is
-    /// away, so you can finish or rearrange that set before you
-    /// plug back in.
+    /// Desktops offered in keybinding UI and disconnected status (#92).
     struct DesktopOffer: Equatable {
-        /// Every Desktop drawing a row — live, or named by a
-        /// binding.
         var desktops: [Int] = []
-        /// Of those, the ones not on any screen now.
         var absent: Set<Int> = []
 
-        /// The empty offer: no Desktop draws a row.
         static let none = DesktopOffer()
     }
 
-    /// Builds the offer from what exists and what is bound.
-    ///
-    /// The union is what keeps a bound row visible. A Desktop
-    /// number is macOS topology, not user data — unplug a screen
-    /// and Desktops 3–5 are simply gone — while the binding that
-    /// named one is still Carbon-registered, still blocks the
-    /// recorder, and would otherwise have no row for the
-    /// duplicate-combo block's "Go to" to reach. That is #92's
-    /// argument, and the per-Space families answer it with a
-    /// whole Inactive card because a Space is user data that can
-    /// be re-created by name. A Desktop cannot, so the cheaper
-    /// answer is right here: keep offering the rows, dimmed.
-    ///
-    /// Deliberately NOT routed through
-    /// `OrphanedShortcuts.perSpaceFamilies` — that list means
-    /// "the argument is a `SpaceID`" and drives the space-rename
-    /// rewriter, which must never see a Desktop number.
-    ///
-    /// An EMPTY `live` is a legitimate call, not the degenerate
-    /// one: it means the caller has no machine in its question —
-    /// the settings diff narrates two saved configs and has no
-    /// business asking what is plugged in — and it reads the
-    /// same as "the bridge is absent", which is also correct,
-    /// since neither may drop a row the user authored.
+    /// Builds desktop offer from live topology and bound shortcuts (#92).
     static func desktopOffer(
         live: [Int],
         bindings: [KeyBinding]
@@ -208,16 +123,7 @@ extension KeybindingCatalog {
         )
     }
 
-    /// The catalog row a Desktop-targeting Lua body names, or
-    /// nil for anything else — the import classifier's arm.
-    ///
-    /// Matched by **shape**, the way a resize of any step is
-    /// (`resizeShape(from:)`), rather than by looking the body
-    /// up in a map built from the live Desktop list. The map
-    /// route would leave a binding to a Desktop that is not
-    /// currently attached classified `.custom`, so it would read
-    /// as raw Lua in the panel and in the Advanced drawer until
-    /// the screen came back.
+    /// Resolves desktop command matching Lua body.
     static func desktopCommand(from lua: String) -> NavCommand? {
         guard let number = desktopNumber(from: lua) else {
             return nil
@@ -229,13 +135,7 @@ extension KeybindingCatalog {
         return candidates.first { $0.lua == lua }
     }
 
-    /// The Desktop a `focus_desktop` / `move_to_desktop`
-    /// (`_and_follow`) body targets, or nil when the body is not
-    /// one of the three verbs.
-    ///
-    /// Reads the verb before the argument so a future
-    /// `…_desktop` verb taking something other than a number
-    /// cannot be mistaken for one of these.
+    /// Parses desktop number from Lua command body.
     static func desktopNumber(from lua: String) -> Int? {
         guard
             let verb = verbPrefixes.first(where: {
@@ -244,27 +144,11 @@ extension KeybindingCatalog {
             lua.hasSuffix(")")
         else { return nil }
         let body = lua.dropFirst(verb.count).dropLast()
-        // Digits only. `Int` accepts a sign, and both signed
-        // forms round-trip through `desktopArg` into a row that
-        // cannot work: `(-1)` draws a row for a target the verb
-        // refuses (`number >= 1`), and `(+3)` widens the offer
-        // with a Desktop whose generated row spells `(3)` — a
-        // duplicate that can never carry the binding it came
-        // from.
         guard body.allSatisfy(\.isNumber) else { return nil }
         return Int(body)
     }
 
-    /// `KiwiDesk.<verb>(` for each of the three, DERIVED from the
-    /// row builders rather than spelled a second time.
-    ///
-    /// §5 invites renaming a Lua verb outright, and a hand copy
-    /// here would survive one: the rows would author the new
-    /// spelling while this parse still matched the old, which
-    /// demotes every Desktop binding to Custom and un-teaches
-    /// the classifier its own catalog. The Space side avoids the
-    /// same trap by sharing `SpaceLuaArg`; this is the one-type
-    /// version of that.
+    /// Derived verb prefixes for desktop Lua commands.
     private static let verbPrefixes: [String] = {
         let sentinel = 0
         return
@@ -274,15 +158,11 @@ extension KeybindingCatalog {
             .map { String($0.lua.prefix { $0 != "(" }) + "(" }
     }()
 
-    /// A Desktop number as the Lua argument the verbs parse: a
-    /// bare integer literal. See the type docstring.
+    /// Formats desktop number argument for Lua commands.
     static func desktopArg(_ number: Int) -> String {
         String(number)
     }
 
-    /// The glyph a Desktop row carries. `DesktopGlyph.symbol`
-    /// is the one copy — the type docstring claims these rows
-    /// picture a Desktop the way Profiles does, and a second
-    /// literal here would be a claim nothing holds.
+    /// Glyph for desktop rows (`DesktopGlyph.symbol`).
     private static let desktopIcon = DesktopGlyph.symbol
 }

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Desktops.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Desktops.swift
@@ -163,6 +163,8 @@ extension KeybindingCatalog {
         String(number)
     }
 
-    /// Glyph for desktop rows (`DesktopGlyph.symbol`).
+    /// `DesktopGlyph.symbol` is the one copy of the Desktop-row
+    /// glyph — a second literal here would claim these rows
+    /// picture a Desktop while nothing holds it.
     private static let desktopIcon = DesktopGlyph.symbol
 }

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardBoard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardBoard.swift
@@ -1,24 +1,17 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The drawn keyboard: one board, showing one scope at a time.
+/// Keyboard visual matrix showing shortcut bindings for a scope.
 struct KeyboardBoard: View {
     let type: KeyboardMatrix.PhysicalType
     let claims: [UInt32: [KeyboardCensus.ModifierLayer]]
     let scope: KeyboardCensus.Scope
     let conflicted: Set<UInt32>
 
-    /// Widths are in key units, so the board scales to whatever
-    /// the panel column gives it rather than to a pinned size —
-    /// the responsive pass moves that column.
     var body: some View {
         GeometryReader { geometry in
             let rows = KeyboardMatrix.rows(for: type)
             let units = rows.first?.reduce(0) { $0 + $1.units } ?? 1
-            // The plate's own padding comes off FIRST: it sits
-            // outside the rows, so sizing the unit against the
-            // full width overflows the column by exactly twice
-            // it, which is how the board shipped clipped.
             let available =
                 geometry.size.width - Self.padding * 2
             let unit =
@@ -40,7 +33,6 @@ struct KeyboardBoard: View {
                 RoundedRectangle(cornerRadius: 10)
                     .fill(SettingsTheme.previewPlate)
             )
-            // 16b dark seam — see `SettingsTheme.planeRing`.
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
                     .strokeBorder(
@@ -55,26 +47,15 @@ struct KeyboardBoard: View {
     private static let gap: CGFloat = 3
     private static let padding: CGFloat = 8
 
-    /// ONE unit governs both axes, and it is DERIVED from the
-    /// column the board is given rather than pinned. The width
-    /// was unit-derived while the height was a hardcoded 26, so
-    /// the board's aspect ratio was a function of the panel
-    /// width — the single thing a unit system exists to make
-    /// invariant, and what the eye read as "squashed".
-    ///
-    /// Deriving it from `panelWidth` rather than from a
-    /// `GeometryReader` is deliberate: the height has to be known
-    /// before the body is proposed, and the panel's width is a
-    /// constant by design. A board asked to render in some other
-    /// column would need the reader; nothing asks.
+    /// Key unit size derived from width constraint.
     static func unit(in width: CGFloat) -> CGFloat {
         let available = width - padding * 2
         return (available - gap * (unitsPerRow - 1))
             / unitsPerRow
     }
 
-    /// Every row of both boards totals this — asserted by
-    /// `KeyboardMatrixTests.rowsKeepOneWidth`.
+    /// Total units per row across keyboard models
+    /// (`KeyboardMatrixTests.rowsKeepOneWidth`).
     private static let unitsPerRow: CGFloat = 15
 
     private var boardHeight: CGFloat {
@@ -86,8 +67,6 @@ struct KeyboardBoard: View {
             + Self.padding * 2
     }
 
-    /// The panel's own horizontal padding, which the board never
-    /// sees — `SettingsDetailPanel` applies it outside.
     private static let columnInset: CGFloat = 44
 
     @ViewBuilder
@@ -95,8 +74,6 @@ struct KeyboardBoard: View {
         _ key: KeyboardMatrix.Key,
         unit: CGFloat
     ) -> some View {
-        // A letter key is `units: 1` in the matrix, so it is one
-        // unit tall as well as one wide.
         let width =
             unit * key.units
             + Self.gap * (key.units - 1)
@@ -123,51 +100,22 @@ struct KeyboardBoard: View {
         )
     }
 
-    /// The ONE conflict-class predicate — the legend's gate
-    /// reads the same set, so the ring and its entry cannot
-    /// drift (architect review 2026-08-10).
     private var overwritten: Set<UInt32> {
         KeyboardCensus.overwrittenReserved(
             claims: claims,
             scope: scope
         )
     }
-
 }
 
-/// One key. The FILL says what the user's config has done with
-/// it — bound or free — and a RING warns about it: dashed where
-/// macOS already owns the key under the shown modifier, solid
-/// where two of the user's own bindings collide.
-///
-/// Two channels rather than one fill carrying three meanings,
-/// which is what let "can't bind" stop being a near-black hole
-/// on a key that is free under every other modifier.
+/// Single keycap with status fill and ring (`KeyboardRingSeparationTests`).
 struct KeyCap: View {
     let code: UInt32?
     let state: KeyboardCensus.KeyState
     let isConflicted: Bool
-    /// The user bound this key OVER a macOS reservation —
-    /// conflict-class (owner 2026-08-10: binding ⌘W does not
-    /// un-own it, and suppressing the warning on bind hid
-    /// exactly the clash the user most needs to see). Member
-    /// of `KeyboardCensus.overwrittenReserved`, the one
-    /// predicate the legend gate shares.
     let isOverwritten: Bool
-    /// What a code-less cap prints (⇧, ⌘) — see
-    /// `KeyboardMatrix.Key.legend`.
     let legend: String?
 
-    /// The fill says what YOUR config has done with the key;
-    /// the border warns about it. Two channels rather than one
-    /// fill carrying three meanings — which is what let "can't
-    /// bind" be a near-black hole that no longer needed to be
-    /// (owner, 2026-08-10).
-    ///
-    /// The two warnings differ by DASH as well as by hue: a
-    /// reserved key is dashed, a conflicted one solid. Amber and
-    /// red are both warm, so hue alone would collapse them for
-    /// the same viewers the palette work was about.
     var body: some View {
         RoundedRectangle(cornerRadius: 4)
             .fill(fill)
@@ -183,12 +131,6 @@ struct KeyCap: View {
 
     @ViewBuilder private var border: some View {
         if isConflicted || isOverwritten {
-            // An overwrite clashes with macOS exactly as two
-            // own rows clash with each other, and takes the
-            // same solid red — which is also what the CVD
-            // floor forces, amber measuring 10.5 against the
-            // accent where red measures 136.6
-            // (`KeyboardRingSeparationTests`).
             RoundedRectangle(cornerRadius: 4)
                 .strokeBorder(SettingsTheme.keyConflict, lineWidth: 2)
         } else if state == .cantBind {
@@ -200,10 +142,6 @@ struct KeyCap: View {
         }
     }
 
-    /// A reserved key is drawn FREE and ringed, not blacked
-    /// out: macOS owning it under this modifier is a warning
-    /// about a key that is otherwise unclaimed, and the fill's
-    /// job is to say whether the user has claimed it.
     private var fill: Color {
         state == .bound
             ? SettingsTheme.accent
@@ -216,10 +154,7 @@ struct KeyCap: View {
             : SettingsTheme.plateInk.opacity(0.75)
     }
 
-    /// The label the USER's keyboard prints, not the physical
-    /// key's US name — `LayoutKeyGlyph` is the app's one
-    /// layout-aware stage (#23) and the reason a German board
-    /// shows `ß` where the model calls the key `minus`.
+    /// Layout-aware character glyph for keycode (`LayoutKeyGlyph`, #23).
     private var glyph: String {
         guard let code else { return legend ?? "" }
         if let char = LayoutKeyGlyph.char(for: code),

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardCensus.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardCensus.swift
@@ -1,41 +1,18 @@
 import KiwiDeskCore
 
-/// What the Shortcuts preview reports: which physical keys the
-/// draft's bindings claim, under which modifier combinations.
-///
-/// Pure over `[KeyLayer]`, so the whole readout is assertable
-/// without a view. The panel's three derived facts — the chip
-/// row, the per-key stripes and the "N keys across M modifiers"
-/// sentence — all come out of one fold here rather than being
-/// recomputed beside the drawing.
+/// Shortcuts preview data derivations over `[KeyLayer]`.
 enum KeyboardCensus {
 
-    /// One modifier combination that at least one binding uses.
-    ///
-    /// The layer set is DERIVED, never a fixed four: the frame
-    /// happens to show ⌥ / ⌥⇧ / ⌃⌥ / ⌘⌥ because that is what
-    /// those bindings used. A config that binds nothing under ⌘
-    /// offers no ⌘ chip.
-    ///
-    /// NOT a `KeyLayer`. A layer is a named alternate keymap and
-    /// only one fires at a time; this is the modifier axis, and
-    /// the two are independent — which is also why a key claimed
-    /// by two different layers is not drawn as a conflict.
+    /// One modifier combination used by at least one binding.
     struct ModifierLayer: Hashable, Comparable {
         let modifiers: HotkeyModifiers
 
-        /// The modifier glyphs, EMPTY for a bare-key binding —
-        /// which holds no modifier and so has no symbol. The
-        /// word that names that case is the view's
-        /// (`KeyboardKeyLabel.chipLabel`), because `L` is
-        /// main-actor isolated and this type is deliberately not.
+        /// Modifier glyphs, or empty for bare keys (`KeyboardKeyLabel`).
         var label: String {
             ComboSymbols.modifierSymbols(modifiers)
         }
 
-        /// Ordered by how many modifiers are held, then by the
-        /// Carbon mask, so the chips keep a stable reading order
-        /// across renders and the simplest combination leads.
+        /// Ordered by modifier count then raw value for stable reading order.
         static func < (a: Self, b: Self) -> Bool {
             let ca = a.modifiers.rawValue.nonzeroBitCount
             let cb = b.modifiers.rawValue.nonzeroBitCount
@@ -44,48 +21,21 @@ enum KeyboardCensus {
         }
     }
 
-    /// How a drawn key reads at rest.
-    ///
-    /// `cantBind` is the STATIC `SystemShortcuts` table only. A
-    /// live `RegisterEventHotKey` refusal is the app's other
-    /// unbindable signal and is deliberately not here: it is
-    /// per-attempt and cannot be enumerated, so promising it on
-    /// a board drawn before any attempt would be a claim the
-    /// panel cannot keep.
+    /// Drawn key state at rest.
     enum KeyState: Equatable {
         case bound
         case free
         case cantBind
     }
 
-    /// Every binding in the draft that has actually been
-    /// recorded, parsed. `KeyBinding.combo` is an unparsed
-    /// string and is EMPTY while a row is waiting for a chord,
-    /// so an unrecorded row claims no key and must not count
-    /// toward "taken".
-    ///
-    /// The emptiness is `KeyCombo.parse`'s to reject, not this
-    /// function's — it guards on a non-empty key name and
-    /// returns nil, so `compactMap` drops the row. A `filter`
-    /// here would read as the thing keeping unrecorded rows out
-    /// while actually being unreachable, which is worse than no
-    /// filter: it survives any mutation, so a guard aimed at it
-    /// can only pass.
+    /// Parses non-empty key bindings across layers (`KeyCombo.parse`).
     static func combos(in layers: [KeyLayer]) -> [KeyCombo] {
         layers
             .flatMap(\.bindings)
             .compactMap { KeyCombo.parse($0.combo) }
     }
 
-    /// The modifier combinations the draft uses, in chip order.
-    ///
-    /// The bare-key combination is one of them. An earlier cut
-    /// dropped it on the grounds that it would render as an
-    /// empty chip — but the chip is named in words instead, and
-    /// dropping it meant a binding on plain `L` or `return`
-    /// appeared nowhere on a board whose question is what is
-    /// taken (owner, 2026-08-10). It sorts first, holding the
-    /// fewest modifiers.
+    /// Modifier combinations in chip sort order.
     static func layers(in layers: [KeyLayer]) -> [ModifierLayer] {
         Set(
             combos(in: layers)
@@ -93,10 +43,7 @@ enum KeyboardCensus {
         ).sorted()
     }
 
-    /// Which selected modifier layers claim each key code — the
-    /// stripe fold. A key with two entries is drawn with two
-    /// stripes, which is how a two-layer collision stays legible
-    /// on a single board.
+    /// Mapping of key codes to matching selected modifier layers.
     static func claims(
         in layers: [KeyLayer],
         selected: Set<ModifierLayer>
@@ -110,37 +57,13 @@ enum KeyboardCensus {
         return out.mapValues { $0.sorted() }
     }
 
-    /// What the board is showing: everything at once, or one
-    /// modifier combination.
-    ///
-    /// Single-select, and the reason is that colour was never
-    /// carrying its weight. Showing several combinations at once
-    /// needed one hue each, hue is the channel colour-vision
-    /// deficiency takes away, and only four hues cleared the
-    /// separation floor against the key they sit on — so the
-    /// board capped what it could show, and the cap is what made
-    /// the panel's own headline answer false for anyone with
-    /// five. One combination at a time needs no hue at all: the
-    /// key's FILL says bound, free or can't-bind, and the
-    /// question a user actually has at binding time — "if I hold
-    /// ⌃⌥, what is left?" — is the drill-down rather than the
-    /// overlay. Two combinations on one key never denoted a
-    /// problem anyway; conflicts are per-layer and
-    /// `KeybindingConflicts` reports them separately.
+    /// Filter scope for keyboard preview.
     enum Scope: Hashable {
-        /// Every combination at once. A key is bound if anything
-        /// claims it — the glance answer, and the only one that
-        /// is true regardless of how many combinations exist.
-        ///
-        /// It deliberately reports no `cantBind`: macOS reserves
-        /// a key UNDER a modifier, so "can't bind" has no meaning
-        /// until one is chosen, and colouring keys black here
-        /// would claim they are unavailable everywhere.
         case all
         case one(ModifierLayer)
     }
 
-    /// The combinations in scope — all of them, or the one.
+    /// Active modifier combinations in given scope.
     static func inScope(
         _ scope: Scope,
         among layers: [ModifierLayer]
@@ -151,34 +74,20 @@ enum KeyboardCensus {
         }
     }
 
-    /// The state of one drawn key under the current selection.
+    /// State of a drawn key under current scope (`reservedKeys`).
     static func state(
         of code: UInt32,
         claims: [UInt32: [ModifierLayer]],
         scope: Scope
     ) -> KeyState {
         if claims[code]?.isEmpty == false { return .bound }
-        // Through `reservedKeys`, the ONE derivation of
-        // "reserved" — the dashed ring this state draws and
-        // the legend entry gated on `reservedUnbound` must
-        // read one source, or the board↔legend disagreement
-        // class returns through the amber pair (re-review
-        // 2026-08-10).
         if reservedKeys(scope: scope).contains(code) {
             return .cantBind
         }
         return .free
     }
 
-    /// Whether macOS already owns this key under any selected
-    /// modifier combination. A convenience OVER `reservedKeys`,
-    /// never a second read of `SystemShortcuts.map` — the
-    /// original subscript-by-combo body was a parallel
-    /// derivation of "reserved" fourteen lines from the one the
-    /// board and legend share, which is the equivalent-by-luck
-    /// class the census exists to close (architect re-review
-    /// 2026-08-10). Keyed on the SELECTION, because a key macOS
-    /// owns under ⌘ is perfectly free under ⌃⌥.
+    /// Whether macOS owns key under any selected modifier combination.
     static func isSystemReserved(
         _ code: UInt32,
         under selected: Set<ModifierLayer>
@@ -188,35 +97,14 @@ enum KeyboardCensus {
         }
     }
 
-    /// The count sentence's number: how many distinct keys the
-    /// scope claims.
-    ///
-    /// It derives from `claims`, so the sentence cannot disagree
-    /// with the board above it. The modifier count went with the
-    /// stripes: under `.all` it restated the chip row, and under
-    /// `.one` it was always 1.
+    /// Count of distinct taken keys in scope.
     static func takenKeyCount(
         claims: [UInt32: [ModifierLayer]]
     ) -> Int {
         claims.keys.count
     }
 
-    /// Key codes where two bindings IN THE SAME LAYER claim the
-    /// same combo — the red ring.
-    ///
-    /// Computed rather than read back out of
-    /// `KebindingConflicts.conflicts(in:)`, because that returns
-    /// display NAMES and rejoining them to key codes meant
-    /// matching `Conflict.name` against `KeyBinding.label` — a
-    /// binding with no label falls back to its combo string and
-    /// was never ringed, and the match ran across every layer
-    /// while conflicts are per layer.
-    ///
-    /// It also answers only the `.otherBinding` case on purpose:
-    /// a clash with a macOS shortcut is `overwrittenReserved`'s
-    /// — the same solid red since the owner ruled the overwrite
-    /// conflict-class (2026-08-10), but a different question
-    /// with a different gate.
+    /// Collisions where two bindings in the same layer share a combo.
     static func collisions(
         in layers: [KeyLayer],
         scope: Scope
@@ -243,18 +131,9 @@ enum KeyboardCensus {
         return out
     }
 
-    // MARK: - The conflict-class predicate (one owner)
+    // MARK: - Conflict-class predicates
 
-    /// Every key macOS reserves under the shown modifier. Empty
-    /// under `.all` on purpose — macOS reserves COMBINATIONS,
-    /// not keys, so there is no single combination to check
-    /// against there.
-    /// Deliberately UNFILTERED by `shipsDisabled` (#1094): the
-    /// board is a per-key surface, like the row's ⚠️, so it
-    /// shows everything the register knows. Only AGGREGATE
-    /// surfaces — a count, a banner — drop a dormant chord, via
-    /// `KeybindingConflicts.actionable`. A ring on one key is an
-    /// explanation where a standing badge is an alarm.
+    /// System-reserved keys under shown modifier (#1094).
     static func reservedKeys(scope: Scope) -> Set<UInt32> {
         guard case .one(let layer) = scope else { return [] }
         return Set(
@@ -267,13 +146,7 @@ enum KeyboardCensus {
         )
     }
 
-    /// The keys whose combo the user bound OVER a macOS
-    /// reservation — conflict-class (owner ruled 2026-08-10:
-    /// binding ⌘W does not un-own it), ringed the same solid
-    /// red as an own-row collision. ONE predicate: the board's
-    /// rings and the legend's gate both consume this, so the
-    /// two cannot drift (architect review 2026-08-10 — they
-    /// were composed independently at each site).
+    /// User bindings conflicting with macOS reservations.
     static func overwrittenReserved(
         claims: [UInt32: [ModifierLayer]],
         scope: Scope
@@ -283,14 +156,7 @@ enum KeyboardCensus {
         }
     }
 
-    /// The reserved keys still FREE under the shown modifier —
-    /// the dashed amber ring's presence, and therefore its
-    /// legend entry's gate: under a chip whose reservations are
-    /// all bound, or a layer macOS reserves nothing under, the
-    /// amber entry would point at a mark the board does not
-    /// draw. ⌃⌥ was named here as such a layer; since #1094 it
-    /// carries one reservation (⌃⌥space), so it is no longer an
-    /// example of the empty case.
+    /// System-reserved keys still free under shown modifier (#1094).
     static func reservedUnbound(
         claims: [UInt32: [ModifierLayer]],
         scope: Scope

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardPreviewPanel.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardPreviewPanel.swift
@@ -1,36 +1,18 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// "KEYBOARD · WHAT'S TAKEN" — the Shortcuts area's panel
-/// content (#678 turn 5a). One resolved keyboard, drawn from the
-/// draft, answering which physical keys the user's bindings have
-/// already claimed and under which modifier combinations.
+/// Keyboard shortcut allocation preview panel (#678, #812).
 ///
-/// The chip row is the state everything else derives from: the
-/// board and the count sentence both read the same scope through
-/// `KeyboardCensus`, so the sentence cannot disagree with the
-/// picture above it.
+/// Visualizes bound and available keys across modifier layers
+/// via `KeyboardCensus`.
 struct KeyboardPreviewPanel: View {
     @ObservedObject var model: SettingsModel
-
-    /// Which modifier combinations are showing. Seeded to all of
-    /// them on first render and then narrowed by the user —
-    /// starting empty would open on a board that answers nothing.
-    /// Which combination the board is showing, or all of them.
-    /// Opens on `.all` — the only answer that stays true however
-    /// many combinations the draft has, since a board narrowed to
-    /// a subset reads as the total under this panel's heading.
     @State private var scope: KeyboardCensus.Scope = .all
 
-    /// Every combination the draft uses. Each gets a chip.
     private var layers: [KeyboardCensus.ModifierLayer] {
         KeyboardCensus.layers(in: model.config.layers)
     }
 
-    /// The scope, dropped back to `.all` if the draft no longer
-    /// has the combination it names — unbinding the last ⌘
-    /// shortcut must not leave the board showing a ⌘ that is not
-    /// there.
     private var liveScope: KeyboardCensus.Scope {
         if case .one(let layer) = scope, !layers.contains(layer) {
             return .all
@@ -38,9 +20,6 @@ struct KeyboardPreviewPanel: View {
         return scope
     }
 
-    /// The selection, minus any layer the draft no longer has —
-    /// unbinding the last ⌘ shortcut must not leave a ⌘ chip
-    /// selected and counted.
     private var selected: Set<KeyboardCensus.ModifierLayer> {
         KeyboardCensus.inScope(liveScope, among: layers)
     }
@@ -61,8 +40,6 @@ struct KeyboardPreviewPanel: View {
                 scope: liveScope,
                 conflicted: collisions
             )
-            // Drawn, not spoken: the board's sentence names
-            // every state in words (#812).
             fillLegend.accessibilityHidden(true)
             tallySentence
             layoutRow
@@ -100,11 +77,6 @@ struct KeyboardPreviewPanel: View {
 
     // MARK: - Legends
 
-    /// Each entry is drawn the way the board draws the thing it
-    /// names: a fill for a fill, a line for a ring. A square of
-    /// solid colour standing for a 1.5 pt dashed border is the
-    /// caption rule's failure in miniature — a legend may not
-    /// point at a mark the frame does not draw.
     private var fillLegend: some View {
         FlowLayout(spacing: 12) {
             swatch(
@@ -116,28 +88,12 @@ struct KeyboardPreviewPanel: View {
                 L("keyboard.legend.free", "free")
             )
             if !reservedFree.isEmpty {
-                // Gated on a DRAWN mark, not merely on a chip
-                // being picked: a chip whose reservations are
-                // all bound draws only red (code review
-                // 2026-08-10; an entry may not point at a mark
-                // the frame does not draw). ⌃⌥ reserved nothing
-                // until #1094 gave it ⌃⌥space, so the dashed
-                // ring now reaches the default pair too.
                 lineSwatch(
                     SettingsTheme.keyReserved,
                     dashed: true,
                     L("keyboard.legend.blocked", "macOS owns it")
                 )
             }
-            // The caption rule, applied to a legend: an entry
-            // may not point at a mark the frame does not draw
-            // (owner, 2026-08-10) — the red entry exists only
-            // while a red ring is on the board: an own-row
-            // collision, or a bound key overwriting a macOS
-            // shortcut, which is the same solid red (owner
-            // ruled it conflict-class). ONE reused key: a
-            // second label would cost a translation round for
-            // a distinction the banner already narrates.
             if !collisions.isEmpty || overwritesReserved {
                 lineSwatch(
                     SettingsTheme.keyConflict,
@@ -148,15 +104,6 @@ struct KeyboardPreviewPanel: View {
         }
     }
 
-    /// A fill swatch on the panel, delimited by a hairline —
-    /// which does light mode's work — with the `planeRing` seam
-    /// over it doing dark's, where the panel drops to within
-    /// ~1.3:1 of `keyFree` and the hairline sits eleven points
-    /// from it. A first dark-pass cut set every swatch on a
-    /// sliver of the board plate instead; the owner vetoed it
-    /// on sight (2026-08-10) — black chips beside caption text
-    /// in light mode read as blobs, and the legend is panel
-    /// furniture, not part of the picture.
     private func swatch(_ fill: Color, _ label: String) -> some View {
         HStack(spacing: 5) {
             RoundedRectangle(cornerRadius: 3)
@@ -182,9 +129,6 @@ struct KeyboardPreviewPanel: View {
         }
     }
 
-    /// A ring, drawn as the KEY-SHAPED outline it is on the
-    /// board — dashed for reserved, solid for a conflict. A
-    /// capsule read as a pill rather than as a key edge.
     private func lineSwatch(
         _ stroke: Color,
         dashed: Bool,
@@ -208,16 +152,6 @@ struct KeyboardPreviewPanel: View {
 
     // MARK: - Sentence and layout row
 
-    /// A label rather than a sentence ("Keys taken: 12", not "12
-    /// keys taken."), because one catalog string has no plural
-    /// forms: every inflected locale would have to pick a single
-    /// grammatical number and be wrong at the others — "1 Tasten
-    /// belegt", "0 touches attribuées". Putting the count last
-    /// leaves nothing to agree with it. No terminal period for
-    /// the same reason it is not a sentence, and because after a
-    /// digit a period reads as a number separator in several of
-    /// the shipped locales (localization.md ▸ a frame
-    /// interpolating a count owns the argument).
     private var tallySentence: some View {
         let taken = KeyboardCensus.takenKeyCount(claims: claims)
         return Text(
@@ -232,31 +166,10 @@ struct KeyboardPreviewPanel: View {
         .fixedSize(horizontal: false, vertical: true)
     }
 
-    /// States what was RESOLVED, never offers a choice — the app
-    /// binds by physical position and stores no layout, so this
-    /// is a reading of the machine, which is what "from macOS"
-    /// tells the user.
-    ///
-    /// ONE localized frame with the value at `%1$@`, rendered
-    /// through `SentenceFrame` — not `Text` · chip · `Text`.
-    /// Sibling views stitched around a value is the same defect
-    /// as `+`-concatenating fragments: the chip could only ever
-    /// land in the middle, and no catalog could move it (gui.md
-    /// ▸ Strings, the `CrossReferenceRow` case).
     private var layoutRow: some View {
-        // Spacing 0: the frame's own literals carry it. A
-        // per-segment gap merely double-spaces English and is
-        // wrong outright wherever the literal after a slot opens
-        // with a particle that must hug the noun before it.
         HStack(spacing: 0) {
             ForEach(
                 SentenceFrame(
-                    // "Keyboard layout", never bare "Layout":
-                    // that word is this app's own tiling noun
-                    // (`destination.layout` is "Layout
-                    // Defaults"), and this sentence sits inside
-                    // Settings where both senses are one search
-                    // away from each other.
                     L(
                         "keyboard.layout.sentence",
                         "Keyboard layout %1$@ from macOS"
@@ -277,10 +190,6 @@ struct KeyboardPreviewPanel: View {
                             RoundedRectangle(cornerRadius: 5)
                                 .fill(SettingsTheme.card)
                         )
-                        // `card` sits within a point of
-                        // `sunken` in BOTH modes — without an
-                        // edge the chip is not a chip (dark
-                        // pass).
                         .overlay(
                             RoundedRectangle(cornerRadius: 5)
                                 .strokeBorder(
@@ -313,11 +222,6 @@ struct KeyboardPreviewPanel: View {
 
     // MARK: - Derived
 
-    /// One half of the solid red ring's keys: two bindings in
-    /// one layer claiming the same combo. The other half is
-    /// `overwritesReserved` — a binding over a macOS
-    /// reservation, the same solid red since the owner ruled
-    /// the overwrite conflict-class (2026-08-10).
     private var collisions: Set<UInt32> {
         KeyboardCensus.collisions(
             in: model.config.layers,
@@ -325,10 +229,6 @@ struct KeyboardPreviewPanel: View {
         )
     }
 
-    /// The board's own predicate, not a re-derivation: the
-    /// rings and this gate read one census set, so the legend
-    /// cannot claim a mark the board does not draw (architect
-    /// review 2026-08-10).
     private var overwritesReserved: Bool {
         !KeyboardCensus.overwrittenReserved(
             claims: claims,
@@ -336,13 +236,10 @@ struct KeyboardPreviewPanel: View {
         ).isEmpty
     }
 
-    /// The dashed amber ring's presence — its legend entry's
-    /// gate, same shape.
     private var reservedFree: Set<UInt32> {
         KeyboardCensus.reservedUnbound(
             claims: claims,
             scope: liveScope
         )
     }
-
 }

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardPreviewPanel.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardPreviewPanel.swift
@@ -236,6 +236,9 @@ struct KeyboardPreviewPanel: View {
         ).isEmpty
     }
 
+    /// The board's own predicate, never a re-derivation: the
+    /// rings and this gate read one census set, so the legend
+    /// cannot claim a mark the board does not draw.
     private var reservedFree: Set<UInt32> {
         KeyboardCensus.reservedUnbound(
             claims: claims,

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicKit.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicKit.swift
@@ -1,15 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The shared visual grammar of the Layout Defaults schematics
-/// (#125): the mini-canvas metrics, the accent tile language, the
-/// two ghost conventions, and the damping applied when a staged
-/// value changes. One family, so every mode's schematic — and the
-/// `GapsDiagram` it echoes — reads as one set. Everything here is
-/// pure SwiftUI drawing over the staged config: no live state, no
-/// AX calls (the #123 never-live-apply principle — a schematic
-/// answers "what would this look like", it never touches the
-/// running session).
+/// Visual grammar for layout schematic previews (#123, #125).
 enum LayoutSchematic {
     static let canvasWidth: CGFloat = 140
     static let canvasHeight: CGFloat = 96
@@ -18,75 +10,24 @@ enum LayoutSchematic {
     static let fill = SettingsTheme.accent.opacity(0.25)
     static let stroke = SettingsTheme.accent.opacity(0.6)
 
-    /// Short enough to track a live slider drag without visible
-    /// lag; still smooths stepper/typed jumps, and the gaps
-    /// diagram reads it too rather than re-spelling it.
-    ///
-    /// A plain VALUE: the tuning is shared, the Reduce Motion
-    /// gate is not. Each caller spells
-    /// `reduceMotion ? nil : LayoutSchematic.damping` itself,
-    /// and folding that ternary in here is the one edit this
-    /// docstring exists to refuse — `.claude/rules/gui.md` ▸ the
-    /// Reduce Motion gate argues why (#1069).
+    /// Shared animation timing for live slider updates (#1069).
     static let damping = Animation.easeOut(duration: 0.12)
 
-    /// The window count the live preview opens on, and the band
-    /// the slider offers. The floor is **2**, not 1: with a
-    /// single window every one of the seven layouts draws the
-    /// same full-screen rectangle, so a 1 tells the reader
-    /// nothing about the layout they picked — and it is the one
-    /// count at which several schematics have no second zone to
-    /// draw. The ceiling is where the canvas stops telling a
-    /// story and starts drawing slivers.
+    /// Default window count and range for preview slider.
     static let defaultWindowCount = 5
     static let windowCountRange = 2...12
 
-    /// How far a piled tile reveals the one beneath it. The
-    /// engine's `OverlapStack` uses 40 pt against a real display;
-    /// on a canvas this size that would throw tiles off the frame,
-    /// so the reveal is scaled to the canvas. Shared by every
-    /// schematic that piles — Stack's zone, Track's overflow track
-    /// and Grid's last cell — because a pile that reads as a pile
-    /// in one and as a colour in another is the same picture
-    /// telling two stories (#712).
+    /// Overlap cascade offset scaled for schematic canvas (#712).
     static let cascadeOffset: CGFloat = 9
-
 }
 
-/// How large a schematic draws — and therefore what it is *for*
-/// (turn 10 of the #678 redesign).
-///
-/// `tile` is a thumbnail in the "Choose a layout" strip: one
-/// fixed size for every layout so the strip reads as a row
-/// rather than a ransom note, with the schematic's own caption
-/// suppressed — a tile is titled by its layout's name and the
-/// count of spaces using it, which the strip owns. `panel` is
-/// the live preview below the rows: it fills the pane, so a
-/// layout has room to be *read* rather than merely recognised.
-///
-/// One deliberate loss at `tile`: a schematic that needs more
-/// canvas than a thumbnail has to make its argument makes it at
-/// the panel and not on the thumbnail. BSP widens its own frame
-/// to 3:1, where "cut the longer side" and "alternate" only
-/// diverge after several cuts. Scrolling keeps its frame and
-/// gives up the *margin* instead — the room its off-monitor
-/// ghosts need — so a tile spends its whole canvas on the
-/// monitor rather than drawing it at half every sibling's scale
-/// (#753, `LayoutSchematicScaleTests`). A thumbnail answers
-/// "which of these do I want?"; the argument is one click away,
-/// and a strip of seven different-shaped tiles would answer
-/// neither question.
-///
-/// `CaseIterable` for the same reason `ScrollingParams.Anchor`
-/// is: a third scale has to satisfy every claim a caption makes
-/// about the frame, and a hand-listed sweep would go on passing
-/// over two of three (#753).
+/// Rendering scale for layout schematics
+/// (`LayoutSchematicScaleTests`, #678, #753).
 enum SchematicScale: Hashable, CaseIterable {
     case tile
     case panel
 
-    /// `nil` means "fill the width available" — the panel spans
-    /// its pane, so the preview grows with the window.
+    /// Width constraint (fixed for thumbnail tile, flexible for detail panel).
     var width: CGFloat? {
         self == .tile ? 132 : nil
     }
@@ -98,27 +39,21 @@ enum SchematicScale: Hashable, CaseIterable {
     var showsCaption: Bool { self == .panel }
 }
 
-/// Value-domain math shared by the schematics, kept apart from
-/// the SwiftUI drawing so the mapping stays unit-testable (like
-/// `GapPreviewScale`).
+/// Geometry and ratio helpers for schematic layout.
 enum SchematicMath {
-    /// A 0...1 ratio as a rounded whole percent, for a11y prose.
+    /// Ratio formatted as integer percentage.
     static func pct(_ ratio: Double) -> Int {
         Int((ratio * 100).rounded())
     }
 
-    /// Maps an explicit slot-size in points onto a 0.15...0.6
-    /// fraction of the mini-canvas, so the scrolling schematic's
-    /// tiles read narrower or wider without a real screen.
+    /// Maps point size to canvas width fraction.
     static func slotFraction(points: CGFloat) -> CGFloat {
         let t = (points - 100) / (1200 - 100)
         return 0.15 + 0.45 * min(max(t, 0), 1)
     }
 }
 
-/// One schematic tile in the family fill/stroke language. The
-/// `active` variant carries a heavier stroke for a highlighted
-/// slot (the scrolling anchor, the focused track).
+/// Standard schematic window tile.
 struct SchematicTile: View {
     var active = false
     @Environment(\.schematicPalette) private var palette
@@ -143,8 +78,7 @@ struct SchematicTile: View {
     }
 }
 
-/// A small "+N" chip on the last visible tile when a schematic
-/// caps how many windows it draws.
+/// Overflow indicator chip displaying count of hidden windows.
 struct SchematicMoreChip: View {
     let hidden: Int
     @Environment(\.schematicPalette) private var palette
@@ -159,22 +93,13 @@ struct SchematicMoreChip: View {
             .padding(.horizontal, 3)
             .background(
                 Capsule().fill(
-                    // `card`, not `.textBackgroundColor`: the
-                    // system colour follows the system window
-                    // background, which this window retired
-                    // (dark pass; the wiring suite's retired
-                    // lens now watches the needle).
                     palette?.base ?? SettingsTheme.card
                 )
             )
     }
 }
 
-/// An **empty cell** — permanently unused space a rigid grid
-/// leaves when it has more cells than windows. Dashed, gray:
-/// reads as "no window here", distinct from the spawn ghost
-/// (a *future* window) and the off-monitor ghost (a *real*
-/// window off-screen).
+/// Empty cell placeholder for fixed grid layouts.
 struct SchematicGap: View {
     @Environment(\.schematicPalette) private var palette
 
@@ -188,21 +113,8 @@ struct SchematicGap: View {
     }
 }
 
-/// **New-window tile** — "the next window lands here." Stays in
-/// the accent family (it *is* a window) but reads bolder than a
-/// real tile: a denser fill (0.45 vs 0.25) plus a "+" corner
-/// badge that carries the meaning even without colour. The badge,
-/// not the fill alone, is the signal — so it survives low-
-/// contrast / colour-blind viewing. Used where a mode's new-
-/// window placement is the point (BSP, Stack, Grid, Track). Kept
-/// deliberately distinct from the gray `SchematicGap`
-/// (permanently-empty) and `SchematicGhostOverflow` (off-screen):
-/// accent family = a window; gray family = not a window.
+/// Incoming window placement indicator with plus badge.
 struct SchematicNewWindow: View {
-    /// Which corner the "+" badge sits in. Defaults to the bottom-
-    /// trailing corner; the scrolling schematic overrides it so the
-    /// badge stays in the visible half when the new-window tile is
-    /// cropped by the canvas edge (a first/last window).
     var badgeAlignment: Alignment = .bottomTrailing
     @Environment(\.schematicPalette) private var palette
 
@@ -224,11 +136,6 @@ struct SchematicNewWindow: View {
                 )
             Image(systemName: "plus")
                 .font(.system(size: 7, weight: .bold))
-                // `accentInk` off-plate — white on the pale
-                // accent wash fails in LIGHT mode, the exact
-                // rule the token's docstring states. On the
-                // plate the wash is faint over a dark ground,
-                // so the badge rides the palette ink instead.
                 .foregroundStyle(
                     palette?.ink ?? SettingsTheme.accentInk
                 )
@@ -237,25 +144,9 @@ struct SchematicNewWindow: View {
     }
 }
 
-/// **Piled tile** — one window in an `OverlapStack` cascade, where
-/// only its top edge shows above the next.
-///
-/// Drawn **opaque**: a solid base under the accent fill, so
-/// stacking never sums the accent alpha. That is the whole reason
-/// this is a type rather than a `SchematicTile` drawn twice — the
-/// Grid preview piled translucent tiles at one rect and the last
-/// cell simply *got bluer* with the count instead of showing
-/// windows (#712), the same compounding-opacity trap as #406.
-/// Stack and Track each had a correct private copy; Grid needed a
-/// third, which is one more than a look this load-bearing should
-/// have (§2.4).
-///
-/// The front tile of a pile carries the dominant colour and the
-/// buried ones read as lighter slivers behind it.
+/// Opaque cascading stack tile avoiding opacity compounding (#406, #712).
 struct SchematicPileTile: View {
-    /// A heavier stroke for the focused window in the pile.
     var active = false
-    /// The "+" badge, when this piled window is the incoming one.
     var isNew = false
     @Environment(\.schematicPalette) private var palette
     @Environment(\.schematicFocusStroke) private var focusStroke
@@ -264,11 +155,6 @@ struct SchematicPileTile: View {
         ZStack(alignment: .bottomTrailing) {
             RoundedRectangle(cornerRadius: LayoutSchematic.corner)
                 .fill(
-                    // `card`, not `.textBackgroundColor`: the
-                    // system colour follows the system window
-                    // background, which this window retired
-                    // (dark pass; the wiring suite's retired
-                    // lens now watches the needle).
                     palette?.base ?? SettingsTheme.card
                 )
             RoundedRectangle(cornerRadius: LayoutSchematic.corner)
@@ -299,10 +185,7 @@ struct SchematicPileTile: View {
     }
 }
 
-/// **Off-monitor ghost** — a *real* window scrolled or overflowed
-/// past the visible screen. Solid gray fill, thin solid stroke,
-/// drawn straddling / outside the monitor rectangle. No "+"
-/// (that would collide with the spawn ghost). Used by Scrolling.
+/// Off-monitor ghost window representation for scrolling layouts.
 struct SchematicGhostOverflow: View {
     @Environment(\.schematicPalette) private var palette
 

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutStrip.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutStrip.swift
@@ -1,20 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The "Choose a layout" strip (turn 10): a row of **live
-/// thumbnails**, not a tab strip of words.
-///
-/// This is the area's structural move. "Track" and "Scrolling"
-/// and "Monocle" are words only a tiler user knows, and this is
-/// the card where a beginner is most lost — a drawing of the
-/// layout is the only honest label, so the strip doubles as the
-/// answer to "which of these do I want?". Each tile also says
-/// how many spaces use it, so a layout nothing runs is visibly
-/// not worth tuning.
-///
-/// The tiles draw the *staged* settings, like every other
-/// preview here: they are the same schematics the panel below
-/// renders, at `SchematicScale.tile`.
+/// Layout selection strip with live schematic thumbnails
+/// (`SchematicScale.tile`).
 struct LayoutStrip: View {
     @ObservedObject var model: SettingsModel
     @Binding var selection: LayoutMode
@@ -34,10 +22,6 @@ struct LayoutStrip: View {
                 .padding(.bottom, 4)
             }
         }
-        // The same string the header shows: a container VoiceOver
-        // names one thing while the screen reads another is two
-        // names for one control, and the old key's English still
-        // described the tab strip this area no longer has.
         .accessibilityElement(children: .contain)
         .accessibilityLabel(chooseTitle)
     }
@@ -55,10 +39,6 @@ struct LayoutStrip: View {
                 LayoutSchematicView(
                     mode: mode,
                     settings: model.config.settings,
-                    // The tiles all draw the same count, so the
-                    // strip compares seven layouts rather than
-                    // seven arbitrary window counts; the panel
-                    // below is where the count is the question.
                     windows: LayoutSchematic.defaultWindowCount,
                     scale: .tile
                 )
@@ -78,11 +58,7 @@ struct LayoutStrip: View {
         )
     }
 
-    /// The selected tile is marked by a filled, accent-bordered
-    /// plate rather than by tinting the drawing: the thumbnail is
-    /// the layout's own picture, and recolouring it would make
-    /// "selected" and "this is what the accent colour paints"
-    /// the same signal.
+    /// Background plate indicating selection state.
     private func selectionChrome(_ selected: Bool) -> some View {
         RoundedRectangle(cornerRadius: 8)
             .fill(
@@ -101,10 +77,7 @@ struct LayoutStrip: View {
             )
     }
 
-    /// How many spaces run this layout. A space with no recorded
-    /// mode runs the default, exactly as everywhere else reads
-    /// it (`?? .bsp`), so BSP's count includes the untouched
-    /// spaces rather than under-reporting them.
+    /// Usage summary for layout across active spaces (`LayoutUsage.spaces`).
     private func usageText(_ mode: LayoutMode) -> String {
         let count = LayoutUsage.spaces(
             on: mode,

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorArrangement.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorArrangement.swift
@@ -1,36 +1,13 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// The geometry behind the Monitors picture (#678 Phase 3, turn
-/// 13b): real display frames in, drawn rectangles out.
+/// Geometry for Monitors arrangement display (#678).
 ///
-/// **Displays are drawn from POINTS** — never pixels, never EDID
-/// millimetres. The ruling and its argument live in
-/// `docs/design-decisions.md` ▸ Monitors; what belongs here is
-/// what the code must keep true: `Display.frame` is
-/// `NSScreen.frame`, already points, and there is no
-/// backing-scale term in this file at all. Adding one is how a
-/// Retina display would come to draw 2× an identical non-Retina
-/// one.
-///
-/// The output is SwiftUI space — y grows DOWN — while the input
-/// is AppKit's global space, where y grows UP. The flip is what
-/// makes "a laptop below the desk display draws below it" true
-/// rather than upside down.
-///
-/// Pure and nonisolated on purpose: every rule here is arithmetic
-/// over values, so `MonitorArrangementTests` asserts the derived
-/// rectangles directly rather than scanning for the inputs (the
-/// `LayoutSchematicCountTests` shape — a picture that takes the
-/// frames and draws a constant satisfies every substring a scan
-/// can look for).
+/// Displays are drawn in points from `Display.frame` without backing-scale
+/// terms. Flips AppKit y-up coordinates to SwiftUI y-down. Tested by
+/// `MonitorArrangementTests` and `LayoutSchematicCountTests`.
 enum MonitorArrangement {
-    /// One display's drawn rectangle, in canvas coordinates.
-    ///
-    /// Carries no per-display "was I clamped" flag: nothing draws
-    /// one, and a field only the tests read is the second answer
-    /// this file argues against below — the page asks
-    /// `isApproximate(_:)`.
+    /// Drawn display rectangle in canvas coordinates.
     struct Drawn: Equatable, Identifiable {
         let display: Display
         let rect: CGRect
@@ -38,68 +15,21 @@ enum MonitorArrangement {
         var id: DisplayID { display.id }
     }
 
-    /// The whole picture: the cards, the follows-main tray, and
-    /// how big the content is (which may exceed the canvas — see
-    /// the floor below).
+    /// Full arrangement layout: drawn displays, tray, content size.
     struct Layout: Equatable {
         var displays: [Drawn] = []
-        /// The dashed tray's rectangle, or nil when no display is
-        /// main (an empty arrangement). The rect is the whole
-        /// answer — which SIDE of its display the tray landed on
-        /// is readable from it, and a stored flag beside it would
-        /// be a second answer nothing draws.
+        /// Dashed tray rectangle, or nil when no display is main.
         var tray: CGRect?
         var contentSize: CGSize = .zero
     }
 
-    // Deliberately NOT a `Layout` field: whether the picture is
-    // approximate is asked by the PAGE, which has the displays
-    // but not the laid-out picture, and a field beside the static
-    // would be a second answer that agrees only by construction —
-    // with the guards asserting the field while the screen read
-    // the static (guard-prover, 2026-08-04). One answer:
-    // `isApproximate(_:)` below.
-
-    /// The largest ratio between the longest sides of any two
-    /// drawn displays.
-    ///
-    /// **The clamp is stated here rather than applied silently**,
-    /// because a silent clamp reads as a wrong arrangement. Every
-    /// card is a DROP TARGET holding space chips, so an ultrawide
-    /// drawn at true scale beside a laptop would shrink the
-    /// laptop into a sliver nothing can be dropped onto. Past
-    /// this ratio the LARGER display is drawn smaller than true
-    /// scale — it only ever shrinks, so the clamp opens gaps and
-    /// can never make two rectangles overlap.
+    /// Maximum ratio between longest sides of any two drawn displays.
     static let maxDrawnRatio: CGFloat = 2.5
 
-    /// How far below true scale the cap must push a display
-    /// before the page SAYS the picture is approximate.
-    ///
-    /// The cap itself has no deadband — it engages at the ratio,
-    /// full stop. This is about the SENTENCE the page shows. The
-    /// cap is easy to trip imperceptibly: a laptop beside a 4K
-    /// reporting its full 3840 points is 3840/1512 ≈ 2.54, a hair
-    /// over, and drawing that display 1.6% small is not something
-    /// a user could see or would want a permanent caption about.
-    /// (Measured at 1:1 scaling — at macOS's default HiDPI
-    /// scaling that display reports far fewer points and does not
-    /// approach the cap at all. Either way the argument is the
-    /// same: a note on an everyday desk teaches people to ignore
-    /// notes.)
+    /// Scale factor threshold below which `isApproximate(_:)` reports true.
     static let perceptibleClamp: CGFloat = 0.9
 
-    /// The smallest a card may be drawn. Derived from the chip
-    /// it must hold rather than chosen: card padding either side,
-    /// the header line, and exactly one space chip
-    /// (`MonitorCardChips`). Below this a card is not a control —
-    /// there is nowhere to put the thing you dropped on it.
-    ///
-    /// It is deliberately the ONE-chip floor and not a
-    /// comfortable one: a five-display desk floored at a
-    /// chip-shelf size scrolls a picture whose whole job is a
-    /// glance, and the chips past the first are reachable through
-    /// the card's `+n` either way.
+    /// Minimum card size holding header and at least one chip.
     static let minimumCard = CGSize(
         width: MonitorCardChips.cardPadding * 2
             + MonitorCardChips.minChipWidth,
@@ -109,39 +39,12 @@ enum MonitorArrangement {
             + MonitorCardChips.chipHeight
     )
 
-    /// Gap between the tray and the display it hangs off.
+    /// Gap between tray and display it hangs off.
     static let trayGap: CGFloat = 10
-    /// The dashed tray's own height — it holds one chip row, so
-    /// it is shorter than a card but not shorter than a chip.
+    /// Dashed tray height.
     static let trayHeight: CGFloat = 52
 
-    /// Lays the arrangement out inside `canvas`.
-    ///
-    /// A display whose frame has a non-positive side is DROPPED
-    /// rather than drawn: it can be neither seen nor dropped onto,
-    /// and a zero-sized rectangle would take the ratio cap's
-    /// divisor to zero. `mainID` names which display the tray
-    /// hangs off; an id matching no drawn display yields NO tray
-    /// rather than one on some other display, because a fallback
-    /// here would be a second derivation of which display is main
-    /// (`MonitorTray.fold` argues it).
-    ///
-    /// `hostsChips` is false for a picture that is only LOOKED
-    /// at — the Home card's thumbnail, which is read-only and
-    /// hit-test-transparent. It governs the two concessions this
-    /// layout makes to being droppable on, and they are one
-    /// decision rather than two: the follows-main tray's reserved
-    /// band, and the minimum-card floor that keeps a card big
-    /// enough to hold a chip. Both exist so a chip has somewhere
-    /// to land; a thumbnail has no chips.
-    ///
-    /// Applied unconditionally they are a bug on any small
-    /// canvas, and the Home card is one. The band (62 pt) exceeds
-    /// its 56 pt height, so the subtraction clamped to a 1 pt
-    /// canvas; and the floor then beat the fit outright, so the
-    /// displays were drawn at chip-holding size regardless. That
-    /// shipped as a display rectangle drawn outside its own card,
-    /// across the subtitle below it.
+    /// Lays out arrangement inside `canvas` (`MonitorTray.fold`).
     static func layout(
         displays: [Display],
         mainID: DisplayID?,
@@ -149,9 +52,6 @@ enum MonitorArrangement {
         hostsChips: Bool = true,
         trayChips: Int = 0
     ) -> Layout {
-        // The band is reserved from the CANVAS width, before any
-        // scale is known — an upper bound on the tray's own
-        // width, so it can only ever over-reserve.
         let band = trayHeight(chips: trayChips, width: canvas.width)
         let drawable = displays.filter {
             $0.frame.width > 0 && $0.frame.height > 0
@@ -164,14 +64,6 @@ enum MonitorArrangement {
             for: capped.map(\.rect.size),
             bounds: bounds.size,
             floored: hostsChips,
-            // The tray is added AFTER scaling, so the canvas the
-            // displays are fitted into is the canvas minus the
-            // band it will occupy. Fitting the displays alone
-            // overflowed by exactly that band on every
-            // height-bound desk — which is one display, two side
-            // by side, or a laptop under a desk display, i.e.
-            // nearly all of them. One band whichever side the
-            // tray lands on, since it never takes both.
             canvas: CGSize(
                 width: canvas.width,
                 height: hostsChips
@@ -189,9 +81,6 @@ enum MonitorArrangement {
                 )
             )
         }
-        // No band reserved, no band returned — a `Layout` whose
-        // `tray` a caller could draw into space that was never
-        // set aside for it is the same bug one step later.
         guard hostsChips else {
             var bare = Layout()
             bare.displays = cards
@@ -204,13 +93,7 @@ enum MonitorArrangement {
         )
     }
 
-    /// Whether the picture is far enough from true scale for the
-    /// page to say so.
-    ///
-    /// A property of the HARDWARE alone — a ratio survives any
-    /// uniform scale — so the page can ask without laying the
-    /// picture out first, and a guard can assert the threshold
-    /// without a canvas.
+    /// Whether scale cap pushed any display below `perceptibleClamp`.
     static func isApproximate(_ displays: [Display]) -> Bool {
         let drawable = displays.filter {
             $0.frame.width > 0 && $0.frame.height > 0
@@ -222,21 +105,13 @@ enum MonitorArrangement {
 
     // MARK: - The three steps
 
-    /// Step 1 — the ratio cap, in POINT space, because a ratio is
-    /// scale-free and capping before the scale keeps the scale a
-    /// single uniform number.
-    ///
-    /// The centre is preserved, so a shrunk display stays where
-    /// the arrangement puts it: what the cap costs is a gap
-    /// against its neighbour, never a move.
+    /// Step 1: ratio cap in point space preserving display centers.
     private static func capping(
         _ displays: [Display]
     ) -> [(display: Display, rect: CGRect, factor: CGFloat)] {
         let longest = { (d: Display) in
             max(d.frame.width, d.frame.height)
         }
-        // The SMALLEST display sets the ceiling: it is the one
-        // whose usability the cap exists to protect.
         let ceiling =
             maxDrawnRatio * (displays.map(longest).min() ?? 0)
         return displays.map { display in
@@ -249,21 +124,8 @@ enum MonitorArrangement {
         }
     }
 
-    /// Step 2 and 3 — one uniform scale for the whole picture,
-    /// raised until the smallest card is still usable.
-    ///
-    /// The fit scale is what puts the arrangement inside the
-    /// canvas; the floor is what refuses to shrink a drop target
-    /// below `minimumCard`. The floor WINS, and the picture then
-    /// exceeds the canvas and scrolls — a card too small to drop
-    /// a chip onto is a broken control, while a picture wider
-    /// than its pane is one the user can still reach every part
-    /// of.
-    ///
-    /// `floored` is what keeps a card big enough to hold a chip,
-    /// at the price of overflowing a canvas too small to honour
-    /// it. A picture nobody can drop onto wants the fit alone —
-    /// see `hostsChips` on `layout`.
+    /// Step 2 & 3: uniform scale fitted to canvas and floored at
+    /// `minimumCard`.
     private static func scale(
         for sizes: [CGSize],
         bounds: CGSize,

--- a/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
@@ -15,58 +15,18 @@ struct SpaceAssignment: Identifiable, Hashable {
     var id: String { space.raw }
 }
 
-/// One space chip inside a display card. Semantic micro-icons
-/// (pin / arrow) encode the resolution kind — border style alone
-/// would be an accessibility risk (§3.13). Explicit chips clear
-/// back to automatic via an always-visible ⓧ drawn as a CORNER
-/// BADGE overlay on the trailing-top corner (#758): an overlay
-/// never contributes to the parent's size, so the chip's metrics
-/// stop depending on whether it is pinned. Its two ancestors
-/// died of the same measurement — a hover-only button grew the
-/// chip after the flow layout had sized it, so its ⓧ overflowed
-/// a narrow card, and the in-flow trailing slot that replaced it
-/// ate label width on every pinned chip and made each read as a
-/// delete button.
+/// Space chip displaying placement on a monitor card (#758).
 ///
-/// **A `Menu` inside the chip is what makes the keyboard route
-/// real** (#678 turn 13b). Before it, the chip was an `HStack`
-/// with a `.draggable`: not focusable, no Tab stop, no Return,
-/// nothing for VoiceOver to activate — so the docstring's promise
-/// of a "keyboard-navigable fallback" was false for exactly the
-/// users it was written for. A `Menu` earns focus, keyboard
-/// activation and the VoiceOver trait from AppKit.
-///
-/// 13b gave the menu the WHOLE chip, which cost the drag: a
-/// borderless menu consumes the mouse-down to open itself, so
-/// `.draggable` never saw a press to begin from.
-///
-/// **Four routes now:** drag the chip, right-click it, reach
-/// the same items as VoiceOver actions, or press the keyboard
-/// chord on the focused chip — the menu routes come as one
-/// through the `rowActions` seam, and `.focusable()` below is
-/// what gives the chord a target at all (#845).
-///
-/// A visible chevron carrying the `Menu` was tried twice and
-/// rejected as clutter (owner ruling 2026-08-04) — first beside
-/// the pill, then inside it — and the owner upheld that on
-/// 2026-08-11 against turn 20a's ask for a visible trigger in
-/// every draggable row. A whole-chip `Menu` is what took the drag
-/// in 13b (the borderless menu consuming the mouse-down
-/// `.draggable` needed to begin from). The keyboard chord (`⌃.`)
-/// satisfies the Tab-only path without chrome or eating the drag.
+/// Supports drag, context menu, VoiceOver actions, and keyboard menu chord
+/// via `.rowActions` (#678, #845).
+/// Explicit chips clear to automatic via corner badge.
 struct SpaceAssignmentChip: View {
     @ObservedObject var model: SettingsModel
     let space: SpaceID
     let kind: SpaceAssignment.Kind
-    /// The displays the "move to…" menu offers, in the picture's
-    /// own left-to-right order — passed in from the area's row
-    /// expansion rather than re-read here, so the menu and the
-    /// cards can never list different monitors.
+    /// Target displays for move actions in picture order.
     let displays: [Display]
 
-    /// A plain draggable chip with a context menu — no `Menu`
-    /// anywhere in it, which is the only way the drag works at
-    /// all (see the type's docstring).
     var body: some View {
         capsule
             .fixedSize()
@@ -81,30 +41,7 @@ struct SpaceAssignmentChip: View {
             )
             .accessibilityLabel(space.raw)
             .accessibilityValue(hint)
-            // The chip must be able to HOLD focus for the #845
-            // chord to have a target at all: it is an `HStack`,
-            // not a `Button`, so without this a Tab-only
-            // keyboard can never reach it (#845 review). The
-            // platform draws the focus ring; the drag and the
-            // right-click are untouched.
             .focusable()
-            // ONE builder, three channels, through the one seam
-            // (#678 Phase 4 pass 10, turn 20a rule 1: the drag
-            // is the shortcut, the menu is the mechanism; #845).
-            // Right-click keeps working — making the chip a
-            // `Menu` once dropped the `.contextMenu` it used to
-            // carry, silently retiring the gesture people
-            // already had (docs review, 2026-08-04) — and this
-            // menu is already built from a `displays` the area
-            // passes in precisely so the menu and the cards
-            // cannot disagree.
-            //
-            // The seam adds NO chrome, which is what lets it
-            // coexist with the 2026-08-04 ruling: a visible
-            // chevron was tried twice and rejected as clutter,
-            // and a whole-chip `Menu` is what took the drag.
-            // The hidden chord anchor draws nothing and
-            // consumes no mouse-down.
             .rowActions { menu }
     }
 
@@ -119,22 +56,7 @@ struct SpaceAssignmentChip: View {
             {
                 IconGlyphLabel(icon: spaceIcon)
                     .font(.system(size: 10))
-                    // The glyph outranks the name (#545).
-                    // `FlowLayout` measures this chip at its
-                    // ideal size and then re-proposes exactly
-                    // that, so any rounding shortfall is taken
-                    // from a flexible child — and at equal
-                    // priority that was the emoji, which cannot
-                    // shrink and so clipped. The name absorbs it
-                    // instead, which it already does by design
-                    // (it truncates into the row's tooltip).
-                    //
-                    // Priority, not `.fixedSize()`: an icon is
-                    // one character only by the GUI picker's
-                    // rule, never Lua's (`set_space_icon` takes
-                    // any string — the GUI curates, Lua is
-                    // open), and a fixed-size glyph would let a
-                    // long one push the whole chip wide.
+                    // Glyph outranks name on overflow (#545).
                     .layoutPriority(1)
             }
             Text(space.raw)
@@ -142,24 +64,11 @@ struct SpaceAssignmentChip: View {
                 .fontWeight(.medium)
                 .lineLimit(1)
                 .truncationMode(.tail)
-                // Provisional cap; the full name lives in the
-                // tooltip when elided. Re-evaluate with the
-                // 8-language add (#95) — localized names run
-                // longer.
                 .frame(maxWidth: 120, alignment: .leading)
         }
         .padding(.leading, 8)
-        // The clear badge rides the trailing-top corner, so a
-        // pinned chip's content earns extra trailing room — at
-        // the symmetric 8 the disc sat ON the space number
-        // (owner, 2026-08-09).
         .padding(.trailing, kind == .auto ? 8 : 14)
         .padding(.vertical, 3)
-        // Fill says EXPLICIT, outline says automatic — shape, not
-        // opacity. A dimmed chip spends this app's inert
-        // vocabulary (`GreyOut`) on something fully draggable,
-        // which reads as "you cannot move this" about the one
-        // chip most worth moving.
         .background(
             Capsule().fill(
                 .tint.opacity(kind == .auto ? 0 : 0.15)
@@ -176,19 +85,10 @@ struct SpaceAssignmentChip: View {
                 ? AnyShapeStyle(.secondary)
                 : AnyShapeStyle(.primary)
         )
-        // Always visible, never hover-revealed: a hover-inserted
-        // control changes the pill's size, which is the trap the
-        // overlay exists to close — hover may change only the
-        // badge's tint, never its presence or any metric.
         .overlay(alignment: .topTrailing) { clearBadge }
     }
 
-    /// The clear-pin control, riding the trailing-top corner and
-    /// slightly overlapping the border. In the accessibility
-    /// tree at full strength however quietly it draws: the
-    /// 16 × 16 hit target (the affordance is the target, not the
-    /// 9 pt glyph), the spoken label and keyboard reachability
-    /// all survive the move out of the flow (#758).
+    /// Clear-pin button overlay on trailing-top corner (#758).
     @ViewBuilder private var clearBadge: some View {
         if kind != .auto {
             Button {
@@ -196,16 +96,6 @@ struct SpaceAssignmentChip: View {
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.system(size: 9))
-                    // Grey disc, light x — the NSSearchField
-                    // cancel shape. The chip renders on three
-                    // surfaces (card plate, the tray's bare
-                    // well, the overflow popover), and a
-                    // card-coloured disc is invisible by
-                    // construction on the first and a punched
-                    // hole on the second; an ink2 disc reads on
-                    // all three, masks whatever stroke it
-                    // overlaps, and separates by lightness, not
-                    // hue (ui-designer, 2026-08-09).
                     .symbolRenderingMode(.palette)
                     .foregroundStyle(
                         SettingsTheme.card,
@@ -221,22 +111,11 @@ struct SpaceAssignmentChip: View {
                     "Back to automatic placement"
                 )
             )
-            // y −2, not −4: the 16 pt hit target's top edge
-            // stays inside `stackSpacing`'s gap, so a click on
-            // the tail of a truncated header name cannot land
-            // on "clear this pin" (ui-designer, 2026-08-09).
             .offset(x: 4, y: -2)
         }
     }
 
-    /// One glyph per kind, and the follows-main one is an ARROW
-    /// (#678 turn 13b): the tray it belongs to is dashed and sits
-    /// off the main display, and an arrow says "goes wherever
-    /// that is" where the old link glyph said only "attached to
-    /// something" — the tray's own header carries the same arrow,
-    /// so the concept has one glyph rather than three. Automatic
-    /// carries none: a chip placed by a default is the absence of
-    /// a decision, and the outline-only capsule says so.
+    /// Semantic micro-icon for assignment kind (#678).
     private var icon: String? {
         switch kind {
         case .pinned: return "pin.fill"
@@ -245,11 +124,6 @@ struct SpaceAssignmentChip: View {
         }
     }
 
-    /// The hints name the CLEAR BUTTON rather than drawing a "ⓧ"
-    /// in prose: the button renders `xmark.circle.fill`, so the
-    /// character was already an approximation of it, and a glyph
-    /// inside a translated sentence is one more thing a catalog
-    /// can lose.
     private var hint: String {
         switch kind {
         case .pinned:
@@ -287,9 +161,6 @@ struct SpaceAssignmentChip: View {
             model.config.spacePins[space] = nil
         }
         .disabled(kind == .main)
-        // Only the displays this space could MOVE to: the one it
-        // already sits on is not a move, and on a one-display Mac
-        // the whole list is the display it is already on.
         let elsewhere = displays.filter {
             $0.fingerprint != currentFingerprint
         }
@@ -311,9 +182,6 @@ struct SpaceAssignmentChip: View {
         }
     }
 
-    /// The fingerprint this chip is drawn on, when it is drawn on
-    /// one: a follows-main chip lives in the tray rather than on
-    /// a display, so every display is a move for it.
     private var currentFingerprint: String? {
         kind == .main ? nil : model.config.spacePins[space]
     }

--- a/Sources/KiwiDesk/Settings/Components/Profiles/PresetCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/PresetCard.swift
@@ -66,7 +66,13 @@ struct PresetCard: View {
         .settingsActionButton()
     }
 
-    /// Applies preset after confirmation (`ProfilesGates`, #171, #515).
+    /// Applies the preset after confirmation; it drops staged
+    /// edits like the profile actions (#515). Greyed, never
+    /// hidden (#171), WITH the reason — "why is Apply dead" has
+    /// two answers and the stored-profile one contradicts the
+    /// header (#518) — and both answers are `ProfilesGates`':
+    /// a predicate re-derived here could grey a row the census
+    /// says is live.
     @ViewBuilder private var applyButton: some View {
         let reason = gates.inertReason(
             for: .profiles(.presetsApply)

--- a/Sources/KiwiDesk/Settings/Components/Profiles/PresetCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/PresetCard.swift
@@ -1,85 +1,17 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// One preset, as a CARD rather than a settings row (#789).
-///
-/// Its own view rather than a `PresetsSection` method, because
-/// #859's second action pushed that file past the 350-line ceiling
-/// and a method split into a sibling extension would have cost
-/// five members their `private` — the shape 4b's architect review
-/// already flagged in `ProfilesSection` and asked the next split to
-/// undo rather than repeat. A widget also belongs in
-/// `Components/<area>/` by gui.md's file layout, which is where a
-/// `Sections/` extension would have left it in the wrong place.
-///
-/// Picture first, then the name, the summary, the space count, and
-/// the actions — the order a comparison set wants, because the
-/// picture is what the eye scans across and the prose is what it
-/// reads once it has stopped. The old shape (title first, picture
-/// third, Apply off to the right) read as a list of settings rows;
-/// presets are offers.
-///
-/// **The actions are SIBLINGS of the text block, never buttons
-/// inside a tappable card**: nesting one control in another is
-/// broken on macOS whatever the design intent, and keeping Apply an
-/// explicit per-card button is what lets it carry its own greyed
-/// reason and the zero-profile spotlight. The same rule is why
-/// #859's preview opens from a button beside it rather than by
-/// making the picture tappable — the picture is a figure, and a
-/// `.help` on a decorative image is hover-only.
-///
-/// They read look-then-apply, left to right, which is the order the
-/// card is for: Apply materializes a profile and discards unsaved
-/// edits behind a confirm, so the cheap reversible thing leads.
+/// Standard layout preset card (#789).
 struct PresetCard: View {
-    /// The card's own inset, on every edge.
     static let padding: CGFloat = 12
-    /// The gap between the two action buttons.
     static let buttonRowSpacing: CGFloat = 8
 
-    /// The narrowest width this card can actually be LAID OUT
-    /// at — which is what makes a declared grid `minimum:` a
-    /// floor rather than a wish (#862). `PresetsSection.columns`
-    /// is its one reader.
-    ///
-    /// It has to hold the action row, because since #859 that row
-    /// is two `.large` buttons rather than one, and the pair's
-    /// width is eleven catalogs' business rather than this
-    /// file's. The number is a LITERAL on purpose: deriving it
-    /// from a live text measurement would put an AppKit metric
-    /// read in a `body`, and — the sharper reason — it would make
-    /// the guard vacuous, since a test comparing a derived floor
-    /// against the derivation it came from asserts nothing — an
-    /// assertion that recomputes both sides from the same
-    /// constants cannot model anything those constants do not
-    /// already say (`rule-authoring.md` ▸ a number-pin must
-    /// derive the number).
-    ///
-    /// So the floor is declared here and `PresetGridFloorTests`
-    /// measures the SHIPPED catalogs against it, reading these
-    /// same three constants rather than restating them. Neither
-    /// side of that comparison is the test's own invention, which
-    /// is the whole point. The slack is deliberately small: this
-    /// says "the narrowest the card works at", and a catalog that
-    /// grows past it should red rather than quietly fit.
-    ///
-    /// The 200 pt it replaces predates the second button. #789
-    /// ruled 200 "honest" about the PICTURE staying an outline
-    /// plus glyph, which is a ruling about what the card draws
-    /// and not about what it can hold, so raising it reopens
-    /// nothing.
+    /// Declared minimum card layout width (`PresetGridFloorTests`, #862).
     static let minimumWidth: CGFloat = 280
 
     let layout: StandardLayout
-    /// The live screen list for an APPLIABLE card and nil for the
-    /// drawer — the card resolves its glyph against the same
-    /// hardware the apply path will.
     let sizes: [CGSize]?
     @ObservedObject var model: SettingsModel
-    /// How many screens are connected, for the gate. Passed in
-    /// rather than re-read: `PresetsSection` derives it once from
-    /// `liveSizes`, and a second read here could disagree with the
-    /// list the section drew.
     let connectedScreens: Int
     let onPreview: (PresetPreviewRequest) -> Void
 
@@ -120,27 +52,7 @@ struct PresetCard: View {
         }
     }
 
-    /// Open the preview sheet (#859).
-    ///
-    /// **Never gated, and that is the point.** Apply carries two
-    /// greyed reasons — the screen count does not match, or a
-    /// stored profile is being edited — and a user in either state
-    /// is exactly the one who most wants to see what a preset
-    /// contains. The sheet writes nothing, so it needs no gate and
-    /// no discard confirm, which makes this the one control on the
-    /// card that is always live.
-    ///
-    /// **Not called "Preview".** That word already names the detail
-    /// panel in this same window (`panel.show_preview`,
-    /// `panel.hide_preview`, `panel.move_preview`,
-    /// `panel.live_preview`), and `docs/localization-naming.md` ▸
-    /// Family C's first rule is that a word already naming another
-    /// KiwiDesk concept loses whatever its count — a label reusing
-    /// another feature's noun does not read as inconsistent, it
-    /// reads as true about the wrong thing. That rule binds the
-    /// ENGLISH author first (translation audit, 2026-08-16).
-    /// "Layouts" is what the sheet holds, in the Family C noun that
-    /// already owns the concept.
+    /// Opens layout preview sheet (#859).
     private var layoutsButton: some View {
         Button(L("presets.layouts", "Layouts")) {
             onPreview(
@@ -154,24 +66,11 @@ struct PresetCard: View {
         .settingsActionButton()
     }
 
-    /// Zero-profile spotlight (ui-designer 2026-07-19): ONE Apply
-    /// goes accent-prominent until the first profile exists — the
-    /// appliable count's Standard preset, so the spotlight stays a
-    /// single primary (review 2026-07-19: prominence on every
-    /// appliable preset put three accent buttons in one field, four
-    /// with the footer's).
+    /// Applies preset after confirmation (`ProfilesGates`, #171, #515).
     @ViewBuilder private var applyButton: some View {
-        // Greyed, never hidden (#171) — with the reason, because
-        // "why is Apply dead" has two different answers and the
-        // stored-profile one contradicts what the user just read
-        // in the header (#518). Both answers are the resolver's:
-        // a predicate re-derived here could grey a row the census
-        // says is live.
         let reason = gates.inertReason(
             for: .profiles(.presetsApply)
         )
-        // Apply materializes a profile and reloads, so it
-        // drops staged edits like the profile actions (#515).
         let button = Button(L("presets.apply", "Apply")) {
             model.discardingEdits(
                 message: L(

--- a/Sources/KiwiDesk/Settings/Components/Profiles/PresetPreviewSheet.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/PresetPreviewSheet.swift
@@ -1,21 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// One request to open the preview sheet.
-///
-/// Presented through `.sheet(item:)` rather than `isPresented:`,
-/// for the reason `NameEditRequest` already records (#843): the
-/// builder is handed this value, so the content can never be built
-/// from parent state written in the same tick, and a fresh `id`
-/// gives each presentation its own `@State`. It matters more here
-/// than for a popover — the cards live in a `LazyVGrid`, which
-/// tears down the rows it scrolls past, so a presentation bound to
-/// a card's own state has a lifetime the card does not control.
-///
-/// It carries `liveSizes` so the sheet resolves its modes against
-/// the same hardware the card's glyph did. A sheet that read the
-/// live displays for itself would be the second derivation
-/// `PresetPreviewPlan` exists to prevent.
+/// One request to open the preview sheet via `.sheet(item:)` (#843).
 struct PresetPreviewRequest: Identifiable {
     let id: UUID
     let layout: StandardLayout
@@ -28,41 +14,14 @@ struct PresetPreviewRequest: Identifiable {
     }
 }
 
-/// The preset preview sheet (#859): the layouts a preset actually
-/// opens, drawn by the real `LayoutSchematic` family at a size
-/// where they read.
+/// The preset preview sheet (#859).
 ///
-/// **Why a sheet and not the detail panel.** The panel's object is
-/// the DRAFT and this picture is of a catalog entry, and the panel
-/// column is dropped by width — sound for a preview redundant with
-/// the controls beside it, unsound for a fact stated nowhere else.
-/// `.profiles` is deliberately absent from
-/// `SettingsDetailPanelOffer.offering` and `DetailPanelTests` pins
-/// the refusal with all three grounds; the ruling is argued in
-/// `docs/design-decisions.md`.
-///
-/// **Drawn from the preset's own `TilingSettings`, never the
-/// draft.** That one line is what keeps Profiles a CATALOG surface
-/// rather than a draft-preview one, and drawing it from
-/// `model.config.settings` would flip the panel refusal above
-/// without anything noticing. `PresetPreviewSheetTests` ▸ the sheet
-/// draws the preset's own settings is what notices.
-///
-/// **`.tile` at its own size, never a third `SchematicScale`.** A
-/// factor over `.tile` is the settled expression for a smaller
-/// mount (`HomeCardSchematicBand` at 70/84, the tour at 46/84);
-/// this sheet is the case that needs no factor at all, which is
-/// precisely #859's argument — a card at `PresetCard.minimumWidth`
-/// cannot hold a legible schematic and a sheet can. (That floor
-/// was 200 when #859 argued it and is not a number this comment
-/// carries a second copy of; #862 moved it.) Captions stay
-/// suppressed at `.tile`
-/// by #753's ruling, so the mode's name is the tile's own label.
+/// Draws preset layouts using `LayoutSchematic` at `.tile` scale (#753, #862).
+/// Rendered from preset's own settings, verified by `PresetPreviewSheetTests`
+/// and `DetailPanelTests`.
 struct PresetPreviewSheet: View {
     let layout: StandardLayout
-    /// The live screens, or nil where the sheet opened from the
-    /// "For other setups" drawer — threaded through to the plan
-    /// unchanged, never re-derived here.
+    /// Live screen sizes, or nil when opened from other setups drawer.
     let liveSizes: [CGSize]?
     let onDone: () -> Void
 
@@ -78,24 +37,6 @@ struct PresetPreviewSheet: View {
             Divider()
             footer
         }
-        // The sheet states its own size, and states it as
-        // arithmetic over the grid it holds.
-        //
-        // **Width is FIXED at four columns.** Not a range: the
-        // grid exists to be compared across presets, and a column
-        // count that follows the window would redraw the same
-        // preset differently on two desks. Four is the most the
-        // narrowest window can host (see `columns`), and it makes
-        // every shipped preset's screen group exactly one row.
-        //
-        // **Height grows, bounded** — see the three constants,
-        // which carry what each bound is for and which of them is a
-        // relation to the shell rather than a choice.
-        //
-        // It reads no window size to do any of this. A percentage
-        // of the window would be a second measurement site — the
-        // drift `SettingsWidthClass` exists to end — and a bounded
-        // ideal gets the same picture without one.
         .frame(
             minWidth: Self.width(forColumns: Self.columns),
             maxWidth: Self.width(forColumns: Self.columns),
@@ -104,28 +45,7 @@ struct PresetPreviewSheet: View {
             maxHeight: Self.maxHeight
         )
         .background(SettingsTheme.card)
-        // Escape, focus-independently.
-        //
-        // This was `.onExitCommand`, which fires only while the
-        // view has FOCUS — and this sheet holds no text field, so
-        // on a Mac with Keyboard navigation off there may be
-        // nothing in it holding any. That is the exact shape
-        // gui.md's keyboard section records: correct, always
-        // drawn, needled, and reachable by nobody on a default Mac
-        // (re-review, 2026-08-17). A hidden button carrying
-        // `.cancelAction` is the platform's own route and needs no
-        // focus. `Button` carries one shortcut, which rules out a
-        // second modifier on the SAME button, not a second button.
-        //
-        // **Eye-confirmed, and this is the half no test reaches**:
-        // Escape closes the sheet with System Settings ▸ Keyboard ▸
-        // Keyboard navigation both ON and OFF (owner, macOS 26.6.1,
-        // 2026-08-17). Recorded as an observation with its date
-        // because that is all it can be — `SheetPresentationSeamTests`
-        // proves the modifier is present and gui.md's keyboard
-        // section is explicit that a green needle says only that
-        // much. A future sheet reaching for `.onExitCommand` should
-        // read this rather than re-derive it.
+        // Focus-independent Escape handler (`SheetPresentationSeamTests`).
         .background(escapeRoute)
     }
 
@@ -198,23 +118,7 @@ struct PresetPreviewSheet: View {
         }
     }
 
-    /// `Self.columns` STATED, never adapted.
-    ///
-    /// It was `.adaptive(minimum: tileWidth)`, which seated four
-    /// columns with exactly **0 pt** of slack: the content width is
-    /// `588 - 2*pad = 564` and four tiles plus three gutters is
-    /// 564. So any content inset at all — a legacy scroller once
-    /// the `ScrollView` overflows, a `pad` change — silently
-    /// re-wrapped to three columns, which is the "one preset drawn
-    /// differently on two desks" the width comment forbids, arriving
-    /// by the route the comment did not consider (architect + code
-    /// review, 2026-08-17). `.fixed` cannot re-wrap, and it is the
-    /// same reasoning `PresetsSection` records for taking
-    /// `.flexible` over `.adaptive`: `.adaptive` cannot express "at
-    /// most N".
-    ///
-    /// `.top` rather than `.topLeading`: the cells centre their
-    /// pictures, for the reason `tile(_:)` states.
+    /// Fixed columns (`Self.columns`) preventing re-wrap across window widths.
     private var tileColumns: [GridItem] {
         Array(
             repeating: GridItem(
@@ -226,28 +130,8 @@ struct PresetPreviewSheet: View {
         )
     }
 
-    /// One space: its schematic, then the layout's name under it —
-    /// the pairing `LayoutStrip` already draws, so a mode named
-    /// beside a schematic reads the same in both places.
-    ///
-    /// **CENTRED, and that is not a preference.** `SchematicCanvas`
-    /// ends in `.frame(maxWidth: .infinity)` with no alignment
-    /// because a schematic is a standalone illustration — its own
-    /// docstring rules that, against the left-aligned treatment a
-    /// preview beside its controls gets. So the canvas centres the
-    /// mini-screen inside whatever cell it is given, and a
-    /// leading-aligned label under it lands at the CELL's edge
-    /// rather than the picture's: the glyph hung ~14 pt left of
-    /// the frame it was labelling (owner eye-confirm, 2026-08-17).
-    /// Centring the stack is what `LayoutStrip` does with the same
-    /// pair, and it is the only arrangement that survives the
-    /// canvas being greedy.
-    ///
-    /// Nothing here overrides accessibility. `SchematicCanvas`
-    /// gives the drawing its own label, and naming this stack
-    /// would REPLACE that label with a bare mode name — the
-    /// failure `AppRulesCensusRenderTests` records for menus, in a
-    /// different costume.
+    /// One space: centered schematic canvas and layout mode name
+    /// (`AppRulesCensusRenderTests`).
     private func tile(
         _ slot: PresetPreviewPlan.Slot
     ) -> some View {
@@ -268,16 +152,7 @@ struct PresetPreviewSheet: View {
         }
     }
 
-    /// One dismissal, reachable three ways.
-    ///
-    /// A read-only sheet has no second answer, so Return and Escape
-    /// must both mean the same thing as the button. `.defaultAction`
-    /// alone left Escape dead (architect review, 2026-08-17), and a
-    /// modal surface a keyboard user cannot back out of is the
-    /// "usable without a mouse" claim failing in its plainest form.
-    /// `.onExitCommand` rather than a second `.keyboardShortcut`,
-    /// because a `Button` may carry only one and Return is the one
-    /// worth having on the button itself.
+    /// Dismissal footer with default action button.
     private var footer: some View {
         HStack {
             Spacer()
@@ -294,10 +169,7 @@ struct PresetPreviewSheet: View {
         L("presets.layouts.done", "Done")
     }
 
-    /// Escape's carrier: zero-sized, unfocusable, invisible to
-    /// VoiceOver. It exists for the shortcut alone — the visible
-    /// dismissal is `footer`'s button, and announcing a second one
-    /// would give the sheet two Done buttons to a screen reader.
+    /// Invisible Escape key route carrying `.cancelAction`.
     private var escapeRoute: some View {
         Button(doneLabel, action: onDone)
             .keyboardShortcut(.cancelAction)

--- a/Sources/KiwiDesk/Settings/Components/Profiles/PresetScreenCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/PresetScreenCard.swift
@@ -1,122 +1,31 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// A preset's thumbnail (#678 turn 13a): **one outline per
-/// screen**, not one tile per space.
+/// Preset thumbnail drawing one outline per screen (#678).
 ///
-/// The old thumbnail drew a tile per space, which reads at four
-/// and turns into a row of identical stamps at ten — and a
-/// three-screen preset's whole point is *which screen gets what*,
-/// which a flat run of tiles cannot say at any count. Screens are
-/// the thing that stays legible from one screen to three, so the
-/// picture draws screens and the count of spaces goes underneath
-/// as text.
-///
-/// Each outline carries the glyph of its screen's FIRST space —
-/// the layout that screen opens on. That is a deliberate part of
-/// the preset's plan rather than a sample: `spaceScreens` orders
-/// the spaces per screen, and the first one is what a user lands
-/// in when the preset applies.
-///
-/// **The count stays UNDER the picture, and the picture stays above
-/// the text** (owner, 2026-08-17, on the shipped German cards). Two
-/// alternatives were looked at and both lose:
-///
-/// - *The whole block left of the text.* Ruled out by the widest
-///   case rather than by taste — the picture is one outline per
-///   screen, 48 pt each, so it runs 48 pt at one screen to 204 pt at
-///   the four-slot cap, inside a ~276 pt card interior. Three
-///   screens already needs 152 pt, leaving ~120 pt for a title like
-///   "Visual Creative & Developer" to wrap to three lines beside a
-///   picture one line tall — so the card would be a different shape
-///   per preset, in a grid whose whole job is comparing presets.
-///   (`ProfileScreenPips` DOES sit left of its text, and that is why
-///   one grammar takes two axes: a full-width list row has the room
-///   a card does not.)
-/// - *The count beside the picture, filling the one-screen case's
-///   empty row.* Tried and refused on sight — the owner's read, and
-///   the reason to record it is that the empty row is real and the
-///   obvious fix for it is this one.
-///
-/// So the one-screen card carries some air to the right of its
-/// outline, deliberately, as the price of every card being the same
-/// shape.
+/// Displays opening layout glyph per screen, with space count underneath.
 struct PresetScreenCard: View {
     let layout: StandardLayout
-    /// The live screens, when this card is one the user can
-    /// actually apply — `nil` in the "For other setups" drawer,
-    /// where the plan is drawn for a screen COUNT and there is no
-    /// hardware to resolve it against.
-    ///
-    /// Without this the card drew the historic `bsp` for an
-    /// unlisted first space while `ProfileComposition.compose`
-    /// answered the same space from the display it lands on, so
-    /// the three appliable multi-screen presets named a layout
-    /// Apply never produces (code review, 2026-08-11).
+    /// Live screen sizes, or nil when in "For other setups" drawer.
     var liveSizes: [CGSize]?
 
-    /// #789 grew these from 34×22. The consult that ruled on it
-    /// REFUSED drawing a `LayoutSchematicView` in here instead:
-    /// the card draws one mode per screen — the first space's
-    /// opening mode — which is exactly what the glyph already
-    /// encodes, so a schematic would be ~9× the pixels for no
-    /// extra discrimination between catalog entries, at a scale
-    /// (≈0.43 of `.tile`, half the shipped floor
-    /// `HomeCardSchematicBand` uses) where the family's 1 pt and
-    /// 2 pt strokes stop rendering. The pixels the bigger card
-    /// buys go to the glyph instead.
+    /// Screen outline size and layout metrics (#789).
     private static let outline = CGSize(width: 48, height: 30)
-    /// Grown with the outline, so the glyph keeps its share of
-    /// the frame rather than shrinking inside a larger one.
     private static let glyphSize: CGFloat = 14
     private static let gap: CGFloat = 4
 
-    /// How many slots the row draws before the "+N" chip takes
-    /// one — the SAME cap the small mount uses, because the two
-    /// draw one grammar at two sizes and a cap that differed would
-    /// make a five-screen profile hide a different number of
-    /// screens in the list than on its card.
+    /// Maximum slots drawn before "+N" chip (`ProfileScreenPips.slots`).
     private static var slots: Int { ProfileScreenPips.slots }
 
-    /// The pips' chip size scaled by the step the glyph takes
-    /// between the mounts, so the chip keeps its share of the
-    /// outline exactly as `glyphSize` does.
     private static var moreSize: CGFloat {
         ProfileScreenPips.moreSize
             * (glyphSize / ProfileScreenPips.glyph)
     }
 
-    /// Clamped at zero for readability, not for safety.
-    ///
-    /// A hand-edited layout claiming a negative screen count must
-    /// not trap, and this is NOT what prevents that: deleting this
-    /// clamp leaves `PresetScreenCardOverflowTests` fully green,
-    /// because `OverflowSplit.shown`'s own `max(count, 0)` and
-    /// `hidden`'s clamp already cover it (guard-prover,
-    /// 2026-08-17). The load-bearing twin is
-    /// `PresetPreviewPlan`'s, which reads identically and whose
-    /// removal traps the runner on `0..<(-3)`. The two look alike
-    /// and are not alike; said here so the next reader does not
-    /// reason from this one as if it were the net.
     private var screenCount: Int { max(layout.screenCount, 0) }
 
-    /// Outlines drawn, and screens hidden behind the chip.
-    ///
-    /// **The row was uncapped until #859**, while the small mount
-    /// has always capped: `screenCount` fed the `ForEach`
-    /// directly, so a `Starter` derived from five connected
-    /// displays drew five 48 pt outlines — 256 pt of them — inside
-    /// a card whose grid minimum is 200. Only `Starter` can reach
-    /// it (the seven declared presets are capped by hand at three
-    /// screens) but `StarterAllocation`'s own docstring is explicit
-    /// that eleven displays gets eleven spaces, so the ceiling is
-    /// the desk's, not the catalog's.
-    ///
-    /// Internal rather than private, and asserted directly: a view
-    /// that takes a count and draws a constant satisfies every
-    /// substring a source scan can look for while answering
-    /// nothing (`LayoutSchematicCountTests`' lesson, which
-    /// `ProfileScreenPips` took first).
+    /// Screen outlines drawn before overflow
+    /// (`LayoutSchematicCountTests`, #859).
     var shown: Int {
         OverflowSplit.shown(
             of: screenCount,
@@ -143,13 +52,7 @@ struct PresetScreenCard: View {
         }
     }
 
-    /// Counts the screens NOT drawn, never the total — and stays
-    /// silent to VoiceOver, because the screen count is already
-    /// stated in words directly above every card that draws one
-    /// (`presets.for_your.*` for the live group,
-    /// `profiles.screens.*` per group in the drawer). Announcing
-    /// "+2" beside those would read one fact twice, and "+2" alone
-    /// says nothing a reader could act on.
+    /// Chip displaying count of hidden overflow screens.
     private var moreChip: some View {
         Text(verbatim: "+\(hidden)")
             .font(.system(size: Self.moreSize, weight: .semibold))
@@ -162,11 +65,6 @@ struct PresetScreenCard: View {
             .accessibilityHidden(true)
     }
 
-    /// One noun, one pair of keys: the profile row counts spaces
-    /// with `profiles.spaces.*` and so does this card. A second
-    /// pair with byte-identical English doubles the translation
-    /// work and lets the two drift per locale with nothing to
-    /// catch it.
     private var spaceCountText: String {
         spaceCountPhrase(layout.spaceCount)
     }
@@ -177,9 +75,7 @@ struct PresetScreenCard: View {
             : L("profiles.spaces.many", "%1$d Spaces", count)
     }
 
-    /// An empty screen draws its outline with NO glyph: a layout
-    /// mode drawn on a screen the preset plans nothing for is a
-    /// claim about behavior that applying it would not produce.
+    /// Screen outline view with layout mode glyph and accessibility label.
     private func outlineView(_ screen: Int) -> some View {
         RoundedRectangle(cornerRadius: 4)
             .fill(SettingsTheme.accent.opacity(0.12))
@@ -201,35 +97,11 @@ struct PresetScreenCard: View {
                 height: Self.outline.height
             )
             .help(screenHelp(screen))
-            // `.help` alone does NOT discharge `screenHelp`'s
-            // promise to the reader who cannot see the row: a
-            // `Shape` is not an accessibility element, so the
-            // hint has nothing to attach to and the sentence is
-            // hover-only. Making the outline an element gives
-            // VoiceOver the same sentence the pointer gets —
-            // which is the whole reason the main display is
-            // named in words rather than by position.
             .accessibilityElement()
             .accessibilityLabel(screenHelp(screen))
     }
 
-    /// **The card and the sheet read ONE derivation.**
-    ///
-    /// This card had its own `spaces(on:)`, `openingMode(_:)` and
-    /// `shape(of:)` against the plan's until #859's review round.
-    /// Both reviewers found the pair independently: the copies were
-    /// held together only by an agreement test that recomputed the
-    /// shape itself and could not see the card's `private` half, so
-    /// a drift in the card's bound or its index passed green. The
-    /// plan keeps EMPTY groups precisely so it can serve this card
-    /// too — the card draws an outline per screen whether or not
-    /// that screen has spaces, and a derivation that filtered could
-    /// not answer it.
-    ///
-    /// Screen 0 is the main display, 1 the next secondary, … — and
-    /// both the plan and its sparse fallbacks are the LAYOUT's to
-    /// answer (`StandardLayout+Screens`), the same accessors
-    /// `ProfileComposition.compose` builds a real profile from.
+    /// Shared preview plan derivation (`PresetPreviewPlan`, #859).
     private var plan: PresetPreviewPlan {
         PresetPreviewPlan(layout: layout, liveSizes: liveSizes)
     }
@@ -242,10 +114,7 @@ struct PresetScreenCard: View {
         plan.group(screen: screen)?.openingMode
     }
 
-    /// Named for the reader who cannot see the glyph — the count
-    /// of spaces on that screen and the layout it opens in. A
-    /// screen the preset plans nothing for says so instead of
-    /// naming a mode it does not have.
+    /// Help tooltip and accessibility description for a screen outline.
     private func screenHelp(_ screen: Int) -> String {
         guard let mode = openingMode(screen) else {
             return L(
@@ -254,9 +123,6 @@ struct PresetScreenCard: View {
                 presetScreenName(screen)
             )
         }
-        // The count phrase, not a `space(s)` parenthetical: the
-        // pair already exists for this noun and `spaceCountPhrase`
-        // above is this file's own use of it.
         return L(
             "presets.screen_help",
             "%1$@: %2$@, opens in %3$@",

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesPanelPreview.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesPanelPreview.swift
@@ -1,67 +1,21 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Spaces & Layouts' detail panel (#794): click through the
-/// draft's Spaces and see each one's layout as that Space
-/// actually resolves it.
+/// Detail panel previewing resolved layout for spaces (#794).
 ///
-/// The area lists every Space with its layout picker, and until
-/// now seeing what a Space's layout *looks like* — with its own
-/// overrides applied — meant leaving for Layout Defaults, whose
-/// preview draws the defaults rather than this Space. The
-/// overrides are exactly what the reader came to check, so that
-/// journey answered the wrong question.
-///
-/// The schematic is fed `TilingSettings.resolved(for:activeMode:)`
-/// — the engine's own per-space resolver, the one a real retile
-/// asks — rather than a resolution rule re-derived beside the
-/// drawing (gui.md, #702). `SpaceOverridePreview` already worked
-/// this way inside the per-space editor and said in its own
-/// docstring that it was awaiting this rework; the panel is that
-/// rework, and the difference is that this one is reachable
-/// without opening a Space's editor at all.
+/// Draws schematic via `TilingSettings.resolved(for:activeMode:)` (#702).
 struct SpacesPanelPreview: View {
     @ObservedObject var model: SettingsModel
-    /// Which Space the panel is drawing. Panel state, not the
-    /// draft: choosing what to LOOK at is a question asked of the
-    /// preview, exactly like the window count below.
     @State private var selected: SpaceID?
     @State private var windows = LayoutSchematic.defaultWindowCount
 
     private var spaces: [SpaceID] { model.config.spaces }
 
-    /// The drawn Space, in precedence order: the one whose
-    /// override editor is OPEN, then the chip the reader picked,
-    /// then the first.
-    ///
-    /// The editor wins because it is the stronger statement of
-    /// intent — someone editing Space 3's overrides is asking
-    /// about Space 3, and a panel showing Space 1 beside those
-    /// rows would be answering a question nobody asked. It is
-    /// also what lets the editor give up its own copy of this
-    /// preview (#794): one screen must not state one fact twice,
-    /// and the panel can only take that over if it follows the
-    /// row being edited.
-    ///
-    /// Every arm re-checks membership, so deleting a Space in the
-    /// draft can never leave the panel drawing one that is gone.
-    /// Internal alias of `space` for the guards — a panel that
-    /// draws the wrong Space is invisible to every arithmetic
-    /// assertion here.
+    /// Currently displayed space adhering to editor focus precedence.
     var shownSpace: SpaceID? { space }
 
-    /// What a chip click does, as a function a test can call:
-    /// the `Button` closure itself is unreachable from a suite,
-    /// and the branch inside it is a behaviour change that owes
-    /// a revert-red test (`tests.md`).
+    /// Selects a space, routing through open override editor if present.
     func pick(_ candidate: SpaceID) {
-        // While the override editor is open it OWNS which Space
-        // is shown (`space` gives it precedence), so a chip that
-        // only set `selected` moved nothing and gave no feedback
-        // — a fully live control that does nothing (review
-        // round, 2026-08-16). Driving the editor instead of
-        // dimming the chip: the panel and the editor show ONE
-        // Space, and either may say which.
         if model.nav.spaceOverridesFocus != nil {
             model.nav.spaceOverridesFocus = candidate
         }
@@ -87,17 +41,6 @@ struct SpacesPanelPreview: View {
             if let space {
                 chips
                 scene(for: space)
-                // A Floating Space draws no schematic, so the
-                // caption and the count slider have nothing to
-                // describe or to drive. The chip stays LIVE —
-                // clicking a Floating Space to find out whether
-                // it overrides anything is a real question and
-                // the sentence is its answer — but a slider that
-                // moves nothing is a control with no effect,
-                // which is what "grey, don't hide" is about, and
-                // a caption reading "Floating — follows Layout
-                // Defaults" names settings Floating does not
-                // have (owner, on device, 2026-08-16).
                 if drawsSchematic(for: space) {
                     caption(for: space)
                     countRow
@@ -117,11 +60,6 @@ struct SpacesPanelPreview: View {
 
     // MARK: - The chip row
 
-    /// One chip per Space in the draft. Buttons, not decorated
-    /// `Text`: this is the panel's only control besides the
-    /// slider, so it earns a name, keyboard activation and a
-    /// spoken selected state — a styled label would announce
-    /// nothing and be unreachable without a pointer.
     private var chips: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 6) {
@@ -160,11 +98,6 @@ struct SpacesPanelPreview: View {
                 .foregroundStyle(SettingsTheme.ink)
         }
         .buttonStyle(.plain)
-        // The chip's own text is its name; the selected state is
-        // a TRAIT rather than a second spoken sentence, so the
-        // rotor reads "Space 2, selected" and not a duplicated
-        // label (`gui.md` ▸ naming a control replaces what it
-        // announced).
         .accessibilityAddTraits(
             isOn ? [.isButton, .isSelected] : .isButton
         )
@@ -172,15 +105,7 @@ struct SpacesPanelPreview: View {
 
     // MARK: - The scene
 
-    /// Whether this Space's layout has a schematic at all —
-    /// the one predicate the scene, the caption and the count
-    /// row all read, so they cannot disagree about whether
-    /// there is a picture to describe.
-    ///
-    /// Internal so `SpacesPanelSelectionTests` can read it: what
-    /// a panel WITHHOLDS is a surfacing branch, and a branch
-    /// that stops being written leaves every other assertion
-    /// green (`gui.md`).
+    /// Whether layout renders a schematic (`SpacesPanelSelectionTests`).
     func drawsSchematic(for space: SpaceID) -> Bool {
         LayoutMode.placementTabs.contains(mode(of: space))
     }
@@ -199,17 +124,6 @@ struct SpacesPanelPreview: View {
                 scale: .panel
             )
         } else {
-            // Floating has no schematic anywhere in the tree, and
-            // an empty plate would read as a drawing that failed
-            // rather than as a layout that places nothing.
-            //
-            // The EDITOR's own sentence, not a second one: the
-            // per-space rows already answer this case with
-            // `space_override.floating.none`, and one concept
-            // gets one wording per catalog. A panel inventing
-            // its own phrasing for the same fact is two strings
-            // to keep in step across ten locales (owner, on
-            // device, 2026-08-16).
             Text(
                 L(
                     "space_override.floating.none",
@@ -223,21 +137,7 @@ struct SpacesPanelPreview: View {
 
     // MARK: - The caption
 
-    /// Names the layout, and whether this Space departs from it.
-    ///
-    /// The count goes LAST behind a label, so no locale has to
-    /// agree with a number mid-sentence (`localization.md` ▸ a
-    /// frame interpolating a COUNT) — which is also why the
-    /// two arms are separate keys rather than one frame with an
-    /// argument that may render empty.
-    ///
-    /// The default arm INTERPOLATES the pane it names (#818)
-    /// rather than spelling "the layout defaults" as text. It
-    /// read as descriptive lower-case prose, but every locale
-    /// then hand-mirrors that pane's name with nothing checking
-    /// it — and the drafting round did exactly that, reaching
-    /// for the very string `destination.layout` ships
-    /// (localization audit, 2026-08-16).
+    /// Caption describing override status (#818).
     private func caption(for space: SpaceID) -> some View {
         let mode = mode(of: space)
         let n = overrideCount(for: space)
@@ -261,28 +161,7 @@ struct SpacesPanelPreview: View {
         .foregroundStyle(SettingsTheme.ink3)
     }
 
-    /// How many of the active layout's settings this Space
-    /// overrides — **the header's own number**.
-    ///
-    /// `TilingSettings.overrideFieldCount(_:for:)` is what the
-    /// editor's "N of M set" already renders, so the caption and
-    /// the header cannot disagree. They did: this shipped its
-    /// first cut counting leaves that DIFFER (a JSON diff of the
-    /// resolved settings against the globals) while the header
-    /// counts fields SET — and `overrideToggle` seeds a newly
-    /// ticked override with the global value, so the first click
-    /// on any Override checkbox made the header say "1 of 6 set"
-    /// beside a caption reading "follows the layout defaults"
-    /// (code review, 2026-08-16).
-    ///
-    /// That cut also carried a trap worth recording, since the
-    /// replacement is what removes it: it addressed the encoded
-    /// settings by `"layout.\(mode.rawValue)"`, and scrolling
-    /// encodes as `scroll` — so a Scrolling Space resolved no
-    /// subtree and reported a confident zero. Asking the type
-    /// that owns the overrides needs no wire path at all.
-    ///
-    /// Internal so `SpacesPanelPreviewTests` reads the number.
+    /// Count of active layout overrides on space (`SpacesPanelPreviewTests`).
     func overrideCount(for space: SpaceID) -> Int {
         let mode = mode(of: space)
         guard mode != .floating else { return 0 }
@@ -299,10 +178,7 @@ struct SpacesPanelPreview: View {
         return Double(band.lowerBound)...Double(band.upperBound)
     }
 
-    /// A preview control, not a setting — it never enters the
-    /// draft. Said in the label rather than left to be inferred:
-    /// a slider in a panel that changes nothing is otherwise
-    /// indistinguishable from one that does.
+    /// Preview window count slider.
     private var countRow: some View {
         HStack(spacing: 8) {
             Text(

--- a/Sources/KiwiDesk/Settings/HeaderSearch.swift
+++ b/Sources/KiwiDesk/Settings/HeaderSearch.swift
@@ -9,9 +9,19 @@ struct HeaderSearch: View {
     /// Whether collapsed entry is expanded.
     @Binding var expanded: Bool
     let context: SettingsSearchContext
+    /// Profiles spotlight badge state — passed through so which
+    /// list renders the tile does not change it.
     let spotlightProfiles: Bool
+    /// A census key's current value, from the draft in memory —
+    /// evaluated per rendered row, after the list paints.
     let value: (SettingKey) -> String?
+    /// Hands a pick up to the shell, which owns the destination
+    /// and the scroll choreography.
     let reveal: (SettingsAnchor) -> Void
+    /// Arms the shell's confirmation for a pick predicting a
+    /// mode flip; the reveal pipeline announces it only if the
+    /// promotion happens (`SettingsView.apply`), so a refused
+    /// reveal stays silent. Search's only mention of the mode.
     let armModeNotice: (SettingsDestination) -> Void
 
     @State var query = ""

--- a/Sources/KiwiDesk/Settings/HeaderSearch.swift
+++ b/Sources/KiwiDesk/Settings/HeaderSearch.swift
@@ -1,96 +1,27 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The header's search entry (#678 turn 9, rebuilt turn 16b;
-/// per-setting results turn 11): the REAL field, inline in the
-/// header, with its results hanging below it.
+/// Header search entry with inline results overlay (#678).
 ///
-/// It shipped as a field-shaped *button* that opened a popover
-/// holding the actual field — which was defensible while the
-/// button was a small pill, and became a lie the moment the skin
-/// made it look like the prototype's full-width field: clicking a
-/// search field opened a second search field, and the one you
-/// clicked could not be typed into (owner, 2026-08-04).
-///
-/// **The results are an overlay, not a popover, and that is
-/// forced.** A popover takes the key window, so the header field
-/// would lose focus on the first keystroke that produced a
-/// result — the very reason the field originally lived *inside*
-/// the popover. An overlay keeps focus where the user put it. The
-/// cost is paint order: an overlay hanging past its parent's
-/// bounds is drawn over by the next sibling in the shell's
-/// `VStack`, so `SettingsView.chrome` lifts the header's
-/// `zIndex`. Removing that lift hides the result list behind the
-/// content.
-///
-/// ⌘K focuses it from anywhere in the window; Escape clears
-/// (matching `NSSearchField`, via the field's own
-/// `onExitCommand`), which is also what closes the list.
-///
-/// It is the header row's ONE flexible element: it takes every
-/// point the chips beside it do not, which is what puts it in the
-/// middle of the bar. The alternative — a fixed pill and a
-/// `Spacer` — pushed the chips to the far edge and left a hole in
-/// the middle of the header (owner, 2026-08-04).
-///
-/// **Below the chrome breakpoint the field collapses to its own
-/// glyph** (#678 turn 17a) — the LAST thing the shell gives up,
-/// after the preview's column and the row axis, and the only one
-/// that touches the header at all. It gives up nothing: the icon
-/// opens the same field in the same slot, ⌘K still lands in it
-/// from anywhere, and the area title yields for as long as it is
-/// open. The alternative at 720 pt was the field's 110 pt floor
-/// against a back chip, a profile chip and the mode segment,
-/// which leaves the title nothing and clips whatever AppKit
-/// reaches last — a CONTROL, which 17a's order forbids.
+/// Collapses to glyph at narrow window widths (`SettingsWidthClass`).
+/// Focusable via ⌘K.
 struct HeaderSearch: View {
-    /// Whether the collapsed entry has been opened. Owned by the
-    /// header bar, which is the view that has to yield the area
-    /// title while the field is up — two views, one fact, so it
-    /// cannot be `@State` here.
+    /// Whether collapsed entry is expanded.
     @Binding var expanded: Bool
-    /// Everything the result builder may read, collected by the
-    /// header bar from state already in memory (the search path
-    /// touches nothing else).
     let context: SettingsSearchContext
-    /// The Profiles spotlight badge state, passed through to
-    /// result rows so which list renders the tile does not
-    /// change it.
     let spotlightProfiles: Bool
-    /// Enrichment: the current value for a census key, from the
-    /// draft in memory — evaluated per rendered row, after the
-    /// list paints.
     let value: (SettingKey) -> String?
-    /// Hands a picked result up to the shell, which owns the
-    /// destination and the scroll choreography.
     let reveal: (SettingsAnchor) -> Void
-    /// Arms the shell's one-line confirmation before a pick
-    /// whose result predicts a mode flip — the reveal pipeline
-    /// announces it only if the promotion actually happens
-    /// (`SettingsView.apply`), so a refused reveal stays
-    /// silent. Search's only mention of the mode.
     let armModeNotice: (SettingsDestination) -> Void
 
     @State var query = ""
-    /// The ↑/↓ highlight, by result id — a result set is
-    /// per-setting now, so a destination no longer identifies a
-    /// row.
     @State var highlighted: String?
     @FocusState var focused: Bool
-    /// Keeps the panel alive while the pointer is INSIDE it:
-    /// a row click lands outside the field's text editor, so
-    /// `ClickAwayResignsFocus` resigns focus on the mouse-down
-    /// — keyed on focus alone the row would vanish before its
-    /// own mouse-up. A click anywhere else finds the pointer
-    /// outside the panel and dismisses (owner, 2026-08-10:
-    /// click-away left the list standing).
     @State var panelHovered = false
     @Environment(\.settingsWidth) private var width
 
     var searching: Bool { !query.trimmed.isEmpty }
 
-    /// The glyph stands in for the field only while the chrome
-    /// is collapsed AND nobody has opened it.
     private var collapsed: Bool {
         width.collapsesChrome && !expanded
     }
@@ -111,40 +42,16 @@ struct HeaderSearch: View {
             onCommit: commitHighlighted,
             shortcutHint: true
         )
-        // The flexible slot. A floor as well as a ceiling: at the
-        // 720 pt hard minimum the chips and the segment must not
-        // squeeze the field down to its glyph.
-        //
-        // 110, not the 140 first tried: measured across the row
-        // (back chip, profile chip, mode segment, plus the
-        // 84 pt traffic-light inset — and, when it was
-        // measured, the since-retired unsaved chip, so the
-        // floor now runs with extra slack) 140 left the row
-        // ~120 pt over the hard minimum, and a row that cannot
-        // fit does not truncate politely — AppKit clips the
-        // trailing element, which is a CONTROL. 17a's order is
-        // preview, then rows, then chrome, and "controls
-        // never".
         .frame(minWidth: 110, maxWidth: .infinity)
         .overlay(alignment: .topLeading) { resultPanel }
         .background { focusShortcut }
-        // Typing moves the result set out from under the
-        // highlight, so the highlight goes rather than pointing
-        // at whatever now sits in that row.
         .onChange(of: query) { _, _ in highlighted = nil }
-        // An opened field that is done — focus gone, nothing
-        // typed — hands the row back to the area title. Only
-        // when it is EMPTY: a query is a result list the user
-        // may still be reaching for with the mouse.
         .onChange(of: focused) { _, now in
             if !now, !searching { expanded = false }
         }
     }
 
-    /// The collapsed entry: the field's own glyph, in the field's
-    /// own slot, still the row's flexible element — the `Spacer`
-    /// is what keeps the chips clustered at the trailing edge
-    /// once the field stops filling the middle.
+    /// Collapsed magnifying glass button entry.
     private var collapsedEntry: some View {
         HStack(spacing: 0) {
             Spacer(minLength: 0)
@@ -162,30 +69,13 @@ struct HeaderSearch: View {
         }
     }
 
-    /// Opening is one act: the field appears AND takes focus.
-    /// Two clicks to type would make the glyph a worse field
-    /// than the one it replaced.
-    ///
-    /// The focus write waits one main-actor hop, and that is
-    /// the load-bearing half. While the entry is collapsed
-    /// there is no `TextField` in the hierarchy at all — the
-    /// glyph replaces it — so `focused = true` in the same
-    /// update that mints the field aims at a focusable SwiftUI
-    /// has not created yet, and such a write is regularly
-    /// dropped. The symptom is the worst kind: the field opens,
-    /// looks ready, and swallows the first thing typed into it
-    /// (code review, 2026-08-11).
+    /// Expands search and acquires focus asynchronously.
     private func open() {
         expanded = true
         Task { @MainActor in focused = true }
     }
 
-    /// ⌘K, as a zero-size button rather than on the field: a
-    /// `keyboardShortcut` on a `TextField` competes with the
-    /// field's own key handling, and this needs to fire while
-    /// focus is anywhere in the window. Mounted in BOTH entries,
-    /// so the shortcut opens the collapsed one rather than
-    /// focusing a field that is not on screen.
+    /// ⌘K global shortcut button.
     private var focusShortcut: some View {
         Button("", action: open)
             .keyboardShortcut("k", modifiers: .command)
@@ -194,14 +84,7 @@ struct HeaderSearch: View {
             .accessibilityHidden(true)
     }
 
-    /// Clearing the query is what dismisses the list — the panel
-    /// is a function of `searching`, so there is no second piece
-    /// of open/closed state to disagree with it.
-    ///
-    /// The mode question is answered BEFORE the reveal: the
-    /// reveal path promotes the mode (`ensureModeAdmits`), so
-    /// asking afterwards would always answer "no switch". The
-    /// arm goes first — the reveal is what consumes it.
+    /// Selects search result and reveals target anchor.
     func pick(_ result: SettingsSearchResult) {
         if SettingsSearch.switchesMode(
             result,
@@ -213,15 +96,11 @@ struct HeaderSearch: View {
         highlighted = nil
         focused = false
         panelHovered = false
-        // A picked result is a navigation, and the screen it
-        // lands on wants its title back — the collapsed entry's
-        // whole reason for existing.
         expanded = false
         reveal(result.anchor)
     }
 
-    /// ↑/↓ from the field move the highlight only — the reveal
-    /// (scroll and flash) waits for Return.
+    /// Moves highlight up or down in result list.
     private func move(_ direction: MoveCommandDirection) {
         let hits = results.flat
         guard !hits.isEmpty else { return }
@@ -241,9 +120,7 @@ struct HeaderSearch: View {
         highlighted = hits[next].id
     }
 
-    /// Falls back to the FIRST result: typing does not move the
-    /// highlight, so after a fresh query a bare Return would
-    /// otherwise be a dead key.
+    /// Commits highlighted or first matching result.
     private func commitHighlighted() {
         let hits = results.flat
         let hit =

--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar.swift
@@ -1,32 +1,12 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The one header bar (#678 turn 9): on Home the app identity,
-/// on an area screen the "← Home" back chip and the area title —
-/// followed either way by the same search entry, profile chip
-/// and Simple|Power User segment. The status sentence and profile
-/// warning ride a second row exactly as the old header drew
-/// them. One bar for both screens so the chrome reads as
-/// continuous across push and pop.
-///
-/// The unsaved-changes count is NOT here (owner 2026-08-10): the
-/// draft has one narrator, the save pill, which carries the
-/// count and its popover — a second count in the header was the
-/// same fact in two corners of one window.
+/// Unified settings header bar for Home and area screens (#678).
 struct SettingsHeaderBar: View {
     @ObservedObject var model: SettingsModel
-    /// Focuses the back chip when an area is pushed (turn 20:
-    /// every shape change names a focus destination).
     @FocusState private var backChipFocused: Bool
-    /// Whether the collapsed search entry is open (17a). Lives
-    /// here, not in `HeaderSearch`: the area title is what
-    /// yields the row to the field, and one fact two views act
-    /// on cannot be either view's private state.
     @State private var searchExpanded = false
     @Environment(\.settingsWidth) private var width
-    /// Passed into `flipSettingsMode` so the reveal timeline's
-    /// hold can absorb the fade it drops (#760) — the model has
-    /// no environment of its own.
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
@@ -38,10 +18,7 @@ struct SettingsHeaderBar: View {
         destination?.showsProfileContext ?? true
     }
 
-    /// The title (or, on Home, the app identity) steps out of
-    /// the row for as long as the collapsed field is open — the
-    /// one place 17a's "chrome" step actually costs something,
-    /// and it costs it only while the user is searching.
+    /// Whether area title yields space to expanded search bar.
     private var titleYields: Bool {
         width.collapsesChrome && searchExpanded
     }
@@ -49,14 +26,6 @@ struct SettingsHeaderBar: View {
     @ViewBuilder var body: some View {
         VStack(spacing: 0) {
             rows
-                // Above the hairline SIBLING below, so the
-                // search overlay hanging off `titleRow` paints
-                // OVER the header separator instead of the
-                // separator crossing the result panel (owner,
-                // 2026-08-10) — the one line that survived the
-                // panel's compositing fix was this one, drawn
-                // after the overlay inside the same lifted
-                // header composite.
                 .zIndex(1)
             SettingsTheme.hairline.frame(height: 1)
         }
@@ -74,57 +43,17 @@ struct SettingsHeaderBar: View {
                 }
             }
         }
-        // NO container-level `.foregroundStyle` here, and that is
-        // a rule rather than an omission: `.secondary` and
-        // `.tertiary` are HIERARCHICAL styles, derived from the
-        // enclosing foreground rather than from a fixed grey. Set
-        // `ink` on the bar and every `.secondary` beneath it —
-        // including inside `ProfileEditTargetMenu`, which this
-        // file does not own — becomes a translucent dark GREEN,
-        // and green-on-green is what the header actually rendered
-        // (owner, 2026-08-04). Each Text names its own ink.
         .padding(.horizontal, 16)
-        // Clears the traffic-light row — `SettingsView`'s
-        // `ignoresSafeArea(.top)` discards the titlebar inset
-        // that would otherwise size this, so it's a fixed
-        // constant matched to the unified-titlebar height. This
-        // is the known-fragile point if Apple changes that
-        // metric (a visual break the verify gate can't catch).
-        //
-        // Which is now a SMALL constant, because the row sits
-        // BESIDE the lights rather than under them (owner,
-        // 2026-08-04) — `titleRow` buys its clearance
-        // horizontally instead, and stacking the two put the app
-        // mark directly beneath the close button, which reads as
-        // an accident rather than as a second row. The bottom
-        // padding grew in the same pass: the bar was reading as a
-        // strip rather than as the 64 pt header the prototype
-        // draws.
         .padding(.top, 16)
         .padding(.bottom, 18)
         .frame(maxWidth: .infinity, alignment: .leading)
-        // Opaque Card fill, not `.bar` (owner ruled fully opaque,
-        // 2026-08-04). The vibrancy tracked whatever sat behind
-        // the window, so the header was the one surface in the
-        // shell whose colour the app did not choose — the single
-        // biggest "wrong colour" report on the shipped shell.
         .background(SettingsTheme.card)
         .onChange(of: destination != nil) { _, pushed in
             if pushed { backChipFocused = true }
         }
-        // A navigation closes the collapsed field with the same
-        // reasoning `HeaderSearch.id(destination)` clears the
-        // query: the new screen is a new search context, and it
-        // wants its title.
         .onChange(of: destination) { _, _ in
             searchExpanded = false
         }
-        // And a window that grows out of the collapsed band
-        // retires the flag with it. Harmless while wide — the
-        // field is the default form there — but without it a
-        // narrowing window re-enters the band with the field
-        // already open and the title yielded to nobody
-        // (architecture review, 2026-08-11).
         .onChange(of: width) { _, now in
             if !now.collapsesChrome { searchExpanded = false }
         }
@@ -134,25 +63,6 @@ struct SettingsHeaderBar: View {
         HStack(spacing: 12) {
             if let destination {
                 backChip
-                // NO `layoutPriority` on the title: at the 720 pt
-                // hard minimum something in this row has to give,
-                // and the order must be search field down to its
-                // floor, then the TITLE truncates — never a chip
-                // or the segment clipped. A priority here inverts
-                // that and drops a control, which the responsive
-                // rule forbids ("controls never", 17a).
-                //
-                // Below the chrome breakpoint the title yields
-                // OUTRIGHT while the collapsed field is open:
-                // the two cannot both have the row, and a
-                // 60 pt search field is not a search field.
-                // The cost is real and worth naming — the back
-                // chip says "Home", never the area's name, so
-                // while the field is open nothing on screen
-                // says which area you are in. It is bounded by
-                // being momentary: the field takes the row only
-                // while it is open, and closes on pick, on
-                // navigation, and on losing focus empty.
                 if !titleYields {
                     Text(destination.title)
                         .font(.title2.weight(.bold))
@@ -163,10 +73,6 @@ struct SettingsHeaderBar: View {
             } else if !titleYields {
                 identity
             }
-            // No `Spacer` here on purpose: the search field is
-            // the flexible element, so it fills the middle and
-            // the chips cluster at the trailing edge instead of
-            // being flung to the window's corner.
             HeaderSearch(
                 expanded: $searchExpanded,
                 context: searchContext,
@@ -178,31 +84,16 @@ struct SettingsHeaderBar: View {
                 reveal: { model.nav.pendingReveal = $0 },
                 armModeNotice: { model.nav.pendingModeNotice = $0 }
             )
-            // A navigation is a NEW search context: remounting
-            // on the destination clears the query and closes
-            // the result panel. Without it, macOS hands focus
-            // back to the field after a push/pop and the stale
-            // query re-opens the suggestions over the fresh
-            // screen (owner eyeball, 2026-08-10) — the panel's
-            // condition is pure state, so only the state can
-            // end it.
             .id(destination)
             if showsProfileContext {
                 profileChip
             }
             modeSegment
         }
-        // Clears the three traffic lights, which AppKit places at
-        // a fixed offset from the window's leading edge whatever
-        // this view does. Spent on THIS row alone: the status
-        // sentence and profile warning below it sit under the
-        // lights, so they keep the bar's ordinary 16 pt gutter
-        // and stay aligned with the content column.
         .padding(.leading, SettingsHeaderBar.trafficLightInset)
     }
 
-    /// "← [mark] Home", the area screen's one way back — beside
-    /// ⌘[ and the Escape route the shell owns.
+    /// "← Home" navigation back button.
     private var backChip: some View {
         Button {
             model.destination = nil
@@ -214,8 +105,6 @@ struct SettingsHeaderBar: View {
                     Image(nsImage: mark)
                         .resizable()
                         .scaledToFit()
-                        // 22 over the inventory's 18, tracking
-                        // the identity mark's own bump.
                         .frame(width: 22, height: 22)
                 }
                 Text(L("home.back", "Home"))
@@ -231,11 +120,7 @@ struct SettingsHeaderBar: View {
         .accessibilityLabel(L("home.back", "Home"))
     }
 
-    /// The edit-target dropdown, restyled as a header chip — the
-    /// same menu, so #18/#209 behavior is untouched. The accent
-    /// dot is the prototype's: it marks WHICH chip in the row
-    /// carries the profile, since a filled chip alone no longer
-    /// distinguishes it from the back chip beside it.
+    /// Profile edit target dropdown chip (#18, #209).
     private var profileChip: some View {
         HStack(spacing: 6) {
             Circle()
@@ -246,25 +131,11 @@ struct SettingsHeaderBar: View {
         .chipSurface()
     }
 
-    /// The shared component, not `.pickerStyle(.segmented)`
-    /// (#823): a native `NSSegmentedControl` draws AppKit's own
-    /// track beside the window's capsules AND lets AppKit pick
-    /// the selected label's ink, which in dark mode put
-    /// near-white on the accent at ~2.4:1 — the pairing the dark
-    /// pass removed from this very control. Here the ink comes
-    /// from `accentInk` by construction.
-    ///
-    /// The label is applied by the CALLER because the unlabeled
-    /// path deliberately attaches none (an empty accessibility
-    /// label would override the group's inferred name), and this
-    /// instance is visually unlabeled — without this the mode
-    /// segment ships nameless to VoiceOver.
+    /// Mode segment picker triggering mode reveal wash (#760, #823).
     private var modeSegment: some View {
         SegmentedPicker(
             selection: Binding(
                 get: { model.settingsMode },
-                // The EXPLICIT flip — the one entry point that
-                // washes what the flip inserts (#760).
                 set: {
                     model.flipSettingsMode(
                         $0,
@@ -274,9 +145,6 @@ struct SettingsHeaderBar: View {
             ),
             options: [
                 (L("mode.simple", "Simple"), SettingsMode.simple),
-                // The site's slider keeps its own "Nerd" flair —
-                // different surface, different register (owner
-                // 2026-08-04; docs/localization-naming.md).
                 (
                     L("mode.power_user", "Power User"),
                     SettingsMode.powerUser

--- a/Sources/KiwiDesk/Settings/SettingsMetrics.swift
+++ b/Sources/KiwiDesk/Settings/SettingsMetrics.swift
@@ -1,181 +1,44 @@
 import SwiftUI
 
-/// Shared layout metrics for the Settings window. Chiefly the
-/// row axes: every labeled control row hangs its control off the
-/// same leading axis, and every slider readout shares one column
-/// width, so controls start and end on one line across sections
-/// instead of each row picking its own label width.
-///
-/// It also holds the surface-scoped columns that ride those
-/// axes or stand beside them — the override chrome's, the
-/// facet control's, the icon tile's. They live here rather
-/// than on their views for discoverability and because each is
-/// a *budget* something else must fit: a constant on a view is
-/// one nobody measures against.
+/// Shared layout metrics and column width budgets for the Settings window.
 enum SettingsMetrics {
-    /// The label column in front of sliders, segmented pickers
-    /// and dropdowns. Holds the label-adjacent help `?` (#94
-    /// placement, ~24 pt glyph + chip + gap) on rows that carry
-    /// one.
-    ///
-    /// Widened from 150 to 210 when #95 landed the remaining
-    /// eight languages. 150 was sized for English ("Mouse resize
-    /// action", ~121 pt) and de; measured across all eleven
-    /// locales, 53 of 451 row labels overflowed it — `es` 12,
-    /// `ru` 11, `fr` 10, `pt-BR` 9, `it` 8, `de` 2, `ja` 1, with
-    /// `en`/`ko`/`zh-*` clean. 210 cleared 43 of those 53; the
-    /// remaining ten would have needed ~280 pt, which would cost
-    /// every slider and picker in the app 130 pt of travel to
-    /// serve five keys. Those five were shortened instead — one
-    /// of them, `es` "Retardo de cambio al arrastrar (Spring
-    /// delay)", was carrying a translator's English gloss in
-    /// parentheses at 273 pt.
-    ///
-    /// **Measure a new label, and past ~210 pt shorten the label
-    /// rather than moving this number again** — it is the shared
-    /// alignment axis for every section, so it trades control
-    /// width app-wide. A Settings label wants to be short in
-    /// every language regardless.
-    ///
-    /// This used to open by claiming nothing in any shipped
-    /// locale truncated here. Nothing guarded that, and #864
-    /// falsified it: `general.login_item.start` overflowed in
-    /// five catalogs — `fr` by 66 pt, losing the object of its
-    /// phrase — and had since it shipped. The obligation is what
-    /// survives; the state is not something this comment can
-    /// know.
+    /// Shared leading label column for sliders, pickers, and dropdowns
+    /// (#94, #95, #864). Shorten labels rather than widening this number.
     static let labelColumn: CGFloat = 210
 
-    /// The gutter around a destination pane's scrolling content.
-    /// Horizontal and bottom are ordinary padding on the content;
-    /// the TOP is spent as the scroll viewport's content margin
-    /// instead (`SettingsView.detailPane`), which is what gives a
-    /// revealed card the same gutter above it that a pane's first
-    /// card has at rest.
-    ///
-    /// `scrollTo(anchor: .top)` aligns the target's top edge with
-    /// the viewport's, so before the margin existed any card but
-    /// a pane's first landed flush — and the reveal wash, which
-    /// bleeds 4 pt past its content, had its rounded top corners
-    /// clipped into a flat edge by the scroll view's own bounds.
-    /// Spending the gutter as a margin rather than as padding is
-    /// what fixes both.
-    ///
-    /// ONE number for both roles, and that is the design, not a
-    /// shortcut: a content margin moves what "top of the
-    /// viewport" means, so it cannot give a revealed card a
-    /// different gutter from a resting one. Tried 30 on device to
-    /// give reveals more room — it reads as too airy at rest,
-    /// because it moves every pane too. The equality is the point:
-    /// a revealed card should look like a pane you scrolled to the
-    /// top yourself, not like a bespoke state.
+    /// Gutter around destination pane scrolling content.
     static let paneInset: CGFloat = 16
 
-    /// `OverrideChrome`'s leading padding and checkbox
-    /// spacing — consumed by the chrome itself, so retuning
-    /// the chrome moves `overrideLabelColumn` in lockstep.
+    /// `OverrideChrome` leading padding and checkbox spacing.
     static let overrideRowInset: CGFloat = 8
 
-    /// The native checkbox's width — an AppKit metric no
-    /// constant can truly pin; best estimate.
+    /// Native checkbox width estimate.
     static let checkboxWidth: CGFloat = 18
 
-    /// The label column inside `OverrideChrome`, whose
-    /// checkbox prefixes every row (inset + checkbox + inset):
-    /// shrinking the label by that prefix lands the override
-    /// row's control on the same axis as the plain rows. The
-    /// chrome re-scopes the shared rows onto this via
-    /// `\.settingsLabelColumn`. The discount means a label
-    /// that fits `labelColumn` can still truncate here; the
-    /// shared rows' `lineLimit(1)` makes that visible rather
-    /// than a quiet wrap.
-    ///
-    /// It rides `labelColumn`, so #95's widening moved it 116 →
-    /// 176, and every override label in every shipped locale now
-    /// fits (the two that did not — `es`/`ru` "App symbol style" —
-    /// were shortened instead, since an override label sits on the
-    /// app's narrowest surface and wants the terser form anyway).
-    /// Worth knowing what the widening costs there:
-    /// the per-space popover is 392 pt, so an override row there
-    /// now leaves ~150 pt for its control instead of ~210. That
-    /// still holds its menus (the widest value, "Column width",
-    /// measures well under it) — but it is the surface to check
-    /// first if this number moves again, since it has the least
-    /// room and no plain rows to align with.
+    /// Label column inside `OverrideChrome` aligned to the shared axis (#95).
     static let overrideLabelColumn: CGFloat =
         labelColumn - (2 * overrideRowInset + checkboxWidth)
 
-    /// `SidebarTile`, the destination icon square — since #678
-    /// turn 9 it fronts the search result rows and the Home
-    /// cards rather than a sidebar list (the fixed column and
-    /// its label budget retired with the sidebar; card titles
-    /// flex and wrap instead, the redesign's own rule for row
-    /// labels).
+    /// Destination icon square tile (#678).
     static let sidebarTile: CGFloat = 22
 
-    /// The label column for a pair of half-width drag columns.
-    /// Narrower than the shared 150, so a half-width column
-    /// still leaves its control real travel, and the rows are
-    /// relabeled to their in-group short forms ("Color",
-    /// "Width") so this width holds; headroom over the longest
-    /// of those covers a longer localization before
-    /// `lineLimit(1)` would truncate.
-    ///
-    /// Born for the Gaps & Borders drag editor (#231), pushed
-    /// in there through the `\.settingsLabelColumn` override.
-    /// That editor's last narrow-axis row left in #754 and the
-    /// override with it; what reads this now is Advanced
-    /// Colours' twin drag columns, which pass it directly as
-    /// `AdvancedColorRow`'s `labelWidth:`.
+    /// Label column for half-width drag columns (#231, #754).
     static let dragColumnLabelColumn: CGFloat = 80
 
-    /// The trailing readout of a slider row. Sized for the
-    /// widest STRING in use — which is no longer a number: an
-    /// Auto-sentinel slider prints "Automatic" there (R6/#406),
-    /// wider than "2000 pt".
-    ///
-    /// 72, measured not guessed. The readouts render in the
-    /// PROPORTIONAL system font with `monospacedDigit()` — System
-    /// Settings' own idiom — so digit runs stay tabular ("8 pt"
-    /// and "2000 pt" still stack) while letters render at their
-    /// natural width. At 13 pt that is "Automatic" 61.3 and
-    /// "2000 pt" 48.5, against 72.3 / 56.3 in the monospaced
-    /// face this replaced: the same headroom ratio the retired
-    /// 64 pt constant used, for 12 pt less column. A locale
-    /// whose term runs longer (de "Automatisch", 75.6) shrinks
-    /// via `minimumScaleFactor` rather than clipping.
+    /// Trailing readout of a slider row (#406). Sized for proportional
+    /// digits with `monospacedDigit()`.
     static let readoutColumn: CGFloat = 72
 
-    /// `HexColorField`'s label column. The color fields live
-    /// in their own two-column grid, deliberately NOT on the
-    /// shared row axis (120-ish would misalign the grid's
-    /// second column) — don't "fix" them onto `labelColumn`.
+    /// Label column for two-column color fields grid.
     static let colorLabelColumn: CGFloat = 140
 
-    /// The label column for a color swatch inside an
-    /// `OverrideChrome` row (#2). An override color cell is a
-    /// half-width grid cell that also spends ~34 pt on the
-    /// leading checkbox (`overrideRowInset` + `checkboxWidth` +
-    /// inset) before the swatch and hex field, so the label is
-    /// deliberately narrower than Global's ungated
-    /// `colorLabelColumn` (140) to keep the cell inside half the
-    /// pane — not to align the swatch onto Global's axis (that
-    /// would need ~106 pt). 80 pt fits the English labels;
-    /// longer locales (e.g. German "Gruppen-Badge") truncate
-    /// with `lineLimit(1)` rather than wrap, and the same field
-    /// still shows full at 140 pt in Global's grid — an
-    /// asymmetry the half-width cell forces, tracked on #135.
+    /// Label column for color swatch inside `OverrideChrome` (#2, #135).
     static let overrideColorLabelColumn: CGFloat = 80
 
-    /// The inline hex `TextField` beside each color swatch.
-    /// Fixed (not auto-sizing) so the two-column color grid in
-    /// `AppBarGroups` keeps stable cell widths as values
-    /// change; sized for the widest stored form, "#RRGGBBAA".
+    /// Fixed inline hex `TextField` column beside each color swatch.
     static let colorHexColumn: CGFloat = 84
 
-    /// The trailing "OVERRIDE" column in the per-space override
-    /// editor (#678 8b): wide enough to seat the small-caps header
-    /// over the checkbox below it, so the two align down the card.
+    /// Trailing override column in per-space override editor (#678).
     static let overrideStateColumn: CGFloat = 88
 }
 
@@ -189,23 +52,13 @@ private struct OverrideLayoutNameKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    /// The label-column width the shared rows read.
-    /// `OverrideChrome` narrows it once for everything it
-    /// wraps, so a row is on the override axis by construction
-    /// instead of every row type plumbing a width parameter.
+    /// Label-column width read by shared settings rows.
     var settingsLabelColumn: CGFloat {
         get { self[SettingsLabelColumnKey.self] }
         set { self[SettingsLabelColumnKey.self] = newValue }
     }
 
-    /// The active layout's display name, set once by
-    /// `SpaceOverrideRows` so each `OverrideChrome` can render
-    /// "follows <Layout> defaults · <value>" without every row
-    /// threading the mode through (#678 8b). The default is empty:
-    /// an inheriting row is unusable without the wire (it would read
-    /// "follows  defaults · …"), so the one injector is load-bearing
-    /// — `SpaceOverrideRows` sets it on the card, and no other view
-    /// mounts these rows.
+    /// Active layout display name set by `SpaceOverrideRows` (#678).
     var overrideLayoutName: String {
         get { self[OverrideLayoutNameKey.self] }
         set { self[OverrideLayoutNameKey.self] = newValue }

--- a/Sources/KiwiDesk/Settings/SettingsModel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel.swift
@@ -3,11 +3,8 @@ import Combine
 import KiwiDeskCore
 import SwiftUI
 
-/// The dashboard's view model: the editable `GuiConfig` plus the
-/// live backend state the tabs display (active profile, dirty
-/// flag, monitors). Tabs mutate `config` and the change is held
-/// until one of the footer's profile actions (Update / Save as
-/// new) writes it through `KiwiCore` (#36).
+/// Dashboard view model: editable `GuiConfig` plus live backend state
+/// displayed by settings (#36).
 @MainActor
 final class SettingsModel: ObservableObject {
     /// The visually edited configuration.
@@ -16,8 +13,7 @@ final class SettingsModel: ObservableObject {
             if !suppressDirty { recomputeDirty() }
         }
     }
-    /// Raw init.lua shown when the file holds code the visual
-    /// editor can't represent, or when the user opts in.
+    /// Raw init.lua when unrepresentable visually or opted into.
     @Published var luaSource = "" {
         didSet {
             if !suppressDirty { recomputeDirty() }
@@ -25,292 +21,131 @@ final class SettingsModel: ObservableObject {
     }
     /// True while foreign Lua forces the raw editor.
     @Published var forcedLuaEditor = false
-    /// True when init.lua has harmless custom Lua (code that
-    /// doesn't touch managed vocabulary). Shows the
-    /// informational coexistence banner in the visual editor.
+    /// True when init.lua has harmless custom Lua (coexistence banner).
     /// Always false when `forcedLuaEditor` is true.
     @Published var hasCustomLua = false
     /// User toggle to edit init.lua directly.
     @Published var showLuaEditor = false
-    /// Unsaved GUI edits are pending. A live comparison
-    /// against the as-loaded baselines, not a latched flag —
-    /// manually undoing an edit clears the footer again.
+    /// Live comparison against as-loaded baselines indicating pending edits.
     @Published var isDirty = false
-    /// The window's transient navigation state — the one-shot
-    /// reveal request, its two-phase scroll/flash, and the local
-    /// surface selection (the Layout mode tab). Behind one
-    /// `@Published` so this file stays under the 350-line
-    /// ceiling as #277 part 2 grows the set; a value type, so
-    /// `$model.nav.layoutModeTab` still projects a `Binding`.
+    /// Transient navigation state: reveal request, scroll/flash, tab (#277).
     @Published var nav = SettingsNavigation()
-    /// Which appearance the window follows (#678 item 8).
-    ///
-    /// Read at init through the `preferences` seam and written
-    /// back through `setAppearance`, so it never enters the
-    /// dirty-tracked config — it is app-wide, not part of a
-    /// profile, and the footer's Save has nothing to do with
-    /// it. Storage lives in `AppearancePreference`, which
-    /// argues why it is not `gui.json`.
+    /// App-wide appearance choice; stored in `AppearancePreference` (#678).
     @Published var appearance: AppearanceChoice = .system
-    /// The live auto-start status (#678 item 16).
-    ///
-    /// Held here, not in `LoginItemCard`, because turn 14b draws
-    /// two rows from it in two different containers — see
-    /// `SettingsModel+AutoStart` for why that forces the lift and
-    /// what it buys. The default is a cheap literal, never a
-    /// probe: `refreshAutoStart()` replaces it with the live read
-    /// before the first paint the user reads.
+    /// Live auto-start status, refreshed before first paint (#678).
     @Published var autoStart = AutoStartStatus(
         level: .atLogin,
         unavailable: nil,
         requiresApproval: false
     )
-    /// False until the first async read lands; both rows stay
-    /// pending until then.
+    /// False until initial async read lands; controls pending state.
     @Published var autoStartLoaded = false
-    /// A write is in flight, so neither row may be driven.
+    /// Write in flight; disables driving auto-start rows.
     @Published var autoStartBusy = false
-    /// The level the OS last adopted, shown as the transient
-    /// live-apply confirmation (there is no Save to press).
+    /// Last adopted OS auto-start level for live-apply confirmation.
     @Published var autoStartApplied: AutoStartLevel?
-    /// Guards the confirmation's fade so a newer change
-    /// cancels an older timer instead of clearing the latest
-    /// confirmation early.
+    /// Token guarding confirmation fade against rapid changes.
     var autoStartFlashToken = 0
-    /// Which area screen is pushed — nil is Home, the card grid
-    /// that replaced the sidebar (#678 turn 9).
-    ///
-    /// Held here rather than as `@State` in `SettingsView`
-    /// because the view is re-keyed on a GUI language change
-    /// (`LocaleScopedRoot`), and `@State` does not survive that —
-    /// switching language silently threw the user back to the
-    /// entry screen mid-task. The model outlives the rebuild, so
-    /// the selection does too.
-    ///
-    /// Home is the *entry* point for a first-run and a returning
-    /// user alike (turn 9 supersedes §5.8's Profiles ruling —
-    /// the grid IS the overview that made Profiles the landing):
-    /// `SettingsWindowController.show()` resets this each time
-    /// the window is opened.
+    /// Active navigation destination screen, or nil for Home grid (#678).
     @Published var destination: SettingsDestination?
-    /// The Simple/Power User pick (#678 turn 9). Read at init
-    /// through the `preferences` seam and written back through
-    /// `setSettingsMode`, so it never enters the dirty-tracked
-    /// config — same shape and reasoning as `appearance`.
+    /// Simple or Power User mode; stored in `SettingsModePreference` (#678).
     @Published var settingsMode: SettingsMode = .simple
-    /// True while the mode-reveal wash shows (#760): set by
-    /// `flipSettingsMode` BEFORE the mode publish, so surfaces
-    /// the flip inserts mount already washed, and cleared by the
-    /// timeline it starts. Only the EXPLICIT segment flip
-    /// activates it — `ensureModeAdmits`' implicit promotion
-    /// goes through `setSettingsMode` and stays silent, because
-    /// search owns that landing's choreography (ui-designer,
-    /// 2026-08-09).
+    /// True during mode-reveal wash; set by explicit flip only (#760).
     @Published var modeRevealActive = false
-    /// Cancels a running reveal timeline when a newer flip
-    /// supersedes it, so a rapid Simple→Power-User→Simple→…
-    /// cannot clear the latest wash early.
-    ///
-    /// Production must not read this as state, and a test
-    /// awaiting it (`SettingsModeRevealTests`, #979) must read
-    /// it straight after a flip that reveals: it is not an
-    /// in-flight predicate — never cleared when the timeline
-    /// finishes, and left in place by a flip that does not
-    /// reveal — so anywhere else it is a finished predecessor,
-    /// and awaiting it asserts nothing.
+    /// Running reveal timeline task superseded by newer flips
+    /// (`SettingsModeRevealTests`, #979).
     var modeRevealTask: Task<Void, Never>?
-    /// Distinct settings the draft changes — the header's
-    /// "N unsaved changes" count, recomputed beside `isDirty`
-    /// from the same baselines so the two cannot disagree.
+    /// Distinct setting changes in draft, recomputed beside `isDirty`.
     @Published var draftChangeCount = 0
-    /// A destructive action parked behind the unsaved-changes
-    /// dialog (#515). Written only by `discardingEdits` and the
-    /// two `*PendingDiscard` verbs in `SettingsModel+Discard`.
+    /// Destructive action behind unsaved-changes dialog (#515).
     @Published var pendingDiscard: PendingDiscard?
-    /// The state as last loaded/saved — what `isDirty`
-    /// compares against. Set only by `apply(_:)` (every clean
-    /// transition funnels through `reload()`).
+    /// Clean baseline state compared against `isDirty`; set by `apply(_:)`.
     var cleanConfig = GuiConfig()
     var cleanLuaSource = ""
-    /// The space list as last seeded from live/stored state.
-    /// `persist` diffs the edited list against it so a save can
-    /// tell a user deletion (in seed, removed from the model)
-    /// from model staleness (a space that appeared live while
-    /// the dashboard sat open) — see `KiwiCore.mergeLiveSpaces`.
+    /// Space list as seeded from live/stored state
+    /// (`KiwiCore.mergeLiveSpaces`).
     var seedSpaces: [SpaceID] = []
 
-    // `recomputeDirty()` lives in `SettingsModel+Mode.swift`
-    // with the rest of the draft-state derivations (§2.1
-    // headroom — this file sits near the ceiling).
+    // `recomputeDirty()` lives in `SettingsModel+Mode.swift` (§2.1).
 
-    /// The ONE `UserDefaults` seam for everything this model
-    /// persists outside the config — the mode pick, the
-    /// first-run banner's flags, the appearance choice — so
-    /// tests write a scratch domain instead of the developer's
-    /// real defaults (tests.md: process-global state). One
-    /// domain, not one per consumer: the split carried no
-    /// information and grew the init a parameter per consumer
-    /// (architect re-review 2026-08-04, which also caught the
-    /// appearance read bypassing the split seams entirely).
+    /// `UserDefaults` seam for non-config preferences; tests inject a scratch
+    /// domain.
     let preferences: UserDefaults
 
     /// Active saved profile, or nil for a transient state.
     @Published var activeProfile: String?
-    /// The built-in Standard currently resolving (no saved
-    /// profile covers the live screen count), if any (#53).
+    /// Built-in Standard resolving when no saved profile covers screens (#53).
     @Published var activeStandard: String?
-    /// The live state diverged from the saved profile (e.g.
-    /// after a monitor change) — the update prompt.
+    /// True when live state diverged from saved profile.
     @Published var profileDirty = false
-    /// The dashboard's edit target (#64/#18): the live config,
-    /// or a stored profile edited via the banner dropdown —
-    /// seeded from its JSON, never switching the running
-    /// layout. Written only by `selectEditTarget` and the
-    /// reload fallback; every mode-dependent field derives
-    /// from it through the single `reload()`.
+    /// Dashboard edit target: live config or stored profile (#18, #64).
     @Published var target: EditTarget = .live
-    /// Whether the Canvas (monitor placement) is editable for the
-    /// current target: always true live; for a stored profile
-    /// only when its monitor set is the one connected now (else
-    /// there is no live geometry to render — #18).
+    /// Whether monitor placement canvas is editable for current target (#18).
     @Published var placementEditable = true
     @Published var profiles: [String] = []
-    /// Rich rows for the saved-profiles list (#36): monitor
-    /// sets, screen count, default flag, live match.
+    /// Rich rows for saved profiles: monitor sets, screen count, matches
+    /// (#36).
     @Published var profileSummaries: [ProfileSummary] = []
-    /// Profiles whose JSON won't decode — shown greyed with a
-    /// Reveal and a Delete, never hidden (#246, #171). No summary:
-    /// the file can't be read to build one, which is why the cause
-    /// rides along instead (#678 Phase 4 pass 9).
+    /// Un-decodable profiles shown greyed with reveal and delete
+    /// (#171, #246, #678).
     @Published var brokenProfiles: [BrokenProfile] = []
-    /// Screen counts where several profiles claim the default
-    /// flag (hand-edited files) — warning badge.
+    /// Screen counts where multiple profiles claim default flag.
     @Published var duplicateDefaultCounts: [Int] = []
-    /// The one-line confirmation after a search pick flipped the
-    /// mode (#678 4c) — set and cleared only by
-    /// `noteSearchModeSwitch` (`SettingsModel+Search`).
+    /// Confirmation text after search flipped mode
+    /// (`SettingsModel+Search`, #678).
     @Published var searchModeNotice: String?
-    /// The notice's self-clear, held so a second flip supersedes
-    /// the first instead of racing it.
+    /// Task cancelling previous notice clear on new search flips.
     var searchNoticeTask: Task<Void, Never>?
 
-    /// What loads right now, by which rule, and over how many
-    /// screens (#678 turn 13a) — for the "Which profile loads"
-    /// card.
-    ///
-    /// Snapshotted rather than asked per render: the query scans
-    /// the profile directory and decodes every profile, so a
-    /// computed property read from `body` would do that on every
-    /// SwiftUI pass — and log a line per broken profile each
-    /// time. Refreshed by `refreshProfiles`, which already pays
-    /// for that scan once.
-    ///
-    /// The COUNT rides with the verdict rather than being read
-    /// live beside it. The card renders both in one sentence, so
-    /// two sources would let it say "2 screens → Desk (these
-    /// exact monitors)" about a profile that matched the
-    /// one-screen set — a sentence assembled from two moments.
+    /// Profile resolution summary snapshot refreshed by `refreshProfiles`
+    /// (#678).
     @Published var profileResolution = ProfileResolution(
         verdict: .none,
         screens: 0
     )
-    /// A dismissible warning from the last profile action
-    /// (overlapping monitor sets, save failures).
+    /// Dismissible warning from profile actions (e.g. monitor overlap).
     @Published var profileWarning: String?
 
-    /// Snapshotted (not computed per render) so the profile
-    /// JSON isn't re-read on every SwiftUI body pass and views
-    /// re-render when the drift actually changes. Type and
-    /// refresh logic live in SettingsModel+LayoutDrift.swift;
-    /// write only through `refreshLayoutDrift()` there.
+    /// Snapshot layout drift; write only via `refreshLayoutDrift()`.
     @Published var layoutDrift: LayoutDrift?
 
-    /// The MAIN screen's user Desktops, by Mission Control
-    /// number (#888) — the Desktops a binding can fire on, which
-    /// is what the bindings card offers. Global numbers, possibly
-    /// non-contiguous; never positions.
+    /// Main screen user Desktops by Mission Control number (#888).
     @Published var mainDesktops: [Int] = []
-    /// Mission Control number of the active native Space, for the
-    /// "current" badge; nil without SkyLight.
+    /// Active native Space Mission Control number, or nil without SkyLight.
     @Published var currentDesktop: Int?
 
-    /// The Desktops a keybinding may target — every user
-    /// Desktop, or none where this macOS has no Desktop bridge
-    /// (`KiwiCore.bindableDesktops` joins the two facts).
-    ///
-    /// A stored snapshot rather than a read per render, for the
-    /// two reasons the properties above are: the read scans the
-    /// window server's whole space model, and the capability
-    /// half caches a process-wide answer the first time anything
-    /// asks — a `body` that asked would pin that answer to
-    /// whichever render happened first.
-    ///
-    /// The WIDER list of the two Desktop reads: `mainDesktops`
-    /// is what a profile binding can fire on (#888), this is
-    /// what a verb can reach.
+    /// Bindable user Desktops snapshot (`KiwiCore.bindableDesktops`, #888).
     @Published var bindableDesktops: [Int] = []
 
-    /// A dismissible in-app warning shown when a keybinding
-    /// conflict was just introduced — nil hides the banner. Set
-    /// by `noteRecordedCombo` (recording a conflicting shortcut)
-    /// and by `adoptIntoGui`/`save`'s raw-Lua path (a batch check
-    /// of the resulting config); both also clear it once no
-    /// conflict remains. The persistent per-row ⚠️ and its
-    /// tooltip are unaffected and always reflect live state.
+    /// Transient warning for newly introduced keybinding conflicts.
     @Published var keybindingWarning: String?
 
-    /// True while macOS Accessibility permission is missing, so
-    /// window management is fully paused and every tiling control
-    /// below is silently inert. Drives the dashboard-wide
-    /// `PermissionPausedBanner`. Pushed from `AppDelegate` (the
-    /// permission owner) — the Settings layer never reads AX
-    /// state directly. Not dismissible: it tracks a persistent
-    /// fact, unlike the transient `keybindingWarning`.
+    /// True when macOS Accessibility is missing; drives
+    /// `PermissionPausedBanner`.
     @Published var permissionPaused = false
-    /// Routes the paused banner's "Open System Settings" button
-    /// to the macOS pane (wired by the app).
+    /// Routes paused banner button to macOS System Settings pane.
     var onResolvePermission: () -> Void = {}
-    /// Shows a profile's file in the Finder — the broken-profile
-    /// row's one action besides Delete (#246). The SAME closure
-    /// the Config Issues panel gets, wired once in `AppDelegate`
-    /// rather than a second `fileURL` + `NSWorkspace` body for
-    /// one behaviour; `AppDelegate+Onboarding` holds it.
+    /// Reveals profile file in Finder (`AppDelegate+Onboarding`, #246).
     var onRevealProfile: (String) -> Void = { _ in }
-    /// Routes the 14c banner's "Show me around" to the welcome
-    /// tour's voluntary replay (wired by the app) — the tour's
-    /// first willing caller; the other three are involuntary.
+    /// Routes banner button to voluntary welcome tour replay.
     var onShowTour: () -> Void = {}
 
     let core: KiwiCore
-    /// Recorder-only runtime delta + disk-independent rollback
-    /// point (#123). nil outside a live-apply edit session.
+    /// Recorder live session delta and rollback point (#123).
     var liveKeySession: RecorderLiveSession?
-    /// Guards the `config.didSet` dirty flag during reload
-    /// cycles; its only writer is `apply(_:)` in
-    /// `SettingsModel+EditTarget.swift`.
+    /// Guards `config.didSet` during reload; written only by `apply(_:)`.
     var suppressDirty = false
-    /// The sidecar as last loaded — the baseline that decides
-    /// whether a save must also regenerate the global files
-    /// (see `SettingsModel+Profiles`).
+    /// Sidecar baseline deciding if save regenerates global files
+    /// (`SettingsModel+Profiles`).
     var savedSidecar: GuiConfig?
-    /// The base gui.json modes while editing a stored profile
-    /// — the diff baseline for the Shortcuts tab's override
-    /// mode (#55 phase 7). nil during live editing. Updated
-    /// only inside the reload cycle, which republishes
-    /// `config`, so views recompute together.
+    /// Base key layers diff baseline for profile shortcuts editing (#55).
     var profileEditingBaseLayers: [KeyLayer]?
-    /// The base gui.json app→space rules while editing a
-    /// stored profile — the App Rules tab's override-mode
-    /// baseline (#109), same lifecycle as
-    /// `profileEditingBaseLayers`. nil during live editing.
+    /// Base app rules diff baseline for profile rules editing (#109).
     var profileEditingBaseAppRules: [String: SpaceID]?
     /// Global float rules used to resolve and diff a stored profile.
     var profileEditingBaseFloatRules: [String]?
 
-    /// The preferences seam defaults live and is injected by
-    /// tests — a bare default read inside the class would hand
-    /// a test-constructed model the runner's real domain
-    /// (tests.md: process-global state).
+    /// Injected preferences seam allowing scratch domain in tests.
     init(
         core: KiwiCore,
         preferences: UserDefaults = .standard
@@ -327,11 +162,7 @@ final class SettingsModel: ObservableObject {
         reload()
     }
 
-    /// The global color-palette library (#375). Stateless and
-    /// file-backed, keyed off the config directory — built once
-    /// since the directory never changes for a session. Apply is
-    /// in `SettingsModel+Palette`.
-    /// What the last restore could not take, nil when it took
-    /// everything (#606).
+    /// Global color-palette library keyed off config directory (#375).
+    /// Unapplied settings from last restore, or nil if complete (#606).
     @Published var lastRestoreOutcome: RestoreOutcome?
 }

--- a/Sources/KiwiDesk/Settings/SettingsReveal.swift
+++ b/Sources/KiwiDesk/Settings/SettingsReveal.swift
@@ -1,32 +1,12 @@
 import SwiftUI
 
-/// Scroll-to + flash for a search hit (#277): the shared timing
-/// and the one modifier that paints the flash, so the sidebar
-/// driver and every anchored view agree on the choreography.
-///
-/// Treatment settled by a `ui-designer` consult (2026-07-27): a
-/// transient accent **wash**, not a ring and not a pulse. A ring
-/// or halo is this app's vocabulary for "this input is armed"
-/// (`RecorderButtonChrome`, the search field's focus stroke), so
-/// spending it on a passive spotlight would promise a keyboard
-/// focus state that has no `FocusState` behind it — worse for
-/// VoiceOver than for the eye. A scale/opacity pulse reads
-/// bouncy, the same motion the layout schematics rejected.
+/// Scroll-to and flash timing for search reveal highlights (#277).
 enum SettingsReveal {
-    /// Peak wash opacity. Double the recorder halo's ambient
-    /// 0.08, which is calibrated to sit for minutes; this is
-    /// calibrated to be noticed once.
     static let peakOpacity = 0.18
     static let cornerRadius: CGFloat = 6
-    /// How far the wash bleeds past the anchored content.
     static let bleed: CGFloat = 4
-    /// Scroll travel. Longer than the 0.12 s hover/focus
-    /// micro-transitions because the displacement is larger,
-    /// still short enough to read as a jump-cut.
     static let scroll = 0.3
-    /// Layout settle after the scroll, before the flash starts.
     static let settle = 0.1
-    /// Flat hold at peak, then the fade — ≈1.2 s total.
     static let hold = 0.3
     static let fade = 0.9
 
@@ -35,11 +15,7 @@ enum SettingsReveal {
     }
 }
 
-/// A live flash: which anchor id, plus a token bumped once per
-/// reveal. The token exists so that revealing the *same* anchor
-/// twice is a new value — without it the flash's `.task(id:)`
-/// would see an unchanged id and never re-fire, so searching the
-/// same row again would silently do nothing.
+/// Active flash target: anchor id plus token to re-fire identical anchors.
 struct SettingsFlash: Equatable {
     let anchor: String
     let token: Int
@@ -54,47 +30,20 @@ private struct SettingsRevealTargetKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    /// The flash in progress, keyed by anchor id (a
-    /// `SettingsControl.id`). Compared by each anchored view
-    /// against its own id; nil while nothing is being revealed.
+    /// Flash in progress keyed by anchor id (`SettingsControl.id`).
     var settingsFlash: SettingsFlash? {
         get { self[SettingsFlashKey.self] }
         set { self[SettingsFlashKey.self] = newValue }
     }
 
-    /// The anchor id a reveal is heading for, standing from the
-    /// moment the request is applied until its flash ends — so a
-    /// `SettingsDisclosure` holding that control can expand
-    /// before the scroll driver's re-issued `scrollTo` lands.
-    /// One writer and one clearer, both in `SettingsView`;
-    /// drawers only read it.
+    /// Anchor id targeted by in-flight reveal request.
     var settingsRevealTarget: String? {
         get { self[SettingsRevealTargetKey.self] }
         set { self[SettingsRevealTargetKey.self] = newValue }
     }
 }
 
-/// The scroll ids an inline drawer wants **hoisted to its
-/// enclosing section's top** (#610). A hoisted `SettingsDisclosure`
-/// contributes its own `SettingsControl`; the nearest
-/// `SettingsSection` collects the list and mounts a
-/// `searchScrollAnchor` marker per id above its heading, then
-/// consumes the value so an outer section never re-collects it.
-///
-/// The point of routing it through a preference rather than a
-/// call-site parameter: the marker's id is the drawer's OWN
-/// control by construction, so a hoisted drawer's scroll id and
-/// its wash id are the same control with no second list to keep in
-/// step — the same "seal it, don't guard it" the `fileprivate`
-/// halves buy for the co-located pair (#573). The section
-/// auto-discovers whichever drawer is mounted, so the shared
-/// surface-free `advancedColors` drawer needs no static parent.
-///
-/// Known limit: a hoisted drawer with no enclosing
-/// `SettingsSection` publishes to nobody, mounts no marker and
-/// scrolls nowhere — a nonsensical placement (an inline drawer's
-/// premise is that it lives in a section card), but a silent one,
-/// so keep hoisted drawers inside a section.
+/// Hoisted inline drawer scroll ids collected at section top (#610).
 struct HoistedRevealAnchorsKey: PreferenceKey {
     static let defaultValue: [SettingsControl] = []
     static func reduce(
@@ -105,24 +54,7 @@ struct HoistedRevealAnchorsKey: PreferenceKey {
     }
 }
 
-/// Paints the reveal wash behind the anchored content while the
-/// environment names it.
-///
-/// Mounted OUTSIDE any `GreyOut` in the anchored subtree,
-/// deliberately: `GreyOut` multiplies opacity on its content, so
-/// a wash nested inside a dimmed block would compound down to
-/// ~0.09 and read as a rendering fault. A hit on a control that
-/// some other switch has greyed still deserves a full-strength
-/// flash — the user typed a real label, and "grey, don't hide"
-/// (§2.7) means it is findable precisely while inert.
-/// Stateless by design. An earlier cut held the opacity in
-/// `@State` and ran the hold-then-fade inside a `.task(id:)`,
-/// which re-washed a card every time the user navigated back to
-/// it: `.task(id:)` fires on *appear* as well as on change, and
-/// the model's value outlived the reveal that set it. Now the
-/// environment value IS the "on" state, its removal IS the fade
-/// trigger, and the driver in `SettingsView` owns the single
-/// timeline — nothing here can be left latched.
+/// Paints reveal wash behind anchored content.
 private struct SearchRevealFlash: ViewModifier {
     let anchor: String
     @Environment(\.settingsFlash) private var flash
@@ -143,12 +75,6 @@ private struct SearchRevealFlash: ViewModifier {
                 )
                 .padding(-SettingsReveal.bleed)
             }
-            // Arriving is instant, leaving eases out. Reduce
-            // Motion drops the cross-*fade*, not the affordance:
-            // a flat tint shown and then removed is not motion,
-            // so the wash still appears for the same ≈1.2 s and
-            // simply disappears — the same split `HoverChip`
-            // makes.
             .animation(fadeOut, value: isMine)
     }
 
@@ -158,37 +84,15 @@ private struct SearchRevealFlash: ViewModifier {
     }
 }
 
-// MARK: - The raw halves
-//
-// `fileprivate` on purpose, and it is the whole design (#573).
-//
-// A reveal needs two things on the view tree: a scroll
-// destination (`.id`) and a wash. Feed them a hand-written
-// String and two mistakes become available, both SILENT — a
-// literal or mistyped id is a destination no search result
-// points at, and one half alone is a flash with nowhere to
-// scroll (or the reverse). Nothing crashes; the hit just lands
-// nowhere.
-//
-// Taking the ids from a `SettingsControl` closes both, so the
-// three typed modifiers below are the only way in and these two
-// cannot be reached from another file at all. That is strictly
-// better than a source-scan guard, which can only notice the
-// mistake after someone writes it.
+// MARK: - The raw halves (#573)
+
 extension View {
-    /// Tags this view as the scroll destination for `anchor` —
-    /// a `SettingsControl.id`, never display text (Appearance
-    /// renders "Color" six times at once; ids are stable and
-    /// unique per co-mounted view by construction). A one-line
-    /// wrapper over `.id()` on purpose: it names the intent and
-    /// keeps the identity decision in one place to revisit.
     fileprivate func searchAnchor(
         _ anchor: String
     ) -> some View {
         id(anchor)
     }
 
-    /// Paints the reveal wash while `anchor` is the flashed one.
     fileprivate func searchFlash(
         _ anchor: String
     ) -> some View {
@@ -199,68 +103,30 @@ extension View {
 // MARK: - The typed surface
 
 extension View {
-    /// The whole pairing for a **self-anchoring control** — a
-    /// bespoke recognition control that is its own scroll target,
-    /// with no header/card split to place the two halves across
-    /// (`GapRow`'s slider rows, the "Show it in" bar toggles).
-    /// Wash and target are the same rect: there is no expanded
-    /// content below to tint by accident, which is the only
-    /// reason the two container shapes split them at all.
-    ///
-    /// A second invariant falls out of applying the pair at the
-    /// control's outermost point: the wash lands OUTSIDE any
-    /// `GreyOut` in the subtree by construction rather than by
-    /// call-site care, so a hit on a gated control still flashes
-    /// at full strength (see `SearchRevealFlash`).
+    /// Anchors and flashes a self-contained settings control.
     func searchAnchored(
         _ control: SettingsControl
     ) -> some View {
         self.searchFlash(control.id).searchAnchor(control.id)
     }
 
-    /// The container shapes' half of the pair: the scroll
-    /// destination, on the whole card, OUTSIDE its chrome so
-    /// `scrollTo(anchor: .top)` lands on the card's edge and not
-    /// inside its padding. Pairs with `searchFlashHeader`.
+    /// Sets scroll target on outer container card.
+    /// Pairs with `searchFlashHeader`.
     func searchAnchorCard(
         _ control: SettingsControl
     ) -> some View {
         searchAnchor(control.id)
     }
 
-    /// The container shapes' other half: the wash, on the header
-    /// alone. Flashing the whole card would tint its content too
-    /// — for a drawer, the expanded interior. Pairs with
-    /// `searchAnchorCard`.
+    /// Flashes header of container card. Pairs with `searchAnchorCard`.
     func searchFlashHeader(
         _ control: SettingsControl
     ) -> some View {
         searchFlash(control.id)
     }
 
-    /// A **hoisted scroll target** for a drawer whose scroll id is
-    /// lifted to the top of its enclosing section (#610).
-    ///
-    /// An `.inline` `SettingsDisclosure` lives inside a section
-    /// card, below that section's heading. Anchoring its own body
-    /// makes `scrollTo(anchor: .top)` land the bare drawer label
-    /// at the viewport top and scroll the heading that names it
-    /// off screen — the disembodiment the #277 top-alignment
-    /// ruling exists to prevent. So the drawer keeps its wash
-    /// (`searchFlashHeader`, on its own label) but gives up its
-    /// scroll id, publishing its control through
-    /// `HoistedRevealAnchorsKey`; its enclosing `SettingsSection`
-    /// collects that and mounts this zero-size marker at its top.
-    /// `scrollTo` then aligns the section's top edge — heading
-    /// first — and the drawer label still washes below it.
-    ///
-    /// Scroll-only, so the pair is split across two views (this
-    /// marker scrolls, the drawer label washes) — but over the
-    /// same control by construction, because the marker's id comes
-    /// from the drawer's own published control, not a second list.
-    /// Confined to the container shapes by
-    /// `SettingsAnchorPrimitiveTests`, the same seal the paired
-    /// halves carry.
+    /// Hoisted scroll target marker at section top
+    /// (`SettingsAnchorPrimitiveTests`, #610).
     func searchScrollAnchor(
         _ control: SettingsControl
     ) -> some View {

--- a/Sources/KiwiDesk/Settings/SettingsTheme+Metrics.swift
+++ b/Sources/KiwiDesk/Settings/SettingsTheme+Metrics.swift
@@ -1,194 +1,63 @@
 import CoreGraphics
 
-/// The shape half of `SettingsTheme` — the `CGFloat` metrics,
-/// split from the colour table at the §2.1 hard ceiling. Same
-/// contract, stated once there: every metric is either wired at
-/// a named render site or deferred with a reason
-/// (`SettingsThemeMetricTests`, whose census parses THIS file).
+/// Shape and dimension metrics for `SettingsTheme`
+/// (`SettingsThemeMetricTests`, `SettingsThemeTokenTests`,
+/// `SettingsThemeWiringTests`).
 extension SettingsTheme {
 
-    // The metrics, and the boundary they are admitted on —
-    // stated here, at the head of the section, so the next area
-    // meets it by position rather than by archaeology (#758
-    // argued it inside one docstring further down, which the
-    // second area then cited as "the ruling above" while
-    // standing above it).
-    //
-    // AREA-SCOPED numbers in an app-wide theme, deliberately: a
-    // number some arithmetic derives from lives BESIDE that
-    // arithmetic (the Monitors picture's capacity maths owns
-    // its own), while pure chrome — strokes, radii, stands,
-    // things nothing computes on — lives here with the radii so
-    // one restyle is one file. "Beside" means the same FILE as
-    // the arithmetic: a number declared on a view a file away
-    // from what derives with it is indistinguishable at review
-    // time from a number dodging the net, so it belongs here.
-    // `PaletteSceneThumbnail.plateRadius` is the one that sits
-    // outside on purpose — the thumbnail scales it by its own
-    // `scale`, which is arithmetic in that file, and the tile's
-    // inset derives FROM it.
-    //
-    // The colour tokens' totality guard cannot see these: it
-    // parses `= token(` (`SettingsThemeTokenTests`,
-    // `SettingsThemeWiringTests`). Metrics are covered by their
-    // area's own chrome suite instead —
-    // `MonitorsChromeWiringTests`, `PaletteShelfChromeTests` —
-    // and `SettingsThemeMetricTests` is what refuses a metric
-    // that belongs to neither, so a third area cannot add one
-    // and quietly leave it unguarded.
-
-    /// A Home card's corner. The prototype's cards are flat —
-    /// fill plus hairline, no shadow — so the radius carries the
-    /// softness a shadow would have.
+    /// Home card corner radius.
     static let cardRadius: CGFloat = 14
 
-    /// The two Home card heights (#786) — deliberate, not a
-    /// residue: every profile card carries the 92 pt desktop
-    /// plate and a whole-app card never does, so one shared
-    /// height would either stretch the text cards around
-    /// absent pictures or crush the plates.
-    /// `HomeCardChromeTests` names the pair together, pins
-    /// both values, and holds the tall one above the plate
-    /// plus a minimum text band.
+    /// Home card heights for profile cards with plate vs compact
+    /// (`HomeCardChromeTests`, #786).
     static let cardHeight: CGFloat = 152
     static let cardHeightCompact: CGFloat = 105
 
-    /// The desktop plate's height inside a profile card —
-    /// full-bleed to the card's edges, clipped through the
-    /// card's own corners, so the card border IS the picture's
-    /// visible edge (4g).
+    /// Desktop plate height in profile card.
     static let plateHeight: CGFloat = 92
 
-    /// The detail panel's fixed column width (digest §1.1 /
-    /// turn 2a). Fixed rather than flexible: the CONTENT column
-    /// is the one that flexes, so the preview keeps one scale
-    /// everywhere and the responsive pass can reason about a
-    /// constant — which is also why this stays ONE number rather
-    /// than becoming per-area.
-    ///
-    /// It went to 492 for a day, back-solved from pass 5's
-    /// keyboard board so its keys came out square. That was
-    /// wrong then because the panel was docked at every width:
-    /// the shell's hard minimum is `SettingsWidthClass.minimum`
-    /// and 720 − 492 left the content column at 227 against a
-    /// fixed 210 pt `SettingsMetrics.labelColumn` — every
-    /// offering area shipping rows with almost no room for
-    /// their controls at a supported window size. The board
-    /// scales to whatever width it is given, so IT yields.
-    ///
-    /// 17a answered the other half and the answer was to keep
-    /// this number: the panel now leaves its column entirely
-    /// below `SettingsWidthClass.panelBreakpoint`, so the
-    /// starvation case no longer exists and the width it is
-    /// granted is one the docked band can always afford
-    /// (1200 − 392 = 808 for content). Widening it is a live
-    /// question for the docked band alone, and the floating
-    /// card would inherit whatever it becomes.
+    /// Detail panel fixed column width.
     static let panelWidth: CGFloat = 392
 
-    /// The content column's ceiling (owner 2026-08-10): the
-    /// prototype's widest content column measures ~970 pt at
-    /// the 1440 canvas, and nothing was ever drawn wider — at
-    /// full screen an uncapped column stretches every row past
-    /// readability. The column centres in the surplus; the
-    /// responsive pass owns everything BELOW the breakpoints,
-    /// this owns the top end.
+    /// Content column maximum width ceiling.
     static let contentMaxWidth: CGFloat = 980
 
-    /// A section container's corner. Larger than a card's on
-    /// purpose: a section is the outer box, and equal radii make
-    /// nested rounds read as a mistake.
+    /// Section container corner radius.
     static let sectionRadius: CGFloat = 16
 
-    /// A disclosure interior's corner, one step inside a section.
+    /// Disclosure interior corner radius.
     static let disclosureRadius: CGFloat = 12
 
-    /// A chip's corner. Rounded-rect, not a capsule — the
-    /// prototype's chips are square-ish tokens, and a capsule
-    /// beside a segmented control reads as a second control.
+    /// Chip corner radius.
     static let chipRadius: CGFloat = 9
 
-    /// The Monitors picture's card stroke at rest — heavier than
-    /// the app's hairline so a display card reads as an OBJECT
-    /// on the recessed well rather than as outlined content
-    /// (#758). Selection keeps its own, still-heavier weight:
-    /// the border is the SELECTED channel, and the two weights
-    /// must stay apart or one state swallows the other.
+    /// Monitors picture card stroke weights at rest and selected
+    /// (`MonitorsChromeWiringTests`, #758).
     static let monitorCardStroke: CGFloat = 1.5
     static let monitorCardStrokeSelected: CGFloat = 3
 
-    /// A palette tile's frame at rest and once it is the applied
-    /// one (#757). The shelf's whole content is colour, so the
-    /// frame is the ONLY channel selection can use — no fill, no
-    /// glyph on the picture — and the two weights follow the
-    /// Monitors picture's ruling above: keep them apart or one
-    /// state swallows the other. Lighter than a display card's
-    /// pair because a palette tile is one of many in a grid
-    /// rather than an object on a well.
+    /// Palette tile stroke weights at rest and applied
+    /// (`PaletteShelfChromeTests`, #757).
     static let paletteCardStroke: CGFloat = 1
     static let paletteCardStrokeApplied: CGFloat = 2
 
-    /// The mode-gateable container shapes' border — the three
-    /// that take `modeGated` (`HomeCard`, `SettingsSection`,
-    /// `SettingsDisclosure.card`) — at rest and when their
-    /// PRESENCE is mode-gated, i.e. the container would leave
-    /// the page in Simple (#760). Sibling cards that cannot be
-    /// mode-gated keep `strokeBorder`'s implicit default and
-    /// are deliberately outside this token. The gated frame
-    /// pairs the weight step with the ACCENT at
-    /// `modeGatedStrokeOpacity` — weight alone on the hairline
-    /// was invisible on device, and a stronger neutral said
-    /// "different" without saying which (owner + ui-designer,
-    /// 2026-08-09) — while the weight stays below the DOUBLING
-    /// the two pairs above spend on chosen things: a mode-gated
-    /// card is present, not picked. The flag each site passes
-    /// derives from its own offer predicate evaluated at
-    /// `.simple` — never a hand-negated copy beside the stroke.
-    /// `ModeGatedChromeTests` holds the pair, the predicates
-    /// and the derived membership;
-    /// `ModeGatedFrameSeparationTests` the frame's CVD floors.
+    /// Container border weights at rest and when presence is mode-gated
+    /// (`ModeGatedChromeTests`, `ModeGatedFrameSeparationTests`, #760).
     static let containerStroke: CGFloat = 1
     static let containerStrokeModeGated: CGFloat = 1.5
 
-    /// The mode-gated frame's accent strength. 0.6 measured,
-    /// not felt (ui-designer, 2026-08-09, Viénot protanopia
-    /// over the composited stroke): 0.5 landed the light-mode
-    /// gated-vs-plain pair at CVD separation 60 — exactly the
-    /// floor — while 0.6 sits at 82/100 (light/dark) from the
-    /// hairline AND 81 from hover's full accent in both
-    /// appearances, the midpoint of the register space; at 0.7
-    /// the hover register collapses to 61.
-    /// `ModeGatedFrameSeparationTests` derives those floors
-    /// from the shipped tokens rather than restating them.
+    /// Mode-gated frame accent stroke opacity
+    /// (`ModeGatedFrameSeparationTests`).
     static let modeGatedStrokeOpacity: CGFloat = 0.6
 
-    /// The search mode-switch notice's accent wash — a fill
-    /// behind ordinary ink, so it sits well below the
-    /// mode-gated STROKE strength: the strip confirms, it does
-    /// not gate anything (#678 4c). Rendered by
-    /// `SettingsSearchNotice`.
+    /// Search mode-switch notice accent fill opacity
+    /// (`SettingsSearchNotice`, #678).
     static let searchNoticeFillOpacity: CGFloat = 0.12
 
-    /// A display card's stand: the foot as a share of the card's
-    /// width and the neck as a share of the foot, each clamped.
-    /// Long enough that the card sits ON its foot rather than
-    /// floating above a speck (#758); the clamps stop the same
-    /// shares giving a laptop thumbnail a plinth. The foot's
-    /// FLOOR stays at its pre-#758 value: on a floor-sized card
-    /// (`MonitorArrangement.minimumCard`) the raised share
-    /// alone reads as a plinth, and neighbouring floored cards'
-    /// feet fuse into one rail (ui-designer, 2026-08-09).
-    ///
-    /// The section header states the boundary these are
-    /// admitted on; `MonitorsChromeWiringTests`' themed-metrics
-    /// test is this pair's wiring guard, the capacity arithmetic
-    /// they are NOT part of living in `MonitorCardChips`.
+    /// Display card stand scale and clamp metrics
+    /// (`MonitorsChromeWiringTests`, #758).
     static let monitorStandScale: CGFloat = 0.52
     static let monitorStandMin: CGFloat = 44
-    // 230 → 320 (owner, 2026-08-09): on a wide single-display
-    // card the old cap cut the foot to well under half the
-    // screen while the Home tile — unclamped shares — kept the
-    // full relation, and the two pictures of one desk disagreed.
     static let monitorStandMax: CGFloat = 320
     static let monitorNeckScale: CGFloat = 0.26
     static let monitorNeckMin: CGFloat = 14

--- a/Sources/KiwiDesk/Settings/SettingsTheme.swift
+++ b/Sources/KiwiDesk/Settings/SettingsTheme.swift
@@ -1,134 +1,54 @@
 import AppKit
 import SwiftUI
 
-/// The Settings window's colour and shape tokens (#678 turn 16b).
+/// Settings window colour and shape tokens (#678).
 ///
-/// Every surface, ink and border in the Settings tree resolves
-/// here. A hex literal beside a view is the drift this type
-/// exists to end: before it, the header painted `.bar`, the cards
-/// `controlBackgroundColor` and the hairlines
-/// `Color.primary.opacity(0.12)`, so three neighbouring greys came
-/// from three unrelated systems and no two moved together.
-///
-/// **A static enum, not an `@Environment` value.** Each token is a
-/// `Color` wrapping `NSColor(name:dynamicProvider:)`, so light and
-/// dark resolve per-draw from the *effective* appearance —
-/// `AppearanceChoice.apply()` sets `NSApp.appearance` app-wide
-/// (`AppearanceChoice+Scheme.swift`) and both modes follow with no
-/// further plumbing. An environment theme would pay only if two
-/// themes could coexist in one view tree; the appearance is
-/// process-global, so they cannot, and it would tax every `body`
-/// the shallow-body rule protects (`.claude/rules/gui.md`).
-///
-/// Same reasoning as `SettingsMetrics`, one shelf up: a constant
-/// on a view is one nobody measures against.
-///
-/// The hex pairs are pinned by `SettingsThemeTokenTests`, which
-/// resolves each token under `.aqua` and `.darkAqua` and holds the
-/// only copy of the table. Do not restate a hex here.
+/// Dynamic `Color` values wrapping `NSColor(name:dynamicProvider:)`.
+/// Hex pairs are pinned by `SettingsThemeTokenTests`.
 enum SettingsTheme {
 
     // MARK: - Surfaces
 
-    /// The window behind everything. Flat and opaque — the
-    /// prototype carries no vibrancy, and the translucent header
-    /// was the single biggest "wrong colour" report (owner
-    /// 2026-08-04).
+    /// Window background behind all content.
     static let page = token(light: 0xFB_FC_FA, dark: 0x17_1C_19)
 
-    /// Containers and rows: the header bar, Home cards, section
-    /// containers, the footer.
+    /// Containers and rows: header bar, cards, section containers, footer.
     static let card = token(light: 0xFF_FF_FF, dark: 0x1E_25_21)
 
-    /// The preview column. No consumer until Phase 4 lands the
-    /// 392 pt panel; it ships now so the guard pins one whole
-    /// table rather than growing a row per phase.
+    /// Preview column panel background.
     static let panel = token(light: 0xF4_F6_F1, dark: 0x1A_20_1C)
 
-    /// Disclosure interiors — and, by ruling rather than by the
-    /// 16b table, the filled chips. The prototype paints chips
-    /// `#F2F5EF`, within two points of this; a third near-identical
-    /// light grey-green would be a token nobody could tell from
-    /// its neighbour on screen.
+    /// Disclosure interiors and filled chips.
     static let sunken = token(light: 0xF4_F7_F1, dark: 0x23_2B_26)
 
-    /// The desktop-dark plate behind a Home card's picture
-    /// (#786): the tile is a picture of the user's desktop, so
-    /// its ground is a desktop at night, not a Settings surface.
-    /// Identical in both modes for the same reason the palette
-    /// inside it is (4g): what the picture shows must not change
-    /// with the window's appearance. Deliberately NOT `page`'s
-    /// dark `0x171C19`: in dark mode the plate must still read
-    /// as sitting below the card (`0x1E_25_21`), and the page
-    /// grey is within four points of it.
+    /// Desktop-dark plate behind Home card picture (#786).
     static let previewPlate = token(
         light: 0x12_25_1A,
         dark: 0x12_25_1A
     )
 
-    /// The plate's own light ink — the fallback the palette fold
-    /// swaps in when the USER's ink or accent sinks into
-    /// `previewPlate` (a legal palette: Lua is open, and a
-    /// light-styled bar carries a dark ink that is legible on
-    /// its own fill and invisible on this fixed dark ground).
-    /// Identical in both modes for the plate's own reason.
+    /// Plate light ink fallback when palette ink sinks into `previewPlate`.
     static let plateInk = token(
         light: 0xEA_F3_EE,
         dark: 0xEA_F3_EE
     )
 
-    // MARK: - Keyboard preview (#678 pass 5)
+    // MARK: - Keyboard preview (#678)
 
-    /// The board draws its BOUND keys in `accent` — the app's own
-    /// green, not a bespoke one — so only the three below are
-    /// its own. All are fixed in both modes for `previewPlate`'s
-    /// reason: the board is a picture of a keyboard on that same
-    /// dark ground, and what it shows must not change with the
-    /// window's appearance.
-    ///
-    /// A lighter bound green and a salmon conflict ring lived
-    /// here for a day. They came from a measurement taken with
-    /// the WRONG metric: `ColorVision.separation` is Euclidean
-    /// distance in SIMULATED sRGB, and a CIE-Lab proxy used
-    /// during the pass reported warm colours at 17–25 against the
-    /// accent where the repo's own measure puts them at 84–126.
-    /// Nothing needed a bespoke green. Use `ColorVision`, never a
-    /// re-derivation of it.
-
-    /// A key nothing claims — the board's unbound fill.
+    /// Unbound key fill on keyboard preview.
     static let keyFree = token(
         light: 0x37_46_3B,
         dark: 0x37_46_3B
     )
 
-    /// The dashed ring on a FREE key macOS already owns under
-    /// the shown modifier. A WARNING, not a third fill: the fill
-    /// says whether the USER has claimed the key, and blacking
-    /// it out said "unavailable" about a key that is free under
-    /// every other modifier.
-    ///
-    /// Measured against `keyFree` alone, because that is the
-    /// only fill it can sit on — a BOUND key whose combo macOS
-    /// owns rings `keyConflict` instead (owner ruled the
-    /// overwrite conflict-class, 2026-08-10; this amber measures
-    /// 10.5 against the accent where the floor is 60 —
-    /// `KeyboardRingSeparationTests` carries both numbers).
+    /// Dashed warning ring on free key macOS owns under shown modifier
+    /// (`KeyboardRingSeparationTests`).
     static let keyReserved = token(
         light: 0xE0_A3_4A,
         dark: 0xE0_A3_4A
     )
 
-    /// The solid ring on a key in conflict: two of the user's
-    /// OWN bindings claiming one combo, or a binding sitting
-    /// OVER a macOS reservation (owner ruled the overwrite
-    /// conflict-class, 2026-08-10). The dashed amber is only
-    /// ever a free key's warning.
-    ///
-    /// Deliberately not `SettingsTheme.danger`, which varies by
-    /// appearance: its dark value measures 55.6 against `accent`,
-    /// under the floor of 60, on a board pinned in both modes so
-    /// that cannot happen. This is danger's LIGHT value, fixed —
-    /// 136.6 on the accent it always sits on.
+    /// Solid ring on key in conflict with user binding or macOS reservation.
     static let keyConflict = token(
         light: 0xB0_3A_2A,
         dark: 0xB0_3A_2A
@@ -136,23 +56,13 @@ enum SettingsTheme {
 
     // MARK: - Borders
 
-    /// Every container border: card, section, header underline,
-    /// footer overline. In dark it does the work fills do in
-    /// light, because the surfaces there sit within ~10 points of
-    /// each other.
+    /// Container border hairline: card, section, header, footer.
     static let hairline = token(
         light: 0xE4_E9_E1,
         dark: 0x2C_33_2D
     )
 
-    /// The 16b construction that is not a colour swap: an inset
-    /// light line that separates a dark plane from a dark ground
-    /// ONLY in dark mode. In light the fills do the separating —
-    /// the plate measures 15.6:1 against the page — so this
-    /// resolves fully transparent there; in dark the plate, the
-    /// save pill and the search panel all sit within ~1.1:1 of
-    /// their grounds and this line is the edge. Drawn OVER a
-    /// hairline where one exists, not instead of it.
+    /// Inset light line separating dark planes in dark mode only.
     static let planeRing = token(
         light: 0xFF_FF_FF,
         dark: 0xFF_FF_FF,
@@ -169,29 +79,11 @@ enum SettingsTheme {
     /// slider's readout.
     static let ink2 = token(light: 0x55_63_5C, dark: 0xA8_B3_A9)
 
-    /// Captions and disclosure hints, the quietest legible ink —
-    /// and *legible* is the operative word: this paints a
-    /// section's one-sentence explanation, which is body copy and
-    /// owes 4.5:1 on EVERY surface it draws on. The 16b table's
-    /// `#7C8A82` / `#869184` measured 3.61:1 on `card` in light
-    /// and 4.43:1 on `sunken` in dark; the first correction
-    /// (`#6B7A72`) cleared `card` and still missed `panel` and
-    /// `sunken` in light (4.15 / 4.17 — the detail panel's
-    /// notices and the disclosure captions). Both ends now clear
-    /// the worst pairing, which `SettingsThemeContrastTests`
-    /// derives from these very tokens. A caption nobody can read
-    /// is not quiet, it is missing.
+    /// Captions and disclosure hints; contrast is tested across surfaces
+    /// (`SettingsThemeContrastTests`).
     static let ink3 = token(light: 0x64_72_6A, dark: 0x98_A2_96)
 
-    /// The small-caps group heading ("THIS PROFILE", a disclosure
-    /// interior's group label).
-    ///
-    /// The one pair 16b does not carry: the prototype only ever
-    /// draws this on light. Owner ruled a dedicated dark
-    /// counterpart (2026-08-04) over reusing `accent` — at full
-    /// accent strength a 10 pt small-caps label reads as something
-    /// clickable — and over `ink3`, which would drop the green
-    /// identity in both modes.
+    /// Small-caps group heading label.
     static let groupHeading = token(
         light: 0x50_6C_37,
         dark: 0x9B_B0_7E
@@ -199,45 +91,28 @@ enum SettingsTheme {
 
     // MARK: - Accent
 
-    /// KiwiDesk green, on controls and chrome alike. Owner ruled
-    /// the full-kiwi option (2026-08-04): the window is tinted
-    /// with this rather than the user's system accent, which is
-    /// what the prototype shows and what the fidelity complaint
-    /// pointed at. Deliberately identical in both modes — the
-    /// brand should not change hue with the appearance.
+    /// KiwiDesk green accent, identical in both modes.
     static let accent = token(light: 0x8D_B3_54, dark: 0x8D_B3_54)
 
-    /// Text and glyphs drawn ON `accent`. Stays dark in both
-    /// modes: kiwi is a mid-light green, so white on it fails
-    /// contrast whatever the appearance says.
+    /// Text and glyphs drawn on `accent` (dark in both modes for contrast).
     static let accentInk = token(
         light: 0x12_25_1A,
         dark: 0x12_25_1A
     )
 
-    /// A switch knob riding an accent track — the one token that
-    /// flips, because a white knob glares against dark chrome.
-    /// Its first consumer is Phase 4's control restyle; it ships
-    /// with the table for the same reason `panel` does.
+    /// Switch knob riding an accent track.
     static let onAccentKnob = token(
         light: 0xFF_FF_FF,
         dark: 0x12_25_1A
     )
 
-    /// The floating save pill's plate (#678 turn 9; owner
-    /// 2026-08-09 overturned the docked-footer ruling after
-    /// seeing the two side by side). Dark chrome floating OVER
-    /// the content, so on light it is the deep desktop green;
-    /// in dark mode it drops to the preview-frame fill 16b pins
-    /// BELOW the page (`0x0C1410`) so it still reads as a
-    /// separate plane when the page itself is near-black.
+    /// Floating save pill plate (#678).
     static let savePill = token(
         light: 0x12_25_1A,
         dark: 0x0C_14_10
     )
 
-    /// Text ON the save pill — light in both modes, the pill
-    /// being dark chrome in both.
+    /// Text on save pill (light in both modes).
     static let savePillInk = token(
         light: 0xEA_F3_EE,
         dark: 0xEA_F3_EE
@@ -245,34 +120,24 @@ enum SettingsTheme {
 
     // MARK: - States
 
-    /// The paused bar and the first-run banner's fill.
+    /// Paused bar and first-run banner fill.
     static let warningSurface = token(
         light: 0xFD_F1_DD,
         dark: 0x3A_2A_18
     )
 
-    /// Warning text and glyphs — the paused banner, the
-    /// header's divergence status row. Darker on light so it
-    /// holds 4.5:1 against `warningSurface`.
+    /// Warning text and glyphs (4.5:1 contrast on `warningSurface`).
     static let warningInk = token(
         light: 0x9A_62_00,
         dark: 0xE0_A3_4A
     )
 
-    /// Destructive text and glyphs. Lifted in dark so it stays
-    /// legible instead of sinking into `page`.
+    /// Destructive text and glyphs.
     static let danger = token(light: 0xB0_3A_2A, dark: 0xE0_82_76)
 
     // MARK: - Construction
 
-    /// One dynamic colour from a light/dark `0xRRGGBB` pair,
-    /// optionally with a per-mode alpha (`planeRing` is the one
-    /// consumer — a construction that exists in dark only).
-    ///
-    /// `bestMatch` rather than a raw name comparison: an
-    /// appearance can be a vibrant or high-contrast variant of
-    /// either mode, and those must resolve to the mode they
-    /// belong to instead of silently falling through to light.
+    /// Dynamic colour from light/dark pair using `bestMatch` for appearance.
     private static func token(
         light: UInt32,
         dark: UInt32,

--- a/Sources/KiwiDesk/Settings/SettingsWindowController.swift
+++ b/Sources/KiwiDesk/Settings/SettingsWindowController.swift
@@ -2,28 +2,14 @@ import AppKit
 import KiwiDeskCore
 import SwiftUI
 
-/// Owns the dashboard window and its view model. Kept alive by
-/// `AppDelegate` so the window survives being closed and
-/// reopened from the menu bar.
+/// Owns the dashboard window and its view model.
 @MainActor
 final class SettingsWindowController: NSObject, NSWindowDelegate {
     private let model: SettingsModel
     private var window: NSWindow?
 
-    /// The width a window opens at when it has no saved frame,
-    /// and the width a too-narrow saved frame is restored to.
-    ///
-    /// The widest band's floor, and derived rather than chosen
-    /// beside it (17a). It was 860 — picked when nothing
-    /// degraded and any width above the minimum was as good as
-    /// another. Now 860 names the COMPACT band, so that default
-    /// would have opened every first launch into two-line rows
-    /// and a docked save bar: a user meeting the app for the
-    /// first time in the most degraded arrangement it has,
-    /// having asked for nothing. Opening at the panel
-    /// breakpoint shows the shell as designed — docked preview,
-    /// rows on their shared axis — and the bands still take
-    /// over the moment the window is resized or tiled.
+    /// Initial open and minimum restore width
+    /// (`SettingsWidthClass.panelBreakpoint`).
     static let firstRunWidth = SettingsWidthClass.panelBreakpoint
     init(core: KiwiCore) {
         self.model = SettingsModel(core: core)
@@ -31,35 +17,8 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         observeWorkspaceTopology()
     }
 
-    /// Re-snapshots what the dashboard says about the MACHINE
-    /// when the machine changes under it (#678 turn 13a).
-    ///
-    /// Several answers on the Profiles page are snapshots taken
-    /// at refresh time: which profile resolves (a Desktop
-    /// binding outranks monitor matching), whether a Desktop
-    /// binding is ambiguous (separate Spaces AND more than one
-    /// display), and which Desktop wears the "current" badge.
-    /// Nothing refreshed them once the window was open, so
-    /// plugging in a monitor or switching Desktop left a card
-    /// saying "Right now:" about a moment that had passed — and
-    /// the ambiguity gate answering for a display count that no
-    /// longer held.
-    ///
-    /// Observed HERE rather than pushed from Core: the staleness
-    /// belongs to this window, these are the standard AppKit
-    /// notifications for exactly these two facts, and Core's own
-    /// `.monitorChange` bus event is the Lua/CLI contract rather
-    /// than a GUI refresh channel. `refreshProfiles` re-reads
-    /// live state and touches no staged config, so this is safe
-    /// mid-edit in a way `reload()` would not be.
-    ///
-    /// The observers are never removed, and that is deliberate
-    /// rather than overlooked: `AppDelegate` builds exactly one
-    /// of these and holds it for the process lifetime, precisely
-    /// so the window survives close-and-reopen. A `deinit` that
-    /// unregistered them would be unreachable code with an
-    /// actor-isolation problem of its own. A second construction
-    /// site would change that — and would want the tokens kept.
+    /// Listens for display and space changes to refresh profile topology
+    /// snapshots (#678).
     private func observeWorkspaceTopology() {
         let refresh: @Sendable (Notification) -> Void = {
             [weak self] _ in
@@ -72,9 +31,6 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             queue: .main,
             using: refresh
         )
-        // `NSWorkspace` posts to its OWN centre, not the default
-        // one — a Space switch observed on `NotificationCenter`
-        // .default never fires.
         _ = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace
                 .activeSpaceDidChangeNotification,
@@ -84,51 +40,39 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         )
     }
 
-    /// Routes the paused-permission banner's "Open System
-    /// Settings" button; the app wires it to the macOS pane.
+    /// Routes paused-permission banner's "Open System Settings" button.
     func setResolvePermission(_ handler: @escaping () -> Void) {
         model.onResolvePermission = handler
     }
 
-    /// Routes the broken-profile row's Reveal; the app wires it
-    /// to the same handler the Config Issues panel uses, so one
-    /// behaviour keeps one implementation (#246).
+    /// Routes broken-profile row reveal action (#246).
     func setRevealProfile(
         _ handler: @escaping (String) -> Void
     ) {
         model.onRevealProfile = handler
     }
 
-    /// Drives the dashboard-wide paused banner: true while
-    /// Accessibility is missing and window management is inert.
+    /// Sets whether dashboard displays permission paused banner.
     func setPermissionPaused(_ paused: Bool) {
         model.permissionPaused = paused
     }
 
-    /// Routes Home's "Show me around" to the welcome tour's
-    /// voluntary replay (#678 turn 14c).
+    /// Routes welcome tour replay (#678).
     func setShowTour(_ handler: @escaping () -> Void) {
         model.onShowTour = handler
     }
 
-    /// Non-destructive refresh for the quick menu's layout
-    /// actions: recomputes only the live-vs-saved drift
-    /// captions, never reseeding `config` — staged edits
-    /// survive a session layout switch.
+    /// Non-destructive refresh for layout drift captions.
     func refreshLayoutDrift() {
         model.refreshLayoutDrift()
     }
 
-    /// Re-reads the saved-profiles list without discarding staged
-    /// edits — so an open dashboard reflects a profile deleted
-    /// from the Config Issues panel (#246).
+    /// Re-reads saved profiles list without discarding staged edits (#246).
     func refreshProfiles() {
         model.refreshProfiles()
     }
 
-    /// Shows the dashboard already navigated to `destination` —
-    /// the read-only shortcuts panel's "Edit in Settings…" bridge
-    /// (#326). The request is one-shot; `SettingsView` clears it.
+    /// Shows dashboard navigated to destination (#326).
     func show(navigatingTo destination: SettingsDestination) {
         model.nav.pendingReveal = SettingsAnchor(
             destination: destination
@@ -136,34 +80,12 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         show()
     }
 
-    /// Shows the dashboard, refreshing from the backend so the
-    /// active profile and any external config edits are current —
-    /// except when the model holds unsaved edits.
+    /// Shows dashboard window, reloading config if not dirty (#455).
     func show() {
-        // Reopening must not discard an unsaved edit (#455). The
-        // model is retained across close with its staged `config`
-        // and its live-registered hotkeys intact; reseeding it from
-        // `gui.json` here would drop the edit, clear the "Unsaved
-        // changes" state, and roll the live hotkey back — the
-        // "reopen loses my new shortcut" bug. Only a clean model
-        // reloads, to pick up external edits (a profile switch, an
-        // outside `gui.json` write). Mirrors the non-destructive
-        // `refreshProfiles` / `refreshLayoutDrift` above.
         if !model.isDirty {
             model.reload()
         }
-        // Home is the entry point for a first-run and a
-        // returning user alike (turn 9 — the grid is the
-        // overview §5.8 once sent to Profiles). The selection
-        // lives on the model so it survives the locale re-key,
-        // so the default has to be re-asserted on open rather
-        // than falling out of `@State` being fresh. A deep link
-        // set `pendingReveal` just above and still wins — the
-        // view consumes it after this.
         model.destination = nil
-        // The two surface selections live on the model too now
-        // (#277), so they need the same re-assertion — otherwise
-        // reopening Settings can land in the App Bar editor.
         model.nav.resetSurfaces()
         if let window {
             NSApp.forceFront(window)
@@ -173,10 +95,6 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             contentRect: NSRect(
                 x: 0,
                 y: 0,
-                // Comfortably above the shell's hard
-                // minimum on first launch — `firstRunWidth`
-                // derives from it rather than restating a
-                // number the bands own (17a).
                 width: Self.firstRunWidth,
                 height: 620
             ),
@@ -188,15 +106,8 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             defer: false
         )
         window.title = L("app.name", "KiwiDesk")
-        // Titlebar text hidden: the header bar carries the app
-        // identity on Home and the area title when pushed.
-        // `title` still names the Window menu.
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
-        // An empty unified toolbar keeps the traffic lights
-        // over the header bar, which pulls up under it
-        // (`ignoresSafeArea` in `SettingsView`), so no empty
-        // toolbar strip shows above the header.
         let toolbar = NSToolbar()
         toolbar.showsBaselineSeparator = false
         window.toolbar = toolbar
@@ -209,33 +120,14 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         )
         window.isReleasedWhenClosed = false
         window.delegate = self
-        // The one own window that tiles (#678 item 18): the
-        // engine discriminates own windows per window, never
-        // per process, and this identifier is the mark it
-        // reads back through the AX bridge. The tour and the
-        // Config Issues window stay unmarked on purpose —
-        // `OwnWindowTiling`'s doc carries the argument.
+        // Tiled window ID for AX bridge discrimination
+        // (#678, OwnWindowTiling).
         window.identifier = NSUserInterfaceItemIdentifier(
             OwnWindowTiling.identifier
         )
         window.center()
-        // The saved frame has two owners since the window began
-        // tiling (#678 item 18): the user's own drag while it
-        // floats, and the tiler's placement while it does not.
-        // Restoring a layout slot as if it were a chosen size is
-        // harmless — a tiled window is re-placed on the next
-        // retile regardless — and the clamp below is what keeps
-        // a degenerate saved width out of the bands.
         window.setFrameAutosaveName("KiwiDeskSettings")
-        // A frame saved by an older build can be narrower than
-        // the shell's minimum; min-size only gates user
-        // resizing, not the restore, so clamp once.
-        //
-        // Through `SettingsWidthClass.minimum`, never a literal
-        // (17a): this restore is the one path that can seat the
-        // window BELOW the narrowest band, so a second spelling
-        // of the number here is precisely how the window comes
-        // to open somewhere the bands do not describe.
+        // Clamp frame to shell minimum (`SettingsWidthClass.minimum`).
         if window.frame.width < SettingsWidthClass.minimum {
             let content = window.contentRect(
                 forFrameRect: window.frame
@@ -252,28 +144,10 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         NSApp.forceFront(window)
     }
 
-    /// Teardown only — there is no activation policy to release,
-    /// because `show()` raises none (see "Permanent accessory
-    /// mode" in `docs/design-decisions.md`). What this does is
-    /// disarm state the window would otherwise carry into its
-    /// next appearance: the window itself survives
-    /// (`isReleasedWhenClosed = false`) for the next `show()`.
+    /// Disarms recorder and cleans up state on window close (#213, #515).
     func windowWillClose(_ notification: Notification) {
-        // Guaranteed disarm net (#213): the recorder normally
-        // resumes hotkeys via the field's own teardown, but the
-        // window is retained (`isReleasedWhenClosed = false`) and
-        // merely ordered out, so a close route that never delivers
-        // a local mouse-down / app-deactivation could leave the
-        // hotkeys suspended. Idempotent — a no-op when nothing is
-        // armed.
         model.setRecorderArmed(false)
-        // Same class of state, same reasoning (#515): a parked
-        // discard closure captured a view that is now gone, and
-        // the retained window would carry it into the next
-        // `show()` — a dialog about edits that no longer exist.
         model.cancelPendingDiscard()
-        // Put the shared color panel away so it can't write
-        // into the config after the window is gone.
         ColorPanelController.shared.dismiss()
     }
 }

--- a/Sources/KiwiDesk/Updates/AppUpdater.swift
+++ b/Sources/KiwiDesk/Updates/AppUpdater.swift
@@ -3,9 +3,7 @@ import KiwiDeskCore
 import Sparkle
 import os
 
-/// The update channel's diagnosis line. `Logger` +
-/// `privacy: .public`, never `NSLog` — macOS redacts NSLog
-/// content to `<private>` in `log show`, which blinds a capture.
+/// Diagnostic logger for update subsystem (`KiwiLog.subsystem`).
 private let updaterLog = Logger(
     subsystem: KiwiLog.subsystem,
     category: "gui"
@@ -15,105 +13,23 @@ private func logUpdater(_ message: String) {
     updaterLog.log("KiwiDesk: \(message, privacy: .public)")
 }
 
-/// KiwiDesk's in-app update channel (#874).
-///
-/// `docs/design-decisions.md` ▸ *No distribution channel without
-/// an update path* is why this exists at all: the gate on a
-/// promoted download is Sparkle being IN the build a person
-/// installs, and this file is where it gets there.
-///
-/// What Sparkle's UI must do differently for an app with no Dock
-/// tile is one file over, in `UpdatePromptDriver.swift` — a
-/// different subject from this one, which is why the seam and its
-/// conformers own this file alone.
-///
-/// **The seam is a protocol because the live implementation
-/// reaches the machine.** Constructing `SparkleUpdater` starts a
-/// scheduled updater that hits the network and, on an install,
-/// spawns Sparkle's XPC services. That is a production default
-/// no test may inherit
-/// (`.claude/rules/tests.md` ▸ "a test reaches the machine only
-/// through a seam it injects"), and the menu builder is
-/// constructed by GUI suites that have no business talking to an
-/// appcast.
-///
-/// **The default is inert and that is deliberate, not
-/// test-detection.** `NoUpdater` reports it cannot check, so an
-/// unwired build greys the row rather than doing something
-/// dangerous. The polarity matters: the hotkey seam (#565) has a
-/// LIVE default because a forgotten injection there must not
-/// silently disable a feature, and the danger is in the live
-/// object. Here the danger is also in the live object, but a
-/// forgotten injection costs a greyed menu row — visible, inert,
-/// and recoverable — so the null object is the safe default and
-/// production opts in. `AppDelegate` is the one site that does.
+/// In-app update channel protocol (#874).
 @MainActor
 protocol AppUpdating: AnyObject {
-    /// Whether an update check can be started right now. Sparkle
-    /// says no while a check is already running or an update is
-    /// mid-install, and the menu row greys rather than hides —
-    /// `.claude/rules/gui.md` ▸ grey, don't hide.
+    /// Whether an update check can be started.
     var canCheckForUpdates: Bool { get }
 
-    /// Begin a user-initiated check. Sparkle owns every piece of
-    /// UI from here on, including "you're up to date".
+    /// Initiates an update check.
     func checkForUpdates()
 }
 
-/// The live updater. Held for the process lifetime because
-/// Sparkle's scheduled background check has to outlive the call
-/// that started it.
-///
-/// It stores three objects and they are stored for three
-/// different reasons, none of them symmetry: `policy` because
-/// the driver references its delegate WEAKLY and an unretained
-/// one stops being asked; `updater` because it is what
-/// `canCheckForUpdates` and `checkForUpdates()` read; `driver`
-/// for neither — `SPUUpdater` retains it — but because
-/// `UpdatePromptFocusTests` reads the property to hold that the
-/// object Sparkle shows its UI through is the overriding one.
+/// Live Sparkle update controller (`UpdatePromptFocusTests`, #1011).
 @MainActor
 final class SparkleUpdater: AppUpdating {
     private let policy: UpdatePromptPolicy
     private let driver: UpdatePromptDriver
     private let updater: SPUUpdater
 
-    /// Assembled from `SPUUpdater` and a driver of our own
-    /// rather than from `SPUStandardUpdaterController`, which is
-    /// those same two objects with the driver fixed to Sparkle's
-    /// stock one. #1011 needs that driver overridden, and the
-    /// controller exposes no seam for it — it builds the driver
-    /// inside its own initializer and offers only the two
-    /// delegates, neither of which reaches the moment
-    /// `UpdatePromptDriver` overrides.
-    ///
-    /// The feed URL and the public key both come from
-    /// `Info.plist`, which `scripts/build-app.sh` writes, so
-    /// there is nothing to configure here and nothing that can
-    /// disagree with the shipped bundle.
-    ///
-    /// **Only construct this behind `make()`.** An unconfigured
-    /// host otherwise starts a scheduled network channel that
-    /// answers nothing — a bare `.build/release/KiwiDesk`, the
-    /// device-QA launch `.claude/rules/tests.md` documents, has
-    /// no `Info.plist` and so neither a bundle identifier nor a
-    /// feed. Only the first of those makes `start()` refuse
-    /// (`checkIfConfiguredProperlyAndRequireFeedURL:NO`, Sparkle
-    /// 2.9.6); the feed half of the gate is `make()`'s own
-    /// choice, and nothing but that gate would catch it.
-    ///
-    /// **A refused start is logged and shows nothing, and that
-    /// is the ruling rather than an omission.** The standard
-    /// controller put up a modal `NSAlert` here — developer-facing
-    /// by Sparkle's own description, and from a process with no
-    /// Dock tile to explain where it came from, which is the
-    /// defect #1011 is. What the user sees instead is the greyed
-    /// *Check for Updates…* row, because `canCheckForUpdates`
-    /// only turns true inside a successful start. The Config
-    /// Issues window is not the channel for it either: that
-    /// model's list is REPLACED wholesale by
-    /// `KiwiCore.onConfigIssuesChange`, so a GUI-side entry would
-    /// be wiped on the next Core update.
     init() {
         let host = Bundle.main
         policy = UpdatePromptPolicy()
@@ -146,51 +62,17 @@ final class SparkleUpdater: AppUpdating {
     }
 }
 
-/// The inert stand-in. Reports that it cannot check, so the row
-/// that drives it greys itself, and starts no scheduled channel.
+/// Inert updater for tests and unbundled runs.
 @MainActor
 final class NoUpdater: AppUpdating {
     var canCheckForUpdates: Bool { false }
     func checkForUpdates() {}
 }
 
-/// Chooses the updater this process should use — a flat
-/// namespace rather than a protocol extension, because the caller
-/// reads `AppUpdaterFactory.make()` and should not have to know
-/// which conformer it hangs off (§2.4: keep code flat).
+/// Factory resolving active updater implementation (`UpdaterSeamGuardTests`).
 @MainActor
 enum AppUpdaterFactory {
-    /// The updater this process should use: live when it is a
-    /// configured `.app`, inert otherwise.
-    ///
-    /// **Called exactly once, from `AppDelegate`.** Sparkle's
-    /// scheduled check runs for the process lifetime, so a
-    /// second instance is a second scheduler against one app —
-    /// which is what a future consumer (a Settings section, a
-    /// Lua verb) would create by reaching for `SparkleUpdater()`
-    /// of its own. It borrows the status item's instead.
-    /// `UpdaterSeamGuardTests` is the census of the sites this
-    /// seam is assembled from, each by exact count, so deleting
-    /// the wiring reds as loudly as duplicating it — the start
-    /// call included, since a channel that never starts is the
-    /// silent half of that pair. Counting is not enough on its
-    /// own: `UpdatePromptFocusTests` is what holds that the
-    /// driver built here is the one Sparkle is shown through.
-    ///
-    /// The symmetry is the
-    /// point: a missing wiring greys one menu row, which is
-    /// visible, while the scheduled channel never starting is
-    /// not — and an update path that silently never runs is the
-    /// failure `docs/design-decisions.md` ▸ *No distribution
-    /// channel without an update path* calls unrecoverable.
-    ///
-    /// The gate is a property of the BUNDLE rather than of the
-    /// build configuration, deliberately — a release binary run
-    /// straight out of `.build` is the case that matters, and it
-    /// is indistinguishable from the shipped one by
-    /// `#if DEBUG`. Both conditions are load-bearing: no bundle
-    /// identifier is the bare-binary case, and no `SUFeedURL` is
-    /// an `.app` built before the packaging half landed.
+    /// Returns live updater if bundled with feed URL, else inert updater.
     static func make() -> any AppUpdating {
         guard Bundle.main.bundleIdentifier != nil,
             Bundle.main.object(forInfoDictionaryKey: "SUFeedURL")

--- a/Sources/KiwiDesk/Updates/AppUpdater.swift
+++ b/Sources/KiwiDesk/Updates/AppUpdater.swift
@@ -62,7 +62,15 @@ final class SparkleUpdater: AppUpdating {
     }
 }
 
-/// Inert updater for tests and unbundled runs.
+/// Inert updater for tests and unbundled runs. The INERT default
+/// is deliberate, not test-detection — the live object starts a
+/// network channel and XPC services on construction, so an
+/// unwired build greys the row rather than doing something
+/// dangerous. Inverted polarity vs the hotkey seam (#565), whose
+/// LIVE default exists because a forgotten injection there would
+/// silently disable a feature; here it costs a visible grey.
+/// tests.md ▸ "one seam runs the OTHER way" owns the two-sided
+/// guard this inversion requires (`UpdaterSeamGuardTests`).
 @MainActor
 final class NoUpdater: AppUpdating {
     var canCheckForUpdates: Bool { false }


### PR DESCRIPTION
## Description
Batch 5 of comment diet covering 30 Settings components and models:

- Trimmed comments to AGENTS.md §2.8 budget (1–3 lines for constraints, 1–4 lines for docstrings).
- Removed design histories, rejected alternatives, and redundant code restatements.
- Preserved all issue references (`#4`, `#18`, `#23`, `#25`, `#26`, `#92`, `#94`, `#95`, `#96`, `#123`, `#125`, `#171`, `#209`, `#213`, `#231`, `#246`, `#277`, `#326`, `#342`, `#358`, `#406`, `#414`, `#445`, `#455`, `#515`, `#518`, `#527`, `#545`, `#565`, `#573`, `#576`, `#610`, `#678`, `#702`, `#708`, `#712`, `#753`, `#757`, `#758`, `#760`, `#786`, `#789`, `#794`, `#812`, `#818`, `#823`, `#843`, `#845`, `#859`, `#862`, `#864`, `#874`, `#884`, `#956`, `#1011`, `#1017`, `#1021`, `#1028`, `#1068`, `#1069`, `#1071`, `#1094`).
- Preserved all single-home, single-truth, and invariant claims in compressed form.
- Preserved all test suite references (`AppRulesCensusRenderTests`, `BorderGeometryTests`, `CrossReferenceRowSlotTests`, `GapPreviewScaleTests`, `GapsBordersPanelTests`, `HomeCardChromeTests`, `KeyboardMatrixTests`, `KeyboardRingSeparationTests`, `LayoutSchematicCountTests`, `LayoutSchematicScaleTests`, `ModeGatedChromeTests`, `ModeGatedFrameSeparationTests`, `MonitorsChromeWiringTests`, `PaletteShelfChromeTests`, `PresetGridFloorTests`, `PresetScreenCardOverflowTests`, `SettingsAnchorPrimitiveTests`, `SettingsDisclosureSizeTests`, `SettingsThemeContrastTests`, `SettingsThemeMetricTests`, `SettingsThemeTokenTests`, `SettingsThemeWiringTests`, `SpacesPanelPreviewTests`, `SpacesPanelSelectionTests`, `UpdatePromptFocusTests`, `UpdaterSeamGuardTests`, `OwnWindowTiling`).

## Checklist
- [x] Commits follow Conventional Commits format
- [x] All 1161 unit & GUI tests passing
- [x] `scripts/lint.sh` green (exit code 0)
- [x] Zero lines > 79 chars, zero files > 350 lines