### PR TITLE
chore: quiet the local test gate

### DIFF
--- a/.claude/skills/verify-gate/SKILL.md
+++ b/.claude/skills/verify-gate/SKILL.md
@@ -37,9 +37,12 @@ Say in the report which gate you ran and why.
 ## Fast inner loop
 
 1. `swift build`
-2. `swift test` (one command — the old two-command split died
-   with the #494 tail-hang fix; history and the rest of the
-   test conventions live in `.claude/rules/tests.md`)
+2. `swift test -q` (one command — the old two-command split
+   died with the #494 tail-hang fix; history and the rest of
+   the test conventions live in `.claude/rules/tests.md`. `-q`
+   drops the ~20k per-test progress lines a green full run
+   prints (#1140); failure issues and the run summary still
+   print, and a red run is re-run `--filter`ed for detail)
 3. `scripts/lint.sh $ARGUMENTS` (omit the argument to lint the
    repo)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
       # failure attribution; this job mirrors the skill instead,
       # and VerifyGateParityTests pins it there.
       - name: Test
-        run: swift test
+        run: swift test -q
 
 
   release:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -266,7 +266,7 @@ else
     echo "==> swift build"
     swift build
     echo "==> swift test"
-    swift test
+    swift test -q
     echo "==> scripts/lint.sh"
     ./scripts/lint.sh
     echo "==> swift build -c release"


### PR DESCRIPTION
## Description

`swift test -q` in the verify-gate skill and its two ship-grade
parity copies (`scripts/release.sh`, `release.yml`'s verify
job). A green full run printed ~20k per-test progress lines —
scrollback noise locally, a real token cost for agent sessions.
`-q` keeps failure issues and the run summary (measured: 41→10
lines on a filtered run); a red run gets re-run `--filter`ed
for detail. `ci.yml` deliberately stays verbose: its logs are
the searchable record.

fixes #1140

## Checklist

- [x] Commits follow Conventional Commits format
- [x] No contradictions between code and docs
- [x] PR is focused

## How I verified

`VerifyGateParityTests` (+ the three release-workflow guard
suites) green — the parity suite derives the command from
SKILL.md and found it in both copies. Full suite green (one
documented live-mouse flake, passed alone), lint exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)