### PR TITLE
fix(localization): refuse merge-keys under any extract override

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -151,6 +151,14 @@ input. A tool that mints a working file writes it under
 `locale-worksheets/` — outside every tree a target ships from,
 and `scripts/locale_paths.py` is the one definition of that path,
 imported by both scripts that touch it rather than re-derived.
+The `KIWIDESK_EXTRACT_*` env overrides belong to `extract-keys`
+alone; `merge-keys` refuses to run while any is set (#1107,
+`MergeKeysOverrideRefusalTests`), because honouring half the
+family once rewrote a developer's real catalogs under a harness
+that believed it was sandboxed — its one sanctioned harness is
+the repo-shaped `ScriptFixture`, which needs no env hook, and a
+new script wanting a quick env-var test hook must meet the same
+bar rather than widen the family.
 `LocaleWorksheetLocationTests` pins where `extract-keys` writes
 and `LocaleWorksheetRejectionTests` pins that one found among the
 catalogs is still *rejected*. Two rejections exist, deliberately:

--- a/Tests/KiwiDeskCoreTests/LocaleWorksheetRejectionTests.swift
+++ b/Tests/KiwiDeskCoreTests/LocaleWorksheetRejectionTests.swift
@@ -129,8 +129,12 @@ struct LocaleWorksheetRejectionTests {
     /// from the script's own location — so a run under any of
     /// them reads, and under `--prune` rewrites, the developer's
     /// real site catalogs while believing it is redirected. Half
-    /// a redirect is worse than none, so both scripts refuse
-    /// before touching a path.
+    /// a redirect is worse than none, so `extract-keys` refuses
+    /// before touching a path. `merge-keys` refuses the whole
+    /// family in EVERY mode since #1107, with a message that no
+    /// longer names the site tree —
+    /// `MergeKeysOverrideRefusalTests` owns that half, which is
+    /// why this case no longer spawns it.
     ///
     /// Both variables are exercised, and `_LOCALES` is the one
     /// that matters most: it is the mutating half, and the first
@@ -139,27 +143,19 @@ struct LocaleWorksheetRejectionTests {
     /// place and left open the half that rewrites shipped
     /// catalogs.
     ///
-    /// **The status check is inert on the `merge-keys` half** and
-    /// is kept only for symmetry: that script exits 1 anyway with
-    /// "worksheet does not exist". The message needles are what
-    /// carry this test there, so do not trim them as redundant —
-    /// those cases would go green for the wrong reason.
-    ///
-    /// Note when this reds: the `extract-keys` × `_LOCALES` case
-    /// really would run `--site` against the developer's real
-    /// `site/src/i18n` and drop a worksheet into the checkout.
-    /// That is the harm being prevented, and it is invisible to
-    /// `git status` because the worksheet tree is gitignored.
+    /// Note when this reds: the `_LOCALES` case really would run
+    /// `--site` against the developer's real `site/src/i18n` and
+    /// drop a worksheet into the checkout. That is the harm
+    /// being prevented, and it is invisible to `git status`
+    /// because the worksheet tree is gitignored.
     @Test(
         "--site refuses to run under any extract override",
-        arguments: ["extract-keys", "merge-keys"],
-        [
+        arguments: [
             "KIWIDESK_EXTRACT_WORKSHEETS",
             "KIWIDESK_EXTRACT_LOCALES",
         ]
     )
     func siteRefusesUnderTheOverride(
-        script: String,
         variable: String
     ) throws {
         let base = FileManager.default.temporaryDirectory
@@ -168,7 +164,9 @@ struct LocaleWorksheetRejectionTests {
             )
         defer { try? FileManager.default.removeItem(at: base) }
         let result = try runPythonScript(
-            at: repoRoot.appendingPathComponent("scripts/\(script)"),
+            at:
+                repoRoot
+                .appendingPathComponent("scripts/extract-keys"),
             arguments: ["--site", "de"],
             environment: [variable: base.path]
         )

--- a/Tests/KiwiDeskCoreTests/MergeKeysOverrideRefusalTests.swift
+++ b/Tests/KiwiDeskCoreTests/MergeKeysOverrideRefusalTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+
+/// `scripts/merge-keys` refuses to run while any
+/// `KIWIDESK_EXTRACT_*` is set to a non-empty value, in both
+/// modes (issue #1107).
+///
+/// Before the refusal it honoured exactly ONE of the family —
+/// `KIWIDESK_EXTRACT_WORKSHEETS` — while its catalog directory
+/// stayed `__file__`-derived, so a harness that believed it was
+/// sandboxed read redirected worksheets, rewrote the developer's
+/// REAL catalogs, and unlinked the worksheet (the only copy of
+/// the work). The refusal is over the whole family, the same
+/// shape as `site_override_conflict`: a member `merge-keys`
+/// never reads (`KIWIDESK_EXTRACT_SOURCES`) still signals a
+/// caller who believes the run is redirected.
+///
+/// Split from `MergeKeysBehaviourTests`, which sits at the
+/// 350-line ceiling (AGENTS.md §2.1; tests.md "split suites
+/// early"). Per-file private helpers are the convention, so the
+/// small fixture/run pair below is duplicated deliberately.
+///
+/// Each run here sets an override explicitly — the documented
+/// one case for `runRepoScript`'s `environment` parameter, since
+/// the harness otherwise clears the family. The paths point into
+/// the fixture so that even a regression that honours them again
+/// cannot write outside the throwaway tree.
+@Suite("merge-keys override refusal")
+struct MergeKeysOverrideRefusalTests {
+    private var repoRoot: URL { scriptFixtureRepoRoot() }
+
+    /// A fully mergeable fixture, so the override is the ONLY
+    /// reason a refusing run refuses.
+    private func fixture() throws -> RepoShapedFixture {
+        try makeRepoShapedFixture(
+            prefix: "kiwi-merge-override",
+            locales: [
+                "en.json": #"{"a.key": "Hello"}"#,
+                "de.json": #"{}"#,
+                "missing_de.json": #"""
+                {"a.key":
+                  {"source": "Hello", "translation": "Hallo"}}
+                """#,
+            ]
+        )
+    }
+
+    @Test(
+        "any live override refuses before a path is touched",
+        arguments: [
+            "KIWIDESK_EXTRACT_LOCALES",
+            "KIWIDESK_EXTRACT_WORKSHEETS",
+            "KIWIDESK_EXTRACT_SOURCES",
+        ]
+    )
+    func liveOverrideRefuses(variable: String) throws {
+        let fx = try fixture()
+        defer { fx.cleanup() }
+
+        let redirect = fx.root
+            .appendingPathComponent("redirected").path
+        let run = try runRepoScript(
+            "merge-keys",
+            arguments: ["de"],
+            in: fx,
+            repoRoot: repoRoot,
+            environment: [variable: redirect]
+        )
+        #expect(run.status == 1)
+        #expect(run.stderr.contains(variable))
+        #expect(run.stderr.contains("honours no override"))
+        // The refusal precedes every path read: the catalog is
+        // unwritten and the worksheet — the only copy of the
+        // translator's work — is not unlinked.
+        #expect(try fx.decodeLocale("de.json").isEmpty)
+        #expect(fx.worksheetExists("missing_de.json"))
+    }
+
+    /// `--site` was refused under an override before #1107 too
+    /// (`site_override_conflict`); the family-wide predicate
+    /// subsumes that path, so the case pins it is still closed.
+    @Test("--site under a live override still refuses")
+    func siteModeStillRefuses() throws {
+        let fx = try fixture()
+        defer { fx.cleanup() }
+
+        let redirect = fx.root
+            .appendingPathComponent("redirected").path
+        let run = try runRepoScript(
+            "merge-keys",
+            arguments: ["--site", "de"],
+            in: fx,
+            repoRoot: repoRoot,
+            environment: [
+                "KIWIDESK_EXTRACT_LOCALES": redirect
+            ]
+        )
+        #expect(run.status == 1)
+        #expect(
+            run.stderr.contains("KIWIDESK_EXTRACT_LOCALES")
+        )
+    }
+
+    /// `VAR=` exported is "unset" (`locale_paths._override`'s
+    /// rule): a shell that cleared the variable by emptying it
+    /// must not be refused, or the refusal starts costing runs
+    /// the override never endangered.
+    @Test("an override set to the empty string does not refuse")
+    func emptyValueMerges() throws {
+        let fx = try fixture()
+        defer { fx.cleanup() }
+
+        let run = try runRepoScript(
+            "merge-keys",
+            arguments: ["de"],
+            in: fx,
+            repoRoot: repoRoot,
+            environment: ["KIWIDESK_EXTRACT_LOCALES": ""]
+        )
+        #expect(run.status == 0)
+        let merged = try fx.decodeLocale("de.json")
+        #expect(merged["a.key"] == "Hallo")
+        #expect(!fx.worksheetExists("missing_de.json"))
+    }
+}

--- a/Tests/KiwiDeskCoreTests/ScriptFixture.swift
+++ b/Tests/KiwiDeskCoreTests/ScriptFixture.swift
@@ -321,14 +321,11 @@ func runRepoScript(
     // point this run's *writes* at the real checkout. Nothing in
     // the test tree sets them for a repo-shaped run; this makes
     // that a property of the harness instead of a habit.
+    // Swept by prefix (`locale_paths.OVERRIDE_PREFIX`), never a
+    // hand-listed family: a fourth variable a script honours but
+    // this clear misses re-opens #1107 with every suite green.
     var environment = ProcessInfo.processInfo.environment
-    for key in [
-        "KIWIDESK_EXTRACT_SOURCES",
-        "KIWIDESK_EXTRACT_LOCALES",
-        "KIWIDESK_EXTRACT_WORKSHEETS",
-    ] {
-        environment.removeValue(forKey: key)
-    }
+        .filter { !$0.key.hasPrefix("KIWIDESK_EXTRACT_") }
     environment.merge(overrides) { _, new in new }
     return try runPythonScript(
         at: scriptsDir.appendingPathComponent(name),

--- a/scripts/locale_paths.py
+++ b/scripts/locale_paths.py
@@ -78,9 +78,10 @@ def worksheets_dir(root: Path, site: bool = False) -> Path:
     catalogs have no matching override, and redirecting half of
     a mode is worse than redirecting none of it, so
     `extract-keys` refuses the combination outright rather than
-    letting it through here. `merge-keys` refuses the whole
-    family in every mode (`merge_override_conflict`), so only
-    `extract-keys` can reach here with the override live.
+    letting it through here. `merge-keys` must refuse via
+    `merge_override_conflict` before any path computed here is
+    read — `MergeKeysOverrideRefusalTests` pins that with its
+    untouched-fixture assertions.
     """
     base = Path(_override() or str(root / WORKSHEETS_DIRNAME))
     return base / "site" if site else base
@@ -100,18 +101,11 @@ def _live_overrides() -> list[str]:
 def merge_override_conflict() -> str | None:
     """Why a `merge-keys` run must not proceed under any
     override, or None. Called before it touches a path, in both
-    modes.
-
-    `merge-keys` honours no `KIWIDESK_EXTRACT_*` variable: its
-    catalog directory is `__file__`-derived, so honouring the
-    worksheet override alone — what it did before #1107 — read
-    redirected worksheets and rewrote the developer's REAL
-    catalogs while the caller believed the run was sandboxed,
-    then unlinked the worksheet, the only copy of the work. Its
-    sanctioned harness is the repo-shaped `ScriptFixture`, which
-    clears the family, so honouring the rest would add a
-    production-only test hook no test needs; refusing makes the
-    half-redirect unrepresentable instead.
+    modes: merge-keys honours no `KIWIDESK_EXTRACT_*` variable —
+    its sanctioned harness is the repo-shaped fixture, which
+    needs no env hook — so refusal makes a half-redirect
+    unrepresentable (#1107; the argument is in
+    `.claude/rules/localization.md`).
     """
     live = _live_overrides()
     if not live:

--- a/scripts/locale_paths.py
+++ b/scripts/locale_paths.py
@@ -72,21 +72,65 @@ def worksheets_dir(root: Path, site: bool = False) -> Path:
     """The directory `missing_<locale>.json` is written to and
     read from. `site` selects the marketing site's sub-tree.
 
-    The override exists so a test spawning these scripts cannot
+    The override exists so a test spawning `extract-keys` cannot
     write into the developer's own checkout; it is never set for
     a human run. It redirects the app tree only — `--site`'s
     catalogs have no matching override, and redirecting half of
     a mode is worse than redirecting none of it, so
     `extract-keys` refuses the combination outright rather than
-    letting it through here.
+    letting it through here. `merge-keys` refuses the whole
+    family in every mode (`merge_override_conflict`), so only
+    `extract-keys` can reach here with the override live.
     """
     base = Path(_override() or str(root / WORKSHEETS_DIRNAME))
     return base / "site" if site else base
 
 
+def _live_overrides() -> list[str]:
+    """Every `KIWIDESK_EXTRACT_*` set to a non-empty value,
+    sorted. An empty value is not set — `_override`'s rule,
+    applied here per variable."""
+    return sorted(
+        name
+        for name, value in os.environ.items()
+        if name.startswith(OVERRIDE_PREFIX) and value
+    )
+
+
+def merge_override_conflict() -> str | None:
+    """Why a `merge-keys` run must not proceed under any
+    override, or None. Called before it touches a path, in both
+    modes.
+
+    `merge-keys` honours no `KIWIDESK_EXTRACT_*` variable: its
+    catalog directory is `__file__`-derived, so honouring the
+    worksheet override alone — what it did before #1107 — read
+    redirected worksheets and rewrote the developer's REAL
+    catalogs while the caller believed the run was sandboxed,
+    then unlinked the worksheet, the only copy of the work. Its
+    sanctioned harness is the repo-shaped `ScriptFixture`, which
+    clears the family, so honouring the rest would add a
+    production-only test hook no test needs; refusing makes the
+    half-redirect unrepresentable instead.
+    """
+    live = _live_overrides()
+    if not live:
+        return None
+    return (
+        f"{', '.join(live)} set, but merge-keys honours no "
+        "override — its catalog directory is derived from the "
+        "script's own location, so the run would read redirected "
+        "worksheets and rewrite the real catalogs while believing "
+        "it was redirected, then unlink the worksheet. Unset "
+        "them (a test uses the repo-shaped fixture instead)."
+    )
+
+
 def site_override_conflict(site: bool) -> str | None:
     """Why a `--site` run must not proceed under an override, or
-    None. Called by both scripts before either touches a path.
+    None. Called by `extract-keys` before it touches a path
+    (`merge-keys` refuses the family in every mode via
+    `merge_override_conflict`, which subsumes this).
 
     Refuses on ANY `KIWIDESK_EXTRACT_*`, not just the worksheet
     one. Site mode honours none of them — `main()` reassigns
@@ -101,11 +145,7 @@ def site_override_conflict(site: bool) -> str | None:
     """
     if not site:
         return None
-    live = sorted(
-        name
-        for name, value in os.environ.items()
-        if name.startswith(OVERRIDE_PREFIX) and value
-    )
+    live = _live_overrides()
     if not live:
         return None
     return (

--- a/scripts/merge-keys
+++ b/scripts/merge-keys
@@ -81,7 +81,7 @@ from pathlib import Path
 
 from locale_decoder import decode_json_object
 from locale_paths import (
-    site_override_conflict,
+    merge_override_conflict,
     worksheet_name,
     worksheets_dir,
 )
@@ -102,9 +102,8 @@ LOCALES_DIR = (
 # Where `scripts/extract-keys` leaves the worksheet — read here
 # and unlinked here; `<locale>.json` is still written under
 # `LOCALES_DIR`. `scripts/locale_paths.py` is the one definition,
-# imported rather than re-derived: a second literal would agree
-# only until the override is set, and the symptom is this script
-# reporting "does not exist" for a file just written.
+# imported rather than re-derived; any live `KIWIDESK_EXTRACT_*`
+# is refused in `main()` before this path is read (#1107).
 WORKSHEETS_DIR = worksheets_dir(ROOT)
 SITE_WORKSHEETS_DIR = worksheets_dir(ROOT, site=True)
 
@@ -194,9 +193,9 @@ def main(argv: list[str]) -> int:
         return 0
     site = "--site" in args
     flag = "--site " if site else ""
-    conflict = site_override_conflict(site)
+    conflict = merge_override_conflict()
     if conflict:
-        print(f"merge-keys --site: {conflict}", file=sys.stderr)
+        print(f"merge-keys: {conflict}", file=sys.stderr)
         return 1
     if site:
         args = [a for a in args if a != "--site"]


### PR DESCRIPTION
## Description

`scripts/merge-keys` honoured `KIWIDESK_EXTRACT_WORKSHEETS`
(through `locale_paths.worksheets_dir`) while deriving its
catalog directory from its own `__file__`, so a harness that
believed both overrides sandboxed it read the redirected
worksheets, rewrote the developer's **real**
`Sources/KiwiDeskCore/Resources/Locales/<locale>.json`, and
unlinked the worksheet — the only copy of the work.

Per the ruling on the issue, the fix is **refusal** rather than
honouring the second half: `merge-keys` now exits non-zero when
any `KIWIDESK_EXTRACT_*` is set to a non-empty value, in both
modes, via a new family-wide `merge_override_conflict()` in
`scripts/locale_paths.py` (sharing `_live_overrides()` with
`site_override_conflict`). Its sanctioned harness is the
repo-shaped `ScriptFixture`, which now clears the family **by
prefix** rather than a hand-listed loop, so a future fourth
variable cannot silently re-open the hole.

Tests: new `MergeKeysOverrideRefusalTests` (refusal per family
member incl. `_SOURCES`, `--site`, the empty-value carve-out,
and catalog-unwritten / worksheet-kept assertions that red on
the shipped bug itself). The merge-keys half of
`LocaleWorksheetRejectionTests` ▸ "--site refuses…" narrowed to
`extract-keys`: the family predicate takes no mode argument, so
the dropped combination is provably redundant with the new
suite, whose message rightly no longer names the site tree.

## Related Issue(s)

Fixes #1107

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/` (not
  user-facing — dev tooling; the argument landed in
  `.claude/rules/localization.md`)
- [x] No contradictions between code and docs
- [ ] Release build green — CI's `Release Build` job (read it
  before merging; it reports, it does not block), or locally
  for concurrency / `@Sendable` changes
- [x] PR is focused; refactors separated from features

## How I verified

Not app-reachable — a tooling defect. Reproduced the exact
issue scenario against a scratch copy of the script tree
(redirected worksheet read, scratch tree's "real" catalog
rewritten, worksheet unlinked), then re-ran all modes against
the fixed script: every override refuses with the variable
named on stderr, catalog and worksheet untouched; `VAR=` empty
still merges. Full verify gate: `swift build`, `swift test`
(4292 tests), `scripts/lint.sh` — all green. `guard-prover`
(isolated worktree) red-proofed all four new/changed guards,
including that the file-state assertions red on the pre-fix
behaviour itself, not just the exit code.

## Notes for Reviewer

- `LocaleWorksheetDecodeParityTests` seam checked: the refusal
  precedes any worksheet read, and both scripts' decoders are
  untouched — parity does not move.
- review-change round ran (code-reviewer: no findings;
  architect-reviewer: 1 major + 2 minor, all applied in the
  second commit).
- Known inert clause, stated in the prover run: on the
  `_WORKSHEETS` arm of the refusal test the file-state
  assertions cannot red (pre-fix also exited 1 there); the
  stderr clauses are load-bearing on that arm.
