### PR TITLE
fix(gui): state a focus destination on area→area navigation

### DIFF
--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar.swift
@@ -109,8 +109,11 @@ struct SettingsHeaderBar: View {
         // shell whose colour the app did not choose — the single
         // biggest "wrong colour" report on the shipped shell.
         .background(SettingsTheme.card)
-        .onChange(of: destination != nil) { _, pushed in
-            if pushed { backChipFocused = true }
+        // Keyed on the VALUE, never `destination != nil`: an
+        // area→area navigation keeps that Boolean true, so a
+        // Boolean-keyed raise never fires there (#998).
+        .onChange(of: destination) { _, now in
+            if now != nil { backChipFocused = true }
         }
         // A navigation closes the collapsed field with the same
         // reasoning `HeaderSearch.id(destination)` clears the

--- a/Tests/KiwiDeskGuiTests/KeyboardActionParityTests+Shell.swift
+++ b/Tests/KiwiDeskGuiTests/KeyboardActionParityTests+Shell.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+
+/// The SHELL's own two focus statements — the pair gui.md cites
+/// as the exemplars of "every shape change states a focus
+/// destination", and the only wirings in the tree that had no
+/// needle at all until #998 (a push focuses the back chip; a
+/// return restores `nav.homeReturnFocus`).
+///
+/// Split from `KeyboardActionParityTests.swift` under the §2.1
+/// ceiling, same suite. Per-file private helpers are the
+/// convention, so the small wiring/squash pair below is a
+/// deliberate copy of that file's.
+///
+/// The header needle spans the WHOLE `onChange` closure,
+/// including its key: #998 shipped as a wiring keyed on
+/// `destination != nil`, which fires on Home→area and never on
+/// area→area (a cross-reference, a search pick into another
+/// area) — so the raise existed, read as correct, and stated no
+/// destination on one navigation path. A needle on the
+/// assignment alone would have stayed green through exactly
+/// that.
+extension KeyboardActionParityTests {
+    @Test("the shell states its two focus destinations")
+    func shellStatesItsFocusDestinations() throws {
+        let wirings: [ShellWiring] = [
+            ShellWiring(
+                "SettingsHeaderBar.swift",
+                ".focused($backChipFocused)",
+                "the back chip is the push destination — an "
+                    + "unattached @FocusState moves focus nowhere"
+            ),
+            ShellWiring(
+                "SettingsHeaderBar.swift",
+                ".onChange(of: destination) { _, now in "
+                    + "if now != nil { backChipFocused = true } }",
+                "and the raise is keyed on the VALUE: keyed on "
+                    + "`destination != nil` it fires on Home→area "
+                    + "only, so an area→area navigation destroys "
+                    + "the focused subtree and states nothing "
+                    + "(#998)"
+            ),
+            ShellWiring(
+                "HomeScreen.swift",
+                ".focused($focusedCard, equals: destination)",
+                "a Home card is the return destination"
+            ),
+            ShellWiring(
+                "HomeScreen.swift",
+                "model.nav.homeReturnFocus = destination",
+                "the push records which card to return to — "
+                    + "without it the restore reads nil forever"
+            ),
+            ShellWiring(
+                "HomeScreen.swift",
+                "if let last = model.nav.homeReturnFocus { "
+                    + "focusedCard = last "
+                    + "model.nav.homeReturnFocus = nil }",
+                "and the return pays it, once — the whole "
+                    + "closure, so clearing the slot stays beside "
+                    + "the restore rather than leaking a stale "
+                    + "card into the next unrelated appear"
+            ),
+        ]
+        let dir = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDesk/Settings")
+        let files = try SourceScan.swiftSources(under: dir)
+        for wiring in wirings {
+            let file = try #require(
+                files.first {
+                    $0.lastPathComponent == wiring.file
+                },
+                "\(wiring.file) is gone"
+            )
+            let source = squashedShell(
+                SourceScan.stripComments(
+                    try String(contentsOf: file, encoding: .utf8)
+                )
+            )
+            #expect(
+                source.contains(squashedShell(wiring.needle)),
+                Comment(
+                    rawValue:
+                        "\(wiring.file) lost `\(wiring.needle)` "
+                        + "— \(wiring.why), and the failure is "
+                        + "silent to everything except a person "
+                        + "using the keyboard"
+                )
+            )
+        }
+    }
+}
+
+/// Whitespace-free source, so a needle survives the formatter
+/// wrapping a call across lines — this file's copy of the main
+/// file's private `squashed` (per-file helpers, tests.md).
+private func squashedShell(_ source: String) -> String {
+    source.split(whereSeparator: \.isWhitespace).joined()
+}
+
+/// One focus wiring: file, use-site needle, and why it matters.
+private struct ShellWiring {
+    let file: String
+    let needle: String
+    let why: String
+
+    init(_ file: String, _ needle: String, _ why: String) {
+        self.file = file
+        self.needle = needle
+        self.why = why
+    }
+}


### PR DESCRIPTION
## Description

Area→area navigation (a cross-reference link, a search pick into
another area) stated no keyboard focus destination: the back-chip
raise in `SettingsHeaderBar` was keyed on the Boolean
`destination != nil`, which flips only on Home→area — area→area
keeps it `true`, `onChange` never fired, the focused subtree was
destroyed, and focus fell to the top of the window (the #816
outcome by the second road gui.md names). The fix keys the raise
on `destination` itself, exactly as the search-collapse wiring
two modifiers below always did.

The shell's two focus wirings — gui.md's own exemplars ("push
focuses the back chip, return restores `nav.homeReturnFocus`") —
were also the only ones in the tree with no needle, so they join
`KeyboardActionParityTests` keyed on their use sites, in a
sibling file (`+Shell.swift`) since the suite's file sits at the
§2.1 ceiling. The header needle spans the whole `onChange`
closure **including its key**, which is the clause that reds on
this exact defect.

## Related Issue(s)

Fixes #998

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (five use-site needles in
  `KeyboardActionParityTests+Shell.swift`)
- [x] User-facing changes are documented in `docs/` (the user
  guide's keyboard section already describes the promised
  behavior generically; the fix makes the app match it)
- [x] No contradictions between code and docs
- [ ] Release build green — CI's `Release Build` job (read it
  before merging; it reports, it does not block)
- [x] PR is focused; refactors separated from features

## How I verified

A named destination is not focus arriving there, so this had
both halves:

- **Device eye-confirm by the owner** (2026-08-30, keyboard
  navigation ON, signed build of this branch): Home→area focuses
  the back chip; an area→area jump via search pick keeps the
  back chip focused and Tab walks into the new area's content;
  Escape / activating the chip returns to Home with focus on the
  originally opened card. All as intended.
- **Wiring guards**: full gate green (`swift build`,
  `swift test` 4290 tests, `scripts/lint.sh`). `guard-prover`
  (isolated worktree) redded all six mutations, including the
  shipped Boolean-keyed spelling itself — the needle's span
  includes the `onChange` key, so the exact #998 defect cannot
  come back green.

## Notes for Reviewer

- review-change round ran: code-reviewer (1 minor, comment
  budget — applied), architect-reviewer (no findings; confirmed
  the extension-file suite split keeps `RuleCitationTests`'
  citations resolving and the new needles complement the
  existing `Wiring` list with zero overlap).
- The guard proves wirings are spelled, never that SwiftUI
  honors them — the device confirm above is the behavior half,
  per gui.md ▸ the keyboard path.
