### PR TITLE
chore(comments): trim settings and UI components to §2.8 budget (batch 6)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Common/AutoGatedGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/AutoGatedGroup.swift
@@ -32,7 +32,20 @@ struct AutoGatedGroup<Gated: View>: View {
     }
 }
 
-/// Disables and dims inert controls without compounding opacity (#171, #520).
+/// Disables and dims inert controls without compounding opacity
+/// (#171, #520): the first active gate dims and publishes the fact;
+/// nested gates still `.disabled` but leave opacity alone.
+///
+/// `help` is a HOVER fallback only, never the #94 affordance:
+/// `.disabled` is cumulative, so a `HelpButton` inside the gated
+/// content is dead — a block gate anchors a live `?` outside the
+/// subtree (#527). And a "no tooltip" report is AppKit's default
+/// tooltip delay until proven otherwise — `.disabled()` does NOT
+/// suppress `.help()` (2026-08-03).
+///
+/// Do not re-add an `.accessibilityHint` beside the `.help()`:
+/// written and BACKED OUT pending a live VoiceOver observation of
+/// block-granularity hints (#678 Phase 4 pass 10; tracked issue).
 struct GreyOut: ViewModifier {
     let active: Bool
     var help: String = ""

--- a/Sources/KiwiDesk/Settings/Components/Common/AutoGatedGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/AutoGatedGroup.swift
@@ -1,45 +1,15 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// A toggle that gates the control(s) directly below it. One
-/// `VStack` binds the switch above what it owns, so flipping it on
-/// reads as "this switch controls what's under it" — the
-/// Apple-native grouping (AGENTS §2.7). On greys the manual
-/// control(s) via the #171 "grey, don't hide" treatment
-/// (`GreyOut`): they stay visible but disabled and dimmed, never
-/// removed.
-///
-/// Shared by the App Bar Auto item/font-size pairs (the toggle is
-/// the `0 = auto` sentinel exposed through `AutoSentinel.binding`)
-/// and the Grid Auto-size block (a plain `autoSize` bool gating
-/// the Columns/Rows steppers). Before this component those three
-/// spelled the same interaction three ways, with different visual
-/// binding strengths, purely by which feature wave wrote them
-/// (#233).
+/// Toggle gating controls directly below it via `GreyOut` (#171, #233).
 struct AutoGatedGroup<Gated: View>: View {
     let title: String
     @Binding var isOn: Bool
-    /// Optional one-line caption naming where the automatic value
-    /// comes from when the gated control can't show it itself
-    /// (Grid: the screen plus the minimum window size). Omitted
-    /// where the gated slider already teaches its own automatic
-    /// behaviour (the App Bar sizes), keeping the caption's job to
-    /// "name a source the control can't" rather than gloss "why".
+    /// Optional caption explaining automatic source when gated control cannot.
     var caption: String? = nil
-    /// Whether the gated controls are genuinely inert. Defaults
-    /// to `isOn` — the common case, where this toggle is the only
-    /// thing that can silence them. A surface whose value can be
-    /// re-enabled elsewhere passes a narrower predicate: the
-    /// global Grid editor's steppers stay live for any space that
-    /// overrides auto-size OFF, and greying a control something
-    /// still reads is the worse direction (#520, #527).
+    /// Whether gated controls are inert; defaults to `isOn` (#520, #527).
     var gatedIsInert: Bool? = nil
-    /// The why-you-cannot sentence for the greyed controls. The
-    /// toggle directly above them usually answers it by
-    /// adjacency, which is why this is optional — but a caller
-    /// whose gate is resolved from the census carries a reason
-    /// with it, and without somewhere to put it that reason is
-    /// authored, translated and never shown.
+    /// Reason string explaining why controls are disabled.
     var gatedHelp: String = ""
     @ViewBuilder let gated: Gated
 
@@ -62,81 +32,7 @@ struct AutoGatedGroup<Gated: View>: View {
     }
 }
 
-/// The #171 "grey, don't hide" treatment: a control that has no
-/// effect in the current mode stays visible but disabled and
-/// dimmed. Generic (not App-Bar-specific) — `AutoGatedGroup`,
-/// the App Bar roundness gate, and the per-layout override all
-/// share it.
-///
-/// `help` is a HOVER fallback only (`.help()`), never the #94
-/// affordance: `.disabled` is cumulative, so any `HelpButton`
-/// inside the wrapped content is dead while the gate is active.
-/// A *block* gate therefore renders its explanation as a live
-/// `?` on an anchor outside the gated subtree — the
-/// `SettingsSection` header (`help:`) or a disclosure label
-/// (#527). A *control-scoped* gate (one row, its gating control
-/// directly adjacent) keeps just this hover string: the
-/// adjacency already answers "why", the way the toggle above an
-/// `AutoGatedGroup` does.
-///
-/// **A "no tooltip" report is AppKit's tooltip delay until
-/// proven otherwise** (2026-08-03): the greyed Columns/Rows
-/// steppers under Grid's Auto-size toggle read as having no
-/// hover string at all, and the cause was the default delay,
-/// not the gate. `.disabled()` does NOT suppress `.help()`.
-/// Hover long enough and the sentence appears.
-///
-/// That is worth a line here because the wrong reading is the
-/// tempting one — the string is on a disabled control, so the
-/// control looks like the culprit — and it sent one change down
-/// a workaround that fixed nothing. Reach for the delay first.
-///
-/// **Dims once, however deeply it nests.** Opacity multiplies,
-/// so a row inside an already-dimmed block used to land at
-/// `0.25` and read as broken rather than disabled. The #520
-/// sweep, which gates whole editors, made that reachable from
-/// the shipping defaults — an Auto-gated slider inside a
-/// switched-off bar hit it with one click.
-///
-/// The first active gate dims and publishes that fact; every
-/// gate below it still `.disabled`s (correct — the control is
-/// inert either way) but leaves opacity alone. Conjoining each
-/// inner predicate by hand was the alternative and is one more
-/// thing to forget; this makes the invariant unrepresentable
-/// instead of merely documented.
-///
-/// **The reason a grey carries still does not reach the keyboard
-/// path, and that is a KNOWN gap, not an oversight** (#678 Phase
-/// 4 pass 10). A greyed row announces its name and "dimmed"; the
-/// sentence explaining why lives in `.help()`, which needs a
-/// pointer to read.
-///
-/// An `.accessibilityHint(active ? help : "")` beside the
-/// `.help()` was written here and then BACKED OUT, because two
-/// things about it could not be verified without a live
-/// accessibility client and both failure modes are real:
-///
-/// - This modifier is applied at BLOCK granularity in several
-///   places (`BarColorCards`, `AppBarCard`, `LayoutCard`), so
-///   whether a hint on the wrapper reaches the controls inside
-///   decides between "twelve gates announce nothing" and "every
-///   control in a greyed card repeats one sentence".
-/// - The empty string when inactive is on the path of every
-///   descendant that sets a hint of its OWN — `ColorField`'s
-///   swatches do, under exactly these block gates — so if an
-///   ancestor's empty hint wins, the change silently deletes
-///   hints that ship today.
-///
-/// A headless probe cannot answer either: SwiftUI builds its
-/// accessibility children lazily and a hosted view reports only
-/// its root group. So the mechanism needs an Accessibility
-/// Inspector / VoiceOver session on a gated colour card first,
-/// and the answer may well be that a grey's reason belongs
-/// INLINE as text (the redesign's item 19 — "why-you-cannot
-/// always inline, VoiceOver reads it" — which `LoginItemCard`
-/// and `LoginItemCard` already do) rather than in a hint at all.
-/// Tracked as its own issue; do not re-add the hint here without
-/// that observation recorded.
+/// Disables and dims inert controls without compounding opacity (#171, #520).
 struct GreyOut: ViewModifier {
     let active: Bool
     var help: String = ""
@@ -159,26 +55,15 @@ private struct GreyOutDepthKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    /// True once some ancestor has already applied the grey
-    /// treatment, so a nested dim would compound it. Read by
-    /// `GreyOut` and by `OverrideChrome`, which dims inheriting
-    /// rows through the same mechanism.
+    /// True when ancestor already applied dimming, avoiding compounding
+    /// opacity.
     var isInsideGreyOut: Bool {
         get { self[GreyOutDepthKey.self] }
         set { self[GreyOutDepthKey.self] = newValue }
     }
 }
 
-/// The `0 = automatic` sentinel's GUI face: a Bool binding over
-/// a numeric field where `0` means automatic, so the Auto
-/// toggle reads and writes the sentinel without a second stored
-/// flag. Turning auto OFF seeds `restore` — pass the value the
-/// automatic behavior currently produces where it is computable
-/// (the glow size), a sensible constant where it is not (the
-/// bar sizes, whose auto values are content-measured at render).
-/// Promoted from the Bars area (as `AppBarAuto`) when the Focus
-/// border glow became its second client (#551) — `Common/`
-/// admits primitives shared across component areas.
+/// Binding adapter mapping numeric `0 = auto` sentinel to Bool toggle (#551).
 enum AutoSentinel {
     static func binding(
         _ value: Binding<CGFloat>,

--- a/Sources/KiwiDesk/Settings/Components/Common/ContextShortcut.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ContextShortcut.swift
@@ -1,65 +1,14 @@
 import AppKit
 import SwiftUI
 
-/// The ONE composition point for a row's action menu (#845).
-///
-/// A row hands its menu builder to `rowActions(_:)` ONCE, and
-/// the seam applies it to every channel — right-click
-/// (`.contextMenu`), VoiceOver (`.accessibilityActions`), and
-/// the keyboard chord on the row that contains focus. A site
-/// never spells a channel beside the seam: per-site application
-/// is how a crossed pairing or a stale mirrored list ships, and
-/// `KeyboardActionParityTests` reds on a bare channel outside
-/// this file. A FOURTH channel joins here, once, and every row
-/// has it.
-///
-/// The chord is `⌃.` (Control-Period — deliberately not `⌘.`,
-/// macOS's Cancel equivalent), matched in ONE place below,
-/// which the parity suite needles so prose stating the chord
-/// cannot drift from the code.
-///
-/// DELIVERY is a key MONITOR plus a row-anchored popover, and
-/// each half is the residue of a shipped failure (#845 review +
-/// device QA 2026-08-23). The monitor, because per-row
-/// `.keyboardShortcut` bindings are window-scoped and resolve
-/// first-in-hierarchy — N identical bindings cross-targeted the
-/// FIRST row's destructive items — and because a focus-gated
-/// hidden `Menu` never received the key at all on AppKit-backed
-/// controls (a `Picker`'s popup, a `TextField`), whose focus
-/// lives in the AppKit responder chain and publishes no SwiftUI
-/// `FocusedValues`; the chord just beeped. So the seam installs
-/// ONE `NSEvent` local monitor for the whole app and resolves
-/// the focused row itself, across BOTH focus worlds:
-///
-/// - SwiftUI-native focus (a `Button` tile) publishes the row's
-///   catcher through `FocusedValues`, matched directly;
-/// - AppKit-backed focus falls back to geometry — the row whose
-///   catcher frame contains the first responder's frame (the
-///   catcher is the row's `background`, so its frame IS the
-///   row's; rows do not overlap).
-///
-/// And the popover, because nothing can open a `.contextMenu`
-/// programmatically and a synthesized right-click pair proved
-/// nondeterministic on device (one build selected the row
-/// instead of opening its menu): the winner's row presents the
-/// SAME builder's actions in a popover anchored at the row —
-/// deterministic, Escape-dismissable — and the key event is
-/// swallowed. No match (no row focused) returns the event
-/// unhandled, so the system beep stays honest. The catcher
-/// draws nothing and consumes no mouse-down, so `.draggable`
-/// rows keep their drag. A row joining the family must be able
-/// to HOLD focus at all (`SpaceAssignmentChip` takes
-/// `.focusable()` for exactly this), and whether the chord
-/// LANDS is a device fact — verify with keyboard navigation ON;
-/// no headless guard can hear it.
+/// Action menu composition point across context menu, accessibility, and
+/// keyboard chord (#845).
 private struct RowActionFocusKey: FocusedValueKey {
     typealias Value = RowChordCatcher.Token
 }
 
 extension FocusedValues {
-    /// The catcher of the row whose subtree currently holds
-    /// SwiftUI focus — nil under AppKit-backed focus, which the
-    /// monitor's geometry fallback covers.
+    /// Catcher of row holding SwiftUI focus (`KeyboardActionParityTests`).
     var rowActionFocus: RowChordCatcher.Token? {
         get { self[RowActionFocusKey.self] }
         set { self[RowActionFocusKey.self] = newValue }
@@ -67,9 +16,8 @@ extension FocusedValues {
 }
 
 extension View {
-    /// Offers `menu` as the row's action menu on every channel:
-    /// right-click, VoiceOver actions, and the `⌃.` chord while
-    /// this row's subtree holds focus.
+    /// Attaches action menu to right-click, accessibility actions, and `⌃.`
+    /// chord (#845).
     func rowActions<MenuContent: View>(
         @ViewBuilder _ menu: @escaping () -> MenuContent
     ) -> some View {
@@ -80,17 +28,7 @@ extension View {
 private struct RowActions<MenuContent: View>: ViewModifier {
     let menu: () -> MenuContent
     @State private var catcher = RowChordCatcher.Token()
-    /// The chord's presentation: a row-anchored panel of the
-    /// SAME builder's actions. Not a native menu — nothing can
-    /// open a `.contextMenu` programmatically, and synthesizing
-    /// right-clicks proved nondeterministic on device (one
-    /// build selected the row instead of opening its menu) —
-    /// so the chord takes the one presentation SwiftUI can
-    /// drive: deterministic, keyboard-dismissable, anchored.
     @State private var chordMenuShown = false
-    /// The globally focused row's token, read back so THIS row
-    /// can mirror "it is me" into the monitor — `FocusedValues`
-    /// have no app-level observer to do it once.
     @FocusedValue(\.rowActionFocus) private var current
 
     func body(content: Content) -> some View {
@@ -121,9 +59,6 @@ private struct RowActions<MenuContent: View>: ViewModifier {
                         catcher.view
                     )
                 } else if let view = catcher.view {
-                    // Clear only our own claim: A→B focus moves
-                    // deliver A's false AFTER B's true, and an
-                    // unconditional nil would wipe B's.
                     RowChordMonitor.shared.clearFocused(
                         if: view
                     )
@@ -132,19 +67,10 @@ private struct RowActions<MenuContent: View>: ViewModifier {
     }
 }
 
-/// The row-sized, draw-nothing view that (a) gives the monitor
-/// the row's frame and window, and (b) is the thing a SwiftUI
-/// focus publication names. One shared monitor serves every
-/// catcher; it is installed on the first catcher's arrival and
-/// never removed — an app-lifetime singleton, like the menus it
-/// serves.
+/// Zero-size view publishing frame to monitor and anchoring popovers (#845).
 struct RowChordCatcher: NSViewRepresentable {
     let token: Token
 
-    /// Identity + the live `NSView` the monitor measures + the
-    /// row's own opener. A class on purpose: `FocusedValues`
-    /// needs a stable, equatable token per row, and the monitor
-    /// needs to reach the view and the opener from it.
     @MainActor
     final class Token: NSObject {
         weak var view: CatcherView?
@@ -180,25 +106,15 @@ struct RowChordCatcher: NSViewRepresentable {
     }
 }
 
-/// The one chord monitor. `focusedCatcher` is fed by the
-/// SwiftUI side (an app-wide `FocusedValue` observer would be a
-/// second window's to fight over; instead each key press asks
-/// the key window's hosting hierarchy afresh through the two
-/// signals described on the seam's doc).
+/// Monitor intercepting `⌃.` shortcut and presenting focused row's action
+/// popover (#845).
 @MainActor
 final class RowChordMonitor {
     static let shared = RowChordMonitor()
 
-    /// Every live catcher, weakly — rows come and go with their
-    /// `ForEach`.
     private let catchers = NSHashTable<RowChordCatcher.CatcherView>
         .weakObjects()
     private var installed = false
-
-    /// The SwiftUI-focused row's catcher, published through
-    /// `FocusedValues` and mirrored here by `RowActions` via
-    /// `noteFocused(_:)` — nil when focus is AppKit-backed or
-    /// nowhere.
     private weak var focusedCatcher: RowChordCatcher.CatcherView?
 
     func noteFocused(_ view: RowChordCatcher.CatcherView?) {
@@ -213,9 +129,6 @@ final class RowChordMonitor {
         catchers.add(view)
         guard !installed else { return }
         installed = true
-        // Local monitors fire on the main thread; the Bool hop
-        // exists because `assumeIsolated` requires a `Sendable`
-        // return and `NSEvent` is not one.
         _ = NSEvent.addLocalMonitorForEvents(
             matching: .keyDown
         ) { event in
@@ -226,7 +139,7 @@ final class RowChordMonitor {
         }
     }
 
-    /// `⌃.` — the one place the chord is spelled.
+    /// Matches `⌃.` key event (`KeyboardActionParityTests`, #845).
     private func matchesChord(_ event: NSEvent) -> Bool {
         event.charactersIgnoringModifiers == "."
             && event.modifierFlags
@@ -235,10 +148,6 @@ final class RowChordMonitor {
                 ]) == .control
     }
 
-    /// True when the event was the chord AND a focused row took
-    /// it (the caller then swallows it); false hands the event
-    /// on — including a chord press with no row focused, whose
-    /// system beep stays honest.
     private func consume(_ event: NSEvent) -> Bool {
         guard matchesChord(event), let window = event.window
         else { return false }
@@ -249,9 +158,8 @@ final class RowChordMonitor {
         return true
     }
 
-    /// The focused row's catcher: the SwiftUI publication when
-    /// one is live in this window, else the row whose frame
-    /// contains the AppKit first responder's frame.
+    /// Resolves focused row catcher from SwiftUI token or AppKit responder
+    /// frame containment.
     private func target(
         in window: NSWindow
     ) -> RowChordCatcher.CatcherView? {
@@ -262,13 +170,6 @@ final class RowChordMonitor {
         }
         guard let responder = window.firstResponder as? NSView
         else { return nil }
-        // FULL-frame containment, not a midpoint: under
-        // SwiftUI-native focus the first responder is the
-        // hosting view, whose frame is the whole window — a
-        // midpoint test would false-match whichever row sits at
-        // window center. A real AppKit control (a popup, the
-        // field editor) fits inside its row; the hosting view
-        // fits inside none.
         let rect = responder.convert(responder.bounds, to: nil)
         return catchers.allObjects.first { catcher in
             catcher.window === window
@@ -276,5 +177,4 @@ final class RowChordMonitor {
                     .contains(rect)
         }
     }
-
 }

--- a/Sources/KiwiDesk/Settings/Components/Common/ContextShortcut.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ContextShortcut.swift
@@ -1,8 +1,21 @@
 import AppKit
 import SwiftUI
 
-/// Action menu composition point across context menu, accessibility, and
-/// keyboard chord (#845).
+/// The ONE composition point for a row's action menu (#845):
+/// right-click, VoiceOver actions and the `⌃.` chord from one
+/// builder — never spell a channel beside the seam;
+/// `KeyboardActionParityTests` reds on a bare one outside this
+/// file.
+///
+/// Delivery is a key MONITOR plus a row-anchored popover, each the
+/// residue of a shipped failure (#845 review + device QA
+/// 2026-08-23): per-row `.keyboardShortcut` is window-scoped and
+/// cross-targeted the FIRST row; a focus-gated hidden `Menu` never
+/// hears AppKit-backed focus; nothing opens a `.contextMenu`
+/// programmatically, and synthesized right-clicks proved
+/// nondeterministic on device. A row joining the family must be
+/// able to HOLD focus, and whether the chord LANDS is a device
+/// fact — verify with keyboard navigation ON.
 private struct RowActionFocusKey: FocusedValueKey {
     typealias Value = RowChordCatcher.Token
 }
@@ -59,6 +72,9 @@ private struct RowActions<MenuContent: View>: ViewModifier {
                         catcher.view
                     )
                 } else if let view = catcher.view {
+                    // Clear only our own claim: A→B focus moves
+                    // deliver A's false AFTER B's true, and an
+                    // unconditional nil would wipe B's.
                     RowChordMonitor.shared.clearFocused(
                         if: view
                     )
@@ -67,7 +83,10 @@ private struct RowActions<MenuContent: View>: ViewModifier {
     }
 }
 
-/// Zero-size view publishing frame to monitor and anchoring popovers (#845).
+/// Zero-size view publishing frame to monitor and anchoring
+/// popovers (#845). One shared monitor serves every catcher —
+/// installed on the first arrival, never removed: an app-lifetime
+/// singleton, like the menus it serves.
 struct RowChordCatcher: NSViewRepresentable {
     let token: Token
 
@@ -170,6 +189,10 @@ final class RowChordMonitor {
         }
         guard let responder = window.firstResponder as? NSView
         else { return nil }
+        // FULL-frame containment, not a midpoint: under SwiftUI
+        // focus the first responder is the hosting view, whose
+        // frame is the whole window — a midpoint test would
+        // false-match whichever row sits at window center.
         let rect = responder.convert(responder.bounds, to: nil)
         return catchers.allObjects.first { catcher in
             catcher.window === window

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsRows.swift
@@ -9,6 +9,10 @@ struct PtSlider: View {
     @Binding var value: CGFloat
     var range: ClosedRange<Double> = 0...100
     var unit: String = "pt"
+    /// Opt-in: 0 is this slider's Auto sentinel, read out as the
+    /// full word (R6/#406). Explicit, never inferred from the
+    /// range — a 1-floored slider without a sentinel must keep
+    /// printing its number (QA 2026-07-19).
     var autoAtZero: Bool = false
     var help: String? = nil
 
@@ -47,6 +51,11 @@ struct PtSlider: View {
             )
             .foregroundStyle(.secondary)
             .font(.body.monospacedDigit())
+            // A long localized "Automatic" shrinks rather than
+            // truncates. Load-bearing: the word only renders
+            // dimmed beside full-size numbers, so smaller reads
+            // as inert, not broken — don't "fix" the scale
+            // factor away.
             .lineLimit(1)
             .minimumScaleFactor(0.75)
     }
@@ -122,6 +131,8 @@ struct RatioRow: View {
         }
     }
 
+    /// Rounded, not truncated: a stored exact 0.29 must read
+    /// "29%", never "28%".
     private var readoutText: String {
         "\(Int((value * 100).rounded()))%"
     }
@@ -136,6 +147,9 @@ extension View {
 }
 
 /// Labeled checkbox toggle row with optional help popover (#94).
+/// The `?` is a sibling after the toggle, never nested in its
+/// label — an independent hit target and rotor stop the Toggle
+/// would otherwise swallow.
 struct ToggleRow: View {
     let label: String
     @Binding var isOn: Bool

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsRows.swift
@@ -1,44 +1,15 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The shared row vocabulary of the settings tabs. Every row
-/// puts its label in `SettingsMetrics.labelColumn` (sliders,
-/// dropdowns, segmented pickers) or pushes its control to the
-/// trailing edge (steppers), so controls of the same kind line
-/// up across sections.
-///
-/// Since #678 turn 17a the label/control arrangement itself is
-/// `SettingsRowShape`'s, not each row's: below the row
-/// breakpoint the label moves above its control and the shared
-/// column stops applying. A row here supplies the two children
-/// and never the axis.
+/// Shared row vocabulary for settings tabs aligned across sections (#678).
 
-/// A pt-valued slider row with a numeric readout, shared by the
-/// monocle and drag-visual editors. The label column comes from
-/// the environment, so `OverrideChrome` narrows it once for
-/// every row inside.
+/// Point-valued slider row with formatted numeric readout (#406, #94).
 struct PtSlider: View {
     let label: String
     @Binding var value: CGFloat
     var range: ClosedRange<Double> = 0...100
-    /// The readout unit; `pt` by default, `%` for proportion
-    /// sliders (e.g. the App Bar corner roundness).
     var unit: String = "pt"
-    /// Opt-in: 0 is this slider's Auto sentinel (an
-    /// `AutoGatedGroup` toggle wrote it), so the readout says
-    /// "Automatic" instead of "0 pt" — the full word, because a
-    /// readout is a VALUE the user reads, not the adjective in a
-    /// toggle label (R6/#406). It is the widest thing the readout
-    /// column has to hold; see `SettingsMetrics.readoutColumn`.
-    /// Explicit, never inferred from
-    /// the range — a 1-floored slider without a sentinel must
-    /// keep printing its number (QA 2026-07-19).
     var autoAtZero: Bool = false
-    /// Optional `?` popover (#94), label-adjacent and inside the
-    /// shared label column — the same slot `SecondsRow` and
-    /// `RatioRow` carry. Declared LAST so a call site can pass
-    /// it while leaving `unit` and `autoAtZero` at their
-    /// defaults.
     var help: String? = nil
 
     var body: some View {
@@ -76,29 +47,17 @@ struct PtSlider: View {
             )
             .foregroundStyle(.secondary)
             .font(.body.monospacedDigit())
-            // A locale whose word for "Automatic" runs longer
-            // than the column shrinks rather than truncating —
-            // a clipped readout reads as a rendering bug, a
-            // slightly smaller one does not. Load-bearing: the
-            // word ONLY renders on an `AutoGatedGroup`-gated
-            // row, so it is always dimmed and disabled beside
-            // full-size numbers — a slightly smaller word there
-            // reads as "inert", not "broken". Don't "fix" the
-            // scale factor away.
             .lineLimit(1)
             .minimumScaleFactor(0.75)
     }
 }
 
-/// A seconds-valued slider backed by a millisecond `Int` store,
-/// with a `1.5 s` readout — the Space Bar drag-drop spring dwell
-/// (#372). Bounds come in seconds; the binding converts to/from
-/// the stored milliseconds.
+/// Slider row formatted in fractional seconds with millisecond storage (#372,
+/// #94).
 struct SecondsRow: View {
     let label: String
     @Binding var ms: Int
     var range: ClosedRange<Double> = 0.5...4.0
-    /// Optional `?` popover (#94), label-adjacent.
     var help: String? = nil
 
     var body: some View {
@@ -133,13 +92,10 @@ struct SecondsRow: View {
     }
 }
 
-/// A 0.1–0.9 ratio slider with a percentage readout.
+/// Ratio slider row formatted in percentage (0.1–0.9) (#94).
 struct RatioRow: View {
     let label: String
     @Binding var value: Double
-    /// Optional `?` popover (#94), label-adjacent: the
-    /// question is born at the label, so the affordance sits
-    /// where the confusion starts.
     var help: String? = nil
 
     var body: some View {
@@ -166,42 +122,23 @@ struct RatioRow: View {
         }
     }
 
-    /// Rounded, not truncated: a stored exact 0.29
-    /// (Lua/profile) must read "29%", not "28%".
     private var readoutText: String {
         "\(Int((value * 100).rounded()))%"
     }
 }
 
 extension View {
-    /// A slider row's numeric readout is the control's value
-    /// drawn again for the eye; the slider already speaks it
-    /// (`SettingsSlider.spokenValue`), so read aloud as well it
-    /// is the same number twice, in a third element. Every
-    /// readout beside a `SettingsSlider` takes this.
+    /// Hides redundant visual readout from VoiceOver since slider speaks its
+    /// value.
     func settingsReadout() -> some View {
         accessibilityHidden(true)
     }
 }
 
-/// A labeled toggle carrying an optional #94 `?`. A plain
-/// `Toggle` has no help slot, so the switches that want one (wrap
-/// focus, the App Bar group-adjacent toggle) route through this.
-/// The `?` is a **sibling** after the toggle, never nested inside
-/// its label: these render in the checkbox style (box left, label
-/// right — a plain `VStack`, not a `Form`), so a trailing sibling
-/// still lands immediately after the label text (#94 placement),
-/// and staying a sibling keeps the `?` an independent hit target
-/// and VoiceOver rotor stop instead of one the Toggle swallows.
-/// `fixedSize` makes the toggle hug its label so the `?` sits
-/// adjacent rather than pushed to the pane edge. Unlike the
-/// dropdown/ratio rows the `?` can't sit inside the shared
-/// `settingsLabelColumn` — a native toggle is full-width — so it
-/// trails variable-width label text instead of column-aligning.
+/// Labeled checkbox toggle row with optional help popover (#94).
 struct ToggleRow: View {
     let label: String
     @Binding var isOn: Bool
-    /// Optional `?` popover (#94). Omit for a self-evident toggle.
     var help: String? = nil
 
     var body: some View {
@@ -215,12 +152,7 @@ struct ToggleRow: View {
     }
 }
 
-/// Hover-driven background chip for icon-only borderless
-/// buttons that otherwise show no cue until pressed — the
-/// `ColorSwatch` recipe, generalized: a `RoundedRectangle` fill
-/// that lifts from a faint rest state to a stronger one on
-/// `.onHover`. Buttons never change the cursor (AGENTS.md); this
-/// is chrome only, no `pointingHandCursor()`.
+/// Hover-driven background highlight modifier for borderless controls.
 private struct HoverChip: ViewModifier {
     @State private var hovering = false
     @Environment(\.accessibilityReduceMotion)
@@ -255,10 +187,7 @@ private struct HoverChip: ViewModifier {
 }
 
 extension View {
-    /// Wraps an icon-only borderless control in a hover
-    /// background chip (0.06 at rest → 0.12 on hover, matching
-    /// `ColorSwatch.swatchButton`), so it reads as clickable
-    /// before the pointer commits to a press.
+    /// Adds hover background highlight to borderless controls.
     func hoverHighlight(
         restOpacity: Double = 0.06,
         hoverOpacity: Double = 0.12,
@@ -275,10 +204,8 @@ extension View {
         )
     }
 
-    /// Complete treatment for an ambiguous icon-only button:
-    /// visible chip, pointer confirmation, tooltip, and a real
-    /// VoiceOver name. The call site supplies one action phrase
-    /// so those four surfaces cannot drift.
+    /// Complete affordance for icon buttons with hover chip, tooltip, and
+    /// accessibility label.
     func iconButtonAffordance(
         _ label: String,
         cornerRadius: CGFloat = 4,
@@ -292,25 +219,8 @@ extension View {
         .accessibilityLabel(label)
     }
 
-    /// Hover confirmation for a custom full-row button whose
-    /// own resting signal is its context — a list row's
-    /// neighbours, a drawer header's chevron and hairline.
-    /// Unlike icon chips, it adds no fill until the pointer
-    /// enters the hit area.
-    ///
-    /// **That is the whole difference between the two recipes,
-    /// and it is a difference of AREA, not of taste** (#956,
-    /// owner on device 2026-08-24). `hoverHighlight()`'s 0.06
-    /// rest fill is an icon-chip cue: at a glyph's size nobody
-    /// reads its hue. Stretched across a full row it composites
-    /// to an exactly-neutral band — R=G=B — which is the only
-    /// achromatic surface in a green-tinted window, and it
-    /// reads as wrong beside a `sunken` well of nearly the same
-    /// lightness. A full-row control takes this one.
-    ///
-    /// The geometry is a parameter so the next full-row control
-    /// that needs a different inset does not re-coin the
-    /// ladder; the LADDER itself is not a parameter.
+    /// Hover highlight for full-width row buttons starting with transparent
+    /// rest state (#956).
     func rowHoverHighlight(
         cornerRadius: CGFloat = 5,
         padding: CGFloat = 0

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Apps.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Apps.swift
@@ -1,7 +1,9 @@
 import AppKit
 import KiwiDeskCore
 
-/// Launch behavior for Open-Applications shortcut bindings (#334).
+/// Launch behavior for Open-Applications shortcut bindings (#334),
+/// derived from the binding's `lua` verb, never a persisted field
+/// — so there is no `KeyBinding` shape to migrate or parity-test.
 enum AppLaunchBehavior: String, CaseIterable {
     case openOrFocus
     case openNew
@@ -84,6 +86,8 @@ extension KeybindingCatalog {
         } ?? preferred
     }
 
+    /// nil unless `lua` is exactly an app-launch call; an embedded
+    /// quote means escaped content the app menu never authors.
     private static func parseAppCommand(
         _ lua: String
     ) -> (bundleID: String, behavior: AppLaunchBehavior)? {
@@ -195,8 +199,10 @@ extension KeybindingCatalog {
         return id
     }
 
-    /// Resolves user-language display name via Spotlight metadata or
-    /// FileManager fallback.
+    /// Resolves user-language display name via Spotlight metadata
+    /// or FileManager fallback, stripping the soft hyphen some
+    /// localized names carry so it never leaks a line break into
+    /// a label or skews a sort key.
     private static func localizedName(
         url: URL,
         path: String

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Apps.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Apps.swift
@@ -1,21 +1,11 @@
 import AppKit
 import KiwiDeskCore
 
-/// The launch behavior an Open-Applications binding encodes,
-/// derived from its `lua` verb rather than a persisted field
-/// (#334) — so surfacing the choice adds no `KeyBinding` shape to
-/// migrate or parity-test. Both verbs already dispatch to the same
-/// engine helper (`launch(newInstance:)`); the GUI only exposes the
-/// flag. Default is `openOrFocus`, the single most useful behavior.
+/// Launch behavior for Open-Applications shortcut bindings (#334).
 enum AppLaunchBehavior: String, CaseIterable {
-    /// `pull_or_spawn` — pull a running instance into the current
-    /// space, or launch it if absent. The default.
     case openOrFocus
-    /// `spawn_new` — always launch a fresh instance, even when one
-    /// is already running.
     case openNew
 
-    /// The Lua verb this behavior dispatches to.
     var verb: String {
         switch self {
         case .openOrFocus: return "pull_or_spawn"
@@ -24,17 +14,11 @@ enum AppLaunchBehavior: String, CaseIterable {
     }
 }
 
-/// The installed-application catalog and the app-launch command
-/// inverse, split from `KeybindingCatalog` to stay under the
-/// file-size ceiling. Apps are identified by bundle id (the
-/// stable, locale- and rename-proof key — see `AppRef`) and
-/// shown by their localized display name.
+/// Application catalog and command parser helpers for app shortcuts (#334,
+/// #333).
 extension KeybindingCatalog {
-    /// The Open-Applications action for this bundle id and launch
-    /// behavior. Paired with `appBundleID(from:)` /
-    /// `appLaunchBehavior(from:)`, its exact inverse. Behavior
-    /// defaults to open-or-focus so existing call sites keep their
-    /// meaning.
+    /// Formats Lua command for launching bundle identifier with specified
+    /// behavior.
     static func appCommand(
         _ bundleID: String,
         behavior: AppLaunchBehavior = .openOrFocus
@@ -42,27 +26,20 @@ extension KeybindingCatalog {
         "KiwiDesk.\(behavior.verb)(\"\(bundleID)\")"
     }
 
-    /// The bundle id inside `appCommand`'s output, or nil when
-    /// `lua` isn't exactly one of the app-launch calls — the
-    /// inverse used by import classification. Matches either verb.
+    /// Extracts bundle identifier from app-launch Lua command string.
     static func appBundleID(from lua: String) -> String? {
         parseAppCommand(lua)?.bundleID
     }
 
-    /// The launch behavior `lua` encodes, or nil when it isn't an
-    /// app-launch call. The sibling inverse to `appBundleID(from:)`.
+    /// Extracts launch behavior from app-launch Lua command string.
     static func appLaunchBehavior(
         from lua: String
     ) -> AppLaunchBehavior? {
         parseAppCommand(lua)?.behavior
     }
 
-    /// The launch behaviors already bound for `bundleID` across
-    /// these application bindings, `excluding` one row (the one
-    /// being edited). The single basis the GUI reasons over for the
-    /// per-row grey-out, the add-row seed, and the fully-bound
-    /// exclusion (#334) — pure, so it is unit-testable without the
-    /// view.
+    /// Launch behaviors already bound for `bundleID` in given keybindings
+    /// (#334).
     static func takenBehaviors(
         for bundleID: String,
         in bindings: [KeyBinding],
@@ -77,8 +54,7 @@ extension KeybindingCatalog {
         )
     }
 
-    /// The first launch behavior not yet bound for `bundleID`, or
-    /// nil when every behavior is already taken (#334).
+    /// First available launch behavior for `bundleID` (#334).
     static func firstAvailableBehavior(
         for bundleID: String,
         in bindings: [KeyBinding]
@@ -89,12 +65,8 @@ extension KeybindingCatalog {
         }
     }
 
-    /// The behavior a row should carry after (re-)assigning it to
-    /// `bundleID`: keep `preferred` when it's still free for that
-    /// app, else the first free behavior, else `preferred` as a
-    /// last resort (every behavior is already bound on other rows).
-    /// `excluding` drops the row being reassigned. Keeps a re-pick
-    /// from silently colliding with another row (#334).
+    /// Resolves preferred or available behavior when reassigning application
+    /// row (#334).
     static func behaviorForAssignment(
         to bundleID: String,
         preferred: AppLaunchBehavior,
@@ -112,10 +84,6 @@ extension KeybindingCatalog {
         } ?? preferred
     }
 
-    /// Decomposes an app-launch Lua call into its bundle id and
-    /// behavior, or nil when `lua` isn't exactly such a call. An
-    /// embedded quote means escaped content the app menu never
-    /// authors, so such Lua stays unmatched.
     private static func parseAppCommand(
         _ lua: String
     ) -> (bundleID: String, behavior: AppLaunchBehavior)? {
@@ -133,21 +101,13 @@ extension KeybindingCatalog {
         return nil
     }
 
-    /// One app a picker can target: the bundle identifier is
-    /// the stored identity (stable across locale and rename —
-    /// see `AppRef`), the localized display name is what's
-    /// shown. Apps with no bundle id (rare unbundled helpers)
-    /// can't be targeted by a rule and are dropped.
+    /// Target application with bundle ID and display name.
     struct InstalledApp: Hashable, Identifiable {
         let bundleID: String
         let name: String
         var id: String { bundleID }
     }
 
-    /// The single disk scan under the standard roots, run once:
-    /// the app catalog plus each app's path for the icon cache
-    /// to warm from. De-duplicated by bundle id (lower-cased,
-    /// matching the normalized `AppRef.bundleID`).
     private static let diskScan:
         (apps: [InstalledApp], iconPaths: [String: String]) = {
             let manager = FileManager.default
@@ -182,23 +142,15 @@ extension KeybindingCatalog {
             return (Array(byID.values), paths)
         }()
 
-    /// Apps discoverable on disk under the standard roots.
     private static var diskApps: [InstalledApp] { diskScan.apps }
 
-    /// Bundle id → app path for every disk app, the seed the
-    /// icon cache warms from (running apps outside the scanned
-    /// roots resolve lazily on miss). Frozen for process life,
-    /// so the cache needs no invalidation.
+    /// Bundle ID to application file path mapping for disk applications.
     static var diskAppIconPaths: [String: String] {
         diskScan.iconPaths
     }
 
-    /// The picker list: disk apps unioned with currently
-    /// running apps, sorted by display name. Running apps fill
-    /// in bundles outside the scanned roots — Finder (in
-    /// /System/Library/CoreServices) most notably — without
-    /// scanning the noisy system directories for the handful of
-    /// user-facing apps they hold.
+    /// Installed disk and running regular applications sorted by localized
+    /// display name.
     static var installedApps: [InstalledApp] {
         var byID = Dictionary(
             diskApps.map { ($0.bundleID, $0) },
@@ -209,11 +161,6 @@ extension KeybindingCatalog {
             guard let id = app.bundleIdentifier?.lowercased(),
                 byID[id] == nil
             else { continue }
-            // Only fills bundles outside the scanned roots
-            // (Finder in CoreServices). Name via the same Spotlight
-            // resolver so it's localized and matches the disk
-            // entries; `localizedName` (the app's own) is the
-            // fallback when the bundle has no URL.
             let name =
                 app.bundleURL.map {
                     localizedName(url: $0, path: $0.path)
@@ -226,39 +173,19 @@ extension KeybindingCatalog {
         }
     }
 
-    /// A one-shot snapshot of `installedApps` for the picker,
-    /// computed on first access and cached for process life. The
-    /// popover reads this directly, so its list is fully
-    /// populated the instant it renders — no empty-then-fill race
-    /// through view state — and isn't rebuilt on every keystroke.
-    /// The trade is that an app launched mid-session (outside the
-    /// scanned disk roots) won't appear until relaunch; disk apps,
-    /// the bulk, are already frozen for process life.
+    /// Process-lifetime cached snapshot of installed applications.
     static let installedAppsSnapshot: [InstalledApp] = installedApps
 
-    /// Process-life `bundleID → localized name` index over the
-    /// snapshot, so `displayName(forBundleID:)` resolves an
-    /// installed app with a dictionary hit instead of a live
-    /// `NSWorkspace` + Spotlight read. Immutable (`static let`), so
-    /// it's concurrency-safe and shared by every render that
-    /// resolves or sorts app rows (#333 sorts by display name, so
-    /// the App Rules list would otherwise re-hit Spotlight per app
-    /// on every pass — a §5 main-thread cost).
+    /// Process-lifetime dictionary mapping bundle ID to localized name (#333).
     static let installedNameByID: [String: String] =
         Dictionary(
             installedAppsSnapshot.map { ($0.bundleID, $0.name) },
             uniquingKeysWith: { first, _ in first }
         )
 
-    /// The localized display name for a bundle id, for showing
-    /// a stored rule or binding whose identity is the id. Routed
-    /// through the same `localizedName` resolver as the picker,
-    /// so the two surfaces agree for any installed app. Falls
-    /// back to the id itself when the app isn't installed.
+    /// Resolves localized display name for bundle identifier (#333).
     static func displayName(forBundleID id: String) -> String {
         let id = id.lowercased()
-        // The snapshot covers every app present at launch; a live
-        // lookup only remains for one installed mid-session.
         if let name = installedNameByID[id] { return name }
         if let url = NSWorkspace.shared.urlForApplication(
             withBundleIdentifier: id
@@ -268,18 +195,8 @@ extension KeybindingCatalog {
         return id
     }
 
-    /// The app's user-language display name, the single resolver
-    /// both the picker and `displayName(forBundleID:)` use.
-    /// Reads Spotlight's `kMDItemDisplayName` — the same index
-    /// Finder, the Dock, and Spotlight read, so it localizes
-    /// ("Vorschau", "Systemeinstellungen") where a process-local
-    /// bundle lookup can't (KiwiDesk ships an English-only bundle,
-    /// localizing its own GUI via a JSON catalog, not `.lproj`).
-    /// Strips a soft hyphen some localized names carry
-    /// ("System\u{00AD}einstellungen") so it never leaks a line
-    /// break into a label or skews a sort/search key. Falls back
-    /// to `FileManager`'s display name when Spotlight has no entry
-    /// (indexing off, a just-installed or atypical bundle).
+    /// Resolves user-language display name via Spotlight metadata or
+    /// FileManager fallback.
     private static func localizedName(
         url: URL,
         path: String
@@ -301,11 +218,6 @@ extension KeybindingCatalog {
         return appDisplayName(path: path)
     }
 
-    /// `FileManager`'s display name for a bundle, without the
-    /// ".app" extension — the fallback when Spotlight can't name
-    /// the app. Resolves in KiwiDesk's English-only process, so a
-    /// CoreServices-localized system app reads in English here;
-    /// the stored identity is the bundle id regardless (`AppRef`).
     private static func appDisplayName(path: String) -> String {
         let shown = FileManager.default.displayName(
             atPath: path

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingGroups.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingGroups.swift
@@ -205,7 +205,10 @@ struct SizeFloatGroup: View {
         }
     }
 
-    /// Caption describing resize scope across layouts (#818).
+    /// Caption describing resize scope across layouts. It names no
+    /// verb (owner ruling 2026-08-29) — quoting the rows' labels is
+    /// the #818 drift — and scopes by the dimension: it renders
+    /// after SEVEN rows, the four resize ones plus three toggles.
     private var sizeFloatCaption: String {
         L(
             "shortcuts.size_float.layouts_caption",

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingGroups.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingGroups.swift
@@ -1,27 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Shortcuts action groups (#678 Phase 3, turn 5), rendered
-/// FROM the settings census: `ShortcutsRowOrder` gives the
-/// families in display order, `ShortcutsFamilyRows` expands each
-/// into its rows, and `ShortcutsCensusRenderTests` pins both
-/// against the census. Adding a keybinding family to the census
-/// therefore fails the guard until it is placed in an order list,
-/// and fails to compile until it is given an expansion.
-///
-/// Flat titled sections, one level of hierarchy — Focus, Move
-/// windows, Size & float, Switch layers (the old double-nested
-/// disclosures are gone). Space rows generate from the defined
-/// spaces, so adding a space adds its commands. Recording upserts
-/// a `.navigation` row keyed by its Lua; clearing removes it.
+/// Shortcuts action groups mapped from census definitions
+/// (`ShortcutsCensusRenderTests`, #678).
 
-/// One census family's rows, plus the sub-heading and caption a
-/// family carries when its rows need naming as a block.
-///
-/// The heading belongs to the FAMILY, not to the container, which
-/// is why it is resolved from the key rather than written into
-/// each group: the census is what says a family exists, so a
-/// family gains its heading with its rows.
+/// Family rows view displaying heading, caption, and navigation rows (#678).
 struct KeybindingFamilyRows: View {
     @ObservedObject var model: SettingsModel
     @Binding var bindings: [KeyBinding]
@@ -65,21 +48,7 @@ struct KeybindingFamilyRows: View {
         expander.renderedRows(for: key)
     }
 
-    /// The block sentence for a family holding rows whose action
-    /// cannot run right now — drawn ONCE, above the rows.
-    ///
-    /// Once rather than per row, which is the trap gui.md names:
-    /// a reason stamped inside the `ForEach` repeats under every
-    /// child. The rows carry the short spoken mark
-    /// (`NavCommand.unavailable`) and this carries the
-    /// explanation, so the dimming is a sentence on both
-    /// channels rather than a grey with nothing to read.
-    ///
-    /// Generic in the view and Desktop-shaped only in its words,
-    /// because a Desktop is the one thing a row can target that
-    /// the user's HARDWARE can take away — a space, a track and
-    /// a layer are all config, and are never absent while their
-    /// row is drawn.
+    /// Caption for actions targeting temporarily disconnected displays.
     private var unavailableNote: String {
         L(
             "shortcuts.desktop_away",
@@ -90,10 +59,7 @@ struct KeybindingFamilyRows: View {
     }
 }
 
-/// The block headings and captions a family carries above its
-/// rows. Only some families have one: four directional rows read
-/// fine under the container title, while a per-space block needs
-/// saying what the repetition is.
+/// Headings and context captions for shortcut census families (#188).
 @MainActor
 enum ShortcutsFamilyHeading {
     static func title(for key: SettingKey) -> String? {
@@ -116,10 +82,6 @@ enum ShortcutsFamilyHeading {
         }
     }
 
-    /// Track authoring rows are always rendered — no gate (#188).
-    /// The caption tells newcomers these only matter in the track
-    /// layout, so unbound rows in another layout don't read as
-    /// broken.
     static func caption(for key: SettingKey) -> String? {
         switch key {
         case .shortcuts(.moveWindowToTrack):
@@ -178,11 +140,7 @@ struct MoveWindowsGroup: View {
     }
 }
 
-/// Size & float (#68 §3.5): the per-axis Grow/Shrink rows (#56)
-/// and the state toggles, with the unsupported-resize cue (#184)
-/// behind the card's disclosure — the census tiers it
-/// `.showMore`, being the one row here that is a preference
-/// rather than a binding.
+/// Size & float shortcut section (#68, #56, #184).
 struct SizeFloatGroup: View {
     @ObservedObject var model: SettingsModel
     @Binding var bindings: [KeyBinding]
@@ -240,10 +198,6 @@ struct SizeFloatGroup: View {
                 isOn: $model.config.settings.resizeFeedback
             )
         default:
-            // The render-parity guard forces every census row of
-            // this container into an order list — an unhandled
-            // key reaching this arm must fail loud in debug, not
-            // vanish.
             let _ = assertionFailure(
                 "unrendered Shortcuts census key: \(key.id)"
             )
@@ -251,42 +205,7 @@ struct SizeFloatGroup: View {
         }
     }
 
-    // A meaning change replaced the old `axes_caption` key
-    // (stale since track landed, #128/#183): per
-    // docs/translating.md a changed English text gets a NEW
-    // key, never a rename — rename-key would carry the stale
-    // translations forward as if still valid. This caption's
-    // own later rewording took the other sanctioned route,
-    // `scripts/drop-key <key>`, which retires the stale
-    // translations and keeps the key.
-    //
-    // **It names no verb, deliberately** (owner ruling,
-    // 2026-08-29). It used to open "Grow/Shrink", quoting rows
-    // whose own labels are `keybinding.grow_*` /
-    // `keybinding.shrink_*` — the literal-text shape #818 bans,
-    // and the mechanism by which four catalogs came to carry a
-    // second verb for the action their own rows already named
-    // (es, fr, ja, zh-Hans; swept in the change before this).
-    // #818's usual fix is to interpolate the label key, and
-    // there is no single one to interpolate: this stands for
-    // four keys. So the caption stops naming the action
-    // instead, which removes the drift rather than managing it
-    // — with no verb here, there is nothing to disagree with
-    // the rows, and a future verb sweep touches the four labels
-    // alone.
-    //
-    // It scopes by the DIMENSION rather than by "these
-    // shortcuts", and that is a correction rather than a
-    // flourish (localization round, 2026-08-29): the caption
-    // renders after `ShortcutsRowOrder.sizeAndFloatAtRest`,
-    // which is SEVEN rows — the four resize ones and the three
-    // state toggles — so a deictic subject claims Toggle
-    // floating is a no-op in the floating layout. The retired
-    // English was accurate only because naming the verb scoped
-    // it; dropping the verb dropped the scope with it. "Width
-    // and height" names the four rows without quoting a label
-    // ("Grow width", "Shrink height") and without a verb, and
-    // the next sentence already uses that vocabulary.
+    /// Caption describing resize scope across layouts (#818).
     private var sizeFloatCaption: String {
         L(
             "shortcuts.size_float.layouts_caption",
@@ -303,12 +222,7 @@ struct SizeFloatGroup: View {
     }
 }
 
-/// General app actions (#330, #678 item 18): the bindable
-/// "Show shortcuts panel" and "Open Settings" hotkeys — app
-/// chrome, not workspace actions, so they sit in their own low
-/// section rather than among Focus / Move / Size. The panel is
-/// seeded to ⌃⌥K by default (#602); Open Settings ships
-/// deliberately unbound, Settings being no prerequisite.
+/// App-level shortcut hotkeys group (#330, #602).
 struct GeneralShortcutsGroup: View {
     @ObservedObject var model: SettingsModel
     @Binding var bindings: [KeyBinding]
@@ -337,12 +251,3 @@ struct GeneralShortcutsGroup: View {
         }
     }
 }
-
-/// The Layers card: the chip strip that defines the layers, and
-/// the rows that switch between them.
-///
-/// One card because the census places all three families in one
-/// container — the strip, its menu-bar icon and the switch rows —
-/// and because the switch shortcuts belong beside the definition
-/// they act on rather than among the action groups.
-///

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderField.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderField.swift
@@ -2,13 +2,22 @@ import AppKit
 import KiwiDeskCore
 import SwiftUI
 
-/// Keybinding recorder capturing shortcuts into canonical combo strings (#212,
-/// #33, #34).
+/// Keybinding recorder capturing shortcuts into canonical combo
+/// strings (#212, #33, #34). Requires a `RecorderCoordinator` in
+/// the environment — rendering it outside `ShortcutsSection` is a
+/// programmer error and will crash.
 struct KeyRecorderField: View {
+    /// VoiceOver's name for the field — the command it binds. The
+    /// visible text is the COMBO, its value, so without this every
+    /// row announced its value as its name (#812).
     let name: String
     let combo: String
     var conflict: String?
+    /// KiwiDesk-collision check run before committing; nil commits
+    /// unconditionally.
     var preflight: ((String) -> RecorderRejection?)? = nil
+    /// Commits the combo; returns the live-apply feedback to flash
+    /// (#123), or nil when the edit stays staged.
     let onRecord: (String) -> LiveApplyFeedback?
     let onClear: () -> Void
 
@@ -18,6 +27,9 @@ struct KeyRecorderField: View {
     @State private var fieldID = UUID()
     @State private var recorder = ChordRecorder()
     @State private var preview = ""
+    /// Set when a click-away cancelled recording — the button's own
+    /// click lands right after the mouse monitor and must not
+    /// immediately restart it.
     @State private var cancelledByClick: Date?
     @State private var rejection: RecorderRejection?
     @State private var flashing = false
@@ -152,6 +164,9 @@ struct KeyRecorderField: View {
         guard !combo.isEmpty else {
             return L("key_recorder.record", "Record")
         }
+        // Display-only glyph mapping (#23): the stored combo stays
+        // the canonical word form, so a parse failure just shows
+        // the raw string.
         guard let parsed = KeyCombo.parse(combo) else {
             return combo
         }

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderField.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderField.swift
@@ -2,66 +2,26 @@ import AppKit
 import KiwiDeskCore
 import SwiftUI
 
-/// The right-hand column of every keybinding row: a recorder
-/// that captures a chord into a canonical combo string, with a
-/// conflict indicator and a clear button.
-///
-/// Recording snaps in on key-down (`ChordRecorder`, #212):
-/// the field live-previews the held modifiers, and the first
-/// non-modifier key locks the combo instantly — correction is
-/// re-recording, one click.
-/// Coordination (#33): at most one recorder is active — the
-/// shared `RecorderCoordinator` tears the previous field down
-/// synchronously when a new one starts. Duplicates (#34):
-/// when `preflight` reports the combo is taken by another
-/// KiwiDesk row, the lock-in is rejected with a red flash and
-/// inline Steal / Go to actions instead of committing a
-/// silent duplicate.
-///
-/// ShortcutsSection-private: requires a `RecorderCoordinator`
-/// in the environment (`.environmentObject`) — rendering it
-/// outside that tree is a programmer error and will crash.
+/// Keybinding recorder capturing shortcuts into canonical combo strings (#212,
+/// #33, #34).
 struct KeyRecorderField: View {
-    /// What VoiceOver calls the field — the command it binds.
-    /// The visible text is the COMBO, i.e. its value, so without
-    /// this every row announced its value as its name (#812).
     let name: String
     let combo: String
-    /// Conflict tooltip; nil when the combo is unique + valid.
     var conflict: String?
-    /// KiwiDesk-collision check run before committing; nil
-    /// commits unconditionally (no other rows to collide
-    /// with).
     var preflight: ((String) -> RecorderRejection?)? = nil
-    /// Commits the combo; returns the live-apply feedback to
-    /// flash under the field (#123), or nil when the edit
-    /// stays staged (stored-profile target).
     let onRecord: (String) -> LiveApplyFeedback?
     let onClear: () -> Void
 
     @EnvironmentObject private var coordinator: RecorderCoordinator
-    /// Internal: the caption's fade reads it from
-    /// `KeyRecorderField+Feedback.swift`.
     @Environment(\.accessibilityReduceMotion)
     var reduceMotion
     @State private var fieldID = UUID()
     @State private var recorder = ChordRecorder()
-    /// Live preview of the chord being formed ("⌃⌥", then
-    /// "⌃⌥⌘K") while recording.
     @State private var preview = ""
-    /// Set when a click-away cancelled the recording — the
-    /// button's own click lands right after the mouse monitor,
-    /// and must not immediately restart it.
     @State private var cancelledByClick: Date?
     @State private var rejection: RecorderRejection?
     @State private var flashing = false
-    /// The conflict popover (owner 2026-08-10) — internal, its
-    /// view lives in `KeyRecorderField+Conflict.swift`.
     @State var conflictPopoverShown = false
-    /// Transient live-apply caption (#123): "Active now" (or
-    /// the system-denied branch), auto-fading after ~1.5 s —
-    /// internal, its fade lives in
-    /// `KeyRecorderField+Feedback.swift`.
     @State var liveFeedback: LiveApplyFeedback?
 
     private var recording: Bool {
@@ -87,36 +47,21 @@ struct KeyRecorderField: View {
             scheduleFeedbackFade(feedback)
         }
         .onChange(of: coordinator.generation) { _, _ in
-            // The edited mode/target changed — any pending
-            // rejection or feedback captured stale bindings.
             rejection = nil
             liveFeedback = nil
             recorder.stop()
             preview = ""
         }
         .onChange(of: liveRejection == nil) { _, clear in
-            // The latch follows the live check out: once the
-            // conflict is fixed anywhere, a later collision on
-            // the same combo must not resurrect this row.
             if clear { rejection = nil }
         }
         .onDisappear(perform: stop)
     }
 
-    /// The fixed width of a trailing-cluster icon slot (#264).
-    /// `exclamationmark.triangle` / `xmark.circle` plus the
-    /// hover chip's padding fit inside 20 pt. (Deliberately not
-    /// NavRow's 18 pt glyph slot — these icons carry a hover
-    /// chip, that glyph doesn't.)
+    /// Fixed width for trailing action icon slots (#264).
     static let iconSlotWidth: CGFloat = 20
 
-    /// A fixed-width icon slot: `Color.clear` reserves the width
-    /// even when `content` is empty, so the record button's
-    /// leading edge holds its x across unbound/bound/conflict
-    /// states instead of the varying cluster width letting the
-    /// row's `Spacer` push it (#264). The glyph draws in an
-    /// overlay above the reserved base. Internal: the conflict
-    /// badge consumes it from its own file.
+    /// Fixed-width slot reserving space across icon states (#264).
     func iconSlot<Content: View>(
         @ViewBuilder _ content: () -> Content
     ) -> some View {
@@ -143,11 +88,6 @@ struct KeyRecorderField: View {
         }
     }
 
-    /// Extracted from `body` — the full modifier chain in one
-    /// expression blew the type-checker's budget on CI. The
-    /// input-well chrome lives in `RecorderButtonChrome`
-    /// (same accent-layer vocabulary as OverrideChrome's
-    /// active rows).
     private var recordButton: some View {
         Button(action: toggle) {
             Text(label)
@@ -156,24 +96,14 @@ struct KeyRecorderField: View {
         }
         .buttonStyle(.bordered)
         .controlSize(.regular)
-        // Both halves: a field resolving its own tint owes the
-        // same pair `neutralButtonLabel()` argues for, not half.
         .tint(buttonTint)
         .foregroundStyle(buttonTint)
         .modifier(RecorderButtonChrome(recording: recording))
         .help(Self.recordHelp)
         .accessibilityLabel(name)
-        // The combo; "Record" / "Press keys…" are states.
         .accessibilityValue(label)
     }
 
-    // A meaning change replaced the old `help` key (#212 —
-    // the recorder no longer locks on release): per
-    // docs/translating.md a changed English text gets a NEW
-    // key, never a rename. The closing sentence changed again
-    // with the layers rename — the key is right for the same
-    // spot, so it keeps its name and `scripts/drop-key`
-    // retires the eleven translations of the old wording.
     @MainActor private static let recordHelp = L(
         "key_recorder.help_press",
         "A shortcut is one key plus any of "
@@ -185,10 +115,7 @@ struct KeyRecorderField: View {
 
     // MARK: - Rejection UI (#34)
 
-    /// The stored rejection re-validated against live
-    /// bindings on every render — the holder may have been
-    /// cleared or deleted since it was raised, and a stale
-    /// "Assigned to…" row must follow it out.
+    /// Live re-validation of pending rejection (#34).
     private var liveRejection: RecorderRejection? {
         guard let rejection, let preflight else { return nil }
         return preflight(rejection.combo)
@@ -212,23 +139,6 @@ struct KeyRecorderField: View {
         )
     }
 
-    /// Ink unless the chord was rejected. `.bordered` paints its
-    /// label from the tint, so any other resting value is text in
-    /// the accent — the defect `neutralButtonLabel()` removes
-    /// everywhere else, and this field is not exempt from it.
-    ///
-    /// Red survives for the same reason a destructive button's
-    /// does: the flash IS the rejection, and there is nothing
-    /// else on screen saying so.
-    ///
-    /// **Recording used to return the accent and no longer
-    /// does.** The justification was that the tint fed the
-    /// chrome's fill, which is false — `KeyRecorderChrome` fills
-    /// and strokes from `SettingsTheme.accent` directly and never
-    /// reads the tint. So on that arm the tint's only remaining
-    /// job was painting "Press keys…" and the live combo preview
-    /// in the accent: text naming a value. The recording signal
-    /// is unaffected, because the chrome draws it independently.
     private var buttonTint: Color {
         flashing ? SettingsTheme.danger : SettingsTheme.ink
     }
@@ -242,11 +152,6 @@ struct KeyRecorderField: View {
         guard !combo.isEmpty else {
             return L("key_recorder.record", "Record")
         }
-        // Show the shortcut as native macOS glyphs, mapped
-        // through the active keyboard layout (#23). The stored
-        // combo stays the canonical word form; only the display
-        // changes, so a parse failure just shows the raw
-        // string.
         guard let parsed = KeyCombo.parse(combo) else {
             return combo
         }
@@ -259,10 +164,6 @@ struct KeyRecorderField: View {
     // MARK: - Recording lifecycle
 
     private func toggle() {
-        // A click-away cancel fires the mouse monitor first;
-        // when the click was on this very button, the action
-        // arriving now must not restart the recording — the
-        // net effect of that click is "stop", like before.
         if let cancelled = cancelledByClick,
             Date().timeIntervalSince(cancelled) < 0.3
         {
@@ -275,13 +176,6 @@ struct KeyRecorderField: View {
     private func start() {
         rejection = nil
         preview = ""
-        // Claiming tears down whichever field was recording
-        // before — synchronously, so two keyDown monitors
-        // never coexist (#33). Captures reach the heap-backed
-        // State storage either way (via the class reference
-        // and the Binding); the strong recorder capture is
-        // load-bearing — it keeps the recorder alive to run
-        // stop() even if the view's state died first.
         let previewBinding = $preview
         coordinator.claim(fieldID) { [recorder] in
             recorder.stop()
@@ -299,12 +193,7 @@ struct KeyRecorderField: View {
 
     private func finish(_ outcome: ChordRecorder.Outcome) {
         preview = ""
-        // Release BEFORE commit (#213): release resumes the live
-        // hotkeys, so the subsequent live-apply reads a truthful
-        // `activationFailures` and its "Active now" / system-
-        // denied caption is honest. Committing while still armed
-        // would leave the table unregistered and every recording
-        // would falsely report success.
+        // Release coordinator before committing hotkey (#213).
         coordinator.release(fieldID)
         switch outcome {
         case .chord(let combo):
@@ -322,9 +211,7 @@ struct KeyRecorderField: View {
         coordinator.release(fieldID)
     }
 
-    /// Hard-blocks a KiwiDesk duplicate (#34); anything else
-    /// commits (a macOS system shortcut stays the soft per-row
-    /// ⚠ — shadowing one can be intentional).
+    /// Validates preflight and commits recorded combo string (#34).
     private func commit(_ string: String) {
         if let found = preflight?(string) {
             rejection = found

--- a/Sources/KiwiDesk/Settings/Components/Layouts/GridSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/GridSchematic.swift
@@ -66,7 +66,10 @@ struct GridSchematic: View {
         case piled(TileKind, hidden: Int)
     }
 
-    /// Cell ceiling derived from params or auto-size cap (#712).
+    /// Cell ceiling derived from params or auto-size cap (#712) —
+    /// deliberately NOT clamped to what the canvas can draw: a
+    /// legibility clamp made one config draw two pictures. The
+    /// drawing may be clamped; the rule may not.
     var cap: (columns: Int, rows: Int) {
         autoSize
             ? LayoutSchematic.gridAutoSizeCap
@@ -87,7 +90,10 @@ struct GridSchematic: View {
 
     var capacity: Int { max(1, dims.columns * dims.rows) }
 
-    /// Number of overflow windows stacked in the last cell.
+    /// Number of overflow windows stacked in the last cell — zero
+    /// until the count EXCEEDS capacity: the engine piles
+    /// `capacity - 1` plus the rest only past full, and nothing
+    /// at exactly full.
     var piledCount: Int {
         ids.count > capacity ? ids.count - (capacity - 1) : 0
     }

--- a/Sources/KiwiDesk/Settings/Components/Layouts/GridSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/GridSchematic.swift
@@ -1,30 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Grid schematic (#125, recount turn 10):
-///
-/// Both types share one ceiling and both pile past it, which is
-/// the engine's own shape (`GridLayout`) and the half a preview
-/// most easily omits (#712):
-///
-/// - **Dynamic** balances the window count into a square-ish
-///   grid and stops at the ceiling — Columns first grows a
-///   column before a row, Rows first mirrors it. The new window
-///   sits where the placement opens it, and fill-empty-cells
-///   makes the last window span the leftover cell.
-/// - **Rigid** fills the ceiling outright, leaving empty cells
-///   until the count catches up.
-///
-/// The ceiling is the configured columns × rows, or
-/// `LayoutSchematic.gridAutoSizeCap` when auto-size hands the
-/// job to a display this canvas does not have. Past it, the
-/// surplus cascades in the last cell — the real behaviour, and
-/// exactly what a count the reader can drive is for.
-///
-/// The two frames the dynamic arm used to draw ("4 windows" →
-/// "a 5th opens") retired with the slider: a reader who can add
-/// the fifth window themselves does not need it staged, and one
-/// frame that answers every count beats two that answer one.
+/// Grid layout visual preview showing dynamic/rigid cell tiling and overflow
+/// piles (#125, #712).
 struct GridSchematic: View {
     let columns: Int
     let rows: Int
@@ -33,17 +11,13 @@ struct GridSchematic: View {
     let autoSize: Bool
     let splitDirection: GridParams.SplitDirection
     let placement: SpawnPlacement
-    /// Windows on screen, the incoming one included.
     var windows = LayoutSchematic.defaultWindowCount
     var scale: SchematicScale = .tile
 
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// The restage damping, gated on Reduce Motion (#1069) —
-    /// the arrangement still redraws, it just stops travelling.
-    /// The ternary is spelled here rather than folded into
-    /// `LayoutSchematic.damping`; that file says why.
+    /// Damped animation curve gated on Reduce Motion (#1069).
     private var damping: Animation? {
         reduceMotion ? nil : LayoutSchematic.damping
     }
@@ -52,14 +26,7 @@ struct GridSchematic: View {
         splitDirection == .horizontal
     }
 
-    /// The focused window — a stable id so it keeps focus as the
-    /// grid rebalances — and the incoming one, which sorts above
-    /// every established id at any count.
-    ///
-    /// The focus falls back to the single established window
-    /// where the count leaves no second one, so the relative
-    /// placements keep a reference. Pinned at 2, they had none at
-    /// two windows and the grid drew a `+` beside nothing (#702).
+    /// Stable focus window ID and high sentinel for incoming window (#702).
     var focusID: Int { min(2, max(1, windows - 1)) }
     let newID = 9_999
 
@@ -91,50 +58,22 @@ struct GridSchematic: View {
         )
     }
 
-    /// A window's role in a cell — the three things a *window*
-    /// can be. Separate from `CellKind` so that a piled cell can
-    /// carry one without `.piled(.gap)` or `.piled(.piled(_))`
-    /// being sayable: a gap is the absence of a window and can
-    /// never be piled.
     enum TileKind { case tile, focus, new }
 
-    /// What a cell draws. `piled` carries the window's role
-    /// rather than replacing it, so a piled window keeps its
-    /// identity — the incoming one still shows its `+` when the
-    /// placement rule lands it in the pile — plus how many
-    /// further windows the pile stands for when the cell could
-    /// not hold them all.
     enum CellKind {
         case window(TileKind)
         case gap
         case piled(TileKind, hidden: Int)
     }
 
-    // MARK: - Dimensions, capacity and the pile past it
-
-    /// The cell **ceiling** — the engine's own rule, and only
-    /// that. The typed columns × rows, or `gridAutoSizeCap` when
-    /// `auto_size` hands the job to a display the canvas does not
-    /// have (#712).
-    ///
-    /// Deliberately NOT clamped to what the canvas can draw. An
-    /// earlier cut mined it with a legibility ceiling and so made
-    /// the drawn capacity depend on the canvas: rigid 8 × 1 with
-    /// five windows drew a two-window pile on the thumbnail and
-    /// none in the panel — one config, two pictures, and the
-    /// thumbnail's was of an overflow the engine never performs.
-    /// The drawing may be clamped; the rule may not.
+    /// Cell ceiling derived from params or auto-size cap (#712).
     var cap: (columns: Int, rows: Int) {
         autoSize
             ? LayoutSchematic.gridAutoSizeCap
             : (columns: max(1, columns), rows: max(1, rows))
     }
 
-    /// The drawn dimensions — the engine's whole rule, not just
-    /// its balance. Rigid takes the ceiling verbatim; dynamic
-    /// balances *up to* it and stops, which is the behaviour the
-    /// preview used to omit: it called `balanced` alone and so
-    /// kept subdividing forever as the count rose (#712).
+    /// Drawn grid dimensions resolved via GridLayout (#712).
     var dims: (columns: Int, rows: Int) {
         var params = GridParams()
         params.type = type
@@ -146,28 +85,14 @@ struct GridSchematic: View {
         )
     }
 
-    /// Cells the drawn grid holds. Windows past it pile in the
-    /// last one, exactly as `GridLayout` sends them to
-    /// `OverlapStack`.
     var capacity: Int { max(1, dims.columns * dims.rows) }
 
-    /// Windows that do not get a cell of their own.
-    ///
-    /// Zero until the count actually exceeds capacity: the engine
-    /// takes its overflow branch only at `count > capacity`, and
-    /// then tiles `capacity - 1` and piles the rest — so the pile
-    /// starts one cell early, but only once it starts at all. An
-    /// earlier cut dropped the guard and reported one pile at
-    /// exactly full, where the drawing correctly piles nothing.
+    /// Number of overflow windows stacked in the last cell.
     var piledCount: Int {
         ids.count > capacity ? ids.count - (capacity - 1) : 0
     }
 
-    /// The window array with the new window spliced in where
-    /// `placement` opens it, asked of the engine through
-    /// `SchematicPlacement` rather than reproduced here (#702).
-    /// Cells are keyed by id, so the focus follows its window
-    /// when the splice pushes it along.
+    /// Window IDs with incoming window spliced via engine placement (#702).
     var ids: [Int] {
         var ids = Array(1...max(1, windows - 1))
         let index = SchematicPlacement.splice(
@@ -210,12 +135,7 @@ struct GridSchematic: View {
         .animation(damping, value: placement)
     }
 
-    /// Whether the last window spans the leftover cell. Only a
-    /// dynamic grid has leftovers to absorb — the same rule the
-    /// row itself greys on (`LayoutDefaultsGates.fillEmptyIsInert`
-    /// asks the resolved type, since a space may override it) —
-    /// so the rigid arm draws its empty cells whatever the toggle
-    /// says, which is the behaviour the toggle's grey describes.
+    /// Whether last window spans leftover cell in dynamic grid.
     var spansLeftover: Bool {
         fillEmptyCells && type == .dynamic
     }
@@ -223,8 +143,6 @@ struct GridSchematic: View {
     func kind(_ id: Int) -> TileKind {
         id == newID ? .new : id == focusID ? .focus : .tile
     }
-
-    // MARK: - Cell view + caption / a11y
 
     @ViewBuilder
     private func cellView(_ kind: CellKind) -> some View {
@@ -253,19 +171,12 @@ struct GridSchematic: View {
         }
     }
 
-    /// Internal so the guard can read it: the captions state the
-    /// ceiling in words, and nothing else stops them stating a
-    /// different one from the picture — which was two of #712's
-    /// three arms (guard-prover, 2026-08-03).
     var caption: String {
         type == .rigid ? rigidCaption : dynamicCaption
     }
 
     private var rigidCaption: String {
         if autoSize {
-            // The numbers come from the stand-in rather than
-            // prose, so moving it cannot leave twelve translated
-            // captions stating the old one (#712).
             return L(
                 "layout.schematic.grid.caption_rigid_auto",
                 "A fixed grid sized to your screen (about %1$d × "
@@ -294,10 +205,6 @@ struct GridSchematic: View {
                 "layout.schematic.grid.order_rows",
                 "New windows fill down a column, then wrap across."
             )
-        // A dynamic grid balances only *up to* the same ceiling a
-        // rigid one fills, so the ceiling governs it too — the
-        // half of the rule the preview used to omit (#712). The
-        // numbers are the ceiling itself, never a drawing limit.
         return L(
             "layout.schematic.grid.order_capped",
             "%1$@ It balances up to %2$d × %3$d, then the surplus "

--- a/Sources/KiwiDesk/Settings/Components/Layouts/ScrollingSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/ScrollingSchematic.swift
@@ -102,6 +102,10 @@ struct ScrollingSchematic: View {
         let low = placed.slots.lowerBound
         let high = placed.slots.upperBound
         let newIdx = placed.incoming
+        // Where the row rests is the ENGINE's answer (#776): local
+        // anchor math once drew a leading margin no real space can
+        // reach. `.follow` resolves as `.center` — a static preview
+        // has no pan history (#753).
         let count = high - low + 1
         let rowLength = CGFloat(count) * step - gap
         let focusedPos = CGFloat(-low) * step

--- a/Sources/KiwiDesk/Settings/Components/Layouts/ScrollingSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/ScrollingSchematic.swift
@@ -1,109 +1,40 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Scrolling schematic (#125, #239, #753): a **screen
-/// outline** (the monitor) with one continuous row of windows
-/// moving *through* it. The focus anchor sets where the **focused
-/// window** rests inside the frame, applied on every focus:
-///
-/// - **center** → focus centred, a neighbour peeking in on each
-///   side (two partials).
-/// - **start** → focus flush against the leading edge (left when
-///   horizontal, top when vertical), one neighbour peeking on the
-///   trailing side.
-/// - **end** → mirror image (right / bottom).
-/// - **follow** → the neutral resting frame, drawn centred. It
-///   fixes the focus nowhere: it pans the minimum needed to
-///   reveal it, so where the row rests depends on the direction
-///   the reader last moved — history a preview does not have.
-///   Its frame is therefore pixel-identical to `center`'s, and
-///   the caption is the only place the two can be told apart —
-///   which is why the words switch on the anchor
-///   (`ScrollingSchematic+Caption`).
-///
-/// The focused window is always fully visible; neighbours are cut
-/// by the frame so their partial width shows the real slot size
-/// (a wide slot shows slivers, a thin slot shows many). The dense
-/// `+` marks where the current placement opens the next window,
-/// at the counts where the row puts it on the canvas at all.
+/// Scrolling layout schematic showing continuous window row and focus anchor
+/// (#125, #239, #753).
 struct ScrollingSchematic: View {
     let orientation: ScrollingParams.Orientation
     let anchor: ScrollingParams.Anchor
     let slotSize: ScrollSize
     let placement: SpawnPlacement
-    /// Windows in the row, the incoming one included. The row is
-    /// **finite** since turn 10: a Scrolling space with three
-    /// windows and a narrow slot has nothing off either edge, and
-    /// an endlessly-continuing row said otherwise at every count.
+    /// Windows in row including incoming window.
     var windows = LayoutSchematic.defaultWindowCount
     var scale: SchematicScale = .tile
 
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// The restage damping, gated on Reduce Motion (#1069) —
-    /// the arrangement still redraws, it just stops travelling.
-    /// The ternary is spelled here rather than folded into
-    /// `LayoutSchematic.damping`; that file says why.
+    /// Restage animation damping gated by Reduce Motion (#1069).
     private var damping: Animation? {
         reduceMotion ? nil : LayoutSchematic.damping
     }
 
-    /// The monitor's share of the canvas along the scroll axis.
-    ///
-    /// At `.panel` it is a slice of a wider canvas, so the
-    /// off-monitor ghosts have room to be read and carry a real
-    /// fact — the row continues past both edges. At `.tile` there
-    /// is no such room, and reserving it drew the screen outline
-    /// at half the scale of every sibling's (#753), so the
-    /// thumbnail spends its whole canvas on the monitor.
-    ///
-    /// Internal so `LayoutSchematicScaleTests` can assert both
-    /// halves; a scale-blind constant is exactly the regression.
+    /// Monitor share of canvas along scroll axis (`LayoutSchematicScaleTests`,
+    /// #753).
     var screenFraction: CGFloat { scale == .panel ? 0.6 : 1 }
 
-    /// Whether the monitor is a **slice** of the canvas, leaving a
-    /// margin beside it — the one concept two different answers
-    /// turn on, so it is spelled once rather than as two
-    /// `screenFraction < 1`s that agree by coincidence. The margin
-    /// is what the off-monitor ghosts occupy, and what a slot
-    /// adjacent to the focus reaches into.
+    /// Whether canvas leaves margins beside monitor for overflow ghosts.
     var hasMargin: Bool { screenFraction < 1 }
 
-    /// Whether the monitor draws an outline of its own. Only where
-    /// it is a slice: with no margin the canvas border already is
-    /// the monitor, and a second rounded stroke on the same bounds
-    /// double-strikes it.
-    ///
-    /// `LayoutSchematicScaleTests` needles the use site as well as
-    /// the value — a view drawing off a resolved answer is
-    /// deletable at its branch with every property assertion above
-    /// it still green.
+    /// Whether to stroke explicit monitor outline
+    /// (`LayoutSchematicScaleTests`).
     var drawsMonitorOutline: Bool { hasMargin }
 
     private var horizontal: Bool { orientation == .horizontal }
 
-    /// The row's slots and the incoming window's slot among
-    /// them, all read relative to the focused window at 0. The
-    /// row is finite, so the focus sits mid-array and the row
-    /// extends both ways as far as the count allows; first /
-    /// last then land the `+` on the row's real ends rather than
-    /// on whichever tile the canvas happened to crop.
-    ///
-    /// Where the `+` lands is the engine's answer, asked through
-    /// `SchematicPlacement` rather than reproduced here (#702).
-    /// The splice can push the focus a slot along, and since
-    /// this schematic pins the focus to 0 it is the *row* that
-    /// shifts instead — which is why the bounds come from the
-    /// same splice and not from a separate midpoint.
-    ///
-    /// Internal rather than private so `LayoutSchematicCountTests`
-    /// and `LayoutSchematicScrollingTests` can assert the
-    /// arithmetic. A source scan for the count as an input is
-    /// satisfiable by a schematic that takes it and draws a
-    /// constant — guard-prover demonstrated exactly that — so
-    /// the guard has to read the derived value, and the derived
-    /// value has to be reachable.
+    /// Row slot bounds and incoming window offset relative to focus (#702,
+    /// `LayoutSchematicCountTests`, `LayoutSchematicScrollingTests`).
     var row: (slots: ClosedRange<Int>, incoming: Int) {
         let total = max(2, windows)
         let established = total - 1
@@ -118,9 +49,7 @@ struct ScrollingSchematic: View {
         )
     }
 
-    /// The slot's real width as a fraction of the screen axis — a
-    /// wide slot fills most of the frame (one window plus slivers),
-    /// a thin one lets several show.
+    /// Slot thickness as fraction of screen axis.
     private var thickness: CGFloat {
         switch slotSize {
         case .auto:
@@ -151,8 +80,7 @@ struct ScrollingSchematic: View {
         }
     }
 
-    /// Strip geometry derived once. The focused window is index 0,
-    /// centred at `focusCenter`; window `i` sits `i` steps away.
+    /// Layout metrics for continuous scrolling strip.
     struct Metrics {
         var slot: CGFloat
         var step: CGFloat
@@ -174,17 +102,6 @@ struct ScrollingSchematic: View {
         let low = placed.slots.lowerBound
         let high = placed.slots.upperBound
         let newIdx = placed.incoming
-        // Where the row rests is the ENGINE's answer (#776): the
-        // anchor arms lived here once, without the visibility and
-        // boundary clamps, so a row shorter than the screen drew
-        // a leading margin `ScrollingLayout.offset` clamps away —
-        // a state no real space can reach. `.follow` asks as
-        // `.center`: it pins the focus nowhere and the engine
-        // resolves it from the prior offset, pan history a static
-        // preview does not have, so the preview draws the neutral
-        // resting frame — the centred one, the collapse
-        // `LayoutSchematicScrollingTests` and the caption suite
-        // already hold (#753).
         let count = high - low + 1
         let rowLength = CGFloat(count) * step - gap
         let focusedPos = CGFloat(-low) * step
@@ -239,19 +156,6 @@ struct ScrollingSchematic: View {
         m.focusCenter + CGFloat(i) * m.step
     }
 
-    /// A slot the canvas cannot reach draws **nothing**, rather
-    /// than being left to the clip — which does not crop where a
-    /// reader would assume, as `SchematicCanvas.screen` explains.
-    /// A tile just past the canvas therefore still bled a few
-    /// points of itself in, most visibly as a grey ghost at a
-    /// thumbnail's edge, where the monitor IS the canvas and every
-    /// off-monitor slot is one of these.
-    ///
-    /// Otherwise: the new window is the dense `+` tile; a
-    /// window overlapping the monitor at all is on screen (accent,
-    /// the focus heavier), even partially; one entirely past a
-    /// monitor edge but still on the canvas is an off-monitor
-    /// ghost (gray), which only the panel's margin has room for.
     @ViewBuilder
     private func slotView(
         _ i: Int,
@@ -269,11 +173,6 @@ struct ScrollingSchematic: View {
         }
     }
 
-    /// The "+" badge sits on the side of the new-window tile facing
-    /// the screen centre. For a first/last window — which straddles
-    /// the canvas edge — that keeps the badge in the visible half:
-    /// a trailing (last) tile is cropped on its trailing side, so
-    /// the badge moves to the leading corner, and vice versa.
     private func badgeAlignment(_ i: Int) -> Alignment {
         if horizontal {
             return i > 0 ? .bottomLeading : .bottomTrailing
@@ -281,19 +180,15 @@ struct ScrollingSchematic: View {
         return i > 0 ? .topTrailing : .bottomTrailing
     }
 
-    /// Whether window `i` overlaps the screen frame at all.
+    /// Whether window `i` overlaps the screen frame.
     private func onScreen(_ i: Int, _ m: Metrics) -> Bool {
         let c = center(i, m)
         return c + m.slot / 2 > m.screenStart
             && c - m.slot / 2 < m.screenStart + m.screenLen
     }
 
-    /// Whether window `i` reaches the **canvas** at all. The row is
-    /// finite but several canvases wide at most counts, so this is
-    /// what decides how much of it is ever seen. Internal so
-    /// `LayoutSchematicCaptionTests` can hold the caption's `+`
-    /// clause to the drawing rather than to a second model of it
-    /// (#753).
+    /// Whether window `i` reaches canvas (`LayoutSchematicCaptionTests`,
+    /// #753).
     func onCanvas(_ i: Int, _ m: Metrics, along: CGFloat) -> Bool {
         let c = center(i, m)
         return c + m.slot / 2 > 0 && c - m.slot / 2 < along

--- a/Sources/KiwiDesk/Settings/Components/Layouts/TrackSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/TrackSchematic.swift
@@ -1,34 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Track schematic (#125): tracks running along the staged
-/// `axis` (vertical = columns side-by-side, horizontal = rows),
-/// with a far-edge **overflow track** that piles its windows — the
-/// Stack cascade, always vertical (#192). The focused track carries
-/// two windows in a heavier stroke (tracks hold multiple windows),
-/// and the new window reads as either a **whole `+` track** (new
-/// windows open their own) or a **nested `+`** inside the focused
-/// track (they join it), placed where `newWindowPosition` opens it.
-///
-/// A limit shows that many normal tracks; auto-tracks opens them
-/// until the display runs out, which on a canvas is the stand-in
-/// `LayoutSchematic.trackGeoCap`.
-///
-/// The **window count** (turn 10) is what opens and collapses
-/// tracks, and since #708 it does so by the ENGINE's rules rather
-/// than by arithmetic invented here — `TrackSchematic+Fold` owns
-/// the loop and cites them. Two consequences a reader of the
-/// drawing should know:
-///
-/// - `focused_track` is **fill-then-spill** (#437), so windows
-///   join the focused track only until it is full and then open
-///   one beside it. The preview modelled neither half before, and
-///   taught a rule the app does not follow.
-/// - The far-edge overflow track therefore appears when something
-///   overflows and **not at the shipped defaults**, where nothing
-///   does. The caption is conditioned on the same answer
-///   (`drawsOverflowTrack`), because it used to name that track
-///   whether or not the strip drew one.
+/// Track layout schematic displaying track arrangement, focus, and overflow
+/// (#125, #708).
 struct TrackSchematic: View {
     let axis: TrackParams.Axis
     let overflowStyle: StackParams.OverflowStyle
@@ -36,40 +10,21 @@ struct TrackSchematic: View {
     let placement: SpawnPlacement
     let limit: Int
     let autoTracks: Bool
-    /// Windows on screen, the incoming one included.
+    /// Windows on screen including incoming window.
     var windows = LayoutSchematic.defaultWindowCount
     var scale: SchematicScale = .tile
 
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// The restage damping, gated on Reduce Motion (#1069) —
-    /// the arrangement still redraws, it just stops travelling.
-    /// The ternary is spelled here rather than folded into
-    /// `LayoutSchematic.damping`; that file says why.
+    /// Restage animation damping gated by Reduce Motion (#1069).
     private var damping: Animation? {
         reduceMotion ? nil : LayoutSchematic.damping
     }
 
     private var vertical: Bool { axis == .vertical }
 
-    /// Which drawn track wears the focus — **the one the fold
-    /// put it on**, not a fixed middle slot.
-    ///
-    /// It used to be `trackCount / 2`, which was a drawing
-    /// convention from before the preview modelled fill-then-
-    /// spill. Once the fold became real the two disagreed: the
-    /// fold's focus marches to the newest track (a spill opens a
-    /// track and focus follows it), so at auto-tracks with 12
-    /// windows the fold is `[3, 3, 3, 2]` with focus at index 3
-    /// while the strip drew the focus on index 1 and gave it the
-    /// LAST track's run — a middle track drawn holding 2 windows
-    /// that the engine says holds 3 (code review, 2026-08-16).
-    ///
-    /// Clamped into the drawn range: the fold counts marker
-    /// tracks and the strip draws the normal ones, so a focus
-    /// that folded into the overflow pile rides the last normal
-    /// track rather than indexing past the end.
+    /// Index of track wearing focus from the engine fold.
     var focusIdx: Int {
         min(max(0, markerTracks.focus), max(0, trackCount - 1))
     }
@@ -78,15 +33,7 @@ struct TrackSchematic: View {
         var focused = false
         var isNew = false
         var nestedNew = false
-        /// How many windows this track holds, from the fold.
-        ///
-        /// Every non-focused track used to draw as ONE tile
-        /// whatever the fold said, which was true while a track
-        /// conceptually held one window and stopped being true
-        /// the moment #708 taught the preview fill-then-spill:
-        /// at 12 windows the fold said `[3, 3, 3, 2]` and the
-        /// strip drew `[1, 1, 1, 3]` — six windows on a slider
-        /// set to twelve (owner, on device, 2026-08-16).
+        /// Number of windows in track from the fold.
         var run = 1
     }
 
@@ -109,11 +56,8 @@ struct TrackSchematic: View {
         }
     }
 
-    /// The strip's tracks as it draws them: which slot holds the
-    /// new track and which holds the focused one. Read off
-    /// `specs` rather than recomputed, so a splice that lands
-    /// somewhere other than `newTrackIndex` — or never runs —
-    /// shows up in the guard (`LayoutSchematicPlacementTests`).
+    /// Track slot indices for incoming and focused tracks
+    /// (`LayoutSchematicPlacementTests`).
     var trackSlots: (incoming: Int, focus: Int) {
         let drawn = specs
         return (
@@ -122,9 +66,7 @@ struct TrackSchematic: View {
         )
     }
 
-    /// Normal tracks with the new *track* spliced in (for
-    /// `own_track`) at its placement slot; `focused_track` instead
-    /// nests the new window inside the focused track.
+    /// Normal tracks with incoming track/window spliced in.
     var specs: [TrackSpec] {
         let counts = markerTracks.counts
         var s = (0..<trackCount).map { index in
@@ -142,21 +84,8 @@ struct TrackSchematic: View {
         return s
     }
 
-    /// Where the new *track* slots in, asked of the engine
-    /// through `SchematicPlacement` rather than reproduced here
-    /// (#702). The specs array is spliced, so the focused spec
-    /// travels with it and needs no correction — unlike the run
-    /// inside the focused track, which draws fixed slots.
-    ///
-    /// The engine that governs track-mode spawn is really
-    /// `Space.insertIntoTrack` (#128/#188), whose `insertOwnTrack`
-    /// arm positions among tracks by the same splice rule this
-    /// asks for; `LayoutSchematicTrackEngineTests` pins the two
-    /// together rather than leaving it to arithmetic. Its
-    /// fill-then-spill arm (#437) IS modelled now, in
-    /// `TrackSchematic+Fold` — this property is the POSITION
-    /// half alone, which is why the two are guarded by separate
-    /// suites.
+    /// Target track splice index via `SchematicPlacement` (#702, #437,
+    /// `LayoutSchematicTrackEngineTests`).
     private var newTrackIndex: Int {
         SchematicPlacement.splice(
             placement,
@@ -179,10 +108,6 @@ struct TrackSchematic: View {
         ForEach(specs.indices, id: \.self) { i in
             trackView(specs[i])
         }
-        // No overflow track until something overflows. Drawing an
-        // empty one at every count would say the far edge is
-        // always reserved, which is the opposite of what the
-        // track limit does.
         if overflowWindows > 0 {
             overflowTrack
         }
@@ -190,10 +115,7 @@ struct TrackSchematic: View {
 
     enum TrackWindow { case plain, focus, new }
 
-    /// A track's run as the canvas can legibly stack it. The
-    /// CLAMP is the drawing's — the run itself is the engine's
-    /// fold, and the two stay separate exactly as `focusedRun`
-    /// keeps them separate.
+    /// Clamps track run length for legible schematic rendering.
     func drawnRun(_ run: Int) -> Int { min(4, max(1, run)) }
 
     @ViewBuilder
@@ -203,9 +125,6 @@ struct TrackSchematic: View {
         } else if spec.focused {
             focusedTrack(nested: spec.nestedNew)
         } else {
-            // The track's OWN run, stacked along its axis — not
-            // one tile standing in for however many windows the
-            // fold put here.
             axisStack {
                 ForEach(0..<drawnRun(spec.run), id: \.self) { _ in
                     SchematicTile()
@@ -214,11 +133,7 @@ struct TrackSchematic: View {
         }
     }
 
-    /// The focused track holds several windows so multi-window
-    /// tracks read, the focus starting in the middle of the run.
-    /// When new windows join here the `+` lands at its placement
-    /// slot around it — first / last on the ends, before / after
-    /// right beside it.
+    /// Focused track containing primary focus and potential nested window.
     private func focusedTrack(nested: Bool) -> some View {
         let kinds = focusedTrackKinds(nested: nested)
         return axisStack {
@@ -228,15 +143,7 @@ struct TrackSchematic: View {
         }
     }
 
-    /// The focused track's tiles, in the order the run draws them.
-    ///
-    /// This is the line #702 lived on, so it is a value the guard
-    /// can read rather than a ternary inside `body`: a correct
-    /// `focusedSlots` feeding a wrong pick reproduces the whole
-    /// symptom, and reading the tuple alone left that green
-    /// (guard-prover, 2026-08-03). `.new` deliberately wins a tie
-    /// — but `LayoutSchematicPlacementTests` requires there is
-    /// never a tie to win, since swallowing the focus is the bug.
+    /// Ordered tiles in focused track (`LayoutSchematicPlacementTests`, #702).
     func focusedTrackKinds(nested: Bool) -> [TrackWindow] {
         let drawn = focusedSlots(nested: nested)
         return (0..<drawn.count).map { i in
@@ -245,21 +152,7 @@ struct TrackSchematic: View {
         }
     }
 
-    /// The focused track exactly as it is drawn: how many slots,
-    /// which one the joining window takes and which one holds the
-    /// focus. One slot appears for the joining window, and a
-    /// landing at or before the focus pushes the focus along.
-    ///
-    /// The focus is **not** pinned, and this returns the drawn
-    /// numbers rather than the placement rule's so that a guard
-    /// reading it sees what the strip renders. Its own copy of
-    /// the rule returned splice coordinates while the run drew in
-    /// fixed slot coordinates, so `first` marked the wrong window
-    /// and `before focused` resolved the `+` and the focus to one
-    /// slot, where the `+` won the ternary and the run drew no
-    /// focused tile at all (#702). With nothing joining, the
-    /// incoming slot is `-1` — no index the run draws — and the
-    /// focus keeps the middle.
+    /// Drawn slot coordinates and placement indices for focused track (#702).
     func focusedSlots(nested: Bool) -> (
         count: Int, incoming: Int, focus: Int
     ) {

--- a/Sources/KiwiDesk/Settings/Components/Layouts/TrackSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/TrackSchematic.swift
@@ -1,8 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Track layout schematic displaying track arrangement, focus, and overflow
-/// (#125, #708).
+/// Track layout schematic displaying track arrangement, focus, and
+/// overflow (#125, #708). The overflow track piles as the Stack
+/// cascade, always vertical (#192).
 struct TrackSchematic: View {
     let axis: TrackParams.Axis
     let overflowStyle: StackParams.OverflowStyle
@@ -84,8 +85,10 @@ struct TrackSchematic: View {
         return s
     }
 
-    /// Target track splice index via `SchematicPlacement` (#702, #437,
-    /// `LayoutSchematicTrackEngineTests`).
+    /// Target track splice index via `SchematicPlacement` (#702) —
+    /// mirroring `Space.insertIntoTrack` (#128/#188), pinned by
+    /// `LayoutSchematicTrackEngineTests`; the fill-then-spill half
+    /// (#437) lives in `TrackSchematic+Fold`, guarded separately.
     private var newTrackIndex: Int {
         SchematicPlacement.splice(
             placement,

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorCardChips.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorCardChips.swift
@@ -1,80 +1,19 @@
 import CoreGraphics
 
-/// How many space chips fit inside a display card, and what
-/// happens to the ones that do not (#678 Phase 3, turn 13b).
-///
-/// A card's SIZE comes from the monitor and its chip COUNT comes
-/// from the config, so the two can disagree — and the first cut
-/// resolved that disagreement by clipping, which deletes the
-/// chip along with its clear button and its drag handle. Those
-/// are the only ways back out of a pin, so clipping hides a
-/// user's own configuration from them (`docs/design-decisions.md`
-/// — config presence expands the surface, it never shrinks it).
-///
-/// So the overflow is COUNTED instead: the last visible slot
-/// becomes a `+n` chip whose popover holds the rest, affordances
-/// intact.
-///
-/// The metrics are stated here rather than at the drawing,
-/// because two other things derive from them —
-/// `MonitorArrangement.minimumCard` (a card may never be drawn
-/// too small to hold one chip) and this capacity — and a floor
-/// that drifted from the chip it exists to fit would stop
-/// flooring anything.
+/// Calculates visible space chip capacity and overflow counts for display
+/// cards (#678, #758).
 enum MonitorCardChips {
-    /// A chip's drawn height: the caption line plus its vertical
-    /// padding, top and bottom (`SpaceAssignmentChip`).
     static let chipHeight: CGFloat = 22
-    /// The narrowest a chip gets — horizontal padding either
-    /// side, a one-character name, and its kind glyph. The
-    /// clear button no longer takes flow width (#758 moved it
-    /// to a corner-badge overlay), so 52 now carries ~16 pt of
-    /// deliberate breathing room — kept, because a capacity
-    /// computed from this is an UPPER bound on how many fit,
-    /// and erring that way keeps the card honest: a `+n` that
-    /// appears one chip early costs nothing and a chip that
-    /// silently does not fit costs the affordance.
     static let minChipWidth: CGFloat = 52
-    /// The gap `WrapChips` lays chips out with — read from
-    /// `ChipMetrics`, which owns it, since this arithmetic is its
-    /// consumer rather than its source.
     static var spacing: CGFloat { ChipMetrics.spacing }
-    /// The card's own padding, and the header line above the
-    /// chips. `headerHeight` is the CARD's — the tray's header is
-    /// unsized `.caption2` and passes its own, rather than
-    /// inheriting a number that happens to be close.
     static let cardPadding: CGFloat = 6
     static let headerHeight: CGFloat = 16
     static let trayHeaderHeight: CGFloat = 14
-    /// The gap the chip stack puts between its children.
-    ///
-    /// Counted, not ignored: leaving it out overstated the chip
-    /// area at EVERY card size, so `capacity` could return one row
-    /// too many and that row clipped — reintroducing the clip the
-    /// `+n` exists to prevent (code review, 2026-08-04). The card
-    /// and the tray both lay their stacks out with THIS constant
-    /// and hold exactly two children, so one gap is the whole of
-    /// it; a third child would be a second gap this arithmetic
-    /// does not know about, which is why
-    /// `MonitorsGateWiringTests` pins the stacks to it.
+    /// Child spacing for chip stacks pinned in `MonitorsGateWiringTests`.
     static let stackSpacing: CGFloat = 2
-    /// The `+n` marker's own width — a capsule around a two- or
-    /// three-character label, and BOUND: both markers frame
-    /// themselves to it. A constant this arithmetic asserts about
-    /// a view that never reads it is the shape this turn removed
-    /// three times; a `+123` would otherwise run wider and
-    /// squeeze the very rows the reservation protects.
-    ///
-    /// It is a COLUMN, not a slot: the marker sits beside the
-    /// wrapped chips, so it narrows every row rather than
-    /// consuming one chip's worth once. Reserving it per card
-    /// instead let three chips flow into three rows inside a band
-    /// sized for two, and the last row was clipped with its clear
-    /// button and its menu (code review, 2026-08-04).
     static let markerWidth: CGFloat = 34
 
-    /// The chip area inside a card of `size`, given the header
-    /// above it.
+    /// Returns usable chip area inside card geometry.
     static func chipArea(
         in size: CGSize,
         header: CGFloat = headerHeight
@@ -89,15 +28,7 @@ enum MonitorCardChips {
         )
     }
 
-    /// How many chips a card of `size` can show at once — at
-    /// least one, because `MonitorArrangement.minimumCard` is
-    /// derived from exactly that promise.
-    ///
-    /// `reservingMarker` narrows the row by the `+n` column, for
-    /// the case where there is going to be one.
-    /// How many chip ROWS fit — `internal` so a guard reads it
-    /// rather than keeping a second copy of the formula, which is
-    /// how the first cut came to drop the clamp below.
+    /// Number of chip rows fitting card geometry.
     static func rows(
         in size: CGSize,
         header: CGFloat = headerHeight
@@ -109,6 +40,7 @@ enum MonitorCardChips {
         )
     }
 
+    /// Maximum chips fitting card, optionally reserving space for `+n` marker.
     static func capacity(
         in size: CGSize,
         header: CGFloat = headerHeight,
@@ -119,12 +51,6 @@ enum MonitorCardChips {
         let usable =
             reservingMarker
             ? area.width - markerWidth - spacing : area.width
-        // Zero is a real answer WITH the marker reserved: a card
-        // at the floor has room for one chip OR the `+n`, not
-        // both, and it must then show the marker alone rather
-        // than a chip the marker pushes off the edge. Without it
-        // the plain capacity is at least one, because
-        // `MonitorArrangement.minimumCard` promises exactly that.
         let perRow = max(
             reservingMarker ? 0 : 1,
             Int((usable + spacing) / (minChipWidth + spacing))
@@ -132,28 +58,13 @@ enum MonitorCardChips {
         return rows * perRow
     }
 
-    /// Splits a card's chips into the ones it draws and the count
-    /// hiding behind the `+n`.
-    ///
-    /// Two things this owes its callers. The marker is a COLUMN,
-    /// so the capacity it is measured against reserves one —
-    /// see `capacity(in:header:reservingMarker:)`. And it never
-    /// names exactly ONE hidden chip: a card that would hide one
-    /// shows one fewer instead, so the count is always 0 or ≥ 2.
-    /// `monitor_card.more_spaces.axlabel` has no singular, and
-    /// `MonitorCardChipsTests` pins the property rather than the
-    /// two counts that happen to occur.
+    /// Splits chips into visible items and overflow count
+    /// (`MonitorCardChipsTests`).
     static func split<Chip>(
         _ chips: [Chip],
         in size: CGSize,
         header: CGFloat = headerHeight
     ) -> (shown: [Chip], overflow: Int) {
-        // The never-exactly-one rule is `OverflowSplit`'s, not
-        // this file's — it was stated here and again in the
-        // Profiles row pips, and two copies of a rule that each
-        // have their own guard drift silently (§2.4). What stays
-        // local is the measurement: only this card knows how
-        // many chips its own geometry fits.
         let shown = OverflowSplit.shown(
             of: chips.count,
             fitting: capacity(in: size, header: header),

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorCardChips.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorCardChips.swift
@@ -4,6 +4,10 @@ import CoreGraphics
 /// cards (#678, #758).
 enum MonitorCardChips {
     static let chipHeight: CGFloat = 22
+    /// Narrowest chip; ~16 pt of deliberate breathing room since
+    /// #758 moved the clear button — capacity is an UPPER bound,
+    /// and a `+n` one chip early costs nothing where a chip that
+    /// silently does not fit costs its affordance.
     static let minChipWidth: CGFloat = 52
     static var spacing: CGFloat { ChipMetrics.spacing }
     static let cardPadding: CGFloat = 6
@@ -11,6 +15,10 @@ enum MonitorCardChips {
     static let trayHeaderHeight: CGFloat = 14
     /// Child spacing for chip stacks pinned in `MonitorsGateWiringTests`.
     static let stackSpacing: CGFloat = 2
+    /// A COLUMN, not a slot: it narrows every row beside the wrap.
+    /// BOUND — both markers frame themselves to it, or a `+123`
+    /// squeezes the rows the reservation protects (code review,
+    /// 2026-08-04).
     static let markerWidth: CGFloat = 34
 
     /// Returns usable chip area inside card geometry.
@@ -51,6 +59,10 @@ enum MonitorCardChips {
         let usable =
             reservingMarker
             ? area.width - markerWidth - spacing : area.width
+        // Zero is a real answer WITH the marker reserved: a card
+        // at the floor shows the marker alone rather than a chip
+        // pushed off the edge; plain capacity stays >= 1 —
+        // `MonitorArrangement.minimumCard`'s promise.
         let perRow = max(
             reservingMarker ? 0 : 1,
             Int((usable + spacing) / (minChipWidth + spacing))
@@ -58,8 +70,10 @@ enum MonitorCardChips {
         return rows * perRow
     }
 
-    /// Splits chips into visible items and overflow count
-    /// (`MonitorCardChipsTests`).
+    /// Splits chips into visible items and overflow count. The
+    /// count is never exactly one — `OverflowSplit` owns that rule
+    /// (`monitor_card.more_spaces.axlabel` has no singular), and
+    /// `MonitorCardChipsTests` pins the property.
     static func split<Chip>(
         _ chips: [Chip],
         in size: CGSize,

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsFamilyRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsFamilyRows.swift
@@ -16,11 +16,16 @@ struct OrphanPin: Identifiable, Hashable {
     var id: String { space.raw }
 }
 
-/// Expands Monitors census keys into rendered instances (#678,
-/// `MonitorsGateWiringTests`).
+/// Expands Monitors census keys into rendered instances (#678).
+/// The views build one and READ it, never re-derive beside it —
+/// `MonitorsGateWiringTests` pins each call site — and the switch
+/// is exhaustive so a new census key fails to compile until given
+/// an expansion.
 struct MonitorsFamilyRows {
     let spaces: [SpaceID]
     let mainSpaces: Set<SpaceID>
+    /// From the model's one `resolutions()` pass — the runtime's
+    /// own precedence, never re-implemented here.
     let resolutions: [SpaceID: SpaceResolution]
     let pins: [SpaceID: String]
     let displays: [Display]
@@ -64,7 +69,11 @@ struct MonitorsFamilyRows {
             + (isMain ? trayChips.count : 0)
     }
 
-    /// Stored pins for currently disconnected displays.
+    /// Stored pins for currently disconnected displays — read from
+    /// the SAVED pins (a resolution can only name a connected
+    /// display), keeping the user's intent visible and clearable;
+    /// follows-main spaces are excluded, the tray already draws
+    /// them.
     var orphans: [OrphanPin] {
         let connected = Set(displays.map(\.fingerprint))
         return
@@ -75,7 +84,10 @@ struct MonitorsFamilyRows {
             .sorted { $0.space.raw < $1.space.raw }
     }
 
-    /// Deduplicated spaces assigned to display cards.
+    /// Deduplicated spaces assigned to display cards: fingerprint
+    /// twins would each claim the same chips, double-counting the
+    /// census expansion — the picture may draw both, the COUNT
+    /// must not (code review, 2026-08-04).
     var cardedSpaces: [SpaceAssignment] {
         var seen: Set<SpaceID> = []
         return
@@ -110,6 +122,8 @@ struct MonitorsFamilyRows {
                 MonitorsRowInstance.display($0.fingerprint)
             }
         case .placementUnavailable:
+            // Exactly one row, always — on-screen is the GATE's
+            // answer, not this seam's.
             return [.banner]
         }
     }

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsFamilyRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsFamilyRows.swift
@@ -1,28 +1,14 @@
 import KiwiDeskCore
 
-/// One instance a Monitors census key expands into (#678 Phase 3,
-/// turn 13b).
-///
-/// Every container in this area draws a row per live thing —
-/// a space chip, an orphaned pin, a connected display — so the
-/// instance carries the thing's identity, which is what a guard
-/// can compare and what set equality over `SettingKey` cannot
-/// see.
+/// Instance representing expanded row in Monitors census (#678).
 enum MonitorsRowInstance: Hashable {
-    /// One space chip, by space id — in a display card
-    /// (`spacePins`) or in the follows-main tray (`mainSpaces`).
     case space(String)
-    /// One pin waiting on a monitor that is not attached, by the
-    /// pinned space's id.
     case orphan(String)
-    /// One connected display, by fingerprint.
     case display(String)
-    /// The one row in this area that is not per-instance: the
-    /// banner standing in for a picture that cannot be drawn.
     case banner
 }
 
-/// One space pinned to a monitor that is not attached right now.
+/// Space pinned to a monitor currently disconnected.
 struct OrphanPin: Identifiable, Hashable {
     let space: SpaceID
     let fingerprint: String
@@ -30,75 +16,28 @@ struct OrphanPin: Identifiable, Hashable {
     var id: String { space.raw }
 }
 
-/// Expands a Monitors census key into the rows it renders, and is
-/// the same derivation the views draw from (#678 Phase 3, turn
-/// 13b).
-///
-/// The census records settings, not rows: `spacePins` is one case
-/// and puts a chip on every space that resolves to a card,
-/// `fingerprints` one case and a row per connected display. That
-/// is the asymmetry the Shortcuts area met first and Profiles met
-/// again, and it needs the same second seam —
-/// `MonitorsRowOrder` answers *where does this key sit*, this
-/// answers *what does it draw*.
-///
-/// **The views build one of these and read it; they do not
-/// re-derive beside it.** Profiles shipped the opposite twice —
-/// a seam with no call sites, then call sites answering from
-/// separate fixtures — so both halves here come off the same
-/// instance: `rows(for:)` is written in terms of the very
-/// accessors the cards, the tray, the orphan card and the drawer
-/// call. `MonitorsGateWiringTests` pins each call site.
-///
-/// The switch is exhaustive over `MonitorsKey` on purpose: a key
-/// added to the census fails to compile here until it is given an
-/// expansion.
+/// Expands Monitors census keys into rendered instances (#678,
+/// `MonitorsGateWiringTests`).
 struct MonitorsFamilyRows {
-    /// The spaces the config declares, in its own order.
     let spaces: [SpaceID]
-    /// Spaces set to follow whichever display is main.
     let mainSpaces: Set<SpaceID>
-    /// Each space's resolved placement, from the model's one
-    /// `resolutions()` pass — the runtime's own precedence (pin →
-    /// main → positional default), never re-implemented here.
     let resolutions: [SpaceID: SpaceResolution]
-    /// The pins as saved, which is what an ORPHANED pin is read
-    /// from: a resolution can only name a display that exists.
     let pins: [SpaceID: String]
-    /// The connected displays.
     let displays: [Display]
 
-    /// The displays in the order the drawer and the chip menus
-    /// list them: left to right across the desk, so the reading
-    /// order matches the picture above them.
-    ///
-    /// Sorted on THREE keys, because `sorted` is not stable and
-    /// x alone ties on any vertically stacked pair — a list that
-    /// reordered itself between renders would move the menu item
-    /// under the pointer.
+    /// Connected displays in left-to-right desk reading order.
     var orderedDisplays: [Display] {
         DeskOrder.reading(displays)
     }
 
-    /// Whether two connected displays are indistinguishable to
-    /// KiwiDesk.
-    ///
-    /// `Display.fingerprint` is `name:WxH`, so a pair of the same
-    /// model at the same resolution — the commonest twin-monitor
-    /// desk — is ONE identity. Every pin, every card's chips and
-    /// the main badge key off that fingerprint, so the picture
-    /// draws the same spaces on both cards. The page says so
-    /// rather than letting it read as a bug; the real fix is a
-    /// display identity Core can tell apart, which is not this
-    /// turn's to make.
+    /// Whether connected displays share identical model and resolution
+    /// fingerprint.
     var hasAmbiguousDisplays: Bool {
         Set(displays.map(\.fingerprint)).count < displays.count
     }
 
-    /// The chips one display's card holds: spaces pinned to it,
-    /// and spaces the positional default places there. Spaces
-    /// that follow main live in the tray instead, so every space
-    /// appears exactly once (#53: there is no unassigned list).
+    /// Space chips assigned to display card via pin or positional default
+    /// (#53).
     func chips(on fingerprint: String) -> [SpaceAssignment] {
         spaces.compactMap { space in
             guard !mainSpaces.contains(space) else { return nil }
@@ -113,33 +52,19 @@ struct MonitorsFamilyRows {
         }
     }
 
-    /// The chips in the dashed follows-main tray.
+    /// Spaces assigned to follows-main tray.
     var trayChips: [SpaceID] {
         spaces.filter { mainSpaces.contains($0) }
     }
 
-    /// How many spaces a display HOLDS right now — its own chips
-    /// plus, on the main display, the ones that follow main. They
-    /// are on that screen at this moment, which is what the
-    /// readout claims to answer; counting only the carded chips
-    /// made a desk where every space follows main read "0 Spaces
-    /// here" on every card.
+    /// Total spaces active on display including follows-main spaces on main
+    /// display.
     func held(on display: Display, isMain: Bool) -> Int {
         chips(on: display.fingerprint).count
             + (isMain ? trayChips.count : 0)
     }
 
-    /// Pins waiting on hardware that is not attached. Read from
-    /// the SAVED pins rather than from a resolution, which can
-    /// only ever name a display that exists — the user's intent
-    /// has to stay visible and clearable while its monitor is
-    /// away.
-    /// A space that follows main is excluded even when a stale
-    /// pin is still stored against it: the tray already draws it,
-    /// and the runtime resolves main first, so listing it here
-    /// too would put one space in two places and claim it opens
-    /// somewhere it does not. The GUI writers keep the two
-    /// exclusive; Lua can set both (code review, 2026-08-04).
+    /// Stored pins for currently disconnected displays.
     var orphans: [OrphanPin] {
         let connected = Set(displays.map(\.fingerprint))
         return
@@ -150,19 +75,7 @@ struct MonitorsFamilyRows {
             .sorted { $0.space.raw < $1.space.raw }
     }
 
-    /// Every space that draws a chip in some card — the union of
-    /// what the cards hold, derived from `chips(on:)` rather than
-    /// beside it, so the census expansion and the screen cannot
-    /// disagree about which spaces are carded.
-    ///
-    /// Deduplicated by space, because two displays can share a
-    /// fingerprint (`hasAmbiguousDisplays`) and would then each
-    /// claim the same chips — double-counting the census
-    /// expansion and falsifying the partition in exactly the case
-    /// this type dedicates a property to warning about (code
-    /// review, 2026-08-04). The picture still draws the chip on
-    /// both cards, which is the honest rendering of one identity
-    /// the app cannot split; the COUNT is what must not double.
+    /// Deduplicated spaces assigned to display cards.
     var cardedSpaces: [SpaceAssignment] {
         var seen: Set<SpaceID> = []
         return
@@ -197,11 +110,6 @@ struct MonitorsFamilyRows {
                 MonitorsRowInstance.display($0.fingerprint)
             }
         case .placementUnavailable:
-            // Exactly one row, always — whether it is on screen
-            // is its GATE's answer, not this seam's. Expanding to
-            // nil while the picture is drawable would make the
-            // banner indistinguishable from a family that lost
-            // its rows.
             return [.banner]
         }
     }

--- a/Sources/KiwiDesk/Settings/Components/Profiles/ProfileScreenPips.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/ProfileScreenPips.swift
@@ -1,102 +1,19 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// A saved profile's screens, drawn in the SAME grammar as
-/// `PresetScreenCard` (#789) — one outline per screen, each
-/// carrying the glyph of what that screen opens in.
-///
-/// **The grammar is the point.** The saved list and the preset
-/// grid answer one question — "what shape is this profile?" — and
-/// before this they answered it two ways in one scroll: featureless
-/// grey rectangles up top, outlined screens with layout glyphs
-/// below. They are the same object at different ages (the design
-/// digest's own phrase), so they draw the same picture at two
-/// sizes. `PresetScreenCard.outline` is the large mount; this is
-/// the small one, and both take their fill, stroke and radius from
-/// the shared constants below.
-///
-/// **A screen with no answer draws its outline and no glyph**, the
-/// rule the preset card already draws by. A stored profile can say
-/// less than a preset: it pins spaces to fingerprints rather than
-/// to positions, and which monitor is Main is resolved live, so a
-/// multi-screen profile whose spaces were never pinned genuinely
-/// does not say. `Profile.openingModes()` owns that reasoning and
-/// returns `nil` there rather than guessing.
-///
-/// **Not a plate, and no accent.** `HomeCardPlate.plate(for:)`
-/// returns `nil` for `.profiles` — a whole-app card's picture here
-/// is a data row, not a desktop — and the accent marks control
-/// FILLS, so accent-filled screens would read as "these ones are
-/// selected". The active profile is marked by its `BadgeChip`,
-/// which is a text channel. A consult proposed an accent-tinted
-/// tile for the active row (2026-08-16) and it was refused twice
-/// over: it separated active from inactive by hue at one weight,
-/// which is what `paletteCardStroke`'s 1→2 step exists to prevent,
-/// and its two ground tints measured ~3% apart in luminance —
-/// invisible to everyone, CVD or not.
-///
-/// **Silent to VoiceOver**: the count is already in the row's
-/// subtitle and each screen's mode is not a fact the row claims,
-/// so announcing the picture would read one fact twice.
+/// Outlined screen pips displaying layout glyphs for saved profiles (#789).
 struct ProfileScreenPips: View {
-    /// The profile's screen count.
     let count: Int
-    /// What each screen opens in, in the stored set's own order —
-    /// `nil` per screen where the profile does not say. Short or
-    /// empty is legal and draws bare outlines.
     var openingModes: [LayoutMode?] = []
-    /// How many slots the row RESERVES — the widest profile in
-    /// the list, capped at `slots`.
-    ///
-    /// Passed in because alignment is a property of the LIST, not
-    /// of a row: the names line up only if every row reserves the
-    /// same width, and reserving the CAP instead stranded a
-    /// one-screen profile's single outline ~69 pt from its own
-    /// name on a list where nothing had four screens (owner
-    /// eye-confirm, 2026-08-16). Reserving the widest row keeps
-    /// the alignment and spends nothing on screens no profile
-    /// has.
     var reservedSlots: Int = slots
 
-    /// How many slots the row draws — screens, or screens plus
-    /// the "+N" chip. The chip takes a slot of its own
-    /// (`docs/ui-patterns.md` ▸ "+N"), which is what makes
-    /// `hidden` never equal 1.
     static let slots = 4
-    /// The small mount of the shared outline. `PresetScreenCard`
-    /// draws the large one (48×30, glyph 14); the RATIO is what
-    /// keeps them reading as one picture, so a change to either
-    /// is a change to both.
-    ///
-    /// This is ~71% of the card, and it was 42% for one build:
-    /// at 20×13 with a 7 pt glyph the row read as a DIFFERENT
-    /// thing rather than the same thing smaller, which is the
-    /// one job this picture has (owner eye-confirm,
-    /// 2026-08-16). 34×22 is what the card itself drew before
-    /// #789 grew it, so the pair is now "the card, and the card
-    /// one size down" rather than two unrelated sizes.
-    ///
-    /// The ceiling on growing it further is the ROW, not taste:
-    /// the text block beside it is a headline over a caption,
-    /// about 32 pt, and a picture taller than that sets the
-    /// list's row height instead of fitting inside it.
     static let screen = CGSize(width: 34, height: 22)
     static let gap: CGFloat = 3
     static let corner: CGFloat = 3
     static let glyph: CGFloat = 12
-    /// The "+N" chip's type size at THIS mount.
-    ///
-    /// Named rather than inlined because `PresetScreenCard` scales
-    /// it for the large mount (#859), and the two must move
-    /// together for the same reason the outline and the glyph do —
-    /// a chip that keeps 9 pt beside a 14 pt glyph stops being the
-    /// same picture one size up.
     static let moreSize: CGFloat = 9
 
-    /// The grammar, as a function of its inputs rather than of
-    /// the shipped constants — with `slots` a `static let`, no
-    /// assertion over the shipped values can tell a derivation
-    /// from a literal that agrees with it today.
     static func slotWidth(
         slots: Int,
         screen: CGSize,
@@ -105,9 +22,6 @@ struct ProfileScreenPips: View {
         CGFloat(slots) * screen.width + CGFloat(slots - 1) * gap
     }
 
-    /// This row's reserved width — the grammar at whatever the
-    /// LIST reserved. It compares no width, so it adds no second
-    /// derivation beside `SettingsWidthClass`.
     var slotWidth: CGFloat {
         Self.slotWidth(
             slots: max(1, min(reservedSlots, Self.slots)),
@@ -116,20 +30,14 @@ struct ProfileScreenPips: View {
         )
     }
 
-    /// What a list reserves for a set of profiles: the widest
-    /// one, capped, and never less than one slot — a list whose
-    /// profiles all claim zero screens still reserves a column so
-    /// the names do not jump when one is added.
+    /// Reserves slot count based on widest profile in collection.
     static func reservedSlots(
         forScreenCounts counts: some Collection<Int>
     ) -> Int {
         max(1, min(counts.max() ?? 1, slots))
     }
 
-    /// Internal rather than private, and asserted directly: a
-    /// view that takes a count and draws a constant satisfies
-    /// every substring a source scan can look for while
-    /// answering nothing (`LayoutSchematicCountTests`' lesson).
+    /// Number of visible screen pips (`LayoutSchematicCountTests`).
     var shown: Int {
         OverflowSplit.shown(
             of: count,
@@ -151,10 +59,6 @@ struct ProfileScreenPips: View {
         .accessibilityHidden(true)
     }
 
-    /// Bounds-checked rather than assumed: `openingModes` comes
-    /// from a stored file, and a hand-edited profile whose set
-    /// disagrees with its monitor count must draw a bare outline,
-    /// not trap.
     private func mode(at index: Int) -> LayoutMode? {
         guard index < openingModes.count else { return nil }
         return openingModes[index]
@@ -180,7 +84,6 @@ struct ProfileScreenPips: View {
             )
     }
 
-    /// Counts the screens NOT drawn, never the total.
     private var moreChip: some View {
         Text(verbatim: "+\(hidden)")
             .font(.system(size: Self.moreSize, weight: .semibold))

--- a/Sources/KiwiDesk/Settings/Components/Profiles/ProfileScreenPips.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/ProfileScreenPips.swift
@@ -5,13 +5,25 @@ import SwiftUI
 struct ProfileScreenPips: View {
     let count: Int
     var openingModes: [LayoutMode?] = []
+    /// How many slots the row RESERVES — the widest profile in the
+    /// list. Alignment is a property of the LIST, not a row, and
+    /// reserving the cap stranded a one-screen profile's outline
+    /// ~69 pt from its name (owner eye-confirm, 2026-08-16).
     var reservedSlots: Int = slots
 
+    /// The "+N" chip takes a slot of its own, so `hidden` never
+    /// equals 1 (`docs/ui-patterns.md` ▸ "+N").
     static let slots = 4
+    /// The small mount of the outline `PresetScreenCard` draws
+    /// large — the RATIO keeps them one picture, so a change to
+    /// either is a change to both (#789); the ceiling on growing
+    /// it is the row's ~32 pt text block, not taste.
     static let screen = CGSize(width: 34, height: 22)
     static let gap: CGFloat = 3
     static let corner: CGFloat = 3
     static let glyph: CGFloat = 12
+    /// Scaled by `PresetScreenCard` for the large mount (#859) —
+    /// the two must move together.
     static let moreSize: CGFloat = 9
 
     static func slotWidth(

--- a/Sources/KiwiDesk/Settings/Components/Profiles/ProfilesFamilyRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/ProfilesFamilyRows.swift
@@ -1,59 +1,21 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// One instance a Profiles census key expands into (#678 Phase 3,
-/// turn 13a).
-///
-/// Every container in this area draws a row per live thing rather
-/// than a row per setting, so the instance carries the thing's
-/// identity — which is what a guard can compare, and what set
-/// equality over `SettingKey` alone cannot see.
+/// Instance representing expanded row in Profiles census (#678).
 enum ProfilesRowInstance: Hashable {
-    /// One saved profile, by name.
     case profile(String)
-    /// One native macOS Desktop, by Mission Control number.
     case desktop(Int)
-    /// One built-in preset, by its stable English
-    /// `StandardLayout.name` (never the localized display name —
-    /// identity must not move with the GUI language).
     case preset(String)
 }
 
-/// Expands a Profiles census key into the rows it renders (#678
-/// Phase 3, turn 13a).
-///
-/// The census records settings, not rows: `profilesLoad` is one
-/// case and puts one button on every saved profile's row,
-/// `profileBindings` one case and one row per Desktop. That is
-/// the same asymmetry the Shortcuts area met first, and it needs
-/// the same second seam — `ProfilesRowOrder` answers *where does
-/// this key sit*, this answers *what does it draw*, and
-/// `ProfilesCensusRenderTests` pins each against the census
-/// independently.
-///
-/// The switch is exhaustive over `ProfilesKey` on purpose: a key
-/// added to the census fails to compile here until it is given an
-/// expansion, which is a stronger net than the render guard alone.
-///
-/// A key with no rows of its own returns `nil` — and WHICH keys
-/// may answer it is enumerated in `ProfilesCensusRenderTests`
-/// rather than counted here, because a renderer reading
-/// `rows(for:) ?? []` cannot tell a key that never draws from one
-/// whose rows disappeared.
+/// Expands Profiles census keys into rendered instances (#678,
+/// `ProfilesCensusRenderTests`).
 struct ProfilesFamilyRows {
-    /// The saved profiles, unordered — `orderedProfiles` is what
-    /// puts them in display order, and it is the same call the
-    /// list makes.
     let profiles: [ProfileSummary]
-    /// The MAIN screen's native Desktops, by Mission Control
-    /// number (#888) — the ones a binding can fire on. Global
-    /// numbers, possibly non-contiguous; never a count, which
-    /// could only mean `1...n` and would renumber them.
+    /// Main display Mission Control desktops (#888).
     let mainDesktops: [Int]
-    /// Desktop numbers a binding already names, so one to a
-    /// now-absent Space stays listed.
+    /// Desktops currently bound by settings.
     let boundDesktops: [Int]
-    /// The presets the area offers, in catalog order.
     let presets: [StandardLayout]
 
     func rows(for key: SettingKey) -> [ProfilesRowInstance]? {
@@ -61,43 +23,9 @@ struct ProfilesFamilyRows {
         return rows(for: family)
     }
 
-    /// The saved profiles the list draws, in display order: the
-    /// ones matching the connected displays first — the card's
-    /// caption promises one of them loads — then the ones whose
-    /// screen COUNT matches, then by screen count, then by name,
-    /// so the order is stable while nothing is plugged or
-    /// unplugged.
-    ///
-    /// The count key exists because the first key is a
-    /// FINGERPRINT match and the third is a bare number, and a
-    /// profile can be neither: on a two-screen desk a saved
-    /// two-screen profile for different monitors sorted behind
-    /// every one-screen profile, since 1 < 2 — under a caption
-    /// promising one of them loads. It sits SECOND rather than
-    /// first because a fingerprint match is the stronger claim.
-    ///
-    /// Where the two keys could disagree — a hand-edited file
-    /// whose sets are of different sizes, `monitorCount` being
-    /// the FIRST set's — it does not matter: key one dominates,
-    /// so a fingerprint match leads whatever the count says.
-    ///
-    /// Both flags are derived in `refreshProfiles` from one read
-    /// of the live displays, which is why this stayed a pure
-    /// function of its summaries: passing the connected count in
-    /// made "the two answer about one moment" a comment at the
-    /// call site rather than a property of the data, and left a
-    /// second `displays.count` read one edit away.
-    ///
-    /// The ORDER lives here, with the expansion, rather than in
-    /// the view, so the rule is stated once and is reachable
-    /// from a test (`ProfilesFamilyRowsTests`); that the views
-    /// actually call it is
-    /// `ProfilesGateWiringTests.viewsConsultTheFamilySeam`.
-    /// Note which guard holds which: `rows(for:)` and its census
-    /// parity are held over fixtures, and it is this static half
-    /// the screen consumes — including
-    /// `ProfilesSection.neighbourAfterDeleting`, whose focus
-    /// destination IS this order.
+    /// Sorts profiles by live display match, screen count match, count, and
+    /// name
+    /// (`ProfilesFamilyRowsTests`, `ProfilesGateWiringTests`).
     static func orderedProfiles(
         _ summaries: [ProfileSummary]
     ) -> [ProfileSummary] {
@@ -114,20 +42,7 @@ struct ProfilesFamilyRows {
         return summaries.sorted { key($0) < key($1) }
     }
 
-    /// The Desktops the bindings card lists: the MAIN screen's —
-    /// the ones a binding can fire on (#888) — plus any number
-    /// already bound, so a binding on another screen's Desktop,
-    /// or on a now-absent one, stays visible and clearable rather
-    /// than silently lost.
-    ///
-    /// `onMain` carries GLOBAL Mission Control numbers and may be
-    /// non-contiguous: depending on the display order the main
-    /// screen's Desktops can be 3 and 4. That is why this takes
-    /// the numbers rather than a count — a count could only mean
-    /// `1...n`, which would renumber them, and a row reading
-    /// "Desktop 1" that wrote a binding on another Desktop is
-    /// worse than the over-offer this replaced (owner QA,
-    /// 2026-08-18).
+    /// Union of main screen desktops and already-bound desktops (#888).
     static func desktops(
         onMain: some Collection<Int>,
         bound: some Collection<Int>
@@ -135,13 +50,7 @@ struct ProfilesFamilyRows {
         Array(Set(onMain).union(bound)).sorted()
     }
 
-    /// The presets a screen count offers, in catalog order.
-    ///
-    /// `sizes` are the LIVE screens, which the `Starter` entry is
-    /// derived from (#678 Phase 4 pass 11). It follows that the
-    /// drawer below offers no Starter at all: a count you are not
-    /// running has no screen shapes to choose layouts from, so
-    /// "For other setups" is the workflow layouts alone.
+    /// Presets matching screen count, including starter derivation (#678).
     static func presets(
         forScreens screens: Int,
         sizes: [CGSize]
@@ -149,8 +58,7 @@ struct ProfilesFamilyRows {
         StandardProfiles.layouts(for: screens, sizes: sizes)
     }
 
-    /// Every preset for a count that is NOT connected — the
-    /// "For other setups" drawer's contents.
+    /// Presets excluding current connected screen count.
     static func presets(
         excludingScreens screens: Int
     ) -> [StandardLayout] {
@@ -159,19 +67,8 @@ struct ProfilesFamilyRows {
         }
     }
 
-    /// Both halves of the seam answer from ONE derivation.
-    ///
-    /// The static helpers ABOVE are what the three containers
-    /// call; this expansion is what the census guards read, and
-    /// it reaches those same statics rather than re-deriving
-    /// beside them. An earlier cut computed the two separately
-    /// from the same inputs, which made `familiesExpand` and
-    /// `instanceCounts` assert over a structure the screen never
-    /// touched — the dead seam moved rather than removed. The
-    /// join is proved, not asserted: mutating `orderedProfiles`
-    /// reds `ProfilesFamilyRowsTests` AND
-    /// `ProfilesCensusRenderTests.instanceCounts` together
-    /// (guard-prover, 2026-08-04).
+    /// Expands census family key into row instances
+    /// (`ProfilesCensusRenderTests`).
     private func rows(
         for family: ProfilesKey
     ) -> [ProfilesRowInstance]? {
@@ -187,16 +84,10 @@ struct ProfilesFamilyRows {
             )
             .map(ProfilesRowInstance.desktop)
         case .presetsApply, .presetsLayouts:
-            // Both of the card's actions expand per preset, so
-            // they share one arm — the instance set is the card,
-            // not the button.
             return presets.map {
                 ProfilesRowInstance.preset($0.name)
             }
         case .isStarterSetup:
-            // Lua-only: a profile identity flag with no Settings
-            // surface at all (`SettingPlacement.luaOnly`), so it
-            // draws nothing here and never will.
             return nil
         }
     }

--- a/Sources/KiwiDesk/Settings/Components/Profiles/ProfilesFamilyRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/ProfilesFamilyRows.swift
@@ -5,6 +5,8 @@ import KiwiDeskCore
 enum ProfilesRowInstance: Hashable {
     case profile(String)
     case desktop(Int)
+    /// By the stable English `StandardLayout.name` — identity must
+    /// not move with the GUI language.
     case preset(String)
 }
 
@@ -42,7 +44,10 @@ struct ProfilesFamilyRows {
         return summaries.sorted { key($0) < key($1) }
     }
 
-    /// Union of main screen desktops and already-bound desktops (#888).
+    /// Union of main screen desktops and already-bound desktops
+    /// (#888). Takes the NUMBERS, never a count — main's Desktops
+    /// can be 3 and 4, and `1...n` would renumber them (owner QA,
+    /// 2026-08-18).
     static func desktops(
         onMain: some Collection<Int>,
         bound: some Collection<Int>
@@ -67,8 +72,10 @@ struct ProfilesFamilyRows {
         }
     }
 
-    /// Expands census family key into row instances
-    /// (`ProfilesCensusRenderTests`).
+    /// Expands census family key into row instances, reaching the
+    /// same statics the views call — one derivation, the join
+    /// proved: mutating it reds `ProfilesFamilyRowsTests` AND
+    /// `ProfilesCensusRenderTests.instanceCounts` together.
     private func rows(
         for family: ProfilesKey
     ) -> [ProfilesRowInstance]? {

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideControls.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideControls.swift
@@ -12,8 +12,14 @@ import SwiftUI
 /// (#68, #678).
 struct OverrideChrome<Content: View>: View {
     let isOn: Binding<Bool>
+    /// The collapse target when inheriting; nil keeps the live
+    /// control visible-but-disabled — the slot-size pair, whose
+    /// value has no one-line form (#290).
     var inherited: (label: String, value: String)? = nil
     var alignment: VerticalAlignment = .center
+    /// Rendered by the chrome, not the wrapped row, so it escapes
+    /// the inherit-state dim — help stays clickable while the user
+    /// decides whether to override (#94).
     var help: String? = nil
     var subject: String? = nil
     @ViewBuilder let content: Content
@@ -25,6 +31,10 @@ struct OverrideChrome<Content: View>: View {
             alignment: alignment,
             spacing: SettingsMetrics.overrideRowInset
         ) {
+            // Fill a bounded width: a long inheriting readout
+            // otherwise overflows the FIRST layout pass and
+            // shoves the checkbox off the hittable edge — it then
+            // silently ignored the first click.
             leadingContent
                 .frame(maxWidth: .infinity, alignment: .leading)
             overrideCheckbox
@@ -58,13 +68,23 @@ struct OverrideChrome<Content: View>: View {
         } else if let inherited {
             inheritedReadout(inherited)
         } else {
+            // `alignment`, not `.center`: the multi-row slot-size
+            // pair floats a centred `?` between its rows (owner,
+            // on device, 2026-08-16).
             HStack(
                 alignment: alignment,
                 spacing: SettingsMetrics.overrideRowInset
             ) {
                 liveControl
                     .disabled(true)
+                    // Same single-dim rule as `GreyOut` (#520):
+                    // inside a gated block this would compound
+                    // to 0.25.
                     .opacity(!alreadyDimmed ? 0.5 : 1)
+                    // A dim is not a sentence: this branch has no
+                    // inherited value to narrate, so without the
+                    // hint the row announces a disabled control
+                    // and no reason at all.
                     .accessibilityHint(
                         L(
                             "space_override.off.help",
@@ -95,6 +115,9 @@ struct OverrideChrome<Content: View>: View {
     private func inheritedReadout(
         _ inherited: (label: String, value: String)
     ) -> some View {
+        // Through the shared shape so an inheriting row stacks
+        // with its live siblings below the row breakpoint (code
+        // review, 2026-08-11).
         SettingsRowShape {
             HStack(spacing: 4) {
                 Text(inherited.label).lineLimit(1)
@@ -121,6 +144,8 @@ struct OverrideChrome<Content: View>: View {
 }
 
 /// Binding bridging optional override to active bool (#290).
+/// Internal: `OverrideSlotSizeRow` drives the same chrome from
+/// another file and must share this exact seed-on-check semantics.
 func overrideToggle<T: Sendable>(
     _ value: Binding<T?>,
     global: T
@@ -188,7 +213,9 @@ struct OverrideStepperRow: View {
     }
 }
 
-/// Override ratio slider row (#94).
+/// Override ratio slider row (#94); the 0.1–0.9 range matches the
+/// Lua ratio clamp, so the GUI can't store a value the setters
+/// would reject.
 struct OverrideFractionRow: View {
     let label: String
     @Binding var value: Double?

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideControls.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideControls.swift
@@ -8,38 +8,13 @@ import SwiftUI
 /// the point of construction (`@MainActor`, matching every
 /// other GUI-only lookup) rather than as call-site literals.
 
-/// An override row, "visible but inherited" (#68 §3.4, #678 8b
-/// layout): a row overrides its field or inherits the layout's
-/// default, chosen by the **OVERRIDE** checkbox in the trailing
-/// column (checked = overriding). An overriding row shows its live
-/// control, a left accent bar and a subtle tint, so active
-/// overrides form a scannable boundary — and its checkbox is ticked,
-/// agreeing with that emphasis. An inheriting row collapses its
-/// control to a quiet "follows <Layout> defaults · <value>" readout
-/// — the value stays visible without the control's weight.
-/// The one exception is a row whose value has no one-line form (the
-/// slot-size pair): it passes `inherited: nil` and keeps the live
-/// control, disabled and dimmed, as before.
+/// Chrome wrapper providing override toggle and inherited readout styling
+/// (#68, #678).
 struct OverrideChrome<Content: View>: View {
     let isOn: Binding<Bool>
-    /// The collapse target when this row inherits: its label and
-    /// the inherited value's one-line form ("50%", "Horizontal").
-    /// `nil` keeps the live control visible-but-disabled instead —
-    /// the slot-size pair, whose value spans two controls (#290).
     var inherited: (label: String, value: String)? = nil
-    /// Vertical alignment of the checkbox against its wrapped
-    /// content. `.center` for a single-row override (the norm);
-    /// `.top` when the content is a multi-row group (the slot-size
-    /// override, #290) so the checkbox reads as governing the
-    /// stack from its first row rather than floating at its middle.
     var alignment: VerticalAlignment = .center
-    /// Optional `?` popover (#94). Rendered by the chrome, not
-    /// the wrapped row, so it escapes the inherit-state
-    /// `disabled`/dim below — help must stay clickable exactly
-    /// while the user decides whether to override.
     var help: String? = nil
-    /// Field name for the `?`'s VoiceOver label (#251), so the
-    /// rotor reads "Help: Split ratio" not a bare "Help".
     var subject: String? = nil
     @ViewBuilder let content: Content
     @Environment(\.isInsideGreyOut) private var alreadyDimmed
@@ -50,21 +25,10 @@ struct OverrideChrome<Content: View>: View {
             alignment: alignment,
             spacing: SettingsMetrics.overrideRowInset
         ) {
-            // Fill a bounded width rather than let the content take
-            // its ideal: a long inheriting readout ("follows
-            // <Layout> defaults · <value>") would otherwise overflow
-            // the row on the FIRST layout pass and shove the trailing
-            // checkbox off the hittable edge until a re-render — the
-            // checkbox then silently ignored the first click (worst
-            // on Scrolling, whose readout is longest).
             leadingContent
                 .frame(maxWidth: .infinity, alignment: .leading)
             overrideCheckbox
         }
-        // The inset keeps daylight between the 2 pt accent
-        // bar and the content, so the bar reads as a boundary
-        // rather than part of the control. It is a shared
-        // token: `overrideLabelColumn` derives from it.
         .padding(.leading, SettingsMetrics.overrideRowInset)
         .padding(.trailing, SettingsMetrics.overrideRowInset)
         .padding(.vertical, 4)
@@ -83,11 +47,8 @@ struct OverrideChrome<Content: View>: View {
         }
     }
 
-    /// The live control when overriding; when inheriting, either
-    /// the collapsed readout (the norm) or the dimmed control (the
-    /// slot-size pair, `inherited == nil`). The `?` rides alongside
-    /// in every branch, so it stays clickable and label-adjacent
-    /// while the user decides whether to override (#94).
+    /// Renders active control or inherited state with help popover (#94, #520,
+    /// #251).
     @ViewBuilder private var leadingContent: some View {
         if isOn.wrappedValue {
             HStack(spacing: SettingsMetrics.overrideRowInset) {
@@ -97,32 +58,13 @@ struct OverrideChrome<Content: View>: View {
         } else if let inherited {
             inheritedReadout(inherited)
         } else {
-            // `alignment`, not the default `.center`: this branch
-            // is the multi-row group (the slot-size pair), and a
-            // centred `?` floats between its two rows with
-            // nothing to sit beside — it read as a stray control
-            // hanging in the middle of the card (owner, on
-            // device, 2026-08-16). Aligned to the group's own
-            // anchor it lands beside the FIRST row, which is
-            // where every single-row override puts it.
             HStack(
                 alignment: alignment,
                 spacing: SettingsMetrics.overrideRowInset
             ) {
                 liveControl
                     .disabled(true)
-                    // Same single-dim rule as `GreyOut` (#520): an
-                    // inheriting row inside a gated block would
-                    // otherwise compound to 0.25.
                     .opacity(!alreadyDimmed ? 0.5 : 1)
-                    // The dim is the only thing saying why this
-                    // control is inert, and a dim is not a
-                    // sentence (#678 Phase 4 pass 10, turn 20a
-                    // rule 3). This is the branch with no
-                    // inherited VALUE to read out — the other one
-                    // already narrates through `inheritedReadout`
-                    // — so without the hint the row announces a
-                    // disabled control and no reason at all.
                     .accessibilityHint(
                         L(
                             "space_override.off.help",
@@ -137,9 +79,6 @@ struct OverrideChrome<Content: View>: View {
 
     private var liveControl: some View {
         content
-            // The narrowed column pays for the trailing OVERRIDE
-            // column, so the shared rows inside land on the same
-            // control axis as plain rows.
             .environment(
                 \.settingsLabelColumn,
                 SettingsMetrics.overrideLabelColumn
@@ -152,21 +91,10 @@ struct OverrideChrome<Content: View>: View {
         }
     }
 
-    /// `<label>    follows <Layout> defaults · <value>` — the label
-    /// on the same axis a live control would use, then the `?` and
-    /// the quiet readout. Secondary throughout, so an inheriting
-    /// row reads as "not overriding" without an opacity that could
-    /// compound.
+    /// Renders label with inherited summary string.
     private func inheritedReadout(
         _ inherited: (label: String, value: String)
     ) -> some View {
-        // Through the shared shape, on the override column the
-        // live controls beside it use (17a): an inheriting row
-        // that framed its own label kept the WIDE arrangement
-        // below the row breakpoint while every live sibling in
-        // the same list stacked, so one list drew two layouts
-        // (code review, 2026-08-11 — the scan could not see
-        // this spelling, and now does).
         SettingsRowShape {
             HStack(spacing: 4) {
                 Text(inherited.label).lineLimit(1)
@@ -190,14 +118,9 @@ struct OverrideChrome<Content: View>: View {
         )
         .foregroundStyle(.secondary)
     }
-
 }
 
-/// Bindings that map an optional override field + its global
-/// default onto the on/off checkbox and the concrete control.
-/// Internal (not private): the multi-row slot-size override
-/// (`OverrideSlotSizeRow`, #290) drives the same chrome from
-/// another file and must share this exact seed-on-check semantics.
+/// Binding bridging optional override to active bool (#290).
 func overrideToggle<T: Sendable>(
     _ value: Binding<T?>,
     global: T
@@ -208,6 +131,7 @@ func overrideToggle<T: Sendable>(
     )
 }
 
+/// Binding bridging optional override to concrete value (#290).
 func overrideValue<T: Sendable>(
     _ value: Binding<T?>,
     global: T
@@ -218,6 +142,7 @@ func overrideValue<T: Sendable>(
     )
 }
 
+/// Override row for boolean settings.
 struct OverrideToggleRow: View {
     let label: String
     @Binding var value: Bool?
@@ -242,7 +167,7 @@ struct OverrideToggleRow: View {
     }
 }
 
-/// An override stepper over an integer field, clamped to `range`.
+/// Override stepper over integer field within range.
 struct OverrideStepperRow: View {
     let label: String
     @Binding var value: Int?
@@ -263,16 +188,11 @@ struct OverrideStepperRow: View {
     }
 }
 
-/// An override ratio field riding `RatioRow`, whose 0.1–0.9
-/// range matches the Lua ratio clamp (`parseSplitRatio` /
-/// `parseMasterRatio`) so the GUI can't store a value the
-/// setters would reject.
+/// Override ratio slider row (#94).
 struct OverrideFractionRow: View {
     let label: String
     @Binding var value: Double?
     let global: Double
-    /// Optional `?` popover (#94), rendered by the chrome so
-    /// it stays clickable while the row inherits.
     var help: String? = nil
 
     var body: some View {
@@ -293,21 +213,12 @@ struct OverrideFractionRow: View {
     }
 }
 
-/// An override picker over any labeled, hashable option set.
-/// Renders a `.menu` dropdown: the per-space override editor — the
-/// one override surface left since the per-layout bar overrides
-/// went Lua-only (GUI_REMOVED_2026-08) — is the documented
-/// compact-surface exception to the #291 segmented norm. Its rows
-/// sit in a bounded ~700 pt column with a trailing OVERRIDE
-/// checkbox column, so a segmented row would be cramped and the
-/// `.menu` holds (see `docs/ui-patterns.md`).
+/// Override dropdown picker row (#291, #94).
 struct OverridePickerRow<Value: Hashable & Sendable>: View {
     let label: String
     @Binding var value: Value?
     let global: Value
     let options: [(Value, String)]
-    /// Optional `?` popover (#94), rendered by the chrome so
-    /// it stays clickable while the row inherits.
     var help: String? = nil
 
     var body: some View {

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesGates.swift
@@ -102,8 +102,11 @@ enum SpacesGateHelp {
         }
     }
 
-    /// Remote gate reasons whose switch lives on another destination
-    /// (`GateReasonPlacementTests`, #841).
+    /// Remote gate reasons whose switch lives on another
+    /// destination (#841, #815). A hand-kept copy of what
+    /// `GateReasonPlacement.channel` derives, bound by
+    /// `remoteMatchesTheCensus` (`GateReasonPlacementTests`); the
+    /// derivation is owed (architect review, 2026-08-16).
     static let remote: Set<SpacesGates.InertReason> = [
         .autoSizedGrid, .autoTracks,
     ]

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpacesGates.swift
@@ -1,45 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Spaces & Layouts area's greying, resolved from the census
-/// (#678 Phase 3, turn 8). Keyed on a row's own `SettingKey` and
-/// returning a REASON case rather than a Bool — the shape General,
-/// Layout Defaults and Gaps & Borders already share, so this area
-/// adds no new resolver signature.
-///
-/// Unlike those areas the resolver is PER INSTANCE: every gate
-/// here asks about one space (its resolved layout params, its
-/// override count), so the context carries the space and its
-/// active layout alongside the settings. It answers only ROW
-/// gates — no container in this area carries a
-/// `SettingsContainer.gate` — and it takes no `SettingsMode`
-/// input: the mode never changes what runs (8c), it only decides
-/// what is offered, so an override that exists greys the same way
-/// in Simple and Power User.
-///
-/// The five override-row predicates ask the RESOLVED value for the
-/// space (#406/#520): a control the global would silence is still
-/// live for a space that overrides it, so the per-space editor
-/// reads `resolvedStack(for:)`/`resolvedGrid(for:)`/
-/// `resolvedTrack(for:)`, the same values the Layout Defaults twin
-/// resolves — two surfaces answering "is this Space rigid"
-/// differently is the drift the resolver exists to prevent.
-///
-/// Returning the reason rather than a Bool keeps the grey and its
-/// inline sentence from being two decisions that can disagree
-/// (`SpacesGateHelp` renders it), and keeps the whole resolver
-/// assertable off the main actor.
+/// Resolves row inertness for per-space layout overrides (#678, #406, #520).
 struct SpacesGates {
     let settings: TilingSettings
     let space: SpaceID
-    /// The space's active layout — the one the reset action
-    /// counts overrides for. The five layout-override predicates
-    /// read the space's resolved params directly and do not
-    /// consult it.
     let mode: LayoutMode
 
-    /// Why a row is inert. One case per predicate; the sentence
-    /// lives in `SpacesGateHelp`.
+    /// Why a row is inert.
     enum InertReason: Hashable {
         case noOverrides
         case oneMaster
@@ -48,14 +16,7 @@ struct SpacesGates {
         case autoTracks
     }
 
-    /// Why `key`'s row is inert for this space right now, or nil
-    /// while it is live. Fail-OPEN on a gate this type does not own
-    /// — loud in debug, live in release — matching the other area
-    /// resolvers: a missing case must not lock a shipped Settings
-    /// row, and of the two silent readings a live row the user can
-    /// ignore beats a dead one they cannot explain.
-    /// `everyGatedRowIsResolved` keeps that arm unreachable rather
-    /// than merely believed to be.
+    /// Evaluates inert reason for given setting key on this space.
     func inertReason(for key: SettingKey) -> InertReason? {
         guard key.placement.gate != nil else { return nil }
         switch key {
@@ -83,10 +44,6 @@ struct SpacesGates {
         }
     }
 
-    /// The gated rows this resolver answers. Data, so
-    /// `everyGatedRowIsResolved` reds when a new census gate in
-    /// this area lands in neither set instead of hitting the
-    /// fail-open default at run time.
     static let resolved: Set<SettingKey> = [
         .spaces(.spaceOverrideResetActive),
         .layout(.stackOverrideMasterOrientation),
@@ -96,32 +53,11 @@ struct SpacesGates {
         .layout(.trackOverrideLimit),
     ]
 
-    /// Declared-but-answered-elsewhere. Empty and kept so a new
-    /// gate this resolver cannot answer must land here on purpose
-    /// rather than pass silently.
     static let resolvedElsewhere: Set<SettingKey> = []
 }
 
-/// The inline sentence each `SpacesGates.InertReason` renders —
-/// the "why you can't edit this" a greyed row shows on hover.
-/// Split from the resolver so the resolver stays assertable off
-/// the main actor; the reason and its sentence are one decision,
-/// never two that can disagree (#678, gui.md).
-///
-/// The keys began as verbatim reuses of the hand-wired gates this
-/// conversion replaced, which is why the conversion itself
-/// dropped no translation.
-///
-/// **That is history, not a standing property — editing an
-/// English sentence here runs `scripts/drop-key` in the same
-/// change set.** It shipped as a claim ("the English is unchanged
-/// and no translation is dropped"), and two sentences below were
-/// then reworded to remove a scope claim while the comment went
-/// on asserting the opposite — so ten catalogs kept saying "for
-/// this Space" about rows that no longer say it (localization
-/// audit, 2026-08-16). A state claim about a file is true only on
-/// the day it is written; this one had a reader, and the reader
-/// was the author of the very edit that falsified it.
+/// Localized hover and cross-reference text for gated space settings (#678,
+/// #841).
 @MainActor
 enum SpacesGateHelp {
     static func sentence(
@@ -166,54 +102,14 @@ enum SpacesGateHelp {
         }
     }
 
-    /// The REMOTE reasons — the ones whose switch lives on
-    /// another destination (#841).
-    ///
-    /// `GateReasonPlacement` classifies these three rows
-    /// `.remote`: their gating field has no row in the per-space
-    /// editor, so unlike every inline grey here the reader
-    /// cannot look up and find the switch. Both `.help()` and a
-    /// dim are then dead ends — a keyboard or VoiceOver user got
-    /// "dimmed" and nothing else, which is #815's complaint in
-    /// the one class #815 did not close.
-    ///
-    /// Data rather than a condition at the call site, so the
-    /// classification and the anchor cannot disagree.
-    ///
-    /// Stated residue, because the honest version is not yet
-    /// available: `GateReasonPlacement.channel` already DERIVES
-    /// `.remote` from the census, and this set is a second,
-    /// hand-kept copy of that answer keyed on the reason rather
-    /// than on the `SettingKey` (architect review, 2026-08-16).
-    /// They are bound only by `remoteMatchesTheCensus` in
-    /// `GateReasonPlacementTests`, which reds if a key's channel
-    /// and this set ever disagree — a guard rather than a
-    /// derivation, and the derivation is owed.
+    /// Remote gate reasons whose switch lives on another destination
+    /// (`GateReasonPlacementTests`, #841).
     static let remote: Set<SpacesGates.InertReason> = [
         .autoSizedGrid, .autoTracks,
     ]
 
-    /// The sentence a `CrossReferenceRow` renders for a remote
-    /// reason, carrying the link slot where the destination's
-    /// name belongs.
-    ///
-    /// It names WHERE TO GO, which is the whole of the remote
-    /// rule — a sentence that only restates the state leaves the
-    /// reader knowing why and not knowing where. And it is a
-    /// live link rather than `Text`, or the pointer is dead
-    /// (`docs/ui-patterns.md`).
-    ///
-    /// The gating control's name is **interpolated from its own
-    /// key**, never re-typed (#818). This is the sharpest case
-    /// for that rule: a cross-reference whose only job is to send
-    /// the reader to a row points at nothing once the quoted name
-    /// drifts from it — and the sibling `.gates` sentences these
-    /// were derived from had already drifted in two catalogs
-    /// (`de`'s row reads "Raster automatisch dimensionieren"
-    /// against a sentence saying "Automatisches Raster";
-    /// `ru`'s row and its sentence likewise). Each specifier is
-    /// spent once, so a translation may pronominalise neither
-    /// into the other.
+    /// Cross-reference navigation sentence for remote gate reasons (#818,
+    /// #841).
     static func crossReference(
         for reason: SpacesGates.InertReason
     ) -> String? {

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection+About.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection+About.swift
@@ -1,28 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// General ▸ About: the brand block, the version string and
-/// the support link. Split out of `GeneralSection` when the
-/// turn-16b skin took that file past the §2.1 ceiling — it is
-/// the one part of General that is presentation with no
-/// settings in it at all.
+/// General ▸ About section displaying brand, version, notes, guide, and
+/// support links (#68, #570, #1019).
 extension GeneralSection {
-    /// About (#68 §3.9): the wordmark as the canonical logo +
-    /// name placement, version and the discreet support link
-    /// beneath. Falls back to the pre-logo glyph row when the
-    /// bundled resource is missing.
     var aboutSection: some View {
         SettingsSection(SettingsCatalog.general.aboutCard) {
             VStack(spacing: 10) {
                 aboutBrand
-                // The version and what changed in it are ONE
-                // topic — "what you have" and "what arrived" —
-                // so they sit closer to each other than either
-                // does to the support ask below, which is an
-                // unrelated request and reads best as the card's
-                // last word (ui-designer, 2026-08-17). Uniform
-                // spacing made all three equidistant and said
-                // none of that.
                 VStack(spacing: 4) {
                     Text(KiwiDeskVersion.displayString)
                         .font(.caption)
@@ -37,29 +22,7 @@ extension GeneralSection {
         }
     }
 
-    /// What changed in the version above it (#570).
-    ///
-    /// Deliberately NOT the ask row's shape: its symbols and
-    /// `.callout` mark this card's ask, and an informational
-    /// link drawn to match turns a personal plea into a links
-    /// row, after which nothing on screen says what the maker
-    /// actually wants. So this one takes the plainer
-    /// informational treatment — the caption's size, no symbol —
-    /// and the asymmetry is the point rather than an oversight
-    /// (ui-designer, 2026-08-17; the ask widened to a pair
-    /// 2026-08-26 without touching this rule).
-    ///
-    /// No `.foregroundStyle` here on purpose: `linkHover()`
-    /// already renders secondary at rest and lifts to primary on
-    /// hover, so a foreground of our own would either fight it or
-    /// be overwritten.
-    ///
-    /// A plain outbound `Link` rather than an in-app notes
-    /// reader. `gui.md`'s "a picture whose object is not the
-    /// draft goes in a sheet" does **not** reach this: its scope
-    /// is content this app renders from data it owns, and release
-    /// notes are neither — GitHub already renders them, with
-    /// formatting and images a native sheet would not reproduce.
+    /// Link to GitHub release notes (#570).
     @ViewBuilder var releaseNotesLink: some View {
         Link(destination: SupportLinks.releases) {
             Text(
@@ -72,38 +35,7 @@ extension GeneralSection {
         .linkHover()
     }
 
-    /// The app's PERMANENT route to the written guide (#1019).
-    ///
-    /// The tour's closing card and Home's first-run banner both
-    /// point at it, and both are one-shot: the tour never comes
-    /// back on its own, and the banner retires for good on
-    /// dismiss or on the first save. So a user who dismissed the
-    /// welcome — or simply saved one change — had no route to the
-    /// guide anywhere in the app, which is the gap #1019 is
-    /// titled after rather than a nicety on top of it
-    /// (`ui-designer`, 2026-08-26). This is the half that still
-    /// works on day 30.
-    ///
-    /// Drawn as `releaseNotesLink` is, not as the ask row is:
-    /// that row's symbols and `.callout` are this card's ask,
-    /// and the asymmetry is deliberate (`askRow`'s own doc).
-    /// A third informational link takes the plain treatment.
-    ///
-    /// Its own line rather than inside the version group above:
-    /// that group is "what you have" and "what arrived", and the
-    /// guide is neither.
-    ///
-    /// **It carries a catalog declaration, which is the half that
-    /// makes it reachable.** About is two clicks and a scroll
-    /// from Home; the guide is the one thing in this window a
-    /// stuck reader looks for BY NAME, and `SettingsSearchIndex`
-    /// derives its rows from the census plus the catalog — so
-    /// without the declaration, searching "Guide" (or "Handbuch")
-    /// found nothing at all. Placement was never the problem
-    /// (`ui-designer`, 2026-08-26): Home's grid is destinations
-    /// resolved through one offer predicate and has no
-    /// representation for a URL, so a card here would have to
-    /// invent a second navigation model.
+    /// Link to user guide, registered with search index (#1019).
     @ViewBuilder var guideLink: some View {
         Link(destination: SupportLinks.guide) {
             Text(SettingsCatalog.general.guideLink.text)
@@ -112,23 +44,10 @@ extension GeneralSection {
         .buttonStyle(.plain)
         .font(.caption)
         .linkHover()
-        // Its own scroll target and wash: a search for "guide"
-        // has to land ON the link, not merely on the card that
-        // contains it. Self-anchoring, because there is no
-        // header/card split here to place the two halves across.
         .searchAnchored(SettingsCatalog.general.guideLink)
     }
 
-    /// The card's last word: the ask, a PAIR since the 1.1
-    /// launch (owner, 2026-08-26). The star is the ask a free
-    /// MIT tool lives on and costs the reader nothing; Ko-fi
-    /// stays beside it for the reader who wants to give more.
-    /// One row at one weight rather than two stacked pleas —
-    /// stacked they would read as a fundraising block, and the
-    /// informational links above keep the plain treatment for
-    /// exactly that contrast (the 2026-08-17 asymmetry ruling,
-    /// carried by `releaseNotesLink`'s doc, is about ask versus
-    /// information, not about the ask's arity).
+    /// GitHub star and Ko-fi sponsor links.
     @ViewBuilder var askRow: some View {
         HStack(spacing: 14) {
             starLink
@@ -136,9 +55,6 @@ extension GeneralSection {
         }
     }
 
-    /// The star half of the ask. A bare SwiftUI `Link` at the
-    /// URL, as `guideLink` is — its label IS the destination, so
-    /// no sentence frame is owed.
     @ViewBuilder var starLink: some View {
         Link(destination: SupportLinks.gitHub) {
             HStack(spacing: 4) {
@@ -157,7 +73,6 @@ extension GeneralSection {
         .linkHover()
     }
 
-    /// The sponsor half of the ask.
     @ViewBuilder var supportLink: some View {
         Link(destination: SupportLinks.koFi) {
             HStack(spacing: 4) {
@@ -176,24 +91,8 @@ extension GeneralSection {
         .linkHover()
     }
 
-    /// The wordmark is artwork, not text, so its ink is baked at
-    /// rasterization time rather than tinted at runtime: we ship
-    /// two masters — forest lettering for light, mist-green for
-    /// dark — and swap by `colorScheme`, so no backing card is
-    /// needed and the mark melts into the pane in both. The
-    /// **symbol** is identical in the two (#479); only the
-    /// lettering is themed, and `BrandMasterParityTests` pins
-    /// that.
-    ///
-    /// The fallback is the mark at 42 pt beside the name — the
-    /// About block's size in the #678 §3 mark inventory, and the
-    /// prototype's whole construction there, since it ships no
-    /// wordmark asset. It is a fallback rather than the primary
-    /// because the wordmark carries the same mark AND the
-    /// lettering as one piece of artwork; drawing both would put
-    /// two kiwis in one block. The generic `rectangle.3.group`
-    /// this replaces was the one brand surface in the app with no
-    /// brand in it.
+    /// Wordmark artwork with dynamic dark/light master and fallback glyph
+    /// (#479, `BrandMasterParityTests`).
     @ViewBuilder var aboutBrand: some View {
         if let wordmark {
             Image(nsImage: wordmark)
@@ -223,9 +122,6 @@ extension GeneralSection {
         }
     }
 
-    /// The dark master falls back to the light one if it is
-    /// ever missing — a readable-but-imperfect degrade beats
-    /// showing nothing.
     var wordmark: NSImage? {
         colorScheme == .dark
             ? BrandAssets.wordmarkDark ?? BrandAssets.wordmark

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection+About.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection+About.swift
@@ -91,8 +91,9 @@ extension GeneralSection {
         .linkHover()
     }
 
-    /// Wordmark artwork with dynamic dark/light master and fallback glyph
-    /// (#479, `BrandMasterParityTests`).
+    /// Wordmark artwork with dynamic dark/light master and fallback
+    /// glyph (#479, `BrandMasterParityTests`). The fallback mark is
+    /// 42 pt — the About block's size in the #678 §3 mark inventory.
     @ViewBuilder var aboutBrand: some View {
         if let wordmark {
             Image(nsImage: wordmark)

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection.swift
@@ -7,8 +7,15 @@ struct GeneralSection: View {
     @ObservedObject var model: SettingsModel
     @EnvironmentObject private var localization: LocalizationManager
     @State private var advancedExpanded = false
+    /// The Reset All confirmation (#634); internal because the row
+    /// and dialog live in `GeneralSection+Reset`.
     @State var confirmingReset = false
+    /// The backup waiting on its confirm (#606) — the dialog
+    /// derives from this, never a second Bool, so the two cannot
+    /// disagree.
     @State var pendingRestore: SetupBundle?
+    /// Core names the condition, `SetupBackupText` writes the
+    /// sentence (#96).
     @State var backupError: SetupBundleError?
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.accessibilityReduceMotion)
@@ -152,6 +159,9 @@ struct GeneralSection: View {
                     .settingsActionButton()
                 }
                 Divider()
+                // Opening the raw editor swaps the primary Save to
+                // `.saveLua`, dropping staged visual edits — gated
+                // like every other discard path (#515).
                 Button {
                     model.discardingEdits(
                         message: L(

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection.swift
@@ -1,35 +1,15 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Whole App ▸ General (#68 §3.2): genuinely app-wide state,
-/// never affected by which profile the banner has open —
-/// the Language picker (issue #9), the About area, and the
-/// Advanced config-file tools.
+/// General settings section covering language, appearance, login item, and
+/// backups (#68, #9).
 struct GeneralSection: View {
     @ObservedObject var model: SettingsModel
     @EnvironmentObject private var localization: LocalizationManager
-    /// Advanced is collapsed by default — only interested
-    /// users need the config-file path and the raw editor.
     @State private var advancedExpanded = false
-    /// The Reset All Settings confirmation (#634). Internal:
-    /// the row and dialog live in `GeneralSection+Reset`, and
-    /// an extension in another file cannot reach `private`.
     @State var confirmingReset = false
-    /// The backup waiting on its confirm (#606) — nil while none
-    /// is. The dialog's presentation derives from this rather than
-    /// from a second Bool, so the two cannot disagree. Internal
-    /// for the same reason as `confirmingReset`: the rows live in
-    /// `GeneralSection+Backup`.
     @State var pendingRestore: SetupBundle?
-    /// The last export or restore failure, rendered as an alert.
-    /// Core names the condition, `SetupBackupText` writes the
-    /// sentence (#96).
     @State var backupError: SetupBundleError?
-    /// Drives the light/dark wordmark swap (see `aboutBrand`).
-    /// Internal, not private: the About block lives in
-    /// `GeneralSection+About`, and an extension in another file
-    /// cannot reach `private` — the same reason
-    /// `confirmingReset` above is internal.
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.accessibilityReduceMotion)
     var reduceMotion
@@ -45,31 +25,12 @@ struct GeneralSection: View {
         }
     }
 
-    /// Language (issue #9): "System default" first, then every
-    /// shipped locale by its own native name — the picker itself
-    /// is the live control, no Save button (`setLanguage`
-    /// persists immediately).
-    /// Turn 14b's first group: ONE card, because these rows are
-    /// grouped by the RULE they share rather than by topic —
-    /// none is part of a profile, none is touched by the
-    /// footer's Save. Splitting them into a Language card and a
-    /// Login card is what let Revert look as though it would
-    /// undo them (the 6b audit's fourth finding).
+    /// Settings that apply immediately without manual saving (#9).
     private var appliesImmediatelySection: some View {
         SettingsSection(
             SettingsCatalog.general.appliesImmediatelyCard
         ) {
-            // Uses the house `DropdownRow` (shared label axis,
-            // `.menu` style, large control) like every other
-            // dropdown. The native `.menu` first-letter type-ahead
-            // suffices for a short list; revisit with a searchable
-            // list (`.searchable` in a popover) once shipped
-            // locales approach ~15–20.
             DropdownRow(
-                // The card heading is already the topic noun
-                // "Language"; the control's own label is the more
-                // specific "Display language" so the two don't
-                // read as a doubled word (ui-designer 2026-07-28).
                 label: L(
                     "general.language.display",
                     "Display language"
@@ -110,23 +71,7 @@ struct GeneralSection: View {
         }
     }
 
-    /// Item 8. Sits beside the language pick because the two
-    /// share a rule rather than a topic: both apply the instant
-    /// you choose, neither is part of a profile, and neither is
-    /// touched by the footer's Save. Turn 14b makes that the
-    /// group's heading, because a row Revert appears to undo and
-    /// does not is the 6b audit's fourth finding.
-    ///
-    /// A segmented control rather than a dropdown: three fixed,
-    /// mutually exclusive choices whose whole set fits on one
-    /// line is the case `docs/ui-patterns.md` gives segmented,
-    /// and unlike the locale list it can never grow.
-    /// A direct `SegmentedPicker`, not one inside a
-    /// `DropdownRow` (#823): the shared component draws its own
-    /// `SettingsRowShape` when it carries a label, and
-    /// `DropdownRow` forces `.pickerStyle(.menu)` onto whatever
-    /// it wraps. So the wrapper comes off rather than the picker
-    /// inside it changing.
+    /// Appearance mode selector (#823).
     private var appearanceRow: some View {
         SegmentedPicker(
             L("general.appearance", "Appearance"),
@@ -151,8 +96,6 @@ struct GeneralSection: View {
         )
     }
 
-    /// The picker's choice as VoiceOver hears it — the native
-    /// name, or the "System default" entry when nothing is set.
     private var selectedLanguageName: String {
         guard let code = localization.selection else {
             return L(
@@ -164,13 +107,7 @@ struct GeneralSection: View {
             ?? code
     }
 
-    /// The picker's concrete languages: every shipped locale file
-    /// plus English, native-name-sorted ("Deutsch", "English",
-    /// "Français"). English never ships as a runtime file (it
-    /// lives inline at call sites) but must be an explicit choice
-    /// — otherwise a user on a non-English OS can only reach
-    /// English via "System default", which resolves to *their* OS
-    /// language, leaving no way to force English.
+    /// Shipped locales plus English sorted by native endonym.
     private var sortedLocales: [LocaleOption] {
         (localization.available + ["en"])
             .map { LocaleOption(code: $0) }
@@ -215,12 +152,6 @@ struct GeneralSection: View {
                     .settingsActionButton()
                 }
                 Divider()
-                // Opening the raw editor swaps the primary Save
-                // to `.saveLua`, which writes `luaSource`
-                // verbatim — so staged visual edits are dropped
-                // while the footer still reads "Unsaved
-                // changes". Gated like every other discard
-                // path (#515).
                 Button {
                     model.discardingEdits(
                         message: L(
@@ -234,16 +165,6 @@ struct GeneralSection: View {
                             "Discard & edit init.lua"
                         )
                     ) {
-                        // Discard for real, or the dialog lies:
-                        // flipping the flag alone leaves `config`
-                        // staged and `isDirty` true, so the footer
-                        // still reads "Unsaved changes" and
-                        // leaving again prompts a second time for
-                        // edits the user already discarded. Flag
-                        // first, then reload — `liveState()`
-                        // carries `showLuaEditor` through, and
-                        // this is the exact mirror of "Back to
-                        // visual editor".
                         model.showLuaEditor = true
                         model.reload()
                     }
@@ -261,9 +182,6 @@ struct GeneralSection: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Divider()
-                // Read-only, so it sits ABOVE the ladder; its
-                // destructive twin is the ladder's last rung. The
-                // argument is in `GeneralSection+Backup`.
                 exportBackupRow
                 resetLadder
             }
@@ -275,20 +193,9 @@ struct GeneralSection: View {
             isPresented: backupErrorBinding,
             presenting: backupError
         ) { _ in
-            // No button of our own: an empty actions builder makes
-            // SwiftUI supply the standard dismissal, localized by
-            // the SYSTEM — so it reads correctly even in a
-            // language KiwiDesk does not ship a catalog for, which
-            // an `L("alert.ok", "OK")` of ours could not. The
-            // binding clears the error on dismissal.
         } message: { error in
             Text(SetupBackupText.sentence(for: error))
         }
-        // A restore that happened but could not take everything.
-        // Its own alert rather than a branch inside the error one:
-        // it is not a failure, and a title claiming otherwise
-        // would send the user hunting for a problem that is not
-        // there.
         .alert(
             SetupBackupText.partialTitle,
             isPresented: partialRestoreBinding,
@@ -306,8 +213,6 @@ struct GeneralSection: View {
         )
     }
 
-    /// Presented exactly while an error is held — one source of
-    /// truth rather than a Bool beside an Optional.
     private var backupErrorBinding: Binding<Bool> {
         Binding(
             get: { backupError != nil },
@@ -324,15 +229,10 @@ struct GeneralSection: View {
     }
 }
 
-/// One shipped locale, presented by its own native name (e.g.
-/// "Deutsch" for `de`) — never the English exonym.
+/// Shipped locale option displaying native endonym.
 private struct LocaleOption {
     let code: String
 
-    /// The endonym, through the one shared derivation
-    /// (`LocaleNativeName` carries the casing argument) — the
-    /// Home card's language line renders the same call, so the
-    /// two surfaces cannot drift.
     var nativeName: String {
         LocaleNativeName.name(for: code)
     }

--- a/Sources/KiwiDesk/Settings/Sections/PresetsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/PresetsSection.swift
@@ -1,25 +1,11 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Whole App ▸ Profiles ▸ **Start from a preset** (#53, rebuilt
-/// in #678 turn 13a): the built-in per-screen-count layouts.
-///
-/// Grouped by screen count, and the live count leads under a
-/// heading that names it ("For your 3 screens"). Every other
-/// count folds into one disclosure: a preset for hardware that is
-/// not plugged in cannot be applied, so it is a reference, not an
-/// offer — and eight cards of reference above the user's own
-/// three is what the flat list used to put on screen.
-///
-/// The group heading carries the screen number, so the cards do
-/// not repeat it.
+/// Built-in layout presets section grouped by screen count (#53, #678).
 struct PresetsSection: View {
     @ObservedObject var model: SettingsModel
-    /// The shell's measured band — the ONE width
-    /// derivation this grid is allowed to read.
     @Environment(\.settingsWidth) private var band
     @State private var otherSetupsExpanded = false
-    /// The open preview sheet, or nil (#859).
     @State private var previewRequest: PresetPreviewRequest?
 
     var body: some View {
@@ -28,10 +14,6 @@ struct PresetsSection: View {
             caption: rowsCaption
         ) {
             if model.profileSummaries.isEmpty {
-                // Zero-profile spotlight (ui-designer
-                // 2026-07-19): the lead-in labels the bootstrap
-                // the section already is; state-driven, gone once
-                // any profile exists.
                 Text(startHereText)
                     .font(.callout)
                     .fontWeight(.medium)
@@ -39,33 +21,6 @@ struct PresetsSection: View {
             liveGroup
             otherSetups
         }
-        // Hosted on the SECTION, not on a card. The cards are in
-        // a `LazyVGrid`, which tears down rows it scrolls past,
-        // and a sheet hosted inside a subtree its own presenter
-        // can destroy dies with it — the lesson `SettingsView`
-        // records for the one discard dialog, which sits above
-        // the `editingLua` branch for exactly this reason. This
-        // view's identity is stable for as long as the area is.
-        //
-        // **It states no focus destination, and that is correct
-        // here.** gui.md requires one of every shape change, and
-        // the shell states two itself — but those are NAVIGATIONS,
-        // which replace the subtree that held the focus. A sheet
-        // does not: the presenting tree survives, so AppKit
-        // restores the previous first responder on dismissal.
-        // Eye-confirmed on macOS 26.6.1, 2026-08-17 — with focus on
-        // a control beforehand, Tab after closing resumes there;
-        // the "first Tab lands on the search field" reading came
-        // from opening the sheet with focus nowhere at all, which
-        // is AppKit choosing the window's first responder and not
-        // this sheet losing anything.
-        //
-        // A `@FocusState` restore was written here and BACKED OUT:
-        // it would force focus onto the card that opened the sheet
-        // even when the keyboard had been on a different card, so
-        // it replaced a correct answer with a worse one. A future
-        // sheet needs no destination for the same reason; a future
-        // NAVIGATION still does.
         .sheet(item: $previewRequest) { request in
             PresetPreviewSheet(
                 layout: request.layout,
@@ -74,8 +29,6 @@ struct PresetsSection: View {
         }
     }
 
-    /// Hoisted out of the builder (§5 shallow-body guardrail:
-    /// concatenated literals inside one body expression).
     private var startHereText: String {
         L(
             "presets.start_here",
@@ -93,20 +46,9 @@ struct PresetsSection: View {
         )
     }
 
-    // MARK: - Groups
-
-    /// Derived from `liveSizes`, so the "floor at one screen"
-    /// rule is applied ONCE, in Core. Counting `model.displays`
-    /// separately made the two disagree with nothing published:
-    /// the live group said "no plans for this many screens" while
-    /// a Starter for the nominal screen existed and was filtered
-    /// out by `screenCount != 0` (architect review, 2026-08-11).
     private var liveCount: Int { liveSizes.count }
 
-    /// The live screens in positional order, which the `Starter`
-    /// preset is derived from. Ordered by the same helper the
-    /// first-run seed uses, so the preset a user applies and the
-    /// setup they were seeded with are the same thing.
+    /// Live display dimensions in positional order for starter presets.
     private var liveSizes: [CGSize] {
         StarterSetup.sizes(
             displays: model.displays,
@@ -114,9 +56,6 @@ struct PresetsSection: View {
         )
     }
 
-    // Both preset lists come from the family seam that records
-    // what `presetsApply` expands to, so the guard over that
-    // expansion watches the cards this section actually draws.
     @ViewBuilder private var liveGroup: some View {
         let presets = ProfilesFamilyRows.presets(
             forScreens: liveCount,
@@ -156,19 +95,7 @@ struct PresetsSection: View {
         )
     }
 
-    /// Every preset for a count that is NOT connected, behind one
-    /// disclosure.
-    ///
-    /// **No summary (#1028).** Since #1021 a summary renders
-    /// INSIDE the header button, so its text composes into the
-    /// button's accessibility name and its headings-rotor entry.
-    /// A bare `others.count` therefore announced as an unlabelled
-    /// digit — "Other setups 12, collapsed, heading" — where the
-    /// four sibling drawers announce a phrase saying what is
-    /// inside. The placement is right and is not what changed;
-    /// the owner ruled the label alone, so the header says one
-    /// thing on both channels and the screen counts stay where
-    /// they are already spoken, on the groups inside.
+    /// Presets for disconnected screen counts in disclosure (#1028).
     @ViewBuilder private var otherSetups: some View {
         let others = ProfilesFamilyRows.presets(
             excludingScreens: liveCount
@@ -221,20 +148,8 @@ struct PresetsSection: View {
         }
     }
 
-    // MARK: - Rows
-
-    /// The card, with this section's own inputs supplied once
-    /// rather than at both call sites.
-    ///
-    /// A wrapper rather than two direct `PresetCard(...)` calls,
-    /// and deliberately: `ProfilesGateWiringTests` keys two needles
-    /// on this file's `presetCard($0,sizes:liveSizes)` and
-    /// `presetCard($0,sizes:nil)` spellings — the pin on which
-    /// cards resolve against live hardware and which are drawn as
-    /// plans. Keeping the wrapper means #859 moved the drawing
-    /// without repointing that guard, which is a split "changing
-    /// what a test claims with its bytes untouched"
-    /// (tests.md ▸ Owed).
+    /// Card wrapper maintaining signature for `ProfilesGateWiringTests`
+    /// (#859).
     private func presetCard(
         _ layout: StandardLayout,
         sizes: [CGSize]?
@@ -247,16 +162,7 @@ struct PresetsSection: View {
         ) { previewRequest = $0 }
     }
 
-    /// The grid's columns — the BAND's cap, never a width this
-    /// view measures for itself (`SettingsWidthClass` is the one
-    /// derivation). `.flexible` rather than `.adaptive` so the
-    /// cap is honoured: `.adaptive` cannot express "at most N".
-    ///
-    /// The minimum is `PresetCard`'s own floor rather than a
-    /// number stated here (#862): the card knows what it has to
-    /// hold, and the grid stating a second, smaller opinion is
-    /// how the declared floor came to be a width no locale's
-    /// button row fits in.
+    /// Grid items capped by width class (`SettingsWidthClass`, #862).
     private var columns: [GridItem] {
         Array(
             repeating: GridItem(

--- a/Sources/KiwiDesk/Settings/Sections/PresetsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/PresetsSection.swift
@@ -95,7 +95,10 @@ struct PresetsSection: View {
         )
     }
 
-    /// Presets for disconnected screen counts in disclosure (#1028).
+    /// Presets for disconnected screen counts, behind one
+    /// disclosure — deliberately no summary (#1028): since #1021 a
+    /// header summary composes into the button's accessibility
+    /// name, where a bare count announced as an unlabelled digit.
     @ViewBuilder private var otherSetups: some View {
         let others = ProfilesFamilyRows.presets(
             excludingScreens: liveCount

--- a/Sources/KiwiDesk/Settings/Sections/ShortcutsHeader.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ShortcutsHeader.swift
@@ -1,13 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Shortcuts header: the Import button — placed here,
-/// visible without scrolling, where the new user it serves can
-/// find it — and a label naming which layer the groups below
-/// bind into.
-///
-/// The layer strip itself lives in the Layers card
-/// (`LayerStripEditor`), which is where the census places it.
+/// Header for Shortcuts section with active layer label, Import, and Restore
+/// Defaults (#4, #1096).
 struct ShortcutsHeader: View {
     @ObservedObject var model: SettingsModel
     @Binding var selected: String
@@ -19,35 +14,16 @@ struct ShortcutsHeader: View {
             HStack(spacing: 8) {
                 editingLabel
                 Spacer()
-                // Import only offers itself when init.lua has
-                // custom Lua (the same condition as the
-                // banner): with nothing custom in the file
-                // there is nothing it could find, and inside
-                // the visual editor active foreign binds have
-                // already forced the raw-Lua fallback anyway.
                 if model.hasCustomLua,
                     !model.editingStoredProfile
                 {
                     importButton
                 }
-                // Gated, not permanent: it appears only when
-                // KiwiDesk actually has defaults this install
-                // lacks. That makes its PRESENCE the news #1096
-                // exists to deliver, instead of a destructive-
-                // sounding button standing over every new user's
-                // shortcut list for a condition they do not have
-                // — the same argument that keeps Import absent
-                // until init.lua holds something to adopt.
                 if model.hasDefaultsToRestore {
                     resetButton
                 }
             }
             if importedNote {
-                // `groupHeading` is the green-emphasis TEXT
-                // token (the diff rows' precedent) — `.green`
-                // lifts in dark while the app's greens do not,
-                // and full-strength `accent` on words reads
-                // clickable (dark pass).
                 Text(importedNoteText)
                     .font(.caption)
                     .foregroundStyle(SettingsTheme.groupHeading)
@@ -55,17 +31,7 @@ struct ShortcutsHeader: View {
         }
     }
 
-    /// Which layer the rows below belong to — a LABEL, not a
-    /// control, and shown only once a second layer exists.
-    ///
-    /// The census tiers the layer strip `.showMore`, so the strip
-    /// itself now lives in the Layers card rather than the header
-    /// (owner ruling: the census is the area's authority). But
-    /// every group below binds into the SELECTED layer, and an
-    /// editor that does not say what it is editing is a trap the
-    /// moment a second layer exists — so the header keeps the
-    /// fact and gives up the control. With only `default` there
-    /// is nothing to disambiguate and it stays silent.
+    /// Label indicating active layer when multiple layers exist.
     @ViewBuilder private var editingLabel: some View {
         if model.config.layers.count > 1 {
             Text(
@@ -80,20 +46,7 @@ struct ShortcutsHeader: View {
         }
     }
 
-    // MARK: - Restore defaults (#1096)
-
-    /// Takes up the shipped defaults, which the seed alone
-    /// cannot deliver: it fires only into an empty config, so
-    /// an existing install never sees an improved default.
-    ///
-    /// Disabled rather than hidden off the default layer
-    /// (`gui.md` — grey, don't hide), because the seed only ever
-    /// authored that one; `.help` says which, so the greying
-    /// explains itself.
-    ///
-    /// Danger is signalled by the confirmation's destructive
-    /// role, never a resting red button — the house convention
-    /// `GeneralSection+Reset` states.
+    /// Restores shipped shortcut defaults onto default layer (#1096).
     private var resetButton: some View {
         Button {
             confirmingReset = true
@@ -130,10 +83,6 @@ struct ShortcutsHeader: View {
             }
             Button(role: .cancel) {
             } label: {
-                // NOT `discard.cancel` — that key reads
-                // "Continue editing" in seven locales, and
-                // nothing is being edited on this dialog.
-                // `GeneralSection+Reset` hit the same trap.
                 Text(
                     L("spaces.delete_confirm.cancel", "Cancel")
                 )
@@ -143,22 +92,7 @@ struct ShortcutsHeader: View {
         }
     }
 
-    /// Names the COUNT it would discard rather than asking "are
-    /// you sure": a number is what makes the choice informed,
-    /// and it is zero for the common case of an untouched layer,
-    /// where the sentence says so instead of threatening.
-    /// Leads with the GAIN and treats the loss as the caveat:
-    /// the question a user has here is "what do I get, and what
-    /// does it cost", and an earlier draft answered only the
-    /// second half — telling the very population this exists for
-    /// (people who customised their defaults) that their
-    /// shortcuts were about to be deleted, when what was
-    /// happening was the thing they had asked for.
-    ///
-    /// The loss count is now true collateral only: a shortcut of
-    /// the user's OWN removed because a default reclaims its
-    /// key. A default they merely moved is not a loss — the verb
-    /// comes back on its shipped chord, which is the point.
+    /// Explains restored defaults count and collateral loss count (#1096).
     private var resetMessage: String {
         let restored = model.shortcutsTheResetWouldRestore
         let lost = model.shortcutsTheResetWouldDiscard
@@ -170,21 +104,6 @@ struct ShortcutsHeader: View {
                 restored
             )
         }
-        // The counts are separated by "·", never a comma: six
-        // locales use the comma as a DECIMAL separator, so
-        // "restored: 12, and" starts parsing as a number. The
-        // corpus already settled this in `behavior.quit.summary`.
-        //
-        // The "review below, then Save" beat this frame used to
-        // carry is gone rather than quoted: naming the Save
-        // button as literal text is the #818 violation a
-        // localization audit caught here (German's is "Sichern",
-        // so a translator reaching for the obvious word names a
-        // button that does not exist), and interpolating it reds
-        // `InterpolatedLabelTests` — that guard equates a frame's
-        // ARGUMENT count with its `%N$@` count, which no frame
-        // mixing a label with a count can satisfy. Filed; the
-        // staged-ness is worth saying once the frame can say it.
         return L(
             "shortcuts.restore_defaults.message",
             "Your own shortcuts are kept, except any that use a "
@@ -211,8 +130,7 @@ struct ShortcutsHeader: View {
             )
     }
 
-    // MARK: - Import (#4)
-
+    /// Import button reading shortcuts from init.lua (#4, #818).
     private var importButton: some View {
         Button {
             model.importCurrentShortcuts()
@@ -231,22 +149,11 @@ struct ShortcutsHeader: View {
                 systemImage: "square.and.arrow.down"
             )
         }
-        // Explicitly sealed rather than left to the default
-        // style: the two render alike, but only a named style
-        // is visible to the guard keeping the accent off button
-        // labels.
         .settingsActionButton()
-        // Small: it sits inline beside the layer chips and
-        // must not read as a peer tab.
         .controlSize(.small)
         .help(importHelp)
     }
 
-    /// The destination group is INTERPOLATED from the key that
-    /// labels it rather than named as text (#818): this sentence
-    /// said "lands in Advanced" while the drawer had read "Lua
-    /// bindings" since #68, so every locale had faithfully
-    /// translated a group name no locale draws.
     private var importHelp: String {
         L(
             "shortcuts.import.help",

--- a/Sources/KiwiDesk/Settings/Sections/ShortcutsHeader.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ShortcutsHeader.swift
@@ -104,6 +104,11 @@ struct ShortcutsHeader: View {
                 restored
             )
         }
+        // "·" never a comma — six locales use the comma as a
+        // decimal separator (settled in `behavior.quit.summary`).
+        // Naming Save as literal text is the #818 violation, and
+        // interpolating it reds `InterpolatedLabelTests`; filed —
+        // the staged-ness beat returns once the frame can say it.
         return L(
             "shortcuts.restore_defaults.message",
             "Your own shortcuts are kept, except any that use a "
@@ -154,6 +159,8 @@ struct ShortcutsHeader: View {
         .help(importHelp)
     }
 
+    /// The destination group is interpolated from the key that
+    /// labels it, never named as text (#818).
     private var importHelp: String {
         L(
             "shortcuts.import.help",

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection.swift
@@ -2,62 +2,21 @@ import AppKit
 import KiwiDeskCore
 import SwiftUI
 
-/// This Profile ▸ Spaces (#68 §3.2/§3.3): the profile's space
-/// list — rename, reorder (drag or context menu), pick a layout
-/// mode (with its glyph), designate the fallback space, and open
-/// a space's per-space overrides in the pushed editor (#678 8b,
-/// `SpacesSection+Overrides.swift`).
+/// Profile Spaces management section: list, reorder, modes, and overrides
+/// (#68, #678).
 struct SpacesSection: View {
     @ObservedObject var model: SettingsModel
     @State private var newSpace = ""
-    /// A space awaiting delete confirmation — set only for a
-    /// space that `carriesOverrides`, so a plain empty space
-    /// still deletes in one click (#205).
     @State var pendingDelete: SpaceID?
-    /// A space awaiting `Reset All Layout Overrides` confirmation
-    /// (#290). Held here, not on the popover, so the dialog
-    /// outlives the popover closing — same shape as
-    /// `pendingDelete`. The override rows set it through a binding.
     @State var pendingResetAll: SpaceID?
-    // Drag-reorder state, shared with the handle/gesture
-    // extension (`SpacesSection+Drag.swift`), hence not
-    // `private` (which is file-scoped).
-    /// The space being handle-dragged, if any.
     @State var dragged: SpaceID?
-    /// The live display order *during* a drag — seeded from the
-    /// model on drag start, reordered locally on each threshold
-    /// cross, and written back to `model.config.spaces` once on
-    /// drop. Keeps the per-swap cost to a cheap array move instead
-    /// of a `@Published`/profile write (which re-evaluated the
-    /// whole config every crossing, #299). `nil` when idle: the
-    /// list then renders straight from the model.
     @State var dragOrder: [SpaceID]?
-    /// The handle currently under the pointer — tracked even
-    /// mid-drag (when hover no longer drives the cursor), so
-    /// drag end and row teardown can restore the right cursor.
     @State var hoveredHandle: SpaceID?
-    /// Each row's frame in list space, for retargeting the
-    /// drag — measured via preference so the retarget reads live
-    /// row positions (e.g. after a reorder) rather than stale
-    /// ones.
     @State var rowFrames: [SpaceID: CGRect] = [:]
-    /// The widest Overrides-button label on screen, measured (never
-    /// guessed) so every row's button locks to one column width
-    /// that stays correct across locales and counts (#290).
     @State var overridesButtonWidth: CGFloat = 0
-    /// Whether this window is key/active — watched so a drag the
-    /// app deactivates out of (Cmd-Tab, a mouse-up delivered to
-    /// another app) still commits, since that path reaches
-    /// neither `onEnded` nor `onDisappear` (#299).
     @Environment(\.controlActiveState) var activeState
     @Environment(\.accessibilityReduceMotion)
     var reduceMotion
-    /// The pushed editor's back crumb, and the row to return to
-    /// when it pops (#678 Phase 4 pass 10, turn 20a rule 4). The
-    /// shell's back chip and Home's `nav.homeReturnFocus` are the
-    /// same pair one altitude up; this branch is a sub-view the
-    /// shell cannot see, so it states its own. Both are wired in
-    /// `+Overrides` and `+Customize`, which carry the argument.
     @FocusState var overridesBackFocused: Bool
     @FocusState var returningRow: SpaceID?
 
@@ -69,11 +28,6 @@ struct SpacesSection: View {
                 spaceList
             }
         }
-        // The reset-all dialog is armed from inside the pushed
-        // editor's footer, so it lives on the container present in
-        // both branches — the same reason it sat above the popover
-        // before (#290): the dialog must outlive the surface that
-        // requested it.
         .confirmationDialog(
             deleteConfirmTitle,
             isPresented: deleteConfirmPresented,
@@ -94,12 +48,7 @@ struct SpacesSection: View {
         }
     }
 
-    /// The pushed per-space override editor when a row's cell has
-    /// focused a still-present space, else the list. A deleted
-    /// space (focus left dangling) falls back to the list rather
-    /// than an empty editor — the architect's stale-surface
-    /// downgrade, done at the render read since the nav field is a
-    /// plain `SpaceID?`.
+    /// Pushed per-space override editor or list fallback (#678).
     private var editingSpace: SpaceID? {
         guard
             let space = model.nav.spaceOverridesFocus,
@@ -123,9 +72,6 @@ struct SpacesSection: View {
             }
         }
         .onChange(of: activeState) { _, now in
-            // The app deactivating mid-drag abandons the gesture
-            // without an onEnded — commit the live order so the
-            // list can't keep showing an unsaved reorder (#299).
             if now != .key, dragged != nil {
                 commitDragOrder()
                 dragged = nil
@@ -154,10 +100,6 @@ struct SpacesSection: View {
             addRow
         }
     }
-
-    // Captions live in `SpacesSection+Captions.swift`.
-
-    // MARK: - Rows
 
     private func spaceRow(_ space: SpaceID) -> some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -199,10 +141,6 @@ struct SpacesSection: View {
                 Spacer()
                 modePicker(space)
                 customizeButton(space)
-                // Danger zone: a divider and breathing room set
-                // the destructive delete apart from the mode
-                // picker and Overrides, so the trash can't be
-                // hit reaching for either (#205).
                 Divider()
                     .frame(height: 16)
                     .padding(.horizontal, 2)
@@ -210,8 +148,6 @@ struct SpacesSection: View {
             }
         }
         .padding(8)
-        // Each space is a bordered card: the rows read as
-        // grabbable tiles, not table lines.
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(SettingsTheme.sunken)
@@ -222,31 +158,13 @@ struct SpacesSection: View {
                     SettingsTheme.hairline
                 )
         )
-        // ONE builder, three channels, through the one seam
-        // (#678 Phase 4 pass 10, turn 20a rule 1; #845). It
-        // matters more here than anywhere
-        // else in the tree: Move Up, Move Down and Make Fallback
-        // have no on-screen control at ALL — the context menu is
-        // their only site — so before this the reorder was
-        // pointer-only, and so was the fallback choice. The drag
-        // handle beside it is not a control and takes no focus.
-        // VoiceOver uses the named actions, and the chord fires
-        // on the row whose controls hold focus — the row itself
-        // is not focusable, its fields and buttons are, and the
-        // seam's focused-value publication covers descendants.
         .rowActions { contextActions(space) }
-        // Lifted while dragged: the row itself is what moves
-        // (no system ghost), stepping slot to slot — it never
-        // leaves the column.
         .scaleEffect(dragged == space ? 1.02 : 1)
         .shadow(
             color: .black.opacity(dragged == space ? 0.2 : 0),
             radius: 6,
             y: 2
         )
-        // The black lift above is the drag's only cue and dies
-        // on a dark ground — the 16b seam line takes over there
-        // (`SettingsTheme.planeRing`, transparent in light).
         .overlay(
             RoundedRectangle(cornerRadius: 6)
                 .strokeBorder(
@@ -270,17 +188,6 @@ struct SpacesSection: View {
         )
     }
 
-    // `pinBadge` lives in `SpacesSection+PinBadge.swift`
-    // (turn 8a display-pin badge; file-size split).
-
-    // `modePicker` and its binding live in
-    // `SpacesSection+ModePicker.swift` (#123 file-size split).
-
-    // `customizeButton` (the override cell that pushes the
-    // editor), the delete confirmation, and the empty-state live
-    // in `SpacesSection+Customize.swift` (#205 file-size split);
-    // the pushed editor itself in `SpacesSection+Overrides.swift`.
-
     private var addRow: some View {
         HStack {
             TextField(
@@ -295,14 +202,10 @@ struct SpacesSection: View {
             }
             .disabled(!canAdd)
             .settingsActionButton()
-            // Icon-only, like its sibling icon buttons (#94) —
-            // and named for VoiceOver, which `.help` is not.
             .help(L("spaces.add.help", "Add Space"))
             .accessibilityLabel(L("spaces.add.help", "Add Space"))
         }
     }
-
-    // MARK: - Mutations
 
     private var canAdd: Bool {
         let name = newSpace.trimmed
@@ -316,14 +219,6 @@ struct SpacesSection: View {
         newSpace = ""
     }
 
-    /// The actual delete, reached either straight from
-    /// `requestRemove` (space carries nothing) or after the
-    /// confirmation dialog. Clears the list entry AND every
-    /// reference (pin, Main role, fallback, per-space settings
-    /// maps) — a leftover reference would resurrect the space on
-    /// the next profile load (#68 review).
-    /// The space's optional recognition icon (#68 §6.5):
-    /// empty clears the sparse `space.icon` entry.
     private func iconBinding(
         _ space: SpaceID
     ) -> Binding<String> {
@@ -337,5 +232,4 @@ struct SpacesSection: View {
             }
         )
     }
-
 }

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection.swift
@@ -7,16 +7,28 @@ import SwiftUI
 struct SpacesSection: View {
     @ObservedObject var model: SettingsModel
     @State private var newSpace = ""
+    /// Set only for a space that `carriesOverrides` — a plain
+    /// empty space still deletes in one click (#205).
     @State var pendingDelete: SpaceID?
+    /// Held here, not on the popover, so the dialog outlives the
+    /// popover closing (#290).
     @State var pendingResetAll: SpaceID?
     @State var dragged: SpaceID?
+    /// Live display order during a drag, written back once on
+    /// drop — a per-crossing profile write re-evaluated the whole
+    /// config (#299). nil when idle.
     @State var dragOrder: [SpaceID]?
     @State var hoveredHandle: SpaceID?
     @State var rowFrames: [SpaceID: CGRect] = [:]
+    /// Measured, never guessed, so every row's button locks to one
+    /// column width across locales and counts (#290).
     @State var overridesButtonWidth: CGFloat = 0
     @Environment(\.controlActiveState) var activeState
     @Environment(\.accessibilityReduceMotion)
     var reduceMotion
+    /// The pushed editor's back crumb and the row to return to on
+    /// pop (#678 Phase 4 pass 10); wired in `+Overrides` and
+    /// `+Customize`, which carry the argument.
     @FocusState var overridesBackFocused: Bool
     @FocusState var returningRow: SpaceID?
 
@@ -28,6 +40,8 @@ struct SpacesSection: View {
                 spaceList
             }
         }
+        // On the container present in both branches: the dialog
+        // must outlive the surface that requested it (#290).
         .confirmationDialog(
             deleteConfirmTitle,
             isPresented: deleteConfirmPresented,
@@ -72,6 +86,9 @@ struct SpacesSection: View {
             }
         }
         .onChange(of: activeState) { _, now in
+            // Deactivating mid-drag abandons the gesture with no
+            // onEnded — commit so the list cannot keep showing an
+            // unsaved reorder (#299).
             if now != .key, dragged != nil {
                 commitDragOrder()
                 dragged = nil
@@ -141,6 +158,9 @@ struct SpacesSection: View {
                 Spacer()
                 modePicker(space)
                 customizeButton(space)
+                // Danger zone: set the destructive delete apart
+                // so the trash can't be hit reaching for the
+                // picker or Overrides (#205).
                 Divider()
                     .frame(height: 16)
                     .padding(.horizontal, 2)
@@ -158,6 +178,9 @@ struct SpacesSection: View {
                     SettingsTheme.hairline
                 )
         )
+        // One builder, three channels (#845): the context menu is
+        // the ONLY site for Move Up/Down/Make Fallback, so a bare
+        // channel here was pointer-only for those verbs.
         .rowActions { contextActions(space) }
         .scaleEffect(dragged == space ? 1.02 : 1)
         .shadow(
@@ -202,6 +225,8 @@ struct SpacesSection: View {
             }
             .disabled(!canAdd)
             .settingsActionButton()
+            // Icon-only like its siblings (#94) — and named for
+            // VoiceOver, which `.help` is not.
             .help(L("spaces.add.help", "Add Space"))
             .accessibilityLabel(L("spaces.add.help", "Add Space"))
         }

--- a/Sources/KiwiDesk/Settings/Sections/StandardLayoutDisplay.swift
+++ b/Sources/KiwiDesk/Settings/Sections/StandardLayoutDisplay.swift
@@ -1,15 +1,7 @@
 import KiwiDeskCore
 
-/// Localized display text for the shipped Standard/Preset
-/// layouts (#53). `StandardLayout.name` stays the stable,
-/// English canonical identity — it seeds a new saved profile's
-/// name (`freeName(base: layout.name)`,
-/// `KiwiCore+ProfileResolution.swift`) and labels
-/// `activeStandard`/`Composed.sourceName`, both of which persist
-/// or drive further lookups. Only the GUI rendering translates;
-/// resolution is keyed by `name` so a language switch never
-/// touches the underlying identity. Mirrors `LayoutMode.
-/// displayName` (`LayoutModeGlyph.swift`).
+/// Localized display text for shipped Standard/Preset layouts (#53, #859).
+/// Resolution is keyed by canonical English `name`.
 extension StandardLayout {
     @MainActor var displayName: String {
         switch name {
@@ -44,38 +36,10 @@ extension StandardLayout {
         }
     }
 
+    /// Localized summary describing workflow across spaces (#859,
+    /// `PresetSummaryCoverageTests`).
     @MainActor var displaySummary: String {
         switch name {
-        // The first three used to name LAYOUT MODES in prose
-        // ("IDE stack", "scrolling docs", "a deep-work monocle
-        // Space") and ten catalogs then translated those words
-        // inconsistently — `de` shipped "IDE-Stapel" and
-        // "scrollende Dokumentation" beside a picker reading
-        // "Stack" and "Scrolling", while keeping "Monocle" in the
-        // next key along. No content guard can see it:
-        // `untranslated_mode_names` fires on the OPPOSITE polarity
-        // (a translated picker with English prose), and `de` has
-        // English pickers with translated prose.
-        //
-        // Two words moved again after the round's separate audit
-        // (2026-08-17), both by the SAME rule that refused
-        // "Preview" for the button — Family C rule 1, a word
-        // already naming another KiwiDesk concept loses. "a
-        // fullscreen preview Space" spent the detail panel's word
-        // (`panel.*_preview`, four keys) on the card whose button
-        // is deliberately not called Preview; "dashboards" spent
-        // the one `discard.*` uses for KiwiDesk's own Settings
-        // dashboard. Both were faithfully carried into most
-        // catalogs, so the reuse was ten-fold rather than one.
-        //
-        // So the card stops naming layouts at all (#859). A
-        // summary says what you DO on those Spaces; the layouts
-        // are named where they are drawn — the preview sheet's
-        // tiles, through `LayoutMode.displayName`, which every
-        // catalog already renders under a policy
-        // `LocalizationModeNamePolicyTests` pins. Re-authoring
-        // rather than guarding removes the class instead of
-        // watching it.
         case "Developer":
             return L(
                 "presets.developer.summary",
@@ -94,14 +58,6 @@ extension StandardLayout {
                 "Two task Spaces, and one kept clear for deep "
                     + "work."
             )
-        // "main screen", not "main display": these two lines draw
-        // DIRECTLY above `PresetScreenCard`'s outlines, whose own
-        // label says "Main screen" (#789's `presets.screen_name.*`
-        // pair), so the card named one screen two ways. Fixed
-        // here because #859 re-authors this family anyway — the
-        // repo-wide screen/display/monitor split is a separate
-        // owner ruling plus a catalog-wide sweep, and it is
-        // deliberately NOT in this change set.
         case "Dual Developer":
             return L(
                 "presets.dual_developer.summary",
@@ -126,20 +82,6 @@ extension StandardLayout {
                 "Frontend IDE and previews center, design "
                     + "canvas left, inspectors right."
             )
-        // The Starter setup, which leads its own screen count in
-        // the Presets list. It used to fall through to a
-        // `summary` string built in Core, so the first preset a
-        // new user sees rendered raw English in every locale
-        // (#601).
-        //
-        // ONE key, where the ladder had three. The ladder planned
-        // for a screen COUNT, so its copy could name the modes it
-        // would lay down; this setup derives them from the shapes
-        // of the screens actually connected, and a sentence
-        // listing them would be a different sentence on every
-        // Mac. What stays true everywhere is the rule, so that is
-        // what the summary states — the modes themselves are on
-        // the thumbnails beside it (#678 Phase 4 pass 11).
         case StarterSetup.name:
             return L(
                 "presets.starter.summary",
@@ -147,15 +89,6 @@ extension StandardLayout {
                     + "own layout."
             )
         default:
-            // Unreachable for anything in `StandardProfiles.all`,
-            // and `PresetSummaryCoverageTests` proves it. Core no
-            // longer carries copy to fall back to, so a preset
-            // without a case here renders blank rather than
-            // untranslated English — the right trade (a missing
-            // caption beats an unlocalized one), but a silent
-            // one. Shout in debug so the mistake surfaces where
-            // it is made, while release still never shows
-            // English.
             assertionFailure(
                 "preset '\(name)' (\(screenCount) screen) has "
                     + "no localized summary"
@@ -165,65 +98,13 @@ extension StandardLayout {
     }
 }
 
-/// Resolves a Standard's stable English `name` (e.g.
-/// `activeStandard`, `Composed.sourceName`) to its localized
-/// display text — used wherever the name arrives as a bare
-/// `String` rather than a `StandardLayout`, so `ProfileHeader`
-/// shows the same translated name as the Presets list.
+/// Resolves standard profile English name to localized display string.
 @MainActor func standardDisplayName(_ name: String) -> String {
-    // The WORKFLOW list, not the live catalog. A display name is
-    // keyed on the stable English `name`, and `displayName` has
-    // no Starter case — so the Starter entry resolved through
-    // `default: return name`, byte-identical to the fallback
-    // below, after three allocations and a tuning build ran to
-    // produce it (architect review, 2026-08-11).
     StandardProfiles.workflows.first { $0.name == name }?
         .displayName ?? name
 }
 
-/// A positional screen's name: 0 is the main display and the rest
-/// are numbered (#789).
-///
-/// The preset card denotes "main" by POSITION — leftmost — which
-/// is a claim a reader who cannot see the row has no way to
-/// recover: every screen announced itself as "Screen N" and
-/// nothing said which one the Mac treats as main. The
-/// alternatives were both refused by the consult that ruled this:
-/// a heavier stroke, because `SettingsTheme+Metrics` records that
-/// weight alone on a hairline was invisible on device and because
-/// stroke weight already carries two meanings in this window; and
-/// a micro-label, which at that outline size is ~7 pt type.
-/// Saying it in words costs no pixels and removes the inference
-/// rather than decorating it.
-///
-/// A NAME rather than a branched sentence, so the frames that
-/// interpolate it stay one frame each and a locale reorders them
-/// freely. It feeds `PresetScreenCard`'s two help frames and the
-/// preview sheet's screen headings (#859) — **authored once here**
-/// rather than at each call site, because a pair of keys feeding
-/// one specifier slot is one naming decision and duplicating the
-/// `L()` calls is how the two arms come to disagree.
-///
-/// **Both arms say "screen", and that is load-bearing.** They are
-/// two alternatives for ONE specifier slot, so a pair reading
-/// "Main display" / "Screen %1$d" puts two nouns for one concept
-/// in one slot and makes every catalog reconcile it alone — which
-/// all ten duly did, each picking a different side, while English
-/// was the only catalog whose own pair disagreed (translation
-/// audit, 2026-08-16). The noun is "screen" because this card's
-/// neighbours are: the group heading counts screens
-/// (`presets.for_your.*`), as do `presets.needs_screens`,
-/// `presets.none_for_count`, `presets.starter.summary`,
-/// `profiles.screens.*` — and, since #859, the two preset
-/// summaries that used to read "on the main display"
-/// (`presets.dual_developer.summary`,
-/// `presets.coder_and_monitor.summary`).
-///
-/// This does NOT settle screen vs display vs monitor for the repo
-/// — `config-vocabulary.md`'s glossary and
-/// `docs/localization-naming.md` are both silent on it while
-/// `en.json` uses all three, which is an owner ruling and a
-/// catalog-wide sweep. It settles the Presets surface.
+/// Positional screen name: 0 is main screen, rest are numbered (#789, #859).
 @MainActor func presetScreenName(_ screen: Int) -> String {
     screen == 0
         ? L("presets.screen_name.main", "Main screen")

--- a/Sources/KiwiDesk/Settings/Sections/StandardLayoutDisplay.swift
+++ b/Sources/KiwiDesk/Settings/Sections/StandardLayoutDisplay.swift
@@ -40,6 +40,10 @@ extension StandardLayout {
     /// `PresetSummaryCoverageTests`).
     @MainActor var displaySummary: String {
         switch name {
+        // Never name layout modes in prose — ten catalogs drifted
+        // when these did (#859); modes render only through
+        // `LayoutMode.displayName`, under the policy
+        // `LocalizationModeNamePolicyTests` pins.
         case "Developer":
             return L(
                 "presets.developer.summary",
@@ -82,6 +86,9 @@ extension StandardLayout {
                 "Frontend IDE and previews center, design "
                     + "canvas left, inspectors right."
             )
+        // ONE key (#601): the Starter's modes derive from the
+        // connected screens, so the summary states the rule rather
+        // than a per-Mac list (#678 Phase 4 pass 11).
         case StarterSetup.name:
             return L(
                 "presets.starter.summary",

--- a/Sources/KiwiDesk/Settings/SettingsModel+EditTarget.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+EditTarget.swift
@@ -1,23 +1,14 @@
 import Foundation
 import KiwiDeskCore
 
-/// The dashboard's edit target (#64): the live/active config,
-/// or a stored profile edited without activating (#18). Total —
-/// every mode-dependent field derives from this one value
-/// through the single `reload()` below, so the two modes can
-/// no longer drift apart field by field.
+/// Dashboard edit target: live active config or stored profile (#64, #18).
 enum EditTarget: Equatable {
     case live
     case storedProfile(String)
 }
 
 extension SettingsModel {
-    /// Every field the edit mode owns, decided as one unit.
-    /// The memberwise init forces both branches to assign every
-    /// field — adding a mode-dependent field here breaks the
-    /// build until both `liveState()` and `storedState(_:)`
-    /// decide it (#64; the round-1 #18 defects were exactly a
-    /// forgotten field on one of two hand-kept paths).
+    /// Comprehensive edit target state snapshot (#64).
     struct TargetState {
         var config: GuiConfig
         var luaSource: String
@@ -32,15 +23,8 @@ extension SettingsModel {
         var keybindingWarning: String?
     }
 
-    /// Switches the dashboard's edit target. Passing `nil`
-    /// returns to live editing; any saved profile name — the
-    /// currently-loaded one included (#209) — enters edit-
-    /// without-activating mode on that profile's stored
-    /// overrides. Editing the loaded profile is a real target,
-    /// not a synonym for Live: saving it re-applies in place
-    /// (`saveEditedProfile` → `reapplyIfInEffect`), which Live's
-    /// adopt-on-save path does not do. Pending edits are
-    /// discarded — the caller confirms first.
+    /// Switches dashboard edit target between live config and stored profile
+    /// (#209).
     func selectEditTarget(_ name: String?) {
         let normalized: EditTarget =
             name.map { .storedProfile($0) } ?? .live
@@ -49,10 +33,7 @@ extension SettingsModel {
         reload()
     }
 
-    /// Pulls the current configuration and profile state from
-    /// the core into the view model (discards unsaved edits).
-    /// ONE path for both targets: each branch produces a full
-    /// `TargetState`, applied wholesale.
+    /// Reloads configuration and profile state from core into view model.
     func reload() {
         restoreLiveKeySessionIfNeeded()
         let state: TargetState
@@ -63,28 +44,16 @@ extension SettingsModel {
             if let stored = storedState(name) {
                 state = stored
             } else {
-                // The profile vanished mid-edit — fall back
-                // to live editing.
                 target = .live
                 state = liveState()
             }
         }
         apply(state)
         refreshProfiles()
-        // Recompute, never hand-set: `apply` assigns under
-        // `suppressDirty`, so this is the reload path's one
-        // recompute — a bare `isDirty = false` left the
-        // header's `draftChangeCount` stale on every
-        // save/revert until the next edit (review 2026-08-04).
         recomputeDirty()
     }
 
     private func apply(_ state: TargetState) {
-        // A dirty draft reaching a clean transition means the
-        // user saved, reverted or knowingly discarded — past
-        // needing Home's first-run orientation either way.
-        // (Window open never lands here dirty: `show()` guards
-        // its reload on `!isDirty`.)
         if isDirty {
             HomeFirstRunState.retire(preferences)
         }
@@ -93,9 +62,6 @@ extension SettingsModel {
         luaSource = state.luaSource
         suppressDirty = false
         seedSpaces = state.config.spaces
-        // The dirty baselines: `isDirty` is a live comparison
-        // against the as-applied state, so manually undoing
-        // an edit reads as clean again.
         cleanConfig = state.config
         cleanLuaSource = state.luaSource
         forcedLuaEditor = state.forcedLuaEditor
@@ -111,33 +77,10 @@ extension SettingsModel {
         keybindingWarning = state.keybindingWarning
     }
 
+    /// Assembles live target state with fallback for unseeded engine (#77,
+    /// #326, #516).
     private func liveState() -> TargetState {
         var loaded = core.loadGuiConfig()
-        // `loadGuiConfig` overlays `spaces` from LIVE state, and
-        // in a started engine that overlay is authoritative — it
-        // carries the chosen display ORDER, and a space living
-        // only in `gui.json` was seeded into live at boot (#77).
-        //
-        // It is untrusted in exactly one recognisable state:
-        // live holds ONLY `StateCoordinator`'s boot default, the
-        // shape of an Accessibility-off cold boot where the
-        // engine never started and so never seeded. The overlay
-        // has then silently replaced the authored list with
-        // `["1"]`, and the authored one is the only safe read.
-        // #326 hit the same hazard and fixed it the same way.
-        //
-        // Keyed on the DATA, not on `permissionPaused`: that
-        // flag is pushed in by `setPermissionPaused` AFTER
-        // `SettingsModel.init` has run its first `reload()`, so
-        // gating on it would leave the very first seed
-        // degenerate — and before #516 that only mis-displayed,
-        // while a globals save now PERSISTS what was seeded.
-        //
-        // Kept narrow on purpose. A broader "is the authored
-        // list a subset of live?" test also fires in a HEALTHY
-        // engine — a space deleted at runtime but not yet saved
-        // is absent from live and present in the sidecar — and
-        // would resurrect it in the editor.
         let bootDefault = [SpaceID(1)]
         if loaded.spaces == bootDefault,
             let persisted = core.persistedGuiConfig(),
@@ -146,9 +89,6 @@ extension SettingsModel {
         {
             loaded.spaces = persisted.spaces
         }
-        // Recovered rows arrive as `.custom`; sort the ones
-        // that match a catalog action into their sections
-        // before the tabs render them (#4).
         KeybindingImportClassifier.classify(&loaded)
         let source =
             (try? String(
@@ -161,36 +101,17 @@ extension SettingsModel {
             luaSource: source,
             forcedLuaEditor: flags.foreign,
             hasCustomLua: !flags.foreign && flags.custom,
-            // The user's raw-editor toggle survives a live
-            // reload (Revert keeps the editor open).
             showLuaEditor: showLuaEditor,
             placementEditable: true,
-            // Baseline for `globalsChanged`: the *overlaid*
-            // model, not the raw sidecar — live profile state
-            // merged in (e.g. composed monocle-fill spaces in
-            // the spaces union) must not read as a global
-            // edit, or a tiling-only save would regenerate
-            // gui.json and init.lua and leak transient spaces
-            // into them. Accepted edges: a genuine global
-            // edit still saves the overlaid spaces union, and
-            // deleting + re-adding a transient space alone
-            // doesn't read as an edit.
             savedSidecar: core.isGuiManaged ? loaded : nil,
             profileEditingBaseLayers: nil,
             profileEditingBaseAppRules: nil,
             profileEditingBaseFloatRules: nil,
-            // A reload discards the edits the banner was
-            // about; batch paths (Lua save, Adopt) re-derive
-            // it right after via `warnIfAnyConflict`.
             keybindingWarning: nil
         )
     }
 
-    /// Edit-without-activating (#18): seed the tabs from a
-    /// stored profile's JSON instead of live state. Stored-
-    /// profile edits never touch the raw Lua editor or the
-    /// global sidecar — only the profile JSON is written.
-    /// nil when the profile is unreadable.
+    /// Loads stored profile state without activating (#18, #55, #109).
     private func storedState(_ name: String) -> TargetState? {
         guard
             var loaded = try? core.loadGuiConfig(editing: name)
@@ -200,34 +121,20 @@ extension SettingsModel {
         return TargetState(
             config: loaded,
             luaSource: "",
-            // Stored-profile editing is mutually exclusive
-            // with the raw Lua editor — leaving it on would
-            // let a global init.lua write escape edit mode.
             forcedLuaEditor: false,
             hasCustomLua: false,
             showLuaEditor: false,
-            // The Canvas is editable only when the profile
-            // covers the connected monitors — otherwise there
-            // is no live geometry to render (#18).
             placementEditable: (try? core.profiles.read(name: name))?
                 .set(matching: live) != nil,
             savedSidecar: nil,
-            // Diff baseline for the override-mode Shortcuts
-            // tab (#55 phase 7): the same base the seed
-            // resolved onto (ONE definition,
-            // `KiwiCore.baseKeyLayers`) — never the resolved
-            // set the tabs edit.
             profileEditingBaseLayers: core.baseKeyLayers(),
-            // Same baseline role for the App Rules tab's
-            // space-facet override (#109).
             profileEditingBaseAppRules: core.baseAppRules(),
             profileEditingBaseFloatRules: core.baseFloatRules(),
             keybindingWarning: nil
         )
     }
 
-    /// The stored profile being edited, or nil while live —
-    /// derived from `target` (#64).
+    /// Name of stored profile currently being edited, or nil if live (#64).
     var editingProfile: String? {
         if case .storedProfile(let name) = target {
             return name
@@ -235,10 +142,7 @@ extension SettingsModel {
         return nil
     }
 
-    /// Whether the dashboard is editing a stored profile rather
-    /// than the live config (#18) — hides App Rules, renders
-    /// the Shortcuts tab in override mode (#55 phase 7), and
-    /// swaps the footer's save action. The editing surface
-    /// lives in `SettingsModel+ProfileOverrides.swift`.
+    /// Whether dashboard is editing a stored profile rather than live config
+    /// (#18).
     var editingStoredProfile: Bool { target != .live }
 }

--- a/Sources/KiwiDesk/Settings/SettingsModel+EditTarget.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+EditTarget.swift
@@ -8,7 +8,10 @@ enum EditTarget: Equatable {
 }
 
 extension SettingsModel {
-    /// Comprehensive edit target state snapshot (#64).
+    /// Comprehensive edit target state snapshot (#64). The
+    /// memberwise init forces both branches to assign every field
+    /// — a new mode-dependent field breaks the build until both
+    /// paths decide it.
     struct TargetState {
         var config: GuiConfig
         var luaSource: String
@@ -23,8 +26,10 @@ extension SettingsModel {
         var keybindingWarning: String?
     }
 
-    /// Switches dashboard edit target between live config and stored profile
-    /// (#209).
+    /// Switches dashboard edit target between live config and
+    /// stored profile. Editing the loaded profile is a real target
+    /// (#209), not a synonym for Live: saving re-applies in place,
+    /// which Live's adopt-on-save path does not.
     func selectEditTarget(_ name: String?) {
         let normalized: EditTarget =
             name.map { .storedProfile($0) } ?? .live
@@ -50,6 +55,9 @@ extension SettingsModel {
         }
         apply(state)
         refreshProfiles()
+        // Recompute, never hand-set: `apply` assigns under
+        // `suppressDirty`, and a bare `isDirty = false` left
+        // `draftChangeCount` stale (review 2026-08-04).
         recomputeDirty()
     }
 
@@ -81,6 +89,13 @@ extension SettingsModel {
     /// #326, #516).
     private func liveState() -> TargetState {
         var loaded = core.loadGuiConfig()
+        // The live spaces overlay is authoritative — except in
+        // the one recognisable state where it silently replaced
+        // the authored list: the boot default of an AX-off cold
+        // boot (#77, #326). Keyed on the DATA, since
+        // `permissionPaused` arrives only after the first reload
+        // (#516), and kept this narrow: a broader subset test
+        // would resurrect a space deleted at runtime but unsaved.
         let bootDefault = [SpaceID(1)]
         if loaded.spaces == bootDefault,
             let persisted = core.persistedGuiConfig(),
@@ -103,6 +118,10 @@ extension SettingsModel {
             hasCustomLua: !flags.foreign && flags.custom,
             showLuaEditor: showLuaEditor,
             placementEditable: true,
+            // Baseline for `globalsChanged`: the OVERLAID model,
+            // never the raw sidecar — merged live state must not
+            // read as a global edit, or a tiling-only save leaks
+            // transient spaces into gui.json and init.lua.
             savedSidecar: core.isGuiManaged ? loaded : nil,
             profileEditingBaseLayers: nil,
             profileEditingBaseAppRules: nil,
@@ -121,12 +140,18 @@ extension SettingsModel {
         return TargetState(
             config: loaded,
             luaSource: "",
+            // Mutually exclusive with the raw Lua editor — left
+            // on, a global init.lua write escapes edit mode.
             forcedLuaEditor: false,
             hasCustomLua: false,
             showLuaEditor: false,
             placementEditable: (try? core.profiles.read(name: name))?
                 .set(matching: live) != nil,
             savedSidecar: nil,
+            // The same base the seed resolved onto (ONE
+            // definition, `KiwiCore.baseKeyLayers`) — never the
+            // resolved set the tabs edit (#55); `baseAppRules`
+            // plays the same role for App Rules (#109).
             profileEditingBaseLayers: core.baseKeyLayers(),
             profileEditingBaseAppRules: core.baseAppRules(),
             profileEditingBaseFloatRules: core.baseFloatRules(),

--- a/Sources/KiwiDesk/Settings/SettingsModel+Profiles.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Profiles.swift
@@ -2,26 +2,10 @@ import Foundation
 import KiwiDeskCore
 import SwiftUI
 
-/// The profile half of the dashboard model (#36/#53): the
-/// two-button save UX (Update / Save as new), the preset Apply
-/// flow, list actions, and the Canvas placement resolution.
+/// Profile save, load, and preset operations for dashboard model (#36, #53).
 extension SettingsModel {
-    /// Non-nil while a profile save that captures the live
-    /// monitor set must be blocked (#335): with Accessibility
-    /// off the engine has discovered no displays, so persisting
-    /// records a degenerate 0-screen set that can never resolve.
-    /// Gates the monitor-capturing actions — Save as New Profile,
-    /// Update, and Save a Copy As from the live active profile —
-    /// and doubles as their disabled-button tooltip. Since #516
-    /// the first two are only *reached* by this gate when there
-    /// is nothing global to save; a pending global edit routes
-    /// to `.saveGlobalsOnly` instead. Copy stays unconditionally
-    /// gated — it always captures a monitor set. Stored-
-    /// profile edits are NOT gated: their write path only upserts
-    /// a monitor set that already matches the live set, and while
-    /// paused `set(matching: [])` finds none, so the refresh is
-    /// inert and no degenerate set is written (see
-    /// `KiwiCore+ProfileEdit.applyProfileEdits`).
+    /// Explains why profile saving is blocked when accessibility is disabled
+    /// (#335, #516).
     var profileSaveBlockedReason: String? {
         guard permissionPaused else { return nil }
         return L(
@@ -33,9 +17,7 @@ extension SettingsModel {
         )
     }
 
-    /// Whether Update can write into the active profile: it
-    /// exists and covers the live screen count. A different
-    /// count (extra screen attached) needs "Save as new…".
+    /// Whether active profile matches connected screen count for update.
     var updateEnabled: Bool {
         guard let name = activeProfile,
             let summary = profileSummaries.first(where: {
@@ -45,7 +27,8 @@ extension SettingsModel {
         return summary.count == displays.count
     }
 
-    /// The greyed-out Update button's explanation, when any.
+    /// Tooltip explanation when active profile screen count differs from
+    /// connected displays.
     var updateHint: String? {
         guard let name = activeProfile,
             let summary = profileSummaries.first(where: {
@@ -62,17 +45,12 @@ extension SettingsModel {
         )
     }
 
-    /// Update "<profile>": persists the edited tiling into the
-    /// active profile and adds/refreshes the live monitor set.
-    /// Warns (without mutating them) when other profiles also
-    /// claim this monitor set.
+    /// Persists edited tiling into active profile and refreshes monitor set.
     func updateActiveProfile() {
         guard let name = activeProfile else { return }
         let overlap = core.profilesClaimingLiveSet(
             excluding: name
         )
-        // A save failure must stay visible; only a successful
-        // update may show the overlap warning.
         guard persist(named: name) else { return }
         if !overlap.isEmpty {
             let names = overlap.map { "\"\($0)\"" }
@@ -87,8 +65,7 @@ extension SettingsModel {
         }
     }
 
-    /// Save as new…: creates a profile carrying only the live
-    /// monitor set (name auto-suffixed `_1`, `_2`, … if taken).
+    /// Creates new profile with unique name capturing live monitor set.
     func saveAsNewProfile(named name: String) {
         let trimmed = name.trimmingCharacters(
             in: .whitespaces
@@ -99,11 +76,6 @@ extension SettingsModel {
 
     @discardableResult
     private func persist(named name: String) -> Bool {
-        // Freshness net: a space that appeared live while the
-        // dashboard sat open (profile load, hotkey-created) is
-        // absent from the staged model; without the merge the
-        // apply below would prune it — and pruning the active
-        // space snapped focus to the first space on save.
         core.mergeLiveSpaces(
             into: &config,
             seededWith: seedSpaces
@@ -126,9 +98,7 @@ extension SettingsModel {
         return saved
     }
 
-    /// The sidecar and `init.lua` only regenerate when a global
-    /// (non-profile) setting actually changed, keeping their
-    /// diffs clean (#36).
+    /// Persists global configuration when non-profile settings changed (#36).
     private func persistGlobalsIfNeeded() {
         guard globalsChanged else { return }
         do {
@@ -137,14 +107,6 @@ extension SettingsModel {
             core.onLog("settings save failed: \(error)")
         }
     }
-
-    // MARK: - Editing a stored profile (#18)
-
-    // `selectEditTarget` lives with the edit-mode state machine
-    // in `SettingsModel+EditTarget.swift` (#64);
-    // `saveEditedProfile` / `saveEditedProfileCopy` with the
-    // rest of the stored-profile editing surface in
-    // `SettingsModel+ProfileOverrides.swift`.
 
     func loadProfile(named name: String) {
         _ = core.execute(
@@ -170,15 +132,7 @@ extension SettingsModel {
         refreshProfiles()
     }
 
-    /// Renames a saved profile. Immediate, like Delete / make
-    /// default (pending edits are discarded by the reload).
-    /// The core facade owns the whole chase — file, adopted
-    /// name, runtime native-Space bindings, and the sidecar's
-    /// binding lines — so the model only retargets its edit
-    /// session and reloads.
-    /// Collisions are the core's call (the only
-    /// case-insensitive tier) — a rejection surfaces as
-    /// `profileWarning`, never a silent dead click.
+    /// Renames profile file, references, and active edit target.
     func renameProfile(from old: String, to new: String) {
         let name = new.trimmed
         guard name != old, !name.isEmpty else { return }
@@ -198,10 +152,7 @@ extension SettingsModel {
         reload()
     }
 
-    // MARK: - Presets (#53)
-
-    /// Applies a built-in layout and materializes it as a saved
-    /// profile named after the preset (`_N` when taken).
+    /// Applies standard layout preset as saved profile (#53).
     func applyStandardPreset(_ layout: StandardLayout) {
         do {
             try core.applyStandard(layout)
@@ -215,76 +166,30 @@ extension SettingsModel {
         }
         reload()
     }
-
 }
 
-/// One saved profile as the load list shows it (#36).
+/// Saved profile summary for profile list and resolution (#36, #789, #678).
 struct ProfileSummary: Identifiable {
     let name: String
     let count: Int
-    /// Each covered monitor combination, as fingerprints.
     let sets: [[String]]
     let isDefault: Bool
-    /// One of the sets equals the live monitors.
     let matchesLive: Bool
-    /// The profile is saved for as many screens as are connected
-    /// right now — a WEAKER claim than `matchesLive`, which is a
-    /// fingerprint match (#789).
-    ///
-    /// Its own sort key, because the two are not the same
-    /// question and the gap between them is where a profile got
-    /// lost: a two-screen profile for different monitors matches
-    /// no fingerprint, so without this it sorted behind every
-    /// one-screen profile on the bare count, since 1 < 2 — under
-    /// a card caption promising one of them loads.
-    ///
-    /// Derived beside `matchesLive` in `refreshProfiles` from
-    /// one read of the live displays, so the two cannot answer
-    /// about different moments.
     let matchesConnectedCount: Bool
-    /// What each of this profile's screens opens in, in the
-    /// stored set's canonical monitor order — `nil` where the
-    /// profile does not say (#789).
-    ///
-    /// Carried on the summary rather than derived in the view so
-    /// the row and the preset card read ONE accessor
-    /// (`Profile.openingModes()`), which is also what keeps the
-    /// two surfaces' pictures in one grammar. `count` and this
-    /// array agree by construction — the accessor returns one
-    /// entry per covered screen.
     let openingModes: [LayoutMode?]
-    /// Spaces the profile declares (#678 turn 13a). Part of the
-    /// row's subtitle, which counts only what the profile OWNS.
     let spaceCount: Int
-    /// Keybindings the profile overrides — the count of rows in
-    /// its sparse `layers` override, never the size of the
-    /// resolved set. "18 shortcuts" on a profile row would claim
-    /// the profile carries a keybinding set of its own; it
-    /// carries a diff over the global one (#678 turn 13a).
     let shortcutOverrideCount: Int
     var id: String { name }
 }
 
-/// One profile whose file will not decode (#246), with why.
-///
-/// A sibling of `ProfileSummary` rather than a field on it: a
-/// broken file yields no count, no monitor sets and no default
-/// flag, so every one of that type's fields would be an optional
-/// nobody could fill. The name is the only thing both rows share,
-/// which is exactly the shape two types express and one type with
-/// eight optionals hides.
+/// Unparseable profile with failure cause (#246).
 struct BrokenProfile: Identifiable, Equatable {
     let name: String
     let cause: ProfileBrokenCause
     var id: String { name }
 }
 
-/// The "Which profile loads" answer as one value (#678 turn
-/// 13a): what resolves, and the screen count it resolved over.
-///
-/// One value, not two published fields, because the card renders
-/// them in a single sentence — and two fields refreshed together
-/// today are two fields somebody refreshes apart tomorrow.
+/// Resolution verdict and screen count for profile loading card (#678).
 struct ProfileResolution: Equatable {
     let verdict: ProfileVerdict
     let screens: Int

--- a/Sources/KiwiDesk/Settings/SettingsNavigation.swift
+++ b/Sources/KiwiDesk/Settings/SettingsNavigation.swift
@@ -2,23 +2,33 @@ import KiwiDeskCore
 
 /// Transient navigation and search reveal state for settings window (#277).
 struct SettingsNavigation {
-    /// Pending navigation target from search or shortcuts bridge (#326, #277).
+    /// Pending navigation target from search or shortcuts bridge
+    /// (#326, #277). A request arriving while the raw Lua editor
+    /// shows lingers and resolves when the visual editor returns —
+    /// the detail pane is where a scroll target can exist.
     var pendingReveal: SettingsAnchor?
-    /// Notification target for mode switch during search reveal (#678).
+    /// Notification target for mode switch during search reveal
+    /// (#678 4c) — consumed by the SAME apply that flips the mode,
+    /// so a refused or superseded reveal announces nothing.
     var pendingModeNotice: SettingsDestination?
     /// Active highlight flash state (#277).
     private(set) var flash: SettingsFlash?
     private var flashToken = 0
     /// Target anchor ID for scrolling phase of reveal.
     var pendingScroll: String?
-    /// Standing target ID during reveal animation.
+    /// Standing target ID from `apply` until the flash ends. One
+    /// writer (`SettingsView.apply`), one clearer (`endFlash`) —
+    /// the part-1 #326 bug was two observers of one field clearing
+    /// in unspecified `onAppear` order.
     private(set) var revealTarget: String?
 
     mutating func setRevealTarget(_ id: String?) {
         revealTarget = id
     }
 
-    /// Active layout mode tab selection in Layout Defaults (#277).
+    /// Active layout mode tab selection in Layout Defaults — on
+    /// the model, not view `@State` (#277): outside code must be
+    /// able to set and clear it.
     var layoutModeTab: LayoutMode?
 
     /// Active space ID for pushed space overrides editor (#678).
@@ -27,7 +37,10 @@ struct SettingsNavigation {
     /// Originating card destination when popping back to Home.
     var homeReturnFocus: SettingsDestination?
 
-    /// Resets transient surface selections to default.
+    /// Resets transient surface selections to default — for window
+    /// open and an edit-target switch: moving these off view-local
+    /// `@State` (#277) silently promoted a per-visit landing to a
+    /// process-lifetime one.
     mutating func resetSurfaces() {
         layoutModeTab = nil
         spaceOverridesFocus = nil
@@ -43,7 +56,10 @@ struct SettingsNavigation {
         return flashToken
     }
 
-    /// Concludes flash animation if token is still current.
+    /// Concludes flash animation if token is still current. Must
+    /// be called: `.task(id:)` re-runs on appear, so a value left
+    /// standing re-washes the card on every navigation back; the
+    /// token keeps a superseded finisher from cancelling.
     mutating func endFlash(token: Int) {
         guard flash?.token == token else { return }
         flash = nil

--- a/Sources/KiwiDesk/Settings/SettingsNavigation.swift
+++ b/Sources/KiwiDesk/Settings/SettingsNavigation.swift
@@ -1,119 +1,39 @@
 import KiwiDeskCore
 
-/// The Settings window's transient navigation state, collapsed
-/// behind one `@Published var nav` on `SettingsModel` (#277).
-///
-/// A value type on purpose: `$model.nav.layoutModeTab` still
-/// projects a `Binding`, so call sites keep their shape while the model
-/// file stays under the 350-line ceiling as part 2 grows this set
-/// (drawer expansions, the Shortcuts mode strip). Everything here
-/// is a one-shot navigation request or a local surface selection —
-/// never edited config, which stays on the model.
-///
-/// `pendingScroll`, `revealTarget` and `flash` are three facets of
-/// one in-flight reveal, held apart because their lifetimes differ
-/// (consumed-immediately vs stands-until-flash-ends). A *fourth*
-/// facet would be the point to fold them into a single reveal
-/// state-machine value rather than more correlated optionals —
-/// worth weighing when the Shortcuts mode strip lands.
+/// Transient navigation and search reveal state for settings window (#277).
 struct SettingsNavigation {
-    /// A one-shot navigation request: a destination, the
-    /// local surface to switch to, and optionally a label to
-    /// scroll to and flash. Serves both the read-only shortcuts
-    /// panel's "Edit in Settings…" bridge (#326, destination
-    /// only) and a search hit (#277, full anchor).
-    ///
-    /// `SettingsView` applies the destination and surface; the
-    /// detail pane's scroll driver performs the reveal and clears
-    /// this. A request that arrives while the raw Lua editor is
-    /// showing therefore lingers rather than being dropped, and
-    /// resolves when the visual editor comes back — the detail
-    /// pane is where a scroll target can exist at all.
+    /// Pending navigation target from search or shortcuts bridge (#326, #277).
     var pendingReveal: SettingsAnchor?
-    /// Armed by a search pick whose result predicted a mode
-    /// flip; consumed (and always cleared) by the SAME apply
-    /// that performs the flip, so the confirmation is announced
-    /// by the flipper, never by the prediction — a refused or
-    /// superseded reveal announces nothing (#678 4c).
+    /// Notification target for mode switch during search reveal (#678).
     var pendingModeNotice: SettingsDestination?
-    /// The flash in progress. Read into the environment so each
-    /// anchored view can recognize itself; nil between reveals.
-    /// Written only through `startFlash` / `endFlash`, which own
-    /// the re-trigger token.
+    /// Active highlight flash state (#277).
     private(set) var flash: SettingsFlash?
     private var flashToken = 0
-    /// Phase 2 of a reveal: the anchor id whose pane is now
-    /// showing and can be scrolled. Minted by
-    /// `SettingsView.apply` once the destination and surface are
-    /// set, consumed by the detail pane's scroll driver — see
-    /// `pendingReveal` for why the two phases are separate
-    /// fields.
+    /// Target anchor ID for scrolling phase of reveal.
     var pendingScroll: String?
-    /// The reveal's target id, standing from `apply` until the
-    /// flash ends — unlike `pendingScroll`, which the scroll
-    /// driver consumes immediately. Read (never written) by
-    /// `SettingsDisclosure` through the environment, so a drawer
-    /// holding the target can expand before the driver's
-    /// re-issued `scrollTo`. One writer (`SettingsView.apply`),
-    /// one clearer (`endFlash`) — the part-1 #326 bug was two
-    /// observers of one field, one of which cleared it in
-    /// unspecified `onAppear` order.
+    /// Standing target ID during reveal animation.
     private(set) var revealTarget: String?
 
-    /// `apply`'s write, unconditional for the same supersede
-    /// reason as `pendingScroll`: a destination-only request
-    /// must clear a stale target too.
     mutating func setRevealTarget(_ id: String?) {
         revealTarget = id
     }
-    /// The Layout Defaults mode tab (the Bars editor switch it
-    /// sat beside died with the one-page Bars area, #678
-    /// Phase 2).
-    ///
-    /// On the model rather than in the owning view's `@State`
-    /// (#277): a search hit on a mode-gated control has to
-    /// select the surface that renders it before there is
-    /// anything to scroll to, and view-local state cannot be set
-    /// from outside. Starts nil so the section can still land on
-    /// the profile's most-used mode the first time it appears; a
-    /// user's later pick, and a reveal, both write it.
+
+    /// Active layout mode tab selection in Layout Defaults (#277).
     var layoutModeTab: LayoutMode?
 
-    /// The space whose per-space override editor is pushed over
-    /// the Spaces list, or nil for the list itself (#678 8b). On
-    /// the model, not the section's `@State`, for the same #277
-    /// reason `layoutModeTab` is: a selection that outside code
-    /// (a reset, an edit-target switch) must be able to clear.
-    /// The editor is a view-state branch, not a `SettingsSurface`
-    /// — the override controls are per-space and uncataloged, so
-    /// there is nothing for search or the #326 bridge to reveal;
-    /// add a `.spaceOverrides(SpaceID)` surface only if a
-    /// deep-link INTO a specific space's editor is later wanted.
+    /// Active space ID for pushed space overrides editor (#678).
     var spaceOverridesFocus: SpaceID?
 
-    /// The card whose area is currently pushed, so popping back
-    /// to Home can return keyboard focus to it (turn 20: leaving
-    /// a sub-view returns to the originating row). Written when
-    /// a card pushes; consumed by `HomeScreen.onAppear`.
+    /// Originating card destination when popping back to Home.
     var homeReturnFocus: SettingsDestination?
 
-    /// Forgets the surface selection, so it re-derives its
-    /// default. For window open, which re-asserts `destination`
-    /// for the same reason, and for an **edit-target switch**,
-    /// where a different profile means a different most-used
-    /// mode. Moving this off view-local `@State` (#277) silently
-    /// promoted a per-visit landing to a process-lifetime one.
-    ///
-    /// Also drops the pushed override editor back to the list, so
-    /// opening the window (or switching edit target) never lands
-    /// on a stale per-space editor.
+    /// Resets transient surface selections to default.
     mutating func resetSurfaces() {
         layoutModeTab = nil
         spaceOverridesFocus = nil
     }
 
-    /// Starts a flash on `anchor`, bumping the token so that
-    /// revealing the same anchor twice still re-fires (#277).
+    /// Triggers flash highlight for anchor, returning new token (#277).
     mutating func startFlash(_ anchor: String) -> Int {
         flashToken += 1
         flash = SettingsFlash(
@@ -123,18 +43,7 @@ struct SettingsNavigation {
         return flashToken
     }
 
-    /// Ends the flash, if `token` is still the current one.
-    ///
-    /// Must be called: `SearchRevealFlash` uses `.task(id:)`,
-    /// which runs on *appear* as well as on change, so a value
-    /// left standing re-washes the card every time the user
-    /// navigates back to it — no user action involved. The token
-    /// check makes a late finisher from a superseded flash unable
-    /// to cancel the current one.
-    ///
-    /// Also retires `revealTarget` (same token guard): clearing
-    /// it is what lets a later reveal of the same id register as
-    /// a change on a drawer the user has re-collapsed meanwhile.
+    /// Concludes flash animation if token is still current.
     mutating func endFlash(token: Int) {
         guard flash?.token == token else { return }
         flash = nil

--- a/Sources/KiwiDesk/Settings/SettingsSearchIndex.swift
+++ b/Sources/KiwiDesk/Settings/SettingsSearchIndex.swift
@@ -1,58 +1,15 @@
 import KiwiDeskCore
 
-/// The static settings search index (#678 turn 11, spec 11a):
-/// ONE row per census `SettingKey`, never per instance — a
-/// keybinding family or a per-space override is one setting and
-/// one result, so the index is the same fixed list whatever the
-/// user's config holds. Built once per locale from the census
-/// and matched by synchronous substring scan; everything a
-/// match needs (label, synonyms, breadcrumb, anchor) is resolved
-/// at build time, so the match path allocates nothing and asks
-/// nothing beyond this array.
-///
-/// Enrichment — the current value, gate state, the mode tag's
-/// resolution — deliberately does NOT live here: it is computed
-/// per visible row after the result list paints
-/// (`SettingsSearchRow`), from the draft in memory. Nothing on
-/// the search path touches AX, the session, or the filesystem.
+/// Static settings search index row mapping census setting or catalog anchor
+/// (#678).
 struct SettingsSearchIndexRow: Identifiable, Equatable {
-    /// The census setting this row answers for — or nil for a
-    /// catalog-only anchor row: a Layout Defaults mode tab, a
-    /// drawer title, the Bars switch chips. Those are
-    /// NAVIGATION surfaces rather than settings (no value, no
-    /// tier of their own), but a search that cannot find
-    /// "Monocle" or "Per-edge…" would answer less than the
-    /// sidebar-era search did. Which controls they are is
-    /// derived — every catalog control no census label key
-    /// claims — never a hand-kept list.
     let key: SettingKey?
-    /// Localized label, resolved at build through
-    /// `SettingsCensusLabel` — the diff rows' label authority,
-    /// so search and the draft popover cannot name one row two
-    /// ways.
     let label: String
-    /// Match-only English terms (`SettingsSearchSynonyms`) —
-    /// never displayed, so they stay code data rather than
-    /// catalog keys.
     let synonyms: [String]
     let destination: SettingsDestination
-    /// Where committing the row lands: the catalog control that
-    /// carries the row's label key when one exists (surface +
-    /// scroll id + drawer auto-expand come free), else the bare
-    /// destination. The #277 catalog covers a fraction of the
-    /// census, so MOST census rows land destination-only today
-    /// and gain their scroll anchor as the catalog fills; the
-    /// per-destination anchor-less counts are pinned in
-    /// `SettingsSearchIndexTests`, so a label-key rename that
-    /// silently strips an existing match reds.
+    /// Navigation anchor pinned in `SettingsSearchIndexTests` (#277).
     let anchor: SettingsAnchor
-    /// Breadcrumb above the label, outermost first — the
-    /// destination, the local surface when one must be
-    /// selected, the drawer the row hides inside.
     let path: [String]
-    /// `.atRest` for catalog-only anchor rows — a tab or drawer
-    /// title is on screen (or one honest click away) whenever
-    /// its destination is.
     let tier: SettingTier
     var id: String {
         key.map(\.id) ?? "control/\(anchor.anchor ?? "none")"
@@ -61,19 +18,11 @@ struct SettingsSearchIndexRow: Identifiable, Equatable {
 
 @MainActor
 enum SettingsSearchIndex {
-    /// The tiers with a Settings surface — the index's
-    /// membership line. `.luaOnly`, `.internalOnly` and
-    /// `.outsideSettings` rows have no row on any screen, so a
-    /// result for one would land nowhere.
     static let indexedTiers: Set<SettingTier> = [
         .atRest, .showMore, .immediate,
     ]
 
-    /// Labels resolve per locale and the census is static, so
-    /// the built index is a pure function of the locale.
-    /// `LocaleScopedRoot` rebuilds the search UI on a language
-    /// switch, and the rebuilt rows read the new locale's cache
-    /// entry.
+    /// Locale-keyed search index cache.
     private static var cache = [String: [SettingsSearchIndexRow]]()
 
     static func rows() -> [SettingsSearchIndexRow] {
@@ -86,35 +35,13 @@ enum SettingsSearchIndex {
         return built
     }
 
-    /// Whether `key` is a search row on THIS machine. Beyond the
-    /// tier line, two exclusions, both data-driven:
-    ///
-    /// - A `.dynamic`-labelled key composes its text per
-    ///   instance (space names, per-instance keybinding rows),
-    ///   so it has no static label to match or show; its
-    ///   *family* stays findable through its container and
-    ///   destination. Which keys these are is the census's
-    ///   `SettingLabel.dynamic`, never a hand-kept list here.
-    /// - A row gated on `.liquidGlassUnavailable` is HIDDEN on
-    ///   machines that cannot render it (#390) — search must not
-    ///   return a row that cannot exist on this machine, so the
-    ///   index asks the same one predicate the renderer does
-    ///   (`AppBarStyle.glassAvailable`).
+    /// Tests whether key should be indexed on current runtime environment
+    /// (#390).
     static func indexes(_ key: SettingKey) -> Bool {
         let placement = key.placement
         guard placement.area != nil,
             indexedTiers.contains(placement.tier),
             SettingsCensusLabel.label(for: key) != nil,
-            // A per-space key (`…[space]…` in the census id) is
-            // an INSTANCE of a setting, and overrides are
-            // reachable as links, never as results (spec item
-            // 11) — its editor is the per-space popover, which
-            // opens from a row button and is exactly the
-            // surface a reveal cannot land on
-            // (docs/accepted-limitations.md). Indexing one
-            // sends the user to an area where the label
-            // appears nowhere (owner, 2026-08-10: a Spaces
-            // "Spalten" result with no findable field).
             !key.id.contains("[space]")
         else { return false }
         let conditions =
@@ -124,10 +51,8 @@ enum SettingsSearchIndex {
         return true
     }
 
-    /// Destination order first (`thisProfile` + `wholeApp`, the
-    /// order the old one-per-destination list already answered
-    /// in); within a destination the census rows in declaration
-    /// order, then the catalog-only anchor rows.
+    /// Builds index in destination order: census settings followed by
+    /// catalog-only anchors.
     private static func build() -> [SettingsSearchIndexRow] {
         let all = SettingKey.allCases.filter(indexes)
         let ordered =
@@ -150,12 +75,6 @@ enum SettingsSearchIndex {
         }
     }
 
-    /// The catalog-only anchor rows: every control in the
-    /// destination's catalog that no census row landed on — the
-    /// mode tabs, drawer titles and switch chips the census does
-    /// not model as settings. Derived from the two lists, so a
-    /// control is a search row exactly once however it is
-    /// declared.
     private static func extras(
         in destination: SettingsDestination,
         _ entries: [SettingsIndexEntry],
@@ -227,12 +146,7 @@ enum SettingsSearchIndex {
         )
     }
 
-    /// The anchor-less fallback for LAYOUT keys: their census
-    /// ids are `settings.<mode>.…`, so the tab a row belongs to
-    /// is derivable from the key alone — a "Columns" hit with
-    /// no catalog control still opens the Grid tab instead of
-    /// dumping the user on whatever tab renders first (owner
-    /// eyeball, 2026-08-10). Every other key stays `.main`.
+    /// Derives layout tab surface for anchorless layout mode settings.
     private static func fallbackSurface(
         for key: SettingKey
     ) -> SettingsSurface {
@@ -250,8 +164,6 @@ enum SettingsSearchIndex {
 }
 
 extension SettingsSurface {
-    /// The surface's own user-facing name, reusing the exact
-    /// tuples of the controls that select it, or nil for `.main`.
     @MainActor var displayName: String? {
         switch self {
         case .main: return nil

--- a/Sources/KiwiDesk/Settings/SettingsSearchIndex.swift
+++ b/Sources/KiwiDesk/Settings/SettingsSearchIndex.swift
@@ -1,8 +1,13 @@
 import KiwiDeskCore
 
-/// Static settings search index row mapping census setting or catalog anchor
-/// (#678).
+/// Static settings search index row: ONE row per census
+/// `SettingKey`, never per instance (#678). Everything a match
+/// needs is resolved at build time — nothing on the search path
+/// touches AX, the session, or the filesystem.
 struct SettingsSearchIndexRow: Identifiable, Equatable {
+    /// nil for a catalog-only anchor row (a mode tab, a drawer
+    /// title) — which controls those are is DERIVED, every catalog
+    /// control no census label key claims, never a hand-kept list.
     let key: SettingKey?
     let label: String
     let synonyms: [String]
@@ -18,6 +23,8 @@ struct SettingsSearchIndexRow: Identifiable, Equatable {
 
 @MainActor
 enum SettingsSearchIndex {
+    /// The membership line — the other tiers have no row on any
+    /// screen, so a result for one would land nowhere.
     static let indexedTiers: Set<SettingTier> = [
         .atRest, .showMore, .immediate,
     ]
@@ -35,8 +42,11 @@ enum SettingsSearchIndex {
         return built
     }
 
-    /// Tests whether key should be indexed on current runtime environment
-    /// (#390).
+    /// Tests whether key should be indexed on this machine. The
+    /// exclusions are data-driven: `.dynamic` labels have no
+    /// static text, glass-gated rows ask the renderer's own
+    /// predicate (#390), and a `[space]` key is an INSTANCE —
+    /// reachable as a link, never a result (spec item 11).
     static func indexes(_ key: SettingKey) -> Bool {
         let placement = key.placement
         guard placement.area != nil,
@@ -75,6 +85,9 @@ enum SettingsSearchIndex {
         }
     }
 
+    /// Catalog controls no census row landed on, derived from the
+    /// two lists so a control is a search row exactly once however
+    /// it is declared.
     private static func extras(
         in destination: SettingsDestination,
         _ entries: [SettingsIndexEntry],

--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -1,110 +1,46 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The dashboard shell (#678 turn 9): Home — the card grid that
-/// replaced the sidebar — or one pushed area screen, both
-/// wrapped in the same chrome: the one header bar, the paused
-/// banner, the content, and the stable three-verb save footer
-/// (§3.12) at the bottom.
+/// Settings dashboard shell hosting Home grid or pushed section screen (#678).
 struct SettingsView: View {
     @ObservedObject var model: SettingsModel
-    /// The in-flight scroll+flash choreography, held so a second
-    /// search click supersedes the first instead of overlapping.
-    /// Internal like `ensureModeAdmits`, for the same reason: the
-    /// detail pane and its reveal driver live in
-    /// `SettingsView+Detail` (the §2.1 ceiling split) and `@State`
-    /// must be declared here.
+    /// Scroll and flash task for pending reveal.
     @State var revealTask: Task<Void, Never>?
-    /// The detached preview card's per-mount answer, and `nil`
-    /// while the band's own default stands (17a): `.medium`
-    /// floats it open, the narrower bands wait behind "Show
-    /// preview". Deliberately NOT persisted — the panel is
-    /// dropped by WIDTH, and a stored open/closed flag beside
-    /// that is a preference duplicating what the window already
-    /// decides (`DetailPanelTests`). Cleared on every
-    /// destination change, so an area starts at its band's
-    /// default rather than inheriting the last area's answer.
+    /// Preview card state per mount; nil follows width class default
+    /// (`DetailPanelTests`).
     @State var previewShown: Bool?
     @Environment(\.accessibilityReduceMotion)
     var reduceMotion
-    /// Whether the current destination HAS a panel at all — the
-    /// capability, not the layout. Every responsive verdict
-    /// below is this AND a width question, so an area outside
-    /// the offer set can never reach one.
+
+    /// Whether current destination supports detail panel.
     var panelOffered: Bool {
         SettingsDetailPanelOffer.offers(model.destination)
             && !model.editingLua
     }
-    /// The pushed area lives on the model, not in `@State` —
-    /// see `SettingsModel.destination`. A locale change re-keys
-    /// this view, and `@State` would not survive it. nil is
-    /// Home.
+
     private var selection: SettingsDestination? {
         get { model.destination }
         nonmutating set { model.destination = newValue }
     }
 
     var body: some View {
-        // The one measurement (17a). Everything that yields as
-        // the window narrows — the panel's column, the row axis,
-        // the save pill's kind, the header's search field —
-        // derives from the class this hands down, so no site
-        // compares a width of its own. `HomeScreen` reads its
-        // own geometry for the column COUNT below the cap, which
-        // is the one measurement that is not a band question.
         GeometryReader { geo in
             let width = SettingsWidthClass.of(
                 width: geo.size.width
             )
             shell(width)
                 .environment(\.settingsWidth, width)
-                // Widening back into the docked band retires
-                // the card's per-mount answer. Without this a
-                // card closed at 1100 stays closed on the way
-                // back DOWN from 1400 — the user's "not now"
-                // outliving the band it was given in, which is
-                // the persisted-collapse behaviour this pass
-                // refused to build (architecture review,
-                // 2026-08-11).
                 .onChange(of: width) { _, now in
                     if now.docksPanel { previewShown = nil }
                 }
         }
-        // The digest's hard minimum (17a): below 720 the window
-        // stops resizing — the tiled Settings window must
-        // survive whatever slot the layout gives it. The old
-        // 840 paid for the floating sidebar card, which is gone.
         .frame(
             minWidth: SettingsWidthClass.minimum,
             minHeight: SettingsWidthClass.minimumHeight
         )
-        // The window's accent, set ONCE at the root (owner ruled
-        // full kiwi over the system accent, 2026-08-04): every
-        // toggle, segment and prominent Save below inherits it,
-        // so a control cannot opt out by forgetting to. Above the
-        // `editingLua` branch for the same reason the discard
-        // dialog is — both arms must carry it.
         .tint(SettingsTheme.accent)
-        // The one discard dialog (#515). Hosted HERE, above the
-        // `editingLua` branch, not inside `chrome` — `chrome` is
-        // instantiated in both arms, and two of the gated actions
-        // flip `editingLua`, so a dialog hosted there would be
-        // torn down by its own confirm button. This `Group`'s
-        // identity is stable across that flip, and it still
-        // covers both modes (the raw editor's "Back to visual
-        // editor" needs the gate as much as the shell does).
         .discardConfirmation(model: model)
-        // Two repairs on two different signals, deliberately not
-        // merged: reachability genuinely keys on the BOOLEAN — a
-        // destination only appears or disappears on the
-        // live↔stored transition — while the mode tab keys on the
-        // target itself, because stored A → stored B leaves that
-        // boolean `true` and is exactly the case that needs it.
         .onChange(of: model.editingStoredProfile) { _, editing in
-            // The selection must never point at a destination
-            // the grid just hid (#18). Home is the repair
-            // target now — it always exists, and it is where
-            // the user re-orients.
             if let selection,
                 !selection.isReachable(
                     editingStoredProfile: editing
@@ -114,27 +50,17 @@ struct SettingsView: View {
             }
         }
         .onChange(of: model.target) { _, _ in
-            // A different profile means a different most-used
-            // layout mode, so the mode tab must re-derive (#277).
             model.nav.resetSurfaces()
         }
-        // A navigation request — the #326 "Edit in Settings…"
-        // deep link, or a #277 search hit. Guarded by the same
-        // reachability filter as every other nav path (#18).
         .onChange(of: model.nav.pendingReveal) { _, request in
             apply(request)
         }
         .onAppear { apply(model.nav.pendingReveal) }
-        // A new area starts at its band's preview default: the
-        // card the user closed in Bars says nothing about
-        // whether they want one in Shortcuts.
         .onChange(of: model.destination) { _, _ in
             previewShown = nil
         }
     }
 
-    /// The window's two shells, both under the same chrome and
-    /// both taking the measured band.
     @ViewBuilder private func shell(
         _ width: SettingsWidthClass
     ) -> some View {
@@ -145,21 +71,8 @@ struct SettingsView: View {
         }
     }
 
-    /// The structured settings shell: a fixed-width source list
-    /// and a detail column that carries the full-width header
-    /// bar (section title + profile dropdown + status), the
-    /// scrolling section content, and the save footer.
-    ///
-    /// A plain `HStack`, deliberately not `NavigationSplitView`
-    /// (#297): on macOS 26 the split view's divider cannot be
-    /// locked — `navigationSplitViewColumnWidth(min:ideal:max:)`
-    /// is ignored, `NSSplitViewItem` thickness writes are
-    /// reverted by the private controller on the next layout,
-    /// and replacing its delegate crashes. A static column is
-    /// non-resizable and non-collapsible by construction — the
-    /// System Settings behavior #68 wanted when it removed the
-    /// collapse toggle (a nine-row taxonomy never needs to
-    /// hide).
+    /// Structured settings shell with header, body content, and save footer
+    /// (#297, #68).
     private func structuredShell(
         _ width: SettingsWidthClass
     ) -> some View {
@@ -172,39 +85,23 @@ struct SettingsView: View {
         }
         .frame(maxWidth: .infinity)
         .ignoresSafeArea(.container, edges: .top)
-        // Escape pops an area back to Home whenever no inner
-        // view (a search field, an editor) claimed the key
-        // first.
         .onExitCommand {
             if selection != nil { selection = nil }
         }
         .environment(\.settingsNavigate) { destination in
-            // Third #18 enforcement point beside the grid's
-            // offer filter and the onChange repair above: links
-            // must refuse what the grid hides (the repair only
-            // fires on editing-flag transitions, not
-            // selection).
             guard
                 destination.isReachable(
                     editingStoredProfile:
                         model.editingStoredProfile
                 )
             else { return }
-            // A link into a Power-User-only area switches the mode
-            // (4c/4e: a cross-reference must exist in the
-            // current mode or offer the switch) — the segment
-            // in the header shows the flip.
             ensureModeAdmits(destination)
             selection = destination
         }
     }
 
-    /// Flips Simple → Power User when navigation targets an area the
-    /// current mode withholds — search and cross-references
-    /// index both modes, so landing must switch rather than
-    /// refuse (#678 4c). Internal, not private: the reveal
-    /// pipeline (`SettingsView+Reveal.apply`) is the second
-    /// caller.
+    /// Switches Simple to Power User mode when navigation targets advanced
+    /// section (#678).
     func ensureModeAdmits(
         _ destination: SettingsDestination
     ) {

--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -4,7 +4,8 @@ import SwiftUI
 /// Settings dashboard shell hosting Home grid or pushed section screen (#678).
 struct SettingsView: View {
     @ObservedObject var model: SettingsModel
-    /// Scroll and flash task for pending reveal.
+    /// Scroll and flash task for pending reveal, held so a second
+    /// search click supersedes the first instead of overlapping.
     @State var revealTask: Task<Void, Never>?
     /// Preview card state per mount; nil follows width class default
     /// (`DetailPanelTests`).
@@ -24,12 +25,18 @@ struct SettingsView: View {
     }
 
     var body: some View {
+        // The ONE measurement: every responsive verdict below
+        // derives from the class this hands down, so no site
+        // compares a width of its own (17a).
         GeometryReader { geo in
             let width = SettingsWidthClass.of(
                 width: geo.size.width
             )
             shell(width)
                 .environment(\.settingsWidth, width)
+                // Re-docking retires the per-mount answer — a
+                // "not now" must not outlive the band it was given
+                // in (architecture review, 2026-08-11).
                 .onChange(of: width) { _, now in
                     if now.docksPanel { previewShown = nil }
                 }
@@ -38,8 +45,21 @@ struct SettingsView: View {
             minWidth: SettingsWidthClass.minimum,
             minHeight: SettingsWidthClass.minimumHeight
         )
+        // Set ONCE at the root so no control can opt out (owner
+        // ruled full kiwi, 2026-08-04); above the `editingLua`
+        // branch so both arms carry it.
         .tint(SettingsTheme.accent)
+        // The one discard dialog (#515), hosted above the
+        // `editingLua` branch: `chrome` is instantiated per arm
+        // and two gated actions flip `editingLua`, so a dialog
+        // hosted there is torn down by its own confirm button.
         .discardConfirmation(model: model)
+        // Two repairs on two signals, deliberately unmerged:
+        // reachability keys on the live↔stored transition, the
+        // mode tab on the target — stored A → stored B leaves the
+        // boolean true. The selection must never point at a
+        // destination the grid just hid (#18); Home is the repair
+        // target.
         .onChange(of: model.editingStoredProfile) { _, editing in
             if let selection,
                 !selection.isReachable(
@@ -50,8 +70,13 @@ struct SettingsView: View {
             }
         }
         .onChange(of: model.target) { _, _ in
+            // A different profile means a different most-used
+            // mode, so the tab re-derives (#277).
             model.nav.resetSurfaces()
         }
+        // The #326 "Edit in Settings…" deep link or a #277 search
+        // hit, guarded by the same #18 reachability filter as
+        // every other nav path.
         .onChange(of: model.nav.pendingReveal) { _, request in
             apply(request)
         }
@@ -89,6 +114,10 @@ struct SettingsView: View {
             if selection != nil { selection = nil }
         }
         .environment(\.settingsNavigate) { destination in
+            // Third #18 enforcement point beside the grid's offer
+            // filter and the onChange repair, which only fires on
+            // editing-flag transitions: links must refuse what the
+            // grid hides.
             guard
                 destination.isReachable(
                     editingStoredProfile:

--- a/Sources/KiwiDesk/Settings/SettingsWidthClass.swift
+++ b/Sources/KiwiDesk/Settings/SettingsWidthClass.swift
@@ -8,11 +8,17 @@ enum SettingsWidthClass: String, CaseIterable, Sendable {
     case compact
     case tight
 
+    /// The ruled breakpoints and the hard minimum, public so the
+    /// shell and the tests read the same numbers — a second copy
+    /// of 720 anywhere is the drift this enum exists to prevent.
     static let panelBreakpoint: CGFloat = 1200
     static let rowBreakpoint: CGFloat = 900
     static let chromeBreakpoint: CGFloat = 820
     static let minimum: CGFloat = 720
-    /// Minimum content height (#859).
+    /// Minimum content height — one fact with two axes, homed
+    /// beside `minimum` so surfaces derive from it rather than
+    /// restate it (#859); the window controller's opening HEIGHT
+    /// is still a bare literal, deliberately unclaimed.
     static let minimumHeight: CGFloat = 540
 
     static func of(width: CGFloat) -> SettingsWidthClass {

--- a/Sources/KiwiDesk/Settings/SettingsWidthClass.swift
+++ b/Sources/KiwiDesk/Settings/SettingsWidthClass.swift
@@ -1,70 +1,18 @@
 import SwiftUI
 
-/// The Settings window's width bands (#678 turn 17a) and the one
-/// place they are derived. Everything the shell drops as the
-/// window narrows is a property on this type: the shell measures
-/// once, publishes the CLASS, and every site asks it rather than
-/// comparing a width of its own — the reserved-key lesson from
-/// pass 7, where three sites each re-derived one predicate.
-///
-/// The bands come from the digest's ruled ORDER — "drop the
-/// preview before you drop a control": the preview goes first
-/// (1200), then the row layout reflows (900), then the chrome
-/// collapses (820), **and controls never**. Below 720 the window
-/// stops resizing (`SettingsView`'s `minWidth`), because a
-/// settings window narrower than that is one where every row is
-/// two lines and nothing is comparable.
-///
-/// The order is not decoration: it is why the properties below
-/// are derived from each other rather than each keyed on its own
-/// number. `docksSavePill` IS `stacksRows` — one threshold, so
-/// the two cannot drift apart — and `SettingsResponsiveOrderTests`
-/// walks every supported width to hold the implications.
+/// Settings window responsive width bands (#678,
+/// `SettingsResponsiveOrderTests`).
 enum SettingsWidthClass: String, CaseIterable, Sendable {
-    /// ≥ 1200: the preview panel is docked beside the content,
-    /// the shell's fullest form.
     case wide
-    /// 900 ..< 1200: the panel detaches into a floating card
-    /// over the content; rows keep their full width, because a
-    /// segmented control that wraps is worse than a preview you
-    /// have to move.
     case medium
-    /// 820 ..< 900: rows go two-line and the save pill docks
-    /// into a real footer bar — at this width a floating pill
-    /// sits on top of the rows it is about.
     case compact
-    /// < 820, down to the 720 hard minimum: the header chrome
-    /// collapses too, the search field becoming an icon that
-    /// opens it. No control leaves.
     case tight
 
-    /// The three ruled breakpoints and the hard minimum. Public
-    /// on the type because the shell's `minWidth` and the tests
-    /// read the same numbers — a second copy of 720 anywhere is
-    /// the drift this enum exists to prevent.
     static let panelBreakpoint: CGFloat = 1200
     static let rowBreakpoint: CGFloat = 900
     static let chromeBreakpoint: CGFloat = 820
     static let minimum: CGFloat = 720
-    /// The shell's minimum content HEIGHT — the other half of the
-    /// floor, named here beside its partner so a surface sized
-    /// against the window derives from it rather than restating it
-    /// (#859: a sheet's own bounds were literals whose comment
-    /// claimed a relation to this number that did not hold).
-    ///
-    /// This type is about width BANDS and this is not one; it lives
-    /// here because the MINIMUM is one fact with two axes — the
-    /// smallest content rectangle the window may present — and
-    /// splitting that across two files is how one half moves
-    /// without the other.
-    ///
-    /// Scoped to the minimum deliberately. The window's opening
-    /// WIDTH derives from a band
-    /// (`SettingsWindowController.firstRunWidth`) while its opening
-    /// HEIGHT is still a bare literal there — the very number
-    /// #859's false claim was measured against. Naming that one too
-    /// is a separate change; this docstring does not claim to have
-    /// done it (re-review, 2026-08-17).
+    /// Minimum content height (#859).
     static let minimumHeight: CGFloat = 540
 
     static func of(width: CGFloat) -> SettingsWidthClass {
@@ -74,49 +22,22 @@ enum SettingsWidthClass: String, CaseIterable, Sendable {
         return .tight
     }
 
-    /// Whether the preview panel keeps its own column beside the
-    /// content. Below this the area still HAS a preview — it
-    /// floats (`floatsPreviewByDefault`) or waits behind the
-    /// "Show preview" offer — so this is a layout verdict, never
-    /// a capability one.
+    /// Whether preview panel docks into its own column beside content.
     var docksPanel: Bool { self == .wide }
 
-    /// Whether a detached preview card shows itself without
-    /// being asked. The 1100 pt frame draws the card open; the
-    /// 820 pt frame draws "Show preview" instead, and this is
-    /// the whole difference between them — one mechanism, two
-    /// defaults, so the card the user closes at 1100 and the
-    /// card they summon at 820 are the same card.
+    /// Whether detached preview card defaults to open without explicit summon.
     var floatsPreviewByDefault: Bool { self == .medium }
 
-    /// Whether a labelled row puts its control on a second line
-    /// under the label instead of on the shared label axis
-    /// (`SettingsMetrics.labelColumn`). Read by
-    /// `SettingsRowShape`, which is the one arrangement site.
+    /// Whether labelled row stacks its control beneath the label.
     var stacksRows: Bool { self == .compact || self == .tight }
 
-    /// Whether the save pill stops floating and becomes a real
-    /// footer bar — "same content, same three verbs, different
-    /// physics", the one component that changes KIND rather than
-    /// size. Derived from `stacksRows` rather than re-tested
-    /// against 900: the digest gives both the same threshold, and
-    /// two spellings of one number is how they come apart.
+    /// Whether save pill anchors into persistent footer bar.
     var docksSavePill: Bool { stacksRows }
 
-    /// Whether the header collapses its search field into an
-    /// icon. The last thing to go, and it takes nothing with it:
-    /// the icon opens the same field, in the same row, and the
-    /// area title yields to it for as long as it is open.
+    /// Whether header search field collapses into an icon button.
     var collapsesChrome: Bool { self == .tight }
 
-    /// Home's column ceiling. The count still derives from the
-    /// measured width below this (`HomeScreen.columns`) — cards
-    /// grow into a big screen up to their 360 pt maximum rather
-    /// than a fifth column appearing (owner 2026-08-10) — so
-    /// this caps the top end per band and the measurement owns
-    /// the way down. At the 720 minimum the measurement lands on
-    /// 2, which is why no band names 1: a single 688 pt-wide card
-    /// is not a step this window can reach.
+    /// Maximum columns for Home card grid.
     var homeColumnCap: Int {
         switch self {
         case .wide: return 4
@@ -125,38 +46,16 @@ enum SettingsWidthClass: String, CaseIterable, Sendable {
         }
     }
 
-    /// The preset grid's cap — one column fewer than Home's at
-    /// every band, DERIVED rather than re-tabulated (#789).
-    ///
-    /// Derived because the two share a threshold and this file's
-    /// own rule is that properties which do are derived from each
-    /// other, never re-tested against the number. One fewer
-    /// because Home spans the whole shell while the preset grid
-    /// sits in the CONTENT column, which gives up its width to
-    /// the detail panel wherever one is offered; a cap copied
-    /// from Home would put four preset cards in the room three
-    /// Home cards were eye-confirmed at.
-    ///
-    /// At `.tight` this is 1, and that is the honest answer
-    /// rather than a degenerate one: a grid whose cards cannot
-    /// hold a picture, a title, two lines of prose and a button
-    /// side by side is a list, and reflowing to one is the grid
-    /// working. Reflow is not a control leaving, so the ruled
-    /// narrowing order is untouched.
+    /// Maximum columns for preset card grid (#789).
     var presetColumnCap: Int { max(1, homeColumnCap - 1) }
 }
 
 private struct SettingsWidthClassKey: EnvironmentKey {
-    /// The full shell, so a view mounted outside the measured
-    /// window — a preview, a test constructing a row directly —
-    /// behaves as it did before this pass.
     static let defaultValue = SettingsWidthClass.wide
 }
 
 extension EnvironmentValues {
-    /// The measured width band. Injected ONCE, by
-    /// `SettingsView`, from the shell's own geometry; every
-    /// responsive decision in the tree reads it from here.
+    /// Injected width band from root `SettingsView` geometry.
     var settingsWidth: SettingsWidthClass {
         get { self[SettingsWidthClassKey.self] }
         set { self[SettingsWidthClassKey.self] = newValue }

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsPanelController.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsPanelController.swift
@@ -3,27 +3,18 @@ import KiwiDeskCore
 import SwiftUI
 import os
 
-/// #952 diagnosis lines. `Logger` + `privacy: .public`, never
-/// `NSLog` — macOS redacts NSLog content to `<private>` in
-/// `log show`, which blinds the capture (2026-08-23).
+/// Diagnostic logging for panel activation and hand-back (#952).
 private let panelLog = Logger(
     subsystem: KiwiLog.subsystem,
     category: "gui"
 )
 
-/// One wrapper so every diagnosis line carries the
-/// `KiwiDesk: ` capture prefix and the public privacy the
-/// documented predicate depends on — a hand-spelled prefix
-/// forgotten once is a line the capture silently drops.
 private func logPanel(_ message: String) {
     panelLog.log("KiwiDesk: \(message, privacy: .public)")
 }
 
-/// A floating panel that closes on Esc and, via the controller's
-/// resign-key handler, on click-away. Borderless, so it must opt
-/// into key status (`canBecomeKey`) to receive the keystroke — and
-/// the app is activated on show, or an accessory app's key window
-/// never actually receives keyboard events.
+/// Floating panel receiving keyboard events and dismissing on Esc or
+/// click-away.
 final class ShortcutsPanel: NSPanel {
     var onCancel: () -> Void = {}
 
@@ -33,10 +24,6 @@ final class ShortcutsPanel: NSPanel {
         onCancel()
     }
 
-    /// Explicit Esc handler as well as `cancelOperation` — a
-    /// borderless panel hosting a SwiftUI view doesn't always route
-    /// Esc through the cancel action, so catch the keystroke here
-    /// too (53 = Escape).
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 53 {
             onCancel()
@@ -46,38 +33,19 @@ final class ShortcutsPanel: NSPanel {
     }
 }
 
-/// Owns the read-only shortcuts reference panel (#326). Retained by
-/// `AppDelegate` so it survives close/reopen. Every show reads the
-/// live keybinding snapshot fresh and re-centers on the screen
-/// under the pointer — the panel has no placement of its own to
-/// remember (a summoned reference, not a window the user parks).
+/// Controller for floating shortcuts reference overlay (#326, #952).
 @MainActor
 final class ShortcutsPanelController: NSObject, NSWindowDelegate {
-    // Internal, not private: `+Reference.swift` (a separate file,
-    // split for the 350-line ceiling) reads it to build the
-    // panel's content.
     let core: KiwiCore
-    /// Opens Settings ▸ Shortcuts — the one bridge to editing.
     private let onEdit: () -> Void
     private var panel: ShortcutsPanel?
-    /// The app frontmost before `show()` stole activation, to
-    /// hand back on a keyboard-commanded close (#952). nil when
-    /// the summon came from our own process (a Settings-window
-    /// bridge) — that closes back to Settings naturally, and nil
-    /// when nothing has been shown yet. Internal so a test can
-    /// set it directly without calling `show()` (which activates
-    /// the app and builds panels).
+    /// Previously frontmost application before summon stole activation (#952).
     var returnTarget: NSRunningApplication?
-    /// Machine seam (#565 pattern): the live hand-back, so a
-    /// test can record it instead of touching the real machine.
+    /// Seam for activating return target application (#565).
     var activateReturnTarget: (NSRunningApplication) -> Void = {
         $0.activate()
     }
-    /// Machine seam, live by default: whether KiwiDesk is the
-    /// active app, gating the yield in `close`. A test process
-    /// is never the active app, so this is injectable —
-    /// otherwise the yield gate could never be exercised true
-    /// (the `frontmostPIDProvider` pattern, #565).
+    /// Seam returning whether KiwiDesk is currently active app (#565).
     var isAppActive: () -> Bool = {
         NSApplication.shared.isActive
     }
@@ -88,14 +56,7 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
         super.init()
     }
 
-    /// Whether a close should hand activation back to `target`
-    /// (#952): only a keyboard-commanded close (`commanded` —
-    /// Escape, the toggle-close, `closeIfOpen`'s layer switch)
-    /// while KiwiDesk is still the active app, with a remembered
-    /// target. A click-away close (`windowDidResignKey`) passes
-    /// `commanded: false` — the clicked app is already active,
-    /// and re-activating the remembered one would fight it. Pure
-    /// so all four arms are directly testable without NSApp.
+    /// Whether close should yield activation back to previous app (#952).
     static func shouldYield(
         commanded: Bool,
         appActive: Bool,
@@ -112,10 +73,6 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
                 core: core
             ),
             onEdit: { [weak self] in
-                // A click, not a keyboard command, and its next
-                // step is Settings — our own app — coming
-                // forward, not the remembered app, so this does
-                // not yield (#952).
                 self?.close(yieldingActivation: false)
                 self?.onEdit()
             }
@@ -128,21 +85,6 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
         )
         resize(panel)
         center(panel)
-        // Activate the app so a menu-bar (accessory) app's key window
-        // actually receives keystrokes — without this, Esc and
-        // click-away never fire and the panel can't be dismissed.
-        // Accessory-level: no Dock icon appears (unlike the dashboard,
-        // which promotes to regular). KiwiDesk's tiling hotkeys stay
-        // global Carbon and keep firing while it's open; the panel is
-        // a stateless summon that rebuilds its content on each open.
-        // A layer switch while it's up auto-closes it (#603, see
-        // closeIfOpen) rather than leaving another layer's bindings on
-        // screen — reopen to see the new layer.
-        // Remember what held frontmost before the summon steals
-        // activation, so a keyboard-commanded close can hand it
-        // back (#952) — UNLESS it is our own process (a summon
-        // from Settings' Shortcuts row), which returns there
-        // naturally without a re-activate.
         let frontmost = NSWorkspace.shared.frontmostApplication
         returnTarget =
             frontmost?.processIdentifier
@@ -154,9 +96,6 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
         panel.makeKeyAndOrderFront(nil)
     }
 
-    /// Re-summoning while open dismisses it (the menu row toggles),
-    /// so there is a focus-independent close even if the pointer
-    /// never leaves the panel.
     func toggle() {
         if let panel, panel.isVisible {
             close(yieldingActivation: true)
@@ -165,41 +104,13 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
         }
     }
 
-    /// Orders the panel out. `yieldingActivation` is true for
-    /// every keyboard-commanded close — Escape, this toggle-off,
-    /// and `closeIfOpen`'s layer switch — where the user's focus
-    /// context is the app `show()` remembered; `false` for
-    /// `windowDidResignKey`, whose click-away has already
-    /// activated the clicked app (#952 ruling). `returnTarget` is
-    /// consumed (nilled) on every close, yielding or not, so a
-    /// double close — this, then a resign-key close it triggers —
-    /// cannot yield twice. Internal so a test can call it without
-    /// `show()`, which activates the app and builds panels.
+    /// Dismisses panel, optionally returning activation to prior app (#952).
     func close(yieldingActivation: Bool) {
-        // #952 diagnosis: after orderOut, macOS re-keys the
-        // app's next window — log what it picked one turn
-        // later, and which app is frontmost then. The steal
-        // is expected exactly when our Settings window is the
-        // pick.
         let key = NSApplication.shared.keyWindow?.title ?? "none"
         logPanel("sheet close; key \(key)")
-        // Consume the target BEFORE orderOut: ordering a key
-        // panel out fires `windowDidResignKey`, whose re-entrant
-        // `close(yieldingActivation: false)` would nil
-        // `returnTarget` under this frame — leaving the Escape
-        // yield dead in production while every test (which
-        // orders out no real key panel) stays green.
         let target = returnTarget
         returnTarget = nil
         let active = isAppActive()
-        // Armed BEFORE orderOut, and only on a commanded close
-        // of the still-active app — the one close whose orderOut
-        // blip-keys another own window (Settings), AX's
-        // clickless re-report landing after the yield below
-        // (#952 capture). A click-away close already resigned
-        // active, and the Edit-in-Settings close WANTS the
-        // Settings focus that follows — arming there ate the
-        // intended focus (review, 2026-08-23).
         if yieldingActivation, active {
             core.distrustOwnDismissHandoff()
         }
@@ -221,11 +132,7 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
         }
     }
 
-    /// Close the panel if it is open. Called when the active
-    /// keybinding layer changes (#603): the panel is a per-open
-    /// snapshot of one layer's bindings, so leaving it up after a
-    /// switch would advertise shortcuts that are no longer active.
-    /// Reopening (⌃⌥K) rebuilds it for the new layer.
+    /// Closes panel on keybinding layer switch (#603).
     func closeIfOpen() {
         guard let panel, panel.isVisible else { return }
         close(yieldingActivation: true)
@@ -258,9 +165,6 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
 
     // MARK: - Sizing & placement
 
-    /// Hug the content, capped at 70% of the active screen's
-    /// height (hard ceiling 720pt) — past that the inner scroll
-    /// view takes over. Width is fixed by the view (760pt).
     private func resize(_ panel: ShortcutsPanel) {
         guard let content = panel.contentView else { return }
         let fitting = content.fittingSize
@@ -297,10 +201,6 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
 
     // MARK: - NSWindowDelegate
 
-    /// Click-away dismissal: losing key closes the panel, the
-    /// Character-Viewer / Quick-Look dismissal gesture. The
-    /// click already activated whatever app it landed in, so
-    /// this does not yield activation back (#952).
     func windowDidResignKey(_ notification: Notification) {
         close(yieldingActivation: false)
     }

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsPanelController.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsPanelController.swift
@@ -13,8 +13,10 @@ private func logPanel(_ message: String) {
     panelLog.log("KiwiDesk: \(message, privacy: .public)")
 }
 
-/// Floating panel receiving keyboard events and dismissing on Esc or
-/// click-away.
+/// Floating panel receiving keyboard events and dismissing on Esc
+/// or click-away. Borderless, so it opts into key status — and the
+/// app is activated on show, or an accessory app's key window
+/// never actually receives keyboard events.
 final class ShortcutsPanel: NSPanel {
     var onCancel: () -> Void = {}
 
@@ -24,6 +26,9 @@ final class ShortcutsPanel: NSPanel {
         onCancel()
     }
 
+    /// Esc explicitly as well as `cancelOperation` — a borderless
+    /// panel hosting SwiftUI doesn't always route Esc through the
+    /// cancel action (53 = Escape).
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 53 {
             onCancel()
@@ -56,7 +61,11 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
         super.init()
     }
 
-    /// Whether close should yield activation back to previous app (#952).
+    /// Whether close should yield activation back to the previous
+    /// app (#952): only a keyboard-commanded close — a click-away
+    /// already activated the clicked app, and re-activating the
+    /// remembered one would fight it. Pure, so all four arms are
+    /// testable without NSApp.
     static func shouldYield(
         commanded: Bool,
         appActive: Bool,
@@ -73,6 +82,9 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
                 core: core
             ),
             onEdit: { [weak self] in
+                // A click whose next step is Settings — our own
+                // app — coming forward, not the remembered one,
+                // so it does not yield (#952).
                 self?.close(yieldingActivation: false)
                 self?.onEdit()
             }
@@ -108,9 +120,17 @@ final class ShortcutsPanelController: NSObject, NSWindowDelegate {
     func close(yieldingActivation: Bool) {
         let key = NSApplication.shared.keyWindow?.title ?? "none"
         logPanel("sheet close; key \(key)")
+        // Consume BEFORE orderOut: it fires `windowDidResignKey`,
+        // whose re-entrant close would nil `returnTarget` under
+        // this frame — the Escape yield dead in production while
+        // tests (no real key panel) stay green.
         let target = returnTarget
         returnTarget = nil
         let active = isAppActive()
+        // Armed BEFORE orderOut and only on a commanded close of
+        // the still-active app — a click-away already resigned,
+        // and arming on Edit-in-Settings ate the intended focus
+        // (#952 capture; review, 2026-08-23).
         if yieldingActivation, active {
             core.distrustOwnDismissHandoff()
         }

--- a/Sources/KiwiDesk/StatusItemController.swift
+++ b/Sources/KiwiDesk/StatusItemController.swift
@@ -7,17 +7,25 @@ import SwiftUI
 @MainActor
 final class StatusItemController: NSObject, NSMenuDelegate {
     var onOpenDashboard: () -> Void = {}
+    /// Opens the read-only shortcuts reference panel (#326).
     var onShowShortcuts: () -> Void = {}
     var onShowConfigIssues: () -> Void = {}
+    /// The combo bound to open the shortcuts panel (#330), read
+    /// fresh on each menu open so AppKit renders the live binding.
     var shortcutsComboProvider: () -> KeyCombo? = { nil }
 
+    /// Drives "Check for Updates…" (#874). Inert by default —
+    /// `AppUpdater.swift` owns why.
     var updater: any AppUpdating = NoUpdater()
     var onShowAccessibilityHelp: () -> Void = {}
     var onLoadProfile: (String) -> Void = { _ in }
+    /// Saved profiles, pulled fresh each menu open; broken entries
+    /// stay listed but disabled — greyed, not hidden (#246, #171).
     var profilesProvider:
         () -> (
             active: String?, all: [String], broken: Set<String>
         ) = { (nil, [], []) }
+    /// What the Layout submenu draws from, fresh per open (#752).
     var layoutInfoProvider: () -> LayoutMenuInfo = {
         LayoutMenuInfo.empty
     }
@@ -25,12 +33,23 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     }
     var onSaveLayoutToProfile: () -> Void = {}
 
+    /// Injected menu-bar slot so tests never register a real
+    /// system item (`StatusItemHandle`, the #565-class seam).
     private let item: StatusItemHandle
     private let menu = NSMenu()
+    /// `private(set)`: only `setWarning` may mutate — every write
+    /// goes through `render()`.
     private(set) var warning = false
+    /// Distinct badge so the two causes never blur (§3.7); mutated
+    /// only via `setConfigError`, the same rule as `warning`.
     private(set) var configError = false
     private var modeIcon: String?
+    /// ONE stored value (#802), read by the icon AND the menu
+    /// builder — two reads of one fact showed half the signal
+    /// (architect review, 2026-08-12).
     private(set) var bootPhase: BootPhase = .ready
+    /// Held so a phase published mid-tracking can retitle the open
+    /// menu's row in place (owner, on device, 2026-08-12).
     weak var startingRow: NSMenuItem?
 
     init(item: (any StatusItemHandle)? = nil) {

--- a/Sources/KiwiDesk/StatusItemController.swift
+++ b/Sources/KiwiDesk/StatusItemController.swift
@@ -2,88 +2,37 @@ import AppKit
 import KiwiDeskCore
 import SwiftUI
 
-/// Owns the menu bar item: the status icon's state machine
-/// (§3.7) — permission warning beats config error beats the
-/// active mode's custom icon beats the standard glyph. The quick
-/// menu (#68 §3.10) is built in `StatusItemController+Menu`.
+/// Manages menu bar status item, icon state transitions, and menu coordination
+/// (#68, #802).
 @MainActor
 final class StatusItemController: NSObject, NSMenuDelegate {
     var onOpenDashboard: () -> Void = {}
-    /// Opens the read-only shortcuts reference panel (#326).
     var onShowShortcuts: () -> Void = {}
     var onShowConfigIssues: () -> Void = {}
-    /// The combo bound to open the shortcuts panel (#330), or nil
-    /// when unbound. Read fresh on each menu open so AppKit renders
-    /// the live binding in its native shortcut column (like
-    /// `profilesProvider`).
     var shortcutsComboProvider: () -> KeyCombo? = { nil }
 
-    /// The in-app updater the "Check for Updates…" row drives
-    /// (#874). Inert by default — `AppUpdater.swift` owns why.
     var updater: any AppUpdating = NoUpdater()
-    /// Opens the guided permission fix (the onboarding wizard at
-    /// its grant step). Wired unconditionally; the *row* that
-    /// invokes it appears only while Accessibility is missing.
     var onShowAccessibilityHelp: () -> Void = {}
     var onLoadProfile: (String) -> Void = { _ in }
-    /// The saved profiles, the active one, and the unreadable
-    /// ones, pulled fresh each menu open. Broken entries stay
-    /// listed but disabled — greyed, not hidden; the remedy is
-    /// the Config Issues panel, one entry up (#246, #171).
     var profilesProvider:
         () -> (
             active: String?, all: [String], broken: Set<String>
         ) = { (nil, [], []) }
-    /// What the Layout submenu draws from, fresh per open (#752).
     var layoutInfoProvider: () -> LayoutMenuInfo = {
         LayoutMenuInfo.empty
     }
-    /// Applies `mode` to a space, or to the active space when the
-    /// id is nil — the one-argument `set_mode`.
     var onSetLayoutMode: (LayoutMode, SpaceID?) -> Void = { _, _ in
     }
     var onSaveLayoutToProfile: () -> Void = {}
 
-    /// The menu-bar slot — injected so tests can build the
-    /// quick-menu logic without registering a real system item
-    /// (see `StatusItemHandle`, the #565-class seam).
     private let item: StatusItemHandle
     private let menu = NSMenu()
-    /// Missing-permission warning overrides everything.
-    /// `private(set)`: the menu builder in `+Menu` reads it to add
-    /// the "Window Management Paused…" row, but only `setWarning`
-    /// may mutate it — every write must go through `render()`.
     private(set) var warning = false
-    /// The last config load left issues (§3.7) — a distinct
-    /// badge so the two causes are never confused. `private(set)`
-    /// for the same reason as `warning` (drives the Config Issues
-    /// row; mutated only via `setConfigError`).
     private(set) var configError = false
-    /// Active keybinding mode indicator (SF Symbol or emoji);
-    /// nil restores the standard KiwiDesk icon.
     private var modeIcon: String?
-    /// The last published boot phase — the whole readiness signal
-    /// (#802), read by the icon AND by the menu builder.
-    ///
-    /// ONE stored value rather than a pushed flag beside a pulled
-    /// provider: `core.bootPhase` returns exactly what `publish`
-    /// just handed over, so a pull is never fresher, and two reads
-    /// of one fact let a surface wired to only one of them show
-    /// half the signal — a dimmed mark over an un-greyed menu
-    /// (architect review, 2026-08-12).
     private(set) var bootPhase: BootPhase = .ready
-    /// The open menu's starting row, while one is open. Held so a
-    /// phase published mid-tracking can retitle it in place: the
-    /// row is built once per open, and on a heavy session the menu
-    /// is open for most of the boot it is reporting (owner, on
-    /// device, 2026-08-12).
     weak var startingRow: NSMenuItem?
 
-    /// `nil` means the live system slot. The optional-with-nil
-    /// shape, rather than `= SystemStatusItem()`, is what lets
-    /// the wrapper below stay file-scoped `private` — a
-    /// default-argument expression cannot reference a type less
-    /// accessible than the init, but the body can.
     init(item: (any StatusItemHandle)? = nil) {
         self.item = item ?? SystemStatusItem()
         super.init()
@@ -92,30 +41,20 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         render()
     }
 
-    // MARK: - Icon states
-
-    /// Toggles the missing-permission warning icon.
+    /// Sets missing-permission warning icon state.
     func setWarning(_ warning: Bool) {
         self.warning = warning
         render()
     }
 
-    /// Toggles the config-error badge (§3.7): shown when the
-    /// last config load reported issues; permission warnings
-    /// still win (without Accessibility nothing works
-    /// regardless of config validity).
+    /// Sets config-error badge state (§3.7).
     func setConfigError(_ error: Bool) {
         configError = error
         render()
     }
 
-    /// Reflects how far the boot has got (#802).
-    ///
-    /// Two cheap consequences per chunk: the icon re-renders only
-    /// on the starting↔ready flip, and an open menu's count row is
-    /// retitled in place. Everything else the menu draws off the
-    /// phase (the greys) cannot change without that flip, so the
-    /// row is the only live piece.
+    /// Updates boot readiness phase and re-renders if transition crossed
+    /// (#802).
     func setBootPhase(_ phase: BootPhase) {
         let wasStarting = bootPhase.isStarting
         bootPhase = phase
@@ -126,43 +65,22 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         render()
     }
 
-    /// Whether the readiness signal is owed. Ranked below the
-    /// permission warning and above the config error: without
-    /// Accessibility nothing works regardless of how far a boot
-    /// got, while a config problem is a thing to fix once the app
-    /// can be clicked at all. Derived, never stored — one fact,
-    /// one place (architect review, 2026-08-12).
+    /// Whether startup initialization is in progress (#802).
     var starting: Bool { bootPhase.isStarting }
 
-    /// Reflects the active keybinding mode: a custom mode's
-    /// icon replaces the standard menu bar glyph; the default
-    /// mode (nil) restores it.
+    /// Sets custom icon for active keybinding mode.
     func setModeIcon(_ icon: String?) {
         modeIcon = icon
         render()
     }
 
-    /// The live button, for a surface that must point AT the menu
-    /// bar item rather than drive it — the one-time coach mark
-    /// (#678 Phase 4 pass 11). Read-only and nil behind the test
-    /// seam, which is what makes "there is nothing to point at"
-    /// the same answer as "there is no real item".
+    /// Menu bar button anchor for coach marks (#678).
     var anchorButton: NSStatusBarButton? { item.button }
 
     private func render() {
         guard let button = item.button else { return }
-        // Lightness is the whole starting signal: the menu bar
-        // tints template images itself, so a hue would not
-        // survive it — and would be the one channel colour-vision
-        // deficiency takes away. `appearsDisabled` is AppKit's own
-        // dimming, and the mark returning to full strength IS the
-        // ready signal (#802). Assigned unconditionally, so every
-        // other branch below clears it.
         button.appearsDisabled = starting
         if warning {
-            // Permission failure keeps the loud triangle; config
-            // error uses a distinct, softer circle so the two are
-            // never confused in the always-on glyph (§3.7).
             setStatusSymbol(
                 "exclamationmark.triangle.fill",
                 on: button,
@@ -221,8 +139,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
-    /// Shared SF Symbol → template-image helper for the menu
-    /// builders (`+Menu`, `+Layout`) and `render`.
     func symbol(_ name: String) -> NSImage? {
         let image = NSImage(
             systemSymbolName: name,
@@ -231,21 +147,9 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         image?.isTemplate = true
         return image
     }
-
 }
 
-// MARK: - The live slot
-
-/// The real menu-bar slot: registers a visible item with the
-/// system bar for the life of the process — right for the app,
-/// wrong for a test process. No removal on deinit,
-/// deliberately: the controller is app-lifetime, and `deinit`
-/// is nonisolated where `NSStatusBar` is main-actor.
-///
-/// File-scoped `private` IS the seal — tests cannot name this
-/// type, so a live item cannot be passed through the seam; do
-/// not raise its access (`StatusItemSeamGuardTests` pins the
-/// declaration). The seam's story lives at `StatusItemHandle`.
+/// Live system NSStatusItem wrapper (`StatusItemSeamGuardTests`).
 @MainActor
 private final class SystemStatusItem: StatusItemHandle {
     private let item: NSStatusItem

--- a/Sources/KiwiDesk/Updates/UpdatePromptDriver.swift
+++ b/Sources/KiwiDesk/Updates/UpdatePromptDriver.swift
@@ -1,19 +1,27 @@
 import AppKit
 import Sparkle
 
-/// Sparkle UI delegate customizations for accessory app without Dock tile
-/// (#1011).
+/// Sparkle UI delegate customizations for an accessory app with no
+/// Dock tile (#1011). Held for the process lifetime by
+/// `SparkleUpdater`: the standard driver references its delegate
+/// WEAKLY, so a policy nobody retains is a policy Sparkle stops
+/// asking.
 @MainActor
 final class UpdatePromptPolicy: NSObject,
     @MainActor SPUStandardUserDriverDelegate
 {
-    /// Disallows minimizing status window because accessory app lacks Dock
-    /// tile (#1011).
+    /// Disallows minimizing the status window (#1011): activating
+    /// a process deminiaturizes nothing, so a parked prompt would
+    /// sit in a Dock KiwiDesk has no icon in — refusing the
+    /// affordance is what closes the parking route, and only that.
     func standardUserDriverAllowsMinimizableStatusWindow() -> Bool {
         false
     }
 
-    /// Activates app for modal alerts.
+    /// Activates app for modal alerts — unconditional only because
+    /// Sparkle gates them on user engagement
+    /// (`SPUScheduledUpdateDriver.m`, Sparkle 2.9.6); check that
+    /// gate when the version moves.
     func standardUserDriverWillShowModalAlert() {
         NSApp.activate(ignoringOtherApps: true)
     }
@@ -23,7 +31,11 @@ final class UpdatePromptPolicy: NSObject,
 /// bouncing (#1011).
 @MainActor
 final class UpdatePromptDriver: SPUStandardUserDriver {
-    /// Restores app activation when download starts (#1011).
+    /// Restores app activation when the download starts (#1011):
+    /// the Install click closes Sparkle's alert BEFORE the
+    /// completion block runs, deactivating a now window-less
+    /// accessory app. After `super`, so the status window exists
+    /// when the app is raised.
     override func showDownloadInitiated(
         cancellation: @escaping () -> Void
     ) {
@@ -31,8 +43,10 @@ final class UpdatePromptDriver: SPUStandardUserDriver {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    /// Brings app to front before presenting install-and-restart prompt
-    /// (#1011).
+    /// Brings app to front before the install-and-restart prompt
+    /// (#1011). Depends on `UpdatePromptPolicy` refusing the
+    /// minimize button — a parked window is the one state
+    /// activation cannot recover.
     override func showReadyToInstallAndRelaunch() async
         -> SPUUserUpdateChoice
     {

--- a/Sources/KiwiDesk/Updates/UpdatePromptDriver.swift
+++ b/Sources/KiwiDesk/Updates/UpdatePromptDriver.swift
@@ -1,119 +1,29 @@
 import AppKit
 import Sparkle
 
-/// What Sparkle's stock UI must do differently for an app with
-/// no Dock tile (#1011). Separate from the driver below only
-/// because Sparkle captures a user driver's delegate in its
-/// initializer, so the driver cannot be its own.
-///
-/// Held for the process lifetime by `SparkleUpdater`: the
-/// standard driver references its delegate WEAKLY, so a policy
-/// nobody retains is a policy Sparkle stops asking.
-/// The conformance is isolated rather than `nonisolated` +
-/// `assumeIsolated`: Sparkle calls every user-driver method from
-/// the main thread and asserts on it, so the isolation is the
-/// truth rather than a promise this file makes.
+/// Sparkle UI delegate customizations for accessory app without Dock tile
+/// (#1011).
 @MainActor
 final class UpdatePromptPolicy: NSObject,
     @MainActor SPUStandardUserDriverDelegate
 {
-    /// Refuse the minimize button on the status window.
-    ///
-    /// Sparkle offers it because a regular app update is usually
-    /// quick, and parking the progress window is reasonable when
-    /// a Dock tile can bring it back. Here it cannot: the window
-    /// the user parked during the download is the same one that
-    /// becomes the install-and-restart prompt, and activating a
-    /// process does not deminiaturize anything — so a minimized
-    /// prompt would sit in a Dock KiwiDesk has no icon in.
-    /// Refusing the affordance is what closes the PARKING
-    /// route, and only that one. Activation preserves intra-app
-    /// window order, and `super` reuses a status controller it
-    /// already has rather than re-ordering it — so a Settings or
-    /// Config Issues window opened during the download still
-    /// sits above the prompt after the activation. Closing that
-    /// too would need the status window itself, which Sparkle
-    /// hands out to nobody; it is a rarer shape than the one
-    /// #1011 was reported as, and it is named here rather than
-    /// left to be rediscovered.
+    /// Disallows minimizing status window because accessory app lacks Dock
+    /// tile (#1011).
     func standardUserDriverAllowsMinimizableStatusWindow() -> Bool {
         false
     }
 
-    /// Come forward for Sparkle's modal alerts too. There are
-    /// three: an updater error, "you're up to date", and the
-    /// acknowledgement after an install. Each is a window the
-    /// user must answer, and `.accessory` puts none of them in
-    /// front by itself.
-    ///
-    /// **Unconditional only because Sparkle gates them already**
-    /// — a scheduled check passes `showErrorToUser:_showedUpdate`
-    /// (`SPUScheduledUpdateDriver.m`, Sparkle 2.9.6), so an alert
-    /// reaches here only once the user was engaged, where a
-    /// user-initiated check passes `YES`. That is what keeps this
-    /// on the right side of the scoping in
-    /// `docs/design-decisions.md` ▸ *Permanent accessory mode*:
-    /// none of these is an unsolicited offer. If a Sparkle
-    /// upgrade ever routes one through `showAlert:` unprompted,
-    /// this site would activate for it and no guard would say
-    /// so — check that gate when the version moves.
+    /// Activates app for modal alerts.
     func standardUserDriverWillShowModalAlert() {
         NSApp.activate(ignoringOtherApps: true)
     }
 }
 
-/// Sparkle's stock user driver plus one thing: the prompt that
-/// asks to install and restart brings KiwiDesk to the front
-/// before it appears (#1011).
-///
-/// **Why a subclass, when the seam next door is a delegate.**
-/// Sparkle activates the app itself for the windows it opens on
-/// a check the USER asked for — the update alert, the permission
-/// prompt — and `StatusItemController+Updates` activates once
-/// more before that check, so the window a user asked for is in
-/// front. (A SCHEDULED check is deliberately gentler and stays
-/// behind; `docs/design-decisions.md` ▸ *Permanent accessory
-/// mode* scopes what this rule does and does not promise.) The
-/// install-and-restart prompt is not another window: it is a
-/// later state of the status window the DOWNLOAD opened, and
-/// Sparkle announces it with `NSApp.requestUserAttention`,
-/// which bounces a Dock icon. KiwiDesk has none
-/// (`docs/design-decisions.md` ▸ *Permanent accessory mode*),
-/// so on the ordinary path — start the download, go back to
-/// work while it runs — the app is no longer active when the
-/// prompt arrives and the prompt is behind everything the user
-/// has open, with nothing saying the update is waiting.
-///
-/// Neither `SPUUpdaterDelegate` nor
-/// `SPUStandardUserDriverDelegate` carries a hook at that
-/// moment: the user-driver delegate's alert hooks fire for
-/// modal `NSAlert`s, which this is not, and the updater
-/// delegate's nearest neighbour (`didExtractUpdate`) fires
-/// before the installer has finished preparing. Overriding
-/// `showReadyToInstallAndRelaunch` is the only seam that names
-/// the moment rather than approximating it.
+/// Custom Sparkle user driver ensuring prompts come to front without Dock
+/// bouncing (#1011).
 @MainActor
 final class UpdatePromptDriver: SPUStandardUserDriver {
-    /// Keep the focus the user just gave us (#1011).
-    ///
-    /// Clicking **Install Update** closes Sparkle's update alert
-    /// — `SUUpdateAlert.m` closes the window BEFORE it invokes
-    /// the completion block that starts the download — and at
-    /// that instant an accessory process has no windows left, so
-    /// macOS deactivates it and hands focus to whatever was
-    /// behind. The status window is then created into an app that
-    /// is already inactive, and opens behind it. No switching
-    /// away is needed; it is the click itself that buries it.
-    ///
-    /// This is NOT the "unsolicited offer" the scoping in
-    /// `docs/design-decisions.md` ▸ *Permanent accessory mode*
-    /// leaves alone. The user pressed a button one runloop ago:
-    /// the focus being restored is the focus they just gave, not
-    /// focus taken from them. A later deliberate switch away is
-    /// untouched — nothing here fires again until the prompt.
-    ///
-    /// After `super`, so the window Sparkle is about to create
-    /// exists when the app is raised.
+    /// Restores app activation when download starts (#1011).
     override func showDownloadInitiated(
         cancellation: @escaping () -> Void
     ) {
@@ -121,18 +31,8 @@ final class UpdatePromptDriver: SPUStandardUserDriver {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    /// Come forward, then let Sparkle put up the prompt.
-    ///
-    /// Unconditional rather than gated on `!NSApp.isActive`:
-    /// activating an already-active app does nothing, so the
-    /// branch would only add a second thing to keep true.
-    ///
-    /// The two statements are not ordered against each other and
-    /// the guard does not pin an order: `super` shows the window
-    /// synchronously, so both land in one main-actor stretch
-    /// before anything redraws. What the activation depends on is
-    /// `UpdatePromptPolicy` refusing the minimize button — a
-    /// parked window is the one state activation cannot recover.
+    /// Brings app to front before presenting install-and-restart prompt
+    /// (#1011).
     override func showReadyToInstallAndRelaunch() async
         -> SPUUserUpdateChoice
     {


### PR DESCRIPTION
## Summary
Batch 6 of comment diet per AGENTS.md §2.8 ("Comments: state the constraint, cite the ruling, stop").
Trimmed 30 files in Settings, UI components, and AppKit delegates.
- Preserved all issue refs (#NNN), docstring contracts, and guard test references.
- Deleted design history, reviewer commentary, rejected alternatives, and redundant code restatements.
- Verified line lengths (<= 79) and file sizes (<= 350).

## Verification
- `./scripts/lint.sh` passed
- `swift test --filter KiwiDeskGuiTests` passed (1161 tests in 264 suites)
- `extract-keys --check` passed