### PR TITLE
chore(scripts): make lint's soft file-size warnings opt-in

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # KiwiDesk lint: formatting, line length (79), file size (350).
-# Usage: scripts/lint.sh [file ...]   (defaults to all Swift files)
+# Usage: scripts/lint.sh [--show-warnings] [file ...]
+#        (defaults to all Swift files)
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -8,6 +9,16 @@ MAX_LINE=79
 SOFT_FILE=250
 HARD_FILE=350
 STATUS=0
+
+# Soft-target warnings are advisory — the exit code decides
+# (AGENTS.md §2.5) — and listing all ~150 of them per run drowned
+# the errors, so the list is opt-in and the default is one count.
+SHOW_WARNINGS=0
+SOFT_COUNT=0
+if [ "${1:-}" = "--show-warnings" ]; then
+    SHOW_WARNINGS=1
+    shift
+fi
 
 if [ "$#" -gt 0 ]; then
     FILES=("$@")
@@ -63,9 +74,18 @@ for f in "${FILES[@]}"; do
         echo "ERROR: $f has $lines lines (hard limit $HARD_FILE)"
         STATUS=1
     elif [ "$is_test" -eq 0 ] && [ "$lines" -gt "$SOFT_FILE" ]; then
-        echo "WARNING: $f has $lines lines (sweet spot <=$SOFT_FILE)"
+        SOFT_COUNT=$((SOFT_COUNT + 1))
+        if [ "$SHOW_WARNINGS" -eq 1 ]; then
+            echo "WARNING: $f has $lines lines" \
+                "(sweet spot <=$SOFT_FILE)"
+        fi
     fi
 done
+
+if [ "$SOFT_COUNT" -gt 0 ] && [ "$SHOW_WARNINGS" -eq 0 ]; then
+    echo "NOTE: $SOFT_COUNT file(s) over the $SOFT_FILE-line sweet" \
+        "spot; rerun with --show-warnings to list them"
+fi
 
 # swift-format lint (ships with Xcode 16+ toolchains)
 if swift format --version >/dev/null 2>&1; then


### PR DESCRIPTION
## Description

`scripts/lint.sh` printed ~140 advisory `WARNING` lines (the 250-line
soft file-size target) on every default run. §2.5 already rules that
the exit code decides, not the warnings — so the list drowned the
actual errors and cost every agent session the output tokens. The
default run now prints one summary line
(`NOTE: N file(s) over the 250-line sweet spot…`); the full list is
available with `--show-warnings`. Errors, the hard 350-line ceiling,
`swift format lint` and `extract-keys --check` are untouched, and the
exit-code contract is unchanged.

## Related Issue(s)

None — small tooling ergonomics change.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [ ] New behavior is tested (pure logic / layout code
  required) — shell tooling, no Swift surface; verified by
  running all three modes
- [ ] User-facing changes are documented in `docs/` — not
  user-facing (workshop script; AGENTS.md §2.5's contract is
  unchanged)
- [x] No contradictions between code and docs
- [ ] Release build green — not applicable (no Swift change)
- [x] PR is focused; refactors separated from features

## How I verified

Ran the script three ways on this tree: default (one NOTE line,
`Lint OK`, exit 0), `--show-warnings` (the full 140-line list, as
before), and with a single file argument (the pre-commit hook's
shape — unaffected, the flag parse only consumes a leading
`--show-warnings`). `bash -n` clean.

## Notes for Reviewer

The flag must be the FIRST argument; the pre-commit hook passes
only file paths, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)