### PR TITLE
chore(comments): trim core and gui components to §2.8 budget (batch 7)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutDefaultsGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutDefaultsGates.swift
@@ -1,44 +1,12 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Layout Defaults area's greying, resolved from the census
-/// (#678 Phase 3, turn 10).
-///
-/// No container here carries a `SettingsContainer.gate` — a
-/// layout's card is never off as a unit, because the card IS the
-/// layout the reader picked — so unlike the Bars area this
-/// resolver answers only ROW gates. It answers all of them: a
-/// declared gate is resolved here and never re-implemented
-/// beside its row, because a renderer whose predicate drifts
-/// from the declaration greys the wrong row and the census's
-/// stated owner quietly stops being the owner.
-///
-/// The predicates themselves stay wiring-owned, which is the
-/// split gui.md draws: the census `gate:` names the *setting*
-/// that decides, and the exact question — resolved override
-/// chains, auto sentinels — lives here with the values it reads.
-/// Three of them ask about per-space overrides as well as the
-/// global, and that is not an inconsistency to tidy away: the
-/// census names both owners for exactly those three rows (#406 —
-/// gate on the RESOLVED value, since a control the global would
-/// silence is still live for a space that overrides it), and
-/// names one owner only where the override half is **Lua-only**
-/// and so cannot be surfaced (grid auto-size, track
-/// auto-tracks). A row whose override twin IS in the GUI and is
-/// gated on one owner is that bug, not that exception.
-///
-/// Returning the *reason* rather than a bare Bool is deliberate:
-/// why-you-cannot is always inline (item 19), so a row that
-/// greys and a row that explains why it greys must not be two
-/// decisions that can disagree. The reason is a CASE, and
-/// `LayoutDefaultsGateHelp` renders the sentence — the same
-/// split Core and the GUI keep (#96), and what lets the whole
-/// resolver be asserted off the main actor.
+/// Resolves inert row gates and reasons for Layout Defaults settings
+/// (#678 Phase 3, #406, #96).
 struct LayoutDefaultsGates {
     let settings: TilingSettings
 
-    /// Why a row is inert. Each case is one predicate over the
-    /// staged config; the sentence lives with the renderer.
+    /// Why a setting row is inert.
     enum InertReason: Hashable {
         case oneMaster
         case rigidGrid
@@ -47,15 +15,7 @@ struct LayoutDefaultsGates {
         case scrollAnimationOff
     }
 
-    /// Why `key`'s row is inert right now, or nil while it is
-    /// live. Fail-OPEN on a gate this type does not own — loud in
-    /// debug, live in release — matching `BarsGates` and
-    /// `ShortcutsGates`, which is the one policy this
-    /// codebase has for the class: a missing case must not lock a
-    /// shipped Settings row, and of the two silent readings, a
-    /// live row the user can ignore beats a dead one they cannot
-    /// explain. `everyGatedRowIsResolved` keeps that arm
-    /// unreachable rather than merely believed to be.
+    /// Resolves inert reason for setting key (fail-open if unhandled).
     func inertReason(for key: SettingKey) -> InertReason? {
         guard key.placement.gate != nil else { return nil }
         switch key {
@@ -78,10 +38,6 @@ struct LayoutDefaultsGates {
         }
     }
 
-    /// The gated rows this resolver answers. Data, so the guard
-    /// asserts the split against the census instead of restating
-    /// it — a new gated row in this area lands in neither set and
-    /// reds.
     static let resolved: Set<SettingKey> = [
         .layout(.stackMasterOrientation),
         .layout(.gridFillEmptyCells),
@@ -91,37 +47,9 @@ struct LayoutDefaultsGates {
         .colours(.animationsScrollDurationMS),
     ]
 
-    /// Gated rows the area declares but resolves elsewhere. Empty
-    /// today, and kept as a declared slot rather than dropped:
-    /// its absence is what would otherwise make a future
-    /// unanswerable gate look like an omission instead of a
-    /// decision.
     static let resolvedElsewhere: Set<SettingKey> = []
 
-    // MARK: - The predicates
-
-    /// Whether any overriding space's RESOLVED grid satisfies
-    /// `predicate`.
-    ///
-    /// A control on this GLOBAL editor is inert only when nothing
-    /// still reads it — and a per-space override can keep it live
-    /// after the global condition would silence it. Asking the
-    /// global alone greys a control that is running, the worse of
-    /// the two failure directions (#520 wrote the rule one level
-    /// down: ask the value that is actually read, never the
-    /// global; #527 found this pair still asking the global).
-    ///
-    /// Resolved through Core's own `resolvedGrid(for:)` rather
-    /// than off the raw override fields, because the per-space
-    /// surface that draws the same condition and shows the same
-    /// sentence resolves it that way — two surfaces answering
-    /// "is this Space rigid" differently is the drift the
-    /// resolver exists to prevent.
-    ///
-    /// Deliberately ignores whether that space also overrides the
-    /// gated value itself. If it does, the control is inert for
-    /// it and we leave it enabled anyway — erring toward enabled
-    /// is the safe direction here.
+    /// Checks if any space override satisfies predicate (#520, #527).
     private func anyOverridingSpace(
         _ predicate: (GridParams) -> Bool
     ) -> Bool {
@@ -130,27 +58,16 @@ struct LayoutDefaultsGates {
         }
     }
 
-    /// Fill-empty applies to dynamic grids only, so a rigid
-    /// global silences it — unless a space overrides its type
-    /// back to dynamic, which makes the global value live again.
     private var fillEmptyIsInert: Bool {
         settings.grid.type == .rigid
             && !anyOverridingSpace { $0.type == .dynamic }
     }
 
-    /// Auto-size supplies the dimensions, so it silences the
-    /// Columns/Rows steppers — unless a space overrides auto-size
-    /// OFF, which makes the global dimensions live for it.
     private var dimensionsAreInert: Bool {
         settings.grid.autoSize
             && !anyOverridingSpace { !$0.autoSize }
     }
 
-    /// Orientation only changes anything with more than one
-    /// master — and the count that decides is the RESOLVED one,
-    /// since a space overriding it to several masters reads this
-    /// orientation whatever the global says. The census names
-    /// both owners for this row for that reason.
     private var masterOrientationIsInert: Bool {
         settings.stack.masterCount <= 1
             && !settings.stack.override.keys.contains {
@@ -159,11 +76,7 @@ struct LayoutDefaultsGates {
     }
 }
 
-/// The why-you-cannot sentences for the Layout Defaults rows —
-/// one per `LayoutDefaultsGates.InertReason`, so the compiler
-/// refuses a reason with nothing to say. Authored beside the
-/// predicates that raise them, so a gate and its explanation are
-/// edited together.
+/// User-facing explanations for inert Layout Defaults settings (#96).
 @MainActor
 enum LayoutDefaultsGateHelp {
     static func sentence(

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutDefaultsGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutDefaultsGates.swift
@@ -47,6 +47,10 @@ struct LayoutDefaultsGates {
         .colours(.animationsScrollDurationMS),
     ]
 
+    /// Gated rows the area declares but resolves elsewhere. Empty
+    /// today, and kept as a declared slot rather than dropped: its
+    /// absence would make a future unanswerable gate look like an
+    /// omission instead of a decision.
     static let resolvedElsewhere: Set<SettingKey> = []
 
     /// Checks if any space override satisfies predicate (#520, #527).

--- a/Sources/KiwiDesk/Settings/HomeCardPlate+Bars.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardPlate+Bars.swift
@@ -2,41 +2,18 @@ import CoreGraphics
 import KiwiDeskCore
 import SwiftUI
 
-/// The Bars picture: each bar the desktop actually shows, as a
-/// plate on its own edge in its own fill, the desktop well
-/// between them. The edge-most bar on a shared edge is the
-/// Space Bar, matching the real bars' own coexistence order
-/// (`SpaceBarOverlay`); the Settings strip once named here as
-/// the precedent was retired in #793, when the panels took
-/// its last mount. The scene keeps a screen's shape (16:10, centred)
-/// rather than stretching to its container, and the bars
-/// answer their own Style rows: alignment seats the item run,
-/// `background_fit` decides hug vs span, corner roundness and
-/// item gap remap through the styles' own resolutions, and the
-/// active item is marked per `active_indicator` (owner batch,
-/// 2026-08-10).
+/// Schematic preview of configured App Bar and Space Bar strips
+/// (#793, owner 2026-08-10).
 struct HomeCardBarsTile: View {
     let settings: TilingSettings
-    /// The DRAFT's real space count — the pips are an answer,
-    /// not decoration (owner 2026-08-10: the mock's constant
-    /// three lied next to a six-space profile). Capped in the
-    /// drawing so a Lua-sized space list cannot overflow a
-    /// plate.
+    /// Real space count from draft (owner 2026-08-10).
     var spaceCount: Int = 3
-    /// 1 on the Home plate; the Bars detail panel mounts this
-    /// same scene larger — one renderer, two sizes, never a
-    /// second drawing.
+    /// Scale factor (1 on home plate, larger in detail panel).
     var scale: CGFloat = 1
-    /// Per-space identifiers, the real bar's two-accent model:
-    /// the stored icon, else the space's number. Empty on the
-    /// Home plate — a thumbnail drops a fact it has no room to
-    /// render by not drawing it (the scale rule), so labels
-    /// draw only where the panel passes them.
+    /// Space identifiers for panel scale rendering.
     var spaceLabels: [String] = []
     @Environment(\.schematicPalette) private var palette
 
-    /// One bar item: the pip's colour and along-axis length,
-    /// plus — at panel scale — the identifier it carries.
     struct BarItem {
         var color: String
         var length: CGFloat
@@ -45,50 +22,22 @@ struct HomeCardBarsTile: View {
         var active = false
     }
 
-    /// The style facts one strip draws from — read off the real
-    /// style struct at the call site, so the scene cannot
-    /// answer a row the style did not.
     struct BarSpec {
         var fill: String
         var highlight: String
         var items: [BarItem]
         var alignment: AppBarStyle.BarAlignment
-        /// The style's own `plateSpans` — the one copy of the
-        /// hug/span rule.
         var spans: Bool
-        /// Boxed draws no shared plate; each ITEM wears its
-        /// own box in the fill colour instead.
         var boxed: Bool
-        /// The strip's cross size, the real thickness through
-        /// the mock remap — the Thickness slider moves the
-        /// scene (owner 2026-08-10).
         var thickness: CGFloat
-        /// Corner roundness resolved PER SHAPE at its own
-        /// cross size, the real bar's rule: the plate at the
-        /// strip's thickness, an item at its own.
         var corner: CGFloat
         var itemCorner: CGFloat
         var gap: CGFloat
         var indicator: AppBarStyle.ActiveIndicator
-        /// Item text/glyph size through the bar's OWN font
-        /// ladder at the strip's scene cross — the real auto
-        /// rule scales fonts with thickness, so the Thickness
-        /// slider moves the symbols with the plate (owner
-        /// 2026-08-10).
         var fontSize: CGFloat
     }
 
-    /// Every DISTINCT edge an enabled bar-hosting layout's App
-    /// Bar resolves to — `appBarHosts` is Core's one place that
-    /// decides hosting, and `resolved(with:)` honors per-layout
-    /// edge overrides, the same resolution
-    /// `spaceBarSharesEdgeWithAppBar` reads (review 2026-08-10:
-    /// the raw global edge previewed an overridden bar on the
-    /// wrong side). Stated residue, the #708 shape: the real
-    /// desktop shows ONE layout's bar at a time; this scene
-    /// draws every enabled host's edge at once, because a
-    /// picture of the draft cannot know which layout the user
-    /// will stand in.
+    /// Distinct edges of enabled App Bar hosts (#708; review 2026-08-10).
     private var appBarEdges: Set<AppBarEdge> {
         Set(
             settings.appBarHosts
@@ -111,14 +60,7 @@ struct HomeCardBarsTile: View {
             }
             columnBars(.right)
         }
-        // A screen's own shape, centred — the scene never
-        // stretches to its container (owner 2026-08-10; the
-        // Gaps tile's precedent).
         .padding(3)
-        // The implied screen outline, the Gaps tile's idiom —
-        // the scene reads as a display, not loose chrome
-        // (owner 2026-08-10; deliberately no Monitors stand,
-        // which claims physical-arrangement knowledge).
         .overlay(
             RoundedRectangle(cornerRadius: 5)
                 .strokeBorder(
@@ -146,9 +88,6 @@ struct HomeCardBarsTile: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    /// The bars on a horizontal edge, edge-most first for
-    /// `.top` and window-most first for `.bottom`, so both hug
-    /// the screen edge.
     @ViewBuilder
     private func rowBars(_ edge: AppBarEdge) -> some View {
         if edge == .top {
@@ -207,12 +146,6 @@ struct HomeCardBarsTile: View {
         }
     }
 
-    /// One active pip plus an inactive pip per further declared
-    /// space, capped at eight so the strip never overflows its
-    /// plate — the cap is a drawing limit, not a claim about
-    /// the space list. With labels (panel scale) each pip
-    /// carries its space's identifier in the bar's two-accent
-    /// model.
     private func spaceItems(
         _ style: SpaceBarStyle
     ) -> [BarItem] {
@@ -271,22 +204,11 @@ struct HomeCardBarsTile: View {
         }
     }
 
-    /// Three mock windows at panel scale — recognisable app
-    /// shapes (mail, browser, files), never real app claims
-    /// (owner 2026-08-10 over two identical windows); bare
-    /// pips on the Home plate. What each item shows follows
-    /// the style's own `content` row through the real
-    /// `rendered(horizontal:)` remap, so a vertical bar drops
-    /// names exactly like the real bar does.
+    /// Mock window items at panel scale (owner 2026-08-10).
     private func appItems(
         _ style: AppBarStyle,
         vertical: Bool
     ) -> [BarItem] {
-        // Window TITLES, not app names — the bar draws a title,
-        // so a preview labelled "Mail / Web / Files" would show
-        // the one thing the setting no longer does. Each still
-        // pairs with its app's glyph, which is what the icon
-        // slot really draws.
         let mocks: [(glyph: String, title: String)] = [
             ("envelope", L("bars_scene.title_mail", "Inbox")),
             ("globe", L("bars_scene.title_web", "News")),
@@ -319,18 +241,11 @@ struct HomeCardBarsTile: View {
         return items
     }
 
-    /// The item-gap remap into the scene's own span, the strip
-    /// mock's scale idiom: the stored 0–40 pt band lands on
-    /// 1–7 scene points so a gap drag stays perceptible at
-    /// either mount size.
     private func gapSpacing(_ real: CGFloat) -> CGFloat {
         let t = min(max(real / 40, 0), 1)
         return (1 + t * 6) * scale
     }
 
-    /// The thickness remap, same idiom: the stored 20–80 pt
-    /// band lands on 13–22 scene points per mount scale, so
-    /// the Thickness slider visibly moves the scene.
     private func crossSize(_ real: CGFloat) -> CGFloat {
         let t = min(max((real - 20) / 60, 0), 1)
         return (13 + t * 9) * scale

--- a/Sources/KiwiDesk/Settings/LinkedCaption.swift
+++ b/Sources/KiwiDesk/Settings/LinkedCaption.swift
@@ -1,9 +1,13 @@
 import AppKit
 import SwiftUI
 
-/// Caption sentence with an embedded clickable link formatted via AppKit
-/// (device 2026-08-03, code review 2026-08-12;
-/// tested in `LinkedCaptionHitTests`).
+/// Caption sentence with an embedded clickable link, laid out by
+/// AppKit (`LinkedCaptionHitTests`). SwiftUI's own `.link` run
+/// navigates but gives NO pointing-hand cursor (device
+/// 2026-08-03) — the affordance that says a caption is followable
+/// — and `NSLayoutManager` is also what breaks lines correctly
+/// mid-paragraph in ja/ko/zh, exactly the locales the
+/// name-in-sentence frame exists for.
 struct LinkedCaption: NSViewRepresentable {
     let leading: String
     let linkTitle: String
@@ -16,6 +20,11 @@ struct LinkedCaption: NSViewRepresentable {
     @Environment(\.isEnabled) private var isEnabled
 
     func makeNSView(context: Context) -> CaptionTextView {
+        // A SELECTABLE text view cannot be talked out of the
+        // I-beam — its own tracking area outranks any cursor rects
+        // a subclass sets, and an I-beam over a caption says "type
+        // here" (`resetCursorRects` was tried and lost, device
+        // 2026-08-03).
         let view = CaptionTextView.configured()
         view.delegate = context.coordinator
         return view
@@ -57,7 +66,11 @@ struct LinkedCaption: NSViewRepresentable {
         )
     }
 
-    /// Splits frame text around the `%1$@` link format specifier.
+    /// Splits the RAW frame at `%1$@` — the label is drawn AT the
+    /// specifier, never formatted into it: a frame already through
+    /// `String(format:)` has nothing left to draw at, which is how
+    /// the tour's closing card shipped words with no link under
+    /// them.
     static func split(frame: String) -> (String, String) {
         guard let slot = frame.range(of: "%1$@") else {
             assertionFailure("frame has no link slot")
@@ -76,6 +89,11 @@ struct LinkedCaption: NSViewRepresentable {
         )
     }
 
+    /// Built by hand rather than converted from an
+    /// `AttributedString`: SwiftUI's and AppKit's attribute scopes
+    /// name these differently, and a silently unmapped `.link`
+    /// renders as plain text that still passes every word-level
+    /// test.
     private var sentence: NSAttributedString {
         let out = NSMutableAttributedString()
         out.append(NSAttributedString(string: leading))
@@ -107,6 +125,9 @@ struct LinkedCaption: NSViewRepresentable {
         )
     }
 
+    /// A run needs a URL to BE a link. Nothing resolves this
+    /// scheme — every activation route is wired to `onLink`, and
+    /// none of them opens it.
     private static let href = URL(
         string: "kiwidesk-settings://cross-reference"
     )!

--- a/Sources/KiwiDesk/Settings/LinkedCaption.swift
+++ b/Sources/KiwiDesk/Settings/LinkedCaption.swift
@@ -1,71 +1,21 @@
 import AppKit
 import SwiftUI
 
-/// One caption sentence with a single word or phrase in it
-/// rendered as a link, laid out by AppKit's text system.
-///
-/// SwiftUI's own `Text` can carry a `.link` run and it navigates,
-/// but it gives that run no pointing-hand cursor — confirmed on
-/// device 2026-08-03, which is why this exists. The cursor is
-/// the affordance that says a caption is followable at all, and
-/// the row this replaced had one (a `Button` wearing
-/// `linkHover()`), so losing it was a regression, not a trade.
-///
-/// AppKit is the right tool for the other half too. This sentence
-/// exists so a translation can place the destination's name where
-/// its own word order wants it, which means the name can land
-/// mid-paragraph, which means the paragraph has to break lines
-/// correctly around it in `ja`, `ko`, `zh-Hans` and `zh-Hant` —
-/// languages that do not break on spaces. `NSLayoutManager` does
-/// that; a `FlowLayout` over word-split `Text`s does not, and it
-/// would fail hardest for exactly the locales the change is for.
-///
-/// **Replacing a `Button` means re-earning what a `Button` gave
-/// away free**, and the first cut of this file did not: focus,
-/// keyboard activation and VoiceOver are non-negotiable under
-/// gui.md's north star however much the window's look is
-/// KiwiDesk's own, and a non-selectable `NSTextView` supplies
-/// none of them. `CaptionTextView` puts all three back by hand —
-/// see its own docs — and honours `isEnabled`, which `.disabled()`
-/// sets in the SwiftUI environment and cannot reach an AppKit
-/// subview on its own.
-///
-/// Follows `LuaSourceEditor` (`Components/Lua/LuaEditorTab.swift`)
-/// as the tree's existing `NSTextView` bridge.
+/// Caption sentence with an embedded clickable link formatted via AppKit
+/// (device 2026-08-03, code review 2026-08-12;
+/// tested in `LinkedCaptionHitTests`).
 struct LinkedCaption: NSViewRepresentable {
     let leading: String
     let linkTitle: String
     let trailing: String
     let navigate: () -> Void
-    /// The prose's size and its resting ink.
-    ///
-    /// Defaulted to the caption tier every cross-reference row
-    /// draws at, so those call sites say nothing. The tour passes
-    /// its own: its footer hints are 12.5 pt `ink3`, and a link
-    /// sentence arriving at the system caption size in the
-    /// system's secondary grey made the ONE screen with a link in
-    /// it read a tier apart from the other four (code review,
-    /// 2026-08-12).
     var pointSize: CGFloat = NSFont.preferredFont(
         forTextStyle: .caption1
     ).pointSize
     var ink: NSColor = .secondaryLabelColor
-    /// `.disabled()` is environment-only, so an `NSView` inside a
-    /// representable keeps its own tracking areas and hit
-    /// testing and would stay live inside a `GreyOut`. Read here
-    /// and handed down.
     @Environment(\.isEnabled) private var isEnabled
 
     func makeNSView(context: Context) -> CaptionTextView {
-        // Every caption property lives in `configured()`,
-        // which the test fixture builds through as well and
-        // `LinkedCaptionHitTests` asserts. A
-        // SELECTABLE text view cannot be talked out of the
-        // I-beam: it drives the cursor from its own tracking
-        // area, which outranks the cursor rects a subclass can
-        // set, and an I-beam over a caption says "type here"
-        // (observed on device 2026-08-03, after
-        // `resetCursorRects` was tried and lost).
         let view = CaptionTextView.configured()
         view.delegate = context.coordinator
         return view
@@ -107,21 +57,7 @@ struct LinkedCaption: NSViewRepresentable {
         )
     }
 
-    /// The prose either side of a frame's link slot.
-    ///
-    /// Splits the RAW frame at `%1$@` — the label is drawn AT
-    /// the specifier rather than formatted into it, so a frame
-    /// that has already been through `String(format:)` has
-    /// nothing left to draw at, which is how the tour's closing
-    /// card first shipped the words with no link under them.
-    /// (`CrossReferenceRow` splits at U+FFFC instead, its prose
-    /// arriving already formatted; the two sentinels are the two
-    /// shapes, not a duplication to merge.)
-    ///
-    /// A frame with no slot is a programming error rather than a
-    /// shape to support, so this asserts in debug and still
-    /// renders a followable sentence in release rather than
-    /// dropping the link on a user.
+    /// Splits frame text around the `%1$@` link format specifier.
     static func split(frame: String) -> (String, String) {
         guard let slot = frame.range(of: "%1$@") else {
             assertionFailure("frame has no link slot")
@@ -133,7 +69,6 @@ struct LinkedCaption: NSViewRepresentable {
         )
     }
 
-    /// The link's characters within ``sentence``.
     private var linkRange: NSRange {
         NSRange(
             location: (leading as NSString).length,
@@ -141,17 +76,6 @@ struct LinkedCaption: NSViewRepresentable {
         )
     }
 
-    /// Built here rather than converted from an
-    /// `AttributedString`: SwiftUI's attribute scope and
-    /// AppKit's do not name these attributes the same way, and a
-    /// silently unmapped `.link` would render as plain text that
-    /// still passes every test asserting the sentence's words.
-    ///
-    /// The link's underline is set on the RUN rather than
-    /// through `linkTextAttributes`, which a non-selectable view
-    /// does not apply. `.link` stays on it as the marker the hit
-    /// test reads; `CaptionTextView` owns the colour, which
-    /// lifts on hover.
     private var sentence: NSAttributedString {
         let out = NSMutableAttributedString()
         out.append(NSAttributedString(string: leading))
@@ -175,14 +99,7 @@ struct LinkedCaption: NSViewRepresentable {
         return out
     }
 
-    /// A `▸` breadcrumb carries a break opportunity on each side,
-    /// so "Layout Defaults ▸ Scrolling" could start a line on
-    /// "▸ Scrolling" under a hanging underline, which reads as a
-    /// typo. Bound the separator with non-breaking spaces HERE
-    /// rather than in the catalogs: it is invisible to
-    /// translators, and it leaves the title breakable elsewhere,
-    /// which the German and Russian ones need at the narrowest
-    /// window width.
+    /// Replaces separator spaces with non-breaking spaces around breadcrumbs.
     private static func tightened(_ title: String) -> String {
         title.replacingOccurrences(
             of: " ▸ ",
@@ -190,19 +107,11 @@ struct LinkedCaption: NSViewRepresentable {
         )
     }
 
-    /// A run needs a URL to BE a link. Nothing resolves this
-    /// scheme — the app registers no `CFBundleURLTypes` — so
-    /// every activation route is wired to `onLink` instead,
-    /// `clickedOnLink` included, and none of them opens it.
     private static let href = URL(
         string: "kiwidesk-settings://cross-reference"
     )!
 
     final class Coordinator: NSObject, NSTextViewDelegate {
-        /// The path an accessibility activation and any
-        /// AppKit-offered "Open Link" take. Returning `true`
-        /// claims the click so the unresolvable URL above is
-        /// never handed to the workspace.
         func textView(
             _ view: NSTextView,
             clickedOnLink link: Any,

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+Overrides.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+Overrides.swift
@@ -39,7 +39,16 @@ extension SpacesSection {
                     space: space,
                     pendingResetAll: $pendingResetAll
                 )
+                // Bounded at 700, deliberately: the `.menu`
+                // picker exception (#291) is argued from these
+                // rows sitting in a bounded column, and a width
+                // fix has no business retiring a settled control
+                // ruling as a side effect.
                 .frame(maxWidth: 700, alignment: .leading)
+                // Win the width negotiation, or a preview can
+                // overconstrain the HStack and spill over these
+                // rows' trailing checkboxes — which silently
+                // swallowed clicks until a re-render settled.
                 .layoutPriority(1)
             }
             resetActiveButton(space, mode: mode, gates: gates)
@@ -50,6 +59,10 @@ extension SpacesSection {
     private func overridesBreadcrumb(_ space: SpaceID) -> some View {
         HStack(spacing: 6) {
             Button {
+                // State the return destination BEFORE the pop —
+                // a focus assigned after the branch swaps has no
+                // view to land on and is dropped (#678 Phase 4
+                // pass 10, turn 20a rule 4).
                 returningRow = space
                 model.nav.spaceOverridesFocus = nil
             } label: {
@@ -73,6 +86,9 @@ extension SpacesSection {
         .lineLimit(1)
         .padding(.horizontal, SettingsMetrics.paneInset)
         .padding(.vertical, 10)
+        // Entering the sub-view puts focus on the back button —
+        // never inside the rows, which would strand a keyboard
+        // user one Shift-Tab short of the only way out.
         .onAppear { overridesBackFocused = true }
     }
 

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+Overrides.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+Overrides.swift
@@ -1,21 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The pushed per-space override editor (#678 8b), replacing the
-/// #205 Customize popover. The popover capped the editing surface
-/// at 392 pt — "the app's narrowest editing surface," by its own
-/// docstring — which a side-by-side live preview cannot fit; the
-/// full pane can. This is a view-state branch of `SpacesSection`
-/// driven by `model.nav.spaceOverridesFocus`, not a
-/// `SettingsSurface`: the override controls are per-space and
-/// uncataloged, so there is nothing for search or the #326 bridge
-/// to reveal — the breadcrumb's back segment is the whole
-/// navigation.
-///
-/// This chrome owns the header — the breadcrumb, the title, and
-/// the active-layout reset (top-right, the destructive action that
-/// concerns the rows below it) — while `SpaceOverrideRows` draws
-/// the rows card and the dormant "saved for other layouts" card.
+/// Pushed per-space override editor (#678 8b, #205, #326, #794).
 extension SpacesSection {
     @ViewBuilder
     func overridesEditor(_ space: SpaceID) -> some View {
@@ -39,15 +25,7 @@ extension SpacesSection {
         }
     }
 
-    /// The rows and, BENEATH them, the reset that acts on them.
-    ///
-    /// The button used to ride the header's trailing edge, which
-    /// put it at the far side of the PANE while the rows cap at
-    /// 520 — a lone control floating in a void with the card
-    /// squeezed to the left of it (owner, on device,
-    /// 2026-08-16). Under the column it reads as that column's
-    /// action, which is what it is, and the header goes back to
-    /// being a title.
+    /// Override rows and reset button (owner 2026-08-16, #291, #794).
     @ViewBuilder
     private func overridesBody(
         _ space: SpaceID,
@@ -61,61 +39,17 @@ extension SpacesSection {
                     space: space,
                     pendingResetAll: $pendingResetAll
                 )
-                // The 520 pt cap is GONE, and with it the
-                // reason it existed: it reserved the rest of
-                // the pane for the live preview that used to
-                // sit beside these rows, and #794 moved that
-                // preview into the detail panel. What was left
-                // was a card squeezed to 520 in a pane three
-                // times as wide, truncating its own inherited
-                // readouts — "folgt Scrolling-Standards ·
-                // Hor…" — with the space to finish the sentence
-                // sitting empty beside it (owner, on device,
-                // 2026-08-16). Widening the OVERRIDE column to
-                // fit German took another 24 pt off the same
-                // text.
-                //
-                // Still BOUNDED, at 700 rather than 520: the
-                // `.menu` picker exception (#291) is argued in
-                // `docs/ui-patterns.md` from these rows sitting
-                // in a bounded column, and a width fix has no
-                // business retiring a settled control ruling as
-                // a side effect. 700 finishes the readout and
-                // leaves that argument standing.
                 .frame(maxWidth: 700, alignment: .leading)
-                // Win the width negotiation, so no preview can
-                // overconstrain the HStack and spill its frame
-                // over these rows' trailing checkboxes — which
-                // silently swallowed clicks on a scrolling
-                // space until any re-render settled the layout.
                 .layoutPriority(1)
-                // The live preview LEFT in #794: the
-                // detail panel now draws the Space whose
-                // editor is open (`SpacesPanelPreview`
-                // reads `nav.spaceOverridesFocus`), and
-                // one screen must not state one fact
-                // twice — the migration rule every other
-                // panel area already follows.
             }
-            // Under the rows it acts on, left-aligned with them
-            // rather than pinned to the pane's far edge.
             resetActiveButton(space, mode: mode, gates: gates)
         }
     }
 
-    /// `‹ Spaces › <space> › Overrides` — the first crumb is a
-    /// standard `Button` back to the list, so it keeps focus,
-    /// keyboard activation and VoiceOver for free; there is only
-    /// one back target, since the per-space editor has no
-    /// intermediate space page.
+    /// Breadcrumb navigation with back button (#678 Phase 4 turn 20a).
     private func overridesBreadcrumb(_ space: SpaceID) -> some View {
         HStack(spacing: 6) {
             Button {
-                // State the return destination BEFORE the pop, so
-                // the list is built with it already set — a focus
-                // assigned after the branch swaps has no view to
-                // land on yet and is dropped (#678 Phase 4 pass
-                // 10, turn 20a rule 4).
                 returningRow = space
                 model.nav.spaceOverridesFocus = nil
             } label: {
@@ -125,12 +59,6 @@ extension SpacesSection {
                 )
             }
             .focused($overridesBackFocused)
-            // `.borderless` takes its label colour from the tint
-            // too, so this crumb read green while the shell's own
-            // back chip — same gesture, same chevron — is ink
-            // (`SettingsHeaderBar.backChip`). The chevron carries
-            // "this one goes back"; the colour was carrying it
-            // twice, in the one hue reserved for fills.
             .buttonStyle(.borderless)
             .neutralButtonLabel()
             crumbSeparator
@@ -145,12 +73,6 @@ extension SpacesSection {
         .lineLimit(1)
         .padding(.horizontal, SettingsMetrics.paneInset)
         .padding(.vertical, 10)
-        // Entering the sub-view puts focus on its back button —
-        // never inside the rows, which would strand a keyboard
-        // user one Shift-Tab short of the only way out. On the
-        // crumb rather than the editor's root so it fires when
-        // this view is built, which is the moment the branch
-        // swaps.
         .onAppear { overridesBackFocused = true }
     }
 
@@ -158,11 +80,7 @@ extension SpacesSection {
         Text(verbatim: "›").foregroundStyle(.tertiary)
     }
 
-    /// The title and the active-layout reset. The reset lives here
-    /// rather than in the footer (#678 8b): it acts on the rows
-    /// directly below it, so it reads as their action; the dormant
-    /// card's `Reset all…` stays with the *other* layouts it
-    /// concerns.
+    /// Header with title and active layout fraction (#678 8b).
     private func overridesHeader(
         _ space: SpaceID,
         mode: LayoutMode,
@@ -184,8 +102,6 @@ extension SpacesSection {
             )
             .font(.title2)
             .fontWeight(.semibold)
-            // The active layout's set-vs-total fraction; Floating
-            // has no override fields (capacity 0) so it shows none.
             if capacity > 0 {
                 Text(
                     L(
@@ -221,9 +137,6 @@ extension SpacesSection {
             model.config.settings.resetOverride(mode, for: space)
         }
         .buttonStyle(.bordered)
-        // "Grey, don't hide" (§2.7): the reset is furniture of the
-        // active section, greyed when the layout has nothing to
-        // reset, with the reason on hover.
         .disabled(reason != nil)
         .help(reason.map(SpacesGateHelp.sentence) ?? "")
     }

--- a/Sources/KiwiDesk/Settings/SettingsFloatingPanel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsFloatingPanel.swift
@@ -50,7 +50,13 @@ struct SettingsFloatingPanel: View {
     }
 }
 
-/// Draggable card chrome holding stored child content (#678 turn 17a, #758).
+/// Draggable card chrome holding a STORED child (#678 turn 17a).
+/// Load-bearing split: a drag invalidates the gesture-declaring
+/// view's body every frame, and building the panel inside it
+/// re-ran the whole draft diff per frame — the card stuttered
+/// under the pointer (owner, on device). Never move the
+/// `@GestureState` back up into a view that builds the preview,
+/// and never build the preview inline.
 private struct MovableCard<Content: View>: View {
     let bounds: CGSize
     let close: () -> Void
@@ -106,6 +112,9 @@ private struct MovableCard<Content: View>: View {
             )
             .strokeBorder(SettingsTheme.planeRing, lineWidth: 1)
         )
+        // Without this the shadow halos every primitive inside
+        // the card (#758's lesson); it also gives the drag ONE
+        // composited layer to translate.
         .compositingGroup()
         .shadow(color: .black.opacity(0.18), radius: 18, y: 8)
     }

--- a/Sources/KiwiDesk/Settings/SettingsFloatingPanel.swift
+++ b/Sources/KiwiDesk/Settings/SettingsFloatingPanel.swift
@@ -1,47 +1,21 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The preview panel once the window is too narrow to give it a
-/// column of its own (#678 turn 17a): the same
-/// `SettingsDetailPanel`, floating over the content as a card
-/// you can move out of the way or close.
-///
-/// **The same card in both narrow bands.** Between 900 and 1200
-/// it opens with the screen; below 900 it waits behind "Show
-/// preview". One mechanism, two defaults
-/// (`SettingsWidthClass.floatsPreviewByDefault`) — so the thing
-/// the user closes at 1100 and the thing they summon at 820 is
-/// the same object, not two features.
-///
-/// The prototype's "auto-raises while you drag a slider" needs
-/// no code: an overlay is already above every row, and the card
-/// moves rather than the content moving under it.
+/// Floating preview panel for narrow window widths (#678 turn 17a).
 struct SettingsFloatingPanel: View {
     @ObservedObject var model: SettingsModel
     let destination: SettingsDestination
-    /// The content area the card floats over — its own size and
-    /// its travel both derive from this, so the card cannot be
-    /// dragged out of the window.
     let bounds: CGSize
     let close: () -> Void
 
-    /// The card's ceiling. It floats over content the user is
-    /// still reading, so it takes a fixed share rather than the
-    /// full height a docked panel gets — and a fixed number is
-    /// also what makes the travel clamp exact arithmetic rather
-    /// than a guess about the panel's intrinsic height.
     static let maxHeight: CGFloat = 520
-
-    /// The gutter between the card and the content's edges, at
-    /// rest and as the travel limit.
     static let inset = SettingsMetrics.paneInset
 
     static func height(in bounds: CGSize) -> CGFloat {
         max(min(maxHeight, bounds.height - 2 * inset), 200)
     }
 
-    /// The card's resting origin: the content area's trailing
-    /// top corner, one gutter in.
+    /// Resting origin at trailing top corner.
     static func origin(in bounds: CGSize) -> CGPoint {
         CGPoint(
             x: bounds.width - SettingsTheme.panelWidth - inset,
@@ -49,11 +23,7 @@ struct SettingsFloatingPanel: View {
         )
     }
 
-    /// Clamps a proposed travel so the card always lands whole
-    /// inside `bounds`. Pure and static so the responsive suite
-    /// can assert the limits without mounting a window — the
-    /// failure this prevents is a preview dragged off the
-    /// bottom of a 720 pt window with no way to get it back.
+    /// Clamps proposed drag offset to stay inside bounds.
     static func clamp(
         _ proposed: CGSize,
         in bounds: CGSize
@@ -70,10 +40,6 @@ struct SettingsFloatingPanel: View {
         )
     }
 
-    /// The panel is built HERE and handed to `MovableCard` as a
-    /// stored child — which is the whole reason that type
-    /// exists. See its docstring: the drag must not re-enter
-    /// this body.
     var body: some View {
         MovableCard(bounds: bounds, close: close) {
             SettingsDetailPanel(
@@ -84,36 +50,11 @@ struct SettingsFloatingPanel: View {
     }
 }
 
-/// The card chrome and the drag, with the preview as a STORED
-/// child (#678 turn 17a).
-///
-/// The split is a performance decision, and it is load-bearing
-/// rather than tidiness: a drag emits a gesture update per
-/// frame, and every update invalidates the body of whichever
-/// view declares the gesture state. With the panel built inside
-/// that body, each frame re-ran `SettingsDetailPanel` — which
-/// diffs the whole draft (`SettingsDiffRowSource.rows`) and
-/// redraws a live schematic — and the card visibly stuttered
-/// under the pointer (owner, on device). Declaring the gesture
-/// one level down, over a child that was already built, leaves
-/// the drag re-rendering the chrome and translating a subtree
-/// whose value never changes.
-///
-/// So: never move the `@GestureState` back up into a view that
-/// builds the preview, and never build the preview inline here.
+/// Draggable card chrome holding stored child content (#678 turn 17a, #758).
 private struct MovableCard<Content: View>: View {
     let bounds: CGSize
     let close: () -> Void
-    /// Where the user has put the card, as an offset from its
-    /// resting corner. Per-mount — a card dragged aside in Bars
-    /// starts back in the corner in Shortcuts, which is where
-    /// the eye looks for it — and that is true only because the
-    /// MOUNT is keyed on the destination
-    /// (`SettingsView+Preview.detachedPreview`). The structural
-    /// position is otherwise identical across an area change,
-    /// so this `@State` would simply survive it; the claim
-    /// shipped here for a day before the key existed to make it
-    /// true (code review, 2026-08-11).
+    /// Per-mount drag offset (code review, 2026-08-11).
     @State private var moved: CGSize = .zero
     @GestureState private var dragging: CGSize = .zero
     @ViewBuilder let content: Content
@@ -159,37 +100,18 @@ private struct MovableCard<Content: View>: View {
             )
             .strokeBorder(SettingsTheme.hairline)
         )
-        // The 16b seam: the black shadow below is the card's
-        // lift in light and dies on the dark page, where this
-        // inset light line is the edge instead — by the token,
-        // never a `colorScheme` branch.
         .overlay(
             RoundedRectangle(
                 cornerRadius: SettingsTheme.cardRadius
             )
             .strokeBorder(SettingsTheme.planeRing, lineWidth: 1)
         )
-        // Without this the shadow halos every primitive inside
-        // the card, the hairline ring casting its own shadow
-        // inward (#758's lesson, re-learned on the search
-        // panel). It also gives the drag ONE composited layer
-        // to translate instead of a stack of primitives.
         .compositingGroup()
         .shadow(color: .black.opacity(0.18), radius: 18, y: 8)
     }
 
-    /// The card's handle. The drag gesture lives HERE, not on
-    /// the card: a gesture over the whole card would compete
-    /// with the diff rows' clicks and with any control the
-    /// preview grows later, and losing a click to the container
-    /// is the kind of bug nobody reports as a drag bug.
-    ///
-    /// The grip and the close button are two accessibility
-    /// elements, deliberately. A label on the row that CONTAINS
-    /// the button either renames the ×, swallows it, or is
-    /// dropped — three ways to lose one of the two keys, none
-    /// of them visible to a locale check
-    /// (`localization-auditor`, 2026-08-11).
+    /// Header grab bar with distinct grip and close button
+    /// (localization-auditor 2026-08-11).
     private var grabBar: some View {
         HStack(spacing: 8) {
             grip
@@ -209,13 +131,6 @@ private struct MovableCard<Content: View>: View {
         .padding(.bottom, 2)
     }
 
-    /// The grip, and the only thing the drag is attached to.
-    /// Its name is an INSTRUCTION, not a verb phrase: the card
-    /// moves by gesture alone, and VoiceOver cannot perform a
-    /// SwiftUI drag — an imperative would announce a command
-    /// that cannot be issued. Same shape as the spaces list's
-    /// drag handle, `.help` included so pointer users get it
-    /// too.
     private var grip: some View {
         Capsule()
             .fill(SettingsTheme.ink3.opacity(0.5))
@@ -223,10 +138,6 @@ private struct MovableCard<Content: View>: View {
             .padding(.vertical, 6)
             .contentShape(Rectangle())
             .gesture(
-                // A couple of points of slack: without it a
-                // click that twitches starts a drag, and the
-                // card jumps under a pointer that meant to
-                // press nothing.
                 DragGesture(minimumDistance: 2)
                     .updating($dragging) { value, state, _ in
                         state = value.translation

--- a/Sources/KiwiDesk/Settings/SettingsFooter.swift
+++ b/Sources/KiwiDesk/Settings/SettingsFooter.swift
@@ -1,72 +1,26 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The floating save pill (#678 redesign spec): "N
-/// unsaved changes to Desk | Revert · Save a copy… · Save",
-/// dark chrome floating over the content column. It exists
-/// only while there is something to act on — a dirty draft,
-/// profile-level edits, or layout drift — and disappears at
-/// zero (`GreyOutHidingTests` carries this file's exemption
-/// from grey-don't-hide). Owner 2026-08-09 overturned the
-/// earlier docked-footer ruling on sight — at 1440 the pill
-/// costs 74 px of gutter and covers nothing.
-///
-/// Below the row breakpoint it docks (17a, `docked:`): the same
-/// three verbs and the same count, in a full-width bar the
-/// shell gives its own height, because at 820 pt the floating
-/// version sits on top of the rows it is about. One view, two
-/// physics — never a second footer type, which is how the two
-/// would come to say different things about one draft.
-///
-/// The naming stays POSITIONAL in both forms (owner ruling
-/// 2026-08-10, re-affirmed for this pass): no locale coins a
-/// noun for it, so docking changes nothing a translator sees.
-///
-/// The verbs keep the docked footer's exact semantics per mode
-/// (#68 §3.12):
-/// - Live w/ active profile: Save = update the profile (+
-///   monitor-set refresh); Copy = snapshot into a new profile.
-/// - Stored-profile edit: Save = write that profile's JSON
-///   without switching the layout; Copy = duplicate with the
-///   pending edits (#82). A CLEAN duplicate no longer has a
-///   footer to live in — that offer stays reachable from the
-///   Profiles area, which is its home.
-/// - Live w/ no profile: the primary becomes "Save as New
-///   Profile…".
-/// - Raw-Lua editing: Save writes init.lua verbatim.
+/// Floating save pill and docked footer bar for pending changes
+/// (#678, #68 §3.12, #82).
+/// Excluded from grey-don't-hide rule (`GreyOutHidingTests`;
+/// Owner 2026-08-09, 2026-08-10).
 struct SettingsFooter: View {
     @ObservedObject var model: SettingsModel
-    /// The docked form (17a). A parameter rather than a read of
-    /// `\.settingsWidth`: the shell decides WHERE this mounts —
-    /// overlay or sibling — and a footer that answered the
-    /// width itself could disagree with the container it is in.
+    /// Renders docked bar when true (17a).
     var docked = false
     @State var namingNewProfile = false
     @State var newProfileName = ""
     @State var namingProfileCopy = false
     @State var profileCopyName = ""
-    /// The unsaved-changes popover — turn 9's third view of the
-    /// draft, moved here from the header chip (owner
-    /// 2026-08-10): the pill already narrates the draft, so the
-    /// count it carries is the one that opens the list. View
-    /// state: closing the window closes it, and nothing else
-    /// needs to open it.
+    /// Unsaved changes popover state (owner 2026-08-10).
     @State var unsavedPopoverShown = false
-    /// The pill's pending appearance announcement (#812) — held
-    /// so leaving the dirty state inside the delay cancels it:
-    /// a Save right after the edit must not hear "Unsaved
-    /// changes" over a clean tree, and a re-flip inside the
-    /// window must not stack a second post.
+    /// Delayed VoiceOver appearance announcement (#812).
     @State private var pendingAnnouncement: DispatchWorkItem?
 
-    /// How long the pill's appearance announcement waits for the
-    /// changed control's own value to be spoken first.
+    /// VoiceOver announcement delay before speaking (#812).
     static let announceDelay: TimeInterval = 1.2
 
-    /// Anything that gives a verb meaning. The
-    /// `.saveAsNewProfile` creation offer on a fully clean
-    /// setup deliberately does NOT summon the pill — creation
-    /// lives in Profiles; the pill narrates a draft.
     private var hasWork: Bool {
         model.isDirty || model.profileDirty
             || model.hasLayoutDrift
@@ -83,20 +37,6 @@ struct SettingsFooter: View {
                     )
             }
         }
-        // The pill is last in reading order on both mounts — an
-        // overlay after the content, or the sibling below it —
-        // so a VoiceOver user editing a row never reaches it and
-        // would never learn a Save is pending. Announce ONCE, as
-        // the pill appears, and never the count (owner ruling,
-        // #812 session 2: native macOS narrates no dirty state,
-        // and a count per change is noise — it is one VO-cursor
-        // move to the pill away). Delayed, because posted in the
-        // same instant as the control's own value ("7 pt") the
-        // announcement was dropped on device under keyboard
-        // stepping; the delay lets the value finish first.
-        // Silent on the way out: Save and Discard say their own
-        // outcome, so the flip to false cancels the pending
-        // post rather than letting it land on a clean tree.
         .onChange(of: hasWork) { _, now in
             pendingAnnouncement?.cancel()
             guard now else { return }
@@ -122,15 +62,8 @@ struct SettingsFooter: View {
                 L("footer.profile_name", "Profile name"),
                 text: $newProfileName
             )
-            // This label is INTERPOLATED into sentences
-            // elsewhere ("…review below, then %1$@"), and three
-            // catalogs render those frames with it as a VERB: a
-            // サ変 noun in ja, a 하다-noun in ko, and an
-            // infinitive in de ("und dann Sichern"), so those
-            // frames conjugate it. Retranslating this key to an
-            // ordinary noun would ungrammaticalise four frames
-            // at once, in three languages, and no guard reads
-            // grammar (localization audit, 2026-08-29).
+            // Interpolated as verb in de/ja/ko frames
+            // (localization audit, 2026-08-29).
             Button(L("footer.save", "Save")) {
                 model.saveAsNewProfile(named: newProfileName)
                 newProfileName = ""
@@ -165,8 +98,6 @@ struct SettingsFooter: View {
         }
     }
 
-    /// The verbs, identical in both forms — only the container
-    /// under them changes.
     private var verbs: some View {
         HStack(spacing: 12) {
             leadingReadout
@@ -208,11 +139,6 @@ struct SettingsFooter: View {
                     y: 7
                 )
             )
-            // The 16b dark construction: the self-coloured
-            // shadow above is the pill's lift in light and is
-            // invisible in dark, where the fill sits within
-            // ~1.1:1 of the page — there the inset light line
-            // is the edge.
             .overlay(
                 RoundedRectangle(
                     cornerRadius: SettingsTheme.cardRadius
@@ -224,16 +150,8 @@ struct SettingsFooter: View {
             )
     }
 
-    /// The docked form: full width, square, and trailing-aligned
-    /// so the primary verb keeps the corner the pill's did. No
-    /// shadow — a bar the window's own edge terminates is not a
-    /// floating object, and the lift that reads as elevation on
-    /// a pill reads as a smear along a full-width edge.
     private var dockedBar: some View {
         VStack(spacing: 0) {
-            // The same seam the pill's ring is: this fixed-dark
-            // plane meets the mode-varying page above it, and in
-            // dark the fill sits within ~1.1:1 of that page.
             SettingsTheme.planeRing.frame(height: 1)
             HStack(spacing: 0) {
                 Spacer(minLength: 0)

--- a/Sources/KiwiDesk/Settings/SettingsFooter.swift
+++ b/Sources/KiwiDesk/Settings/SettingsFooter.swift
@@ -21,6 +21,9 @@ struct SettingsFooter: View {
     /// VoiceOver announcement delay before speaking (#812).
     static let announceDelay: TimeInterval = 1.2
 
+    /// Anything that gives a verb meaning. The creation offer on
+    /// a fully clean setup deliberately does NOT summon the pill —
+    /// creation lives in Profiles; the pill narrates a draft.
     private var hasWork: Bool {
         model.isDirty || model.profileDirty
             || model.hasLayoutDrift
@@ -37,6 +40,13 @@ struct SettingsFooter: View {
                     )
             }
         }
+        // Announce ONCE as the pill appears, never the count
+        // (owner ruling, #812 session 2) — the pill is last in
+        // reading order, so an editing VoiceOver user would never
+        // learn a Save is pending. Delayed: posted in the same
+        // instant as the control's own value it was dropped on
+        // device. The flip to false cancels the pending post so
+        // it cannot land on a clean tree.
         .onChange(of: hasWork) { _, now in
             pendingAnnouncement?.cancel()
             guard now else { return }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Reset.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Reset.swift
@@ -13,7 +13,10 @@ extension SettingsModel {
         reload()
     }
 
-    /// Resets default layer shortcuts to current install defaults (#1096).
+    /// Resets default-layer shortcuts to what a fresh install
+    /// would seed for THIS config (#1096) — derived from the live
+    /// `spaces` and `resizeStep`, never a snapshot. Scoped to the
+    /// default layer: it is the only one the seed ever authored.
     func resetShortcutsToDefaults() {
         guard
             let index = config.layers.firstIndex(where: {
@@ -77,6 +80,14 @@ extension SettingsModel {
             || shortcutsTheResetWouldDiscard > 0
     }
 
+    /// Does `row` outlive a reset? Only rows the SEED authors are
+    /// replaced (owner ruling) — a launcher or Desktop row the
+    /// user invented is not a "customised default". Two ways a row
+    /// is the seed's, and both must go: its Lua is a shipped verb
+    /// (leaving it doubles the verb), or its COMBO is a shipped
+    /// chord (the seed reclaims that key — leaving the row puts
+    /// two bindings on it). Combos compare through `KeyCombo`, the
+    /// identity `digitTopUp` uses.
     private static func survivesReset(
         _ row: KeyBinding,
         against shipped: [KeyBinding],

--- a/Sources/KiwiDesk/Settings/SettingsModel+Reset.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Reset.swift
@@ -1,44 +1,19 @@
 import KiwiDeskCore
 
-/// The reset escape hatches — thin facades over the core, with
-/// the rows in `GeneralSection+Reset` (#634) and, since #1096,
-/// one layer-scoped reset whose row lives in `ShortcutsHeader`.
+/// Reset escape hatches for SettingsModel (#634, #1096).
 extension SettingsModel {
-    /// Tier 1. No model/dirty interaction at all: the snapshots
-    /// are not part of the edited `GuiConfig`, so nothing staged
-    /// changes and nothing needs reloading.
+    /// Tier 1: discards saved multi-monitor snapshot.
     func discardSavedArrangement() {
         core.discardSavedArrangement()
     }
 
-    /// Tier 2: reset the core, then re-read the fresh seed.
-    /// Staged edits vanish with the state they edited — the
-    /// confirmation dialog says so, and `reload` drops a
-    /// stored-profile target whose file went with the reset.
+    /// Tier 2: resets core state and reloads freshly seeded configuration.
     func resetAllSettings() {
         core.resetAllSettings(trash: KiwiCore.moveToTrash)
         reload()
     }
 
-    /// Replace the default layer's shortcuts with the set a
-    /// FRESH install would seed for this config (#1096).
-    ///
-    /// The seed only ever fires into emptiness
-    /// (`KiwiCore+GuiConfigSeed`), so before this there was no
-    /// way for an existing install to take up an improved
-    /// default — every seed change reached new installs only,
-    /// and the guide's one shortcut table could describe just
-    /// one of the resulting populations.
-    ///
-    /// Derived from the live config, not from a snapshot: the
-    /// same `spaces` and `resizeStep` the seeder reads, so the
-    /// result is what THIS machine would have been given rather
-    /// than what some other machine was.
-    ///
-    /// Scoped to the default layer because that is the only one
-    /// the seed ever authored — "restore defaults" has no
-    /// meaning for a layer the user invented. The row is
-    /// disabled elsewhere rather than hidden (`gui.md`).
+    /// Resets default layer shortcuts to current install defaults (#1096).
     func resetShortcutsToDefaults() {
         guard
             let index = config.layers.firstIndex(where: {
@@ -57,9 +32,6 @@ extension SettingsModel {
         config.layers[index].bindings = shipped + kept
     }
 
-    /// The set a fresh install would seed for THIS config — the
-    /// same `spaces` and `resizeStep` the seeder reads, so a user
-    /// gets what this machine would have been given.
     private var shippedDefaults: [KeyBinding] {
         DefaultKeybindings.bindings(
             spaces: config.spaces,
@@ -67,18 +39,7 @@ extension SettingsModel {
         )
     }
 
-    /// The Lua of every row in the default layer that targets a
-    /// Space which no longer exists.
-    ///
-    /// Asked of `OrphanedShortcuts`, never re-derived: its own
-    /// docstring rules that a third surface asking "is this
-    /// binding inactive?" asks THERE, because two surfaces
-    /// disagreeing about what is inactive was the whole of #820.
-    ///
-    /// They are stale DEFAULTS, not inventions — a fresh install
-    /// with these Spaces would have none of them — so a restore
-    /// drops them. #92 keeps them as holders through ordinary
-    /// editing; an explicit restore is a different act.
+    /// Inactive Space shortcut Lua in default layer (#820, #92).
     private var orphanLuaInDefaultLayer: Set<String> {
         guard
             let layer = config.layers.first(where: {
@@ -94,9 +55,7 @@ extension SettingsModel {
         )
     }
 
-    /// How many shipped rows this install does not already have,
-    /// exactly as they ship — the GAIN, and the number the
-    /// confirmation leads with.
+    /// Count of default shortcuts restored by reset.
     var shortcutsTheResetWouldRestore: Int {
         guard
             let layer = config.layers.first(where: {
@@ -112,39 +71,12 @@ extension SettingsModel {
         .count
     }
 
-    /// Is there anything to restore? The button's gate: absent
-    /// rather than greyed when this install already matches what
-    /// KiwiDesk ships, so its presence is itself the news.
+    /// True if default layer differs from shipped defaults.
     var hasDefaultsToRestore: Bool {
         shortcutsTheResetWouldRestore > 0
             || shortcutsTheResetWouldDiscard > 0
     }
 
-    /// Does `row` outlive a reset?
-    ///
-    /// Only rows the SEED AUTHORS are replaced — those are the
-    /// only ones KiwiDesk provides, so they are the only ones it
-    /// can restore (owner ruling). An app launcher, a Desktop row
-    /// or anything else the user invented is not a "customised
-    /// default"; it exists only because they made it, and a
-    /// restore has no business deleting it.
-    ///
-    /// Two ways a row is the seed's, and both must go or the
-    /// restored set is not the shipped one:
-    ///
-    /// - its **Lua** is a shipped verb — a default whose combo the
-    ///   user moved; leaving it would double the verb.
-    /// - its **combo** is a shipped chord — the seed is about to
-    ///   reclaim that key, and leaving the row would put two
-    ///   bindings on it, which is precisely the conflict the
-    ///   restore should not manufacture. This is the case that
-    ///   costs a user something real: an app shortcut parked on a
-    ///   default's chord does not survive, which is why the
-    ///   confirmation counts it.
-    ///
-    /// Combos compare through `KeyCombo`, not as text, so a
-    /// hand-authored alias (`ctrl+alt+1`) counts as the same
-    /// chord — the identity `digitTopUp` already uses.
     private static func survivesReset(
         _ row: KeyBinding,
         against shipped: [KeyBinding],
@@ -164,16 +96,7 @@ extension SettingsModel {
         }
     }
 
-    /// How many of the user's own rows the reset would DISCARD —
-    /// the number the confirmation names, so agreeing is an
-    /// informed act rather than a bare "are you sure".
-    ///
-    /// Counts exactly what will not survive: a default whose
-    /// combo was moved, and a row of the user's own parked on a
-    /// chord the seed is about to reclaim. A row that merely
-    /// matches a default is not "theirs", and a row that outlives
-    /// the reset is not discarded — so this is neither the count
-    /// of non-default rows nor the count of changes.
+    /// Count of custom shortcuts displaced by restoring defaults.
     var shortcutsTheResetWouldDiscard: Int {
         guard
             let layer = config.layers.first(where: {
@@ -183,18 +106,10 @@ extension SettingsModel {
         let shipped = shippedDefaults
         let orphanLua = orphanLuaInDefaultLayer
         return layer.bindings.filter { row in
-            // A default — moved or not — is not the user's, and
-            // its verb comes back on the shipped chord. Counting
-            // it told the very population this feature is for
-            // that their shortcuts were being deleted.
             if shipped.contains(where: { $0.lua == row.lua }) {
                 return false
             }
-            // A row for a Space that is gone is KiwiDesk's own,
-            // just stale. Dropping it costs the user nothing.
             if orphanLua.contains(row.lua) { return false }
-            // What is left is theirs. It is lost only if a
-            // default is about to reclaim its chord.
             guard let combo = KeyCombo.parse(row.combo) else {
                 return false
             }

--- a/Sources/KiwiDesk/Settings/SettingsSearchSynonyms.swift
+++ b/Sources/KiwiDesk/Settings/SettingsSearchSynonyms.swift
@@ -1,4 +1,7 @@
-/// Search index alternate vocabulary mapping (spec 11a). English match-only.
+/// Search index alternate vocabulary mapping (spec 11a). English
+/// match-only, never displayed. Sparse by design: a synonym earns
+/// its row by naming a REAL alternate vocabulary (another
+/// platform's term, a retired noun), never by restating the label.
 enum SettingsSearchSynonyms {
     /// Synonym terms for unmodeled catalog items (#1019,
     /// `SettingsSearchIndexTests`).
@@ -28,6 +31,8 @@ enum SettingsSearchSynonyms {
             return ["glass", "translucent", "transparency"]
         case .colours(.animationsMaster):
             return ["motion", "movement"]
+        // Speed is the word people reach for; duration is what
+        // the setting stores (#1020).
         case .colours(.animationsDurationMS):
             return ["speed", "animation speed"]
         case .colours(.animationsScrollDurationMS):
@@ -42,8 +47,10 @@ enum SettingsSearchSynonyms {
             return ["login item", "autostart", "launch"]
         case .shortcuts(.toggleSticky),
             .shortcuts(.toggleDisplaySticky):
-            // Pin synonyms attached to shortcut verbs
-            // (ui-designer/owner 2026-08-26).
+            // The SHORTCUTS carry "pin", not the appearance rows
+            // (owner 2026-08-26): someone typing it wants to pin
+            // a window, not style the mark that says one is
+            // pinned.
             return [
                 "pin", "pinned", "always on top", "all desktops",
             ]

--- a/Sources/KiwiDesk/Settings/SettingsSearchSynonyms.swift
+++ b/Sources/KiwiDesk/Settings/SettingsSearchSynonyms.swift
@@ -1,142 +1,57 @@
-/// Match-only alternate vocabulary for the search index (spec
-/// 11a): the words a user types when they do not know KiwiDesk's
-/// noun yet. English only and never displayed — the localized
-/// LABEL is what the user sees and what locale-language queries
-/// match, so a synonym here widens matching without becoming a
-/// translated string, and it stays code data rather than a
-/// catalog key.
-///
-/// Keyed on the census case itself, so an entry for a renamed or
-/// deleted setting is a compile error, never dead data. Sparse
-/// by design: a synonym earns its row by naming a REAL alternate
-/// vocabulary (another platform's term, a retired noun, a common
-/// near-miss) — not by restating the label, which already
-/// matches.
+/// Search index alternate vocabulary mapping (spec 11a). English match-only.
 enum SettingsSearchSynonyms {
-    /// The same widening for a CATALOG-only row — one the census
-    /// does not model as a setting, so it has no `SettingKey` to
-    /// key on (#1019).
-    ///
-    /// Keyed on the declaration's own `id` rather than on a
-    /// string literal, so renaming the catalog property is a
-    /// compile error and re-keying it follows automatically —
-    /// as close to the census switch's compile-time safety as a
-    /// keyless row can get. `SettingsSearchIndexTests` holds the
-    /// rest: an entry naming a control the catalog does not
-    /// declare is dead vocabulary nothing can match.
-    ///
-    /// **English only, like the census half, and that is a real
-    /// limit rather than an oversight.** A synonym is match-only
-    /// code data, never a displayed or translated string — so a
-    /// German reader finds this row by its LABEL ("Handbuch"),
-    /// which is the word on screen, and typing "Hilfe" matches
-    /// nothing. Localized synonyms would be a different
-    /// mechanism and its own decision.
+    /// Synonym terms for unmodeled catalog items (#1019,
+    /// `SettingsSearchIndexTests`).
     static func catalogTerms(for id: String) -> [String] {
-        // Every Mac app has a Help menu and this app, being
-        // `.accessory`, has none — so "help" is the word a stuck
-        // reader types, and the guide is what they are reaching
-        // for. "docs" is the site's other tree by name.
         guard id == SettingsCatalog.general.guideLink.id else {
             return []
         }
         return ["help", "docs", "documentation", "manual"]
     }
 
+    /// Alternate vocabulary terms for census setting keys.
     static func terms(for key: SettingKey) -> [String] {
         switch key {
-        // Gaps: CSS/System-Settings vocabulary.
         case .gaps(.outer): return ["margin", "padding"]
         case .gaps(.inner): return ["padding", "spacing"]
-        // Borders: the noun glossary retired "outline"/"ring"
-        // in copy; users still type them.
         case .borders(.borderEnabled):
             return ["outline", "focus ring", "highlight"]
         case .borders(.borderFocusedColor):
             return ["outline", "focus ring"]
         case .borders(.borderGlow):
             return ["neon", "shadow"]
-        // Bars: a bar has a thickness, users ask for height.
         case .appBar(.appBarThickness),
             .spaceBar(.spaceBarThickness):
             return ["height", "size"]
         case .appBar(.appBarLiquidGlass),
             .spaceBar(.spaceBarLiquidGlass):
             return ["glass", "translucent", "transparency"]
-        // Animation: speed is the word people reach for,
-        // duration is what the setting stores (#1020). The label
-        // followed the setting; these keep the word reaching it.
         case .colours(.animationsMaster):
             return ["motion", "movement"]
         case .colours(.animationsDurationMS):
             return ["speed", "animation speed"]
         case .colours(.animationsScrollDurationMS):
             return ["speed", "scroll speed", "scrolling speed"]
-        // Palettes read as themes elsewhere. Only the save row
-        // carries the synonyms: the shelf's apply tile is a
-        // `.dynamic`-labelled instance row the index excludes.
         case .colours(.paletteSave):
             return ["theme", "color scheme"]
-        // General: the OS's own vocabulary.
         case .general(.language):
             return ["locale", "translation"]
         case .general(.appearance):
             return ["dark mode", "light mode", "theme"]
         case .general(.startAtLogin):
             return ["login item", "autostart", "launch"]
-        // Sticky: the one family in the census with no
-        // alternate vocabulary at all, which is why nobody who
-        // does not already know KiwiDesk's word finds it
-        // (`ui-designer`, 2026-08-26).
-        //
-        // **`pin` leads because it travels.** These terms are
-        // match-only ENGLISH and never translated, so a phrase
-        // reaches only the reader typing English — and "pin" is
-        // the one candidate that is also the word a German,
-        // French or Italian speaker reaches for, being a UI
-        // loanword in all three. "always on top" and "all
-        // desktops" are kept beside it because they are what the
-        // OTHER platforms call this (Windows, and the GNOME/KDE
-        // window menus), which is exactly the alternate
-        // vocabulary this table is for — they simply help fewer
-        // people, and cost nothing.
-        //
-        // What none of them reaches is a German typing
-        // "anheften". That is the mechanism's own limit, not
-        // this entry's.
-        // **The SHORTCUTS carry it, not the appearance rows**
-        // (owner, 2026-08-26). Someone typing "pin" wants to pin
-        // a window — the action — and would be badly served by
-        // landing on the colour of the mark that says one is
-        // pinned. They reach the styling by searching "sticky"
-        // once the app has taught them the word, which the mark
-        // itself does.
-        //
-        // The Space Bar's sticky badge is absent for a harder
-        // reason: `synonymsAreLive` reds on it, the index not
-        // carrying that key, so a term there would be vocabulary
-        // nothing can ever match.
         case .shortcuts(.toggleSticky),
             .shortcuts(.toggleDisplaySticky):
+            // Pin synonyms attached to shortcut verbs
+            // (ui-designer/owner 2026-08-26).
             return [
                 "pin", "pinned", "always on top", "all desktops",
             ]
-        // The label says "Restore Defaults", so "restore"
-        // and "defaults" already match. "Reset" is the real
-        // alternate vocabulary: it is the word the OTHER
-        // destructive action in this app uses (General ▸
-        // Advanced ▸ Reset All Settings), so a reader who
-        // has met that one types it here — and this is
-        // exactly the row that must answer, since landing on
-        // the whole-config reset instead is the expensive
-        // near-miss. "Factory" and "original" are the
-        // platform-neutral terms for the same idea.
         case .shortcuts(.restoreDefaults):
             return [
                 "reset", "reset shortcuts", "factory",
                 "original shortcuts", "stock shortcuts",
             ]
-        // Behaviour near-misses.
         case .behaviour(.mouseFollowsFocus):
             return ["focus follows mouse", "hover focus"]
         case .behaviour(.minWindowSize):

--- a/Sources/KiwiDeskCore/AX/AXHelper.swift
+++ b/Sources/KiwiDeskCore/AX/AXHelper.swift
@@ -2,24 +2,17 @@ import AppKit
 import ApplicationServices
 
 /// Private AX call that maps an `AXUIElement` to its `CGWindowID`.
-/// Used by every serious macOS window manager; falls back cleanly
-/// (returns an error code) if unavailable.
 @_silgen_name("_AXUIElementGetWindow")
 private func _AXUIElementGetWindow(
     _ element: AXUIElement,
     _ out: UnsafeMutablePointer<UInt32>
 ) -> AXError
 
-/// Thin, synchronous helpers around the public Accessibility API.
-///
-/// AX calls can block (Electron/WebKit apps answer lazily), so
-/// callers must snapshot results instead of querying in loops.
+/// Synchronous helpers around the public Accessibility API.
 public enum AXHelper {
     /// Whether the process has Accessibility permission.
     public static func isTrusted(prompt: Bool = false) -> Bool {
         guard prompt else { return AXIsProcessTrusted() }
-        // Literal value of kAXTrustedCheckOptionPrompt; the SDK
-        // global is not concurrency-safe under Swift 6.
         let key = "AXTrustedCheckOptionPrompt"
         let options = [key: true] as CFDictionary
         return AXIsProcessTrustedWithOptions(options)
@@ -70,20 +63,7 @@ public enum AXHelper {
         return list ?? []
     }
 
-    // WindowServer-side queries (normalWindowCount,
-    // pidsWithNormalWindows) live in
-    // `AXHelper+WindowServer.swift`.
-
-    /// Bounds every AX message this process sends. A message to
-    /// an unresponsive app (stopped, deadlocked, paged out)
-    /// blocks the caller for the system default of ~6 s per
-    /// call; the boot scan makes several sequential main-thread
-    /// calls per app, so one hung helper serializes startup
-    /// into tens of seconds (#672 field report: ~60 s).
-    /// Setting the timeout on the system-wide element makes it
-    /// the process-wide default; an element carrying its own
-    /// timeout keeps it. Deterministic repro for the failure
-    /// this bounds: `kill -STOP` any GUI app, then boot.
+    /// Bounds process-wide AX messaging timeout to avoid hangs (#672).
     public static func setGlobalMessagingTimeout(
         seconds: Float
     ) {
@@ -121,7 +101,6 @@ public enum AXHelper {
             let axValue = value,
             CFGetTypeID(axValue) == AXValueGetTypeID()
         else { return rect }
-        // Sound: type verified via CFGetTypeID above.
         let frameValue = unsafeDowncast(
             axValue,
             to: AXValue.self
@@ -140,9 +119,7 @@ public enum AXHelper {
             ?? ""
     }
 
-    /// Whether a window is minimized to the Dock. Minimized
-    /// windows stay in the AX window list but must not occupy
-    /// layout slots.
+    /// True if window is minimized to the Dock.
     public static func isMinimized(
         _ element: AXUIElement
     ) -> Bool {
@@ -153,12 +130,7 @@ public enum AXHelper {
         ) ?? false
     }
 
-    /// Brings a minimized window back out of the Dock — the
-    /// setter twin of `isMinimized`, writing the same attribute
-    /// (#673). Activating an app does NOT deminiaturize, so this
-    /// is the only way to make an all-minimized app show
-    /// something. Returns whether AX accepted the write; a
-    /// window that is already restored accepts it as a no-op.
+    /// Unminimizes a window from the Dock (#673).
     @discardableResult
     public static func unminimize(
         _ element: AXUIElement
@@ -170,10 +142,7 @@ public enum AXHelper {
         ) == .success
     }
 
-    /// Whether a window is in native (green-button) fullscreen.
-    /// Standard AX attribute string; the SDK header exposes no
-    /// Swift constant for it. Snapshot at track/reconcile only —
-    /// never in the border or layout path (AGENTS.md §5).
+    /// True if window is in native fullscreen.
     public static func isFullscreen(
         _ element: AXUIElement
     ) -> Bool {
@@ -184,11 +153,7 @@ public enum AXHelper {
         ) ?? false
     }
 
-    /// Current `AXEnhancedUserInterface` state of an app, read
-    /// live (nil if the app does not answer). Used to bracket an
-    /// instant frame-set: EUI-on apps animate programmatic frame
-    /// changes themselves, so an un-animated placement must drop
-    /// it for the set and restore whatever it was.
+    /// Reads `AXEnhancedUserInterface` state.
     public static func getEnhancedUserInterface(
         pid: pid_t
     ) -> Bool? {
@@ -199,8 +164,7 @@ public enum AXHelper {
         )
     }
 
-    /// Keeps Electron/WebKit AX trees warm to avoid 100-300 ms
-    /// query latency. See AGENTS.md guardrails before changing.
+    /// Sets `AXEnhancedUserInterface` on application element.
     public static func setEnhancedUserInterface(
         pid: pid_t,
         enabled: Bool
@@ -213,12 +177,7 @@ public enum AXHelper {
         )
     }
 
-    /// Chromium-family browsers (Chrome, Brave, Edge, Arc, …) build
-    /// their AX tree lazily and gate it behind `AXManualAccessibility`
-    /// rather than `AXEnhancedUserInterface` — until it is set,
-    /// `kAXWindowsAttribute` stays empty and their windows are never
-    /// discovered or tiled. Setting it makes that tree materialize.
-    /// Harmless no-op on apps that do not recognize the attribute.
+    /// Sets `AXManualAccessibility` for Chromium-family browsers.
     public static func setManualAccessibility(
         pid: pid_t,
         enabled: Bool
@@ -230,18 +189,8 @@ public enum AXHelper {
         )
     }
 
-    /// Raises a window without focusing it or activating its
-    /// app — z-order only. For a FOREIGN window this is blocking
-    /// IPC and safe off the main thread; for an OWN-process window
-    /// AppKit runs the ordering in-process on the calling thread,
-    /// so the caller must gate on `mustRaiseOnMainThread` (#426).
-    ///
-    /// **The return says the app accepted the action, not that it
-    /// performed it** (#684). Anything that needs several raises
-    /// to land in a given ORDER — or one raise to clear a plane it
-    /// must sit above — verifies against the WindowServer through
-    /// `ZOrderDrain`, which owns the measurements; never issue
-    /// them back to back and trust the returns.
+    /// Raises window without activating app (z-order only, verify via
+    /// `ZOrderDrain`, #426, #684).
     public static func raiseQuietly(_ element: AXUIElement) {
         AXUIElementPerformAction(
             element,
@@ -249,15 +198,8 @@ public enum AXHelper {
         )
     }
 
-    /// Whether `element`'s window belongs to our own process, so
-    /// raising it must happen on the main thread:
-    /// `AXUIElementPerformAction` on an own-process window runs
-    /// AppKit's window ordering in-process on the calling thread,
-    /// and the background z-order queue then trips AppKit's
-    /// main-thread assertion (#426). A failed pid lookup is treated
-    /// as own — the safe default, since a foreign window wrongly
-    /// raised on the main thread only costs a blocking call, while
-    /// an own window wrongly raised off it crashes.
+    /// True if window belongs to own process and must raise on main thread
+    /// (#426).
     public static func mustRaiseOnMainThread(
         _ element: AXUIElement
     ) -> Bool {
@@ -266,36 +208,8 @@ public enum AXHelper {
         return err != .success || pid == getpid()
     }
 
-    /// Raises a window and gives it (and its app) focus.
-    ///
-    /// Order and options are load-bearing (#496): with several
-    /// windows of one app across monitors, a COOPERATIVE
-    /// `activate()` may be deferred by macOS and resolved
-    /// against the app's most-recently-used window — key focus
-    /// then lands on another display's sibling, not the raised
-    /// target. So: make the target the app's MAIN window first,
-    /// raise it (both synchronous AX round-trips — processed by
-    /// the app before the next line runs), then FORCE the
-    /// activation. The AeroSpace-proven sequence for the same
-    /// macOS multi-monitor bug (their #101); public API only.
-    ///
-    /// **The deprecation warning on `.activateIgnoringOtherApps`
-    /// is accepted deliberately — do NOT "clean it up".** Apple
-    /// documents the flag as having no effect from macOS 14 on,
-    /// and 14 is this app's deployment floor, so on paper it is
-    /// dead code that only earns a warning. Observation says
-    /// otherwise: an earlier build without it let focus jump to
-    /// the MRU sibling — the very symptom described above.
-    /// AeroSpace still ships the same flag today.
-    ///
-    /// Removing it needs evidence, not a doc string: an A/B on
-    /// two displays, one app holding a window on each, 20+ focus
-    /// commands per build, checking key focus lands on the
-    /// targeted window and not the sibling. The failure is a
-    /// race, so a handful of repetitions proves nothing — a
-    /// probe of app-level activation proves less still, since
-    /// this bug is about WHICH WINDOW inside an already-active
-    /// app takes key focus.
+    /// Raises window and activates its app with MRU disambiguation (#496).
+    /// `.activateIgnoringOtherApps` accepted deliberately on macOS 14+.
     @MainActor
     public static func raise(
         _ element: AXUIElement,

--- a/Sources/KiwiDeskCore/AX/AXHelper.swift
+++ b/Sources/KiwiDeskCore/AX/AXHelper.swift
@@ -13,6 +13,8 @@ public enum AXHelper {
     /// Whether the process has Accessibility permission.
     public static func isTrusted(prompt: Bool = false) -> Bool {
         guard prompt else { return AXIsProcessTrusted() }
+        // Literal value of kAXTrustedCheckOptionPrompt; the SDK
+        // global is not concurrency-safe under Swift 6.
         let key = "AXTrustedCheckOptionPrompt"
         let options = [key: true] as CFDictionary
         return AXIsProcessTrustedWithOptions(options)
@@ -63,7 +65,11 @@ public enum AXHelper {
         return list ?? []
     }
 
-    /// Bounds process-wide AX messaging timeout to avoid hangs (#672).
+    /// Bounds process-wide AX messaging timeout (#672): set on the
+    /// system-wide element it becomes the process default; an
+    /// element carrying its own timeout keeps it. Deterministic
+    /// repro for the hang this bounds: `kill -STOP` any GUI app,
+    /// then boot.
     public static func setGlobalMessagingTimeout(
         seconds: Float
     ) {
@@ -101,6 +107,7 @@ public enum AXHelper {
             let axValue = value,
             CFGetTypeID(axValue) == AXValueGetTypeID()
         else { return rect }
+        // Sound: type verified via CFGetTypeID above.
         let frameValue = unsafeDowncast(
             axValue,
             to: AXValue.self
@@ -130,7 +137,9 @@ public enum AXHelper {
         ) ?? false
     }
 
-    /// Unminimizes a window from the Dock (#673).
+    /// Unminimizes a window from the Dock (#673). Activating an
+    /// app does NOT deminiaturize, so this is the only way to make
+    /// an all-minimized app show something.
     @discardableResult
     public static func unminimize(
         _ element: AXUIElement
@@ -142,7 +151,9 @@ public enum AXHelper {
         ) == .success
     }
 
-    /// True if window is in native fullscreen.
+    /// True if window is in native fullscreen. Snapshot at
+    /// track/reconcile only — never in the border or layout path
+    /// (AGENTS.md §5).
     public static func isFullscreen(
         _ element: AXUIElement
     ) -> Bool {
@@ -164,7 +175,8 @@ public enum AXHelper {
         )
     }
 
-    /// Sets `AXEnhancedUserInterface` on application element.
+    /// Sets `AXEnhancedUserInterface` — keeps Electron/WebKit AX
+    /// trees warm. See accessibility.md before changing.
     public static func setEnhancedUserInterface(
         pid: pid_t,
         enabled: Bool
@@ -177,7 +189,10 @@ public enum AXHelper {
         )
     }
 
-    /// Sets `AXManualAccessibility` for Chromium-family browsers.
+    /// Sets `AXManualAccessibility` for Chromium-family browsers:
+    /// until set, `kAXWindowsAttribute` stays empty and their
+    /// windows are never discovered or tiled. Harmless no-op on
+    /// apps that do not recognize it.
     public static func setManualAccessibility(
         pid: pid_t,
         enabled: Bool
@@ -198,8 +213,11 @@ public enum AXHelper {
         )
     }
 
-    /// True if window belongs to own process and must raise on main thread
-    /// (#426).
+    /// True if window belongs to own process and must raise on the
+    /// main thread (#426). A failed pid lookup is treated as own —
+    /// the safe default: a foreign window wrongly raised on main
+    /// costs a blocking call, an own window wrongly raised off it
+    /// crashes.
     public static func mustRaiseOnMainThread(
         _ element: AXUIElement
     ) -> Bool {
@@ -208,8 +226,15 @@ public enum AXHelper {
         return err != .success || pid == getpid()
     }
 
-    /// Raises window and activates its app with MRU disambiguation (#496).
-    /// `.activateIgnoringOtherApps` accepted deliberately on macOS 14+.
+    /// Raises window and activates its app (#496). The order is
+    /// load-bearing: make the target the app's MAIN window first,
+    /// raise it (both synchronous), THEN force the activation — or
+    /// macOS resolves a deferred activate against the MRU sibling
+    /// on another display. `.activateIgnoringOtherApps` is accepted
+    /// deliberately on macOS 14+ — do NOT "clean it up": removing
+    /// it needs a 20+-command two-display A/B, not a doc string.
+    /// The AeroSpace-proven sequence for the same bug (their
+    /// #101); public API only.
     @MainActor
     public static func raise(
         _ element: AXUIElement,

--- a/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
+++ b/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
@@ -27,7 +27,10 @@ public final class AnimationEngine {
     /// Log consumer for force-settles and diagnostics (#611, #624).
     public var onLog: @MainActor (String) -> Void = CoreLog.write
 
-    /// Test seam: synchronously snaps to target when false.
+    /// Test seam: synchronously snaps to target when false. Not
+    /// reachable from config — the instant path can't reliably
+    /// place windows on slow-AX apps, so animation is always on
+    /// in production.
     var isEnabled = true
 
     /// Whether macOS Reduce Motion is enabled.
@@ -96,7 +99,11 @@ public final class AnimationEngine {
         )
     }
 
-    /// Animates window to target frame on screen (#45, #593, #599).
+    /// Animates window to target frame on screen (#45, #593,
+    /// #599). `sizing` is deliberately NOT derivable from
+    /// `isNewWindow`: that flag marks the newly-opened window,
+    /// while a make-room shrink hits the SIBLINGS, which retile
+    /// with `isNewWindow: false`.
     public func animate(
         window: WindowID,
         on screen: NSScreen,

--- a/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
+++ b/Sources/KiwiDeskCore/Animation/AnimationEngine.swift
@@ -2,101 +2,44 @@ import AppKit
 import CoreGraphics
 
 /// Spring-based window animation system.
-///
-/// Drives `FrameAnimation`s from one `DisplayLinkDriver` per
-/// monitor. Frames are delivered through the `apply` closure
-/// (wired to `FrameApplier` by the tiler). Starting an
-/// animation for a window that is already animating retargets
-/// it in place: position and velocity carry over, so an
-/// interrupt never causes a visual jump.
-///
-/// Frames are rounded to whole pixels and consecutive
-/// duplicates are skipped: sub-pixel deltas don't render but
-/// each one would still cost a blocking AX round-trip.
-///
-/// The size channel steps under two orthogonal inputs, and the
-/// math for both lives in `SizeStep`. `sizePolicy` (#47) is
-/// engine-wide and swappable for on-device comparison: the
-/// shipping `.throttledSmooth` follows the spring, the legacy
-/// `.midSlide` lands one size-set mid-flight. `BatchSizing` (#593)
-/// is per animation and only ever loosens the shrink direction —
-/// `.mayInstantSize` keeps the #45 first-frame snap so a sibling yielding
-/// room clears at once, `.allSpringSized` lets a shrinking axis follow the
-/// spring where nothing in the batch is instantly sized. Frames
-/// that change no size are position-only — one AX call, and the
-/// target app never re-lays-out its content mid-flight.
+/// Drives `FrameAnimation`s via per-monitor `DisplayLinkDriver`s. Size channel
+/// handles `sizePolicy` (#47) and `BatchSizing` (#45, #593).
 @MainActor
 public final class AnimationEngine {
-    /// Applies one interpolated frame to a real window.
-    /// `setSize` marks the rare frames that change size (a
-    /// size step and the final frame); all others are
-    /// position-only.
+    /// Applies interpolated frame to window. `setSize` marks frames
+    /// altering size.
     public var apply: @MainActor (WindowID, CGRect, Bool) -> Void =
         { _, _, _ in }
 
-    /// Fired when a window starts / stops animating. Wired to
-    /// the per-app `AXEnhancedUserInterface` toggling.
+    /// Fired when an animation starts/stops (for `AXEnhancedUserInterface`).
     public var onAnimationStart: @MainActor (WindowID) -> Void =
         { _ in }
     public var onAnimationEnd: @MainActor (WindowID) -> Void =
         { _ in }
 
-    /// Fired when the last running animation ends (settled,
-    /// cancelled, or display removed). Used for work that
-    /// must wait until windows stop moving, like z-order
-    /// restoration.
+    /// Fired when the last running animation ends (e.g. for z-order restore).
     public var onAllAnimationsEnded: @MainActor () -> Void = {}
 
-    /// Fired when one window's animation reaches its exact target
-    /// (the settle frame), with that target. The strand detector
-    /// (#47 safety net) reads the window back after a grace and
-    /// logs if the app didn't actually land there. Not fired on
-    /// cancel/teardown — those have no target to check. A
-    /// force-settled animation (either net, #611) does fire it:
-    /// `apply` wrote the exact target, so the read-back is as
-    /// meaningful as after a clean settle.
+    /// Fired when window reaches exact target (#47, #611).
     public var onWindowSettled: @MainActor (WindowID, CGRect) -> Void =
         { _, _ in }
 
-    /// Log line consumer, wired to `KiwiCore.onLog` at bootstrap
-    /// like every other subsystem's. It exists for the two
-    /// force-settle nets (#611): both remove a window from a
-    /// wedged state, and a net that fires silently converts the
-    /// loud failure that made #599 findable into a quiet one —
-    /// leaving only a visible jump and no way to tell a rescue
-    /// from a retile. Unwired it goes to syslog rather than
-    /// nowhere (`CoreLog`, #624), so a unit suite that never
-    /// sets it prints the rescue instead of swallowing it.
+    /// Log consumer for force-settles and diagnostics (#611, #624).
     public var onLog: @MainActor (String) -> Void = CoreLog.write
 
-    /// Test seam: when false, `animate` applies the target
-    /// frame synchronously instead of spring-animating it, so
-    /// unit tests get deterministic placement without driving
-    /// the display-link clock. Not reachable from config — the
-    /// instant path can't reliably place windows on slow-AX
-    /// apps, so animation is always on in production.
+    /// Test seam: synchronously snaps to target when false.
     var isEnabled = true
 
-    /// Whether macOS Reduce Motion is on — when true, `animate`
-    /// snaps to the target instantly (Apple's contract for the
-    /// setting). A seam defaulting to `false` so a host's system
-    /// setting can't skew unit tests; `KiwiCore` wires the real
-    /// `NSWorkspace` read in production.
+    /// Whether macOS Reduce Motion is enabled.
     var reduceMotion: @MainActor () -> Bool = { false }
 
-    /// General animation duration in ms, clamped to 50–1000.
-    /// Maps onto the spring's response time (150 ms = 0.21 s).
-    /// Synced from `AnimationSettings.durationMS` on profile
-    /// apply; also set directly by `animations.set_duration`.
+    /// General animation duration in ms (50–1000).
     public var durationMS: Int {
         get { storedDurationMS }
         set { storedDurationMS = min(max(newValue, 50), 1000) }
     }
 
-    /// Scrolling-layout focus-shift duration in ms, clamped
-    /// 50–1000. Independent knob so the scroll and the general
-    /// animation can be tuned separately. Synced from
-    /// `AnimationSettings.scrollDurationMS` on profile apply.
+    /// Scrolling layout focus shift duration in ms (50–1000).
     public var scrollDurationMS: Int {
         get { storedScrollDurationMS }
         set {
@@ -105,24 +48,10 @@ public final class AnimationEngine {
         }
     }
 
-    /// Size-channel policy (#47). Default `.throttledSmooth` at
-    /// the per-tick rate below — a growing window follows the
-    /// spring smoothly, and so does a shrinking one on a
-    /// `.allSpringSized`-marked animation (#593). Engine-only (not
-    /// persisted to a profile), but Lua-overridable:
-    /// `animations.set_size_policy` drops to
-    /// `.midSlide` for a session (e.g. from `init.lua`) if a
-    /// slow-AX app misbehaves. The GUI never exposes it (expert
-    /// knob, like the bars' `dim_factor`).
+    /// Size-channel policy (#47, #593). Default `.throttledSmooth`.
     public var sizePolicy: SizePolicy = .throttledSmooth
 
-    /// Optional size-set rate cap for `.throttledSmooth`, in Hz.
-    /// `nil` (default) = per-tick: the size channel emits every
-    /// display tick, keeping pace with the always-per-tick position
-    /// channel on any refresh rate (60, 120, …) without a magic
-    /// number. A non-nil value throttles *below* the refresh
-    /// (clamped 1–120) to bound a slow-AX app's reflow load. No
-    /// effect under `.midSlide`.
+    /// Optional size update rate limit in Hz for `.throttledSmooth` (1–120).
     public var sizeRateHz: Int? {
         get { storedSizeRateHz }
         set { storedSizeRateHz = newValue.map { min(max($0, 1), 120) } }
@@ -130,26 +59,13 @@ public final class AnimationEngine {
 
     private var storedDurationMS = 150
     private var storedScrollDurationMS = 150
-    // Internal: the tick loop reads it from `+Tick`.
     var storedSizeRateHz: Int?
-    /// Per-window seconds since the last throttled size-set (#47).
-    // Members below are read by the `+Teardown` extension, so they
-    // are module-internal rather than file-private.
     var sizeElapsed: [WindowID: TimeInterval] = [:]
     var animations: [DisplayID: [WindowID: FrameAnimation]] = [:]
     var drivers: [DisplayID: DisplayLinkDriver] = [:]
-    /// Last rounded frame sent per window, for no-op skipping.
     var lastApplied: [WindowID: CGRect] = [:]
-    /// The size a window actually has on screen right now:
-    /// per axis, the target size once shrinking or past
-    /// halfway, otherwise the start size held until then.
     var heldSize: [WindowID: CGSize] = [:]
-    /// The press-scoped commanded base a floating glide
-    /// accumulates against where no animation exists to carry
-    /// one (#1090) — stored here, beside the animation target it
-    /// stands in for. `AnimationEngine+CommandedBase` owns the
-    /// accessor and the domain split against the #881 stamp;
-    /// `GlideCommandedBase` argues the lifetime.
+    /// Commanded base for floating glide accumulation (#1090, #881).
     var glideBase = GlideCommandedBase()
 
     public init() {}
@@ -158,15 +74,12 @@ public final class AnimationEngine {
         animations.values.reduce(0) { $0 + $1.count }
     }
 
-    /// Whether a window is currently being animated. Used to
-    /// tell our own frame updates apart from user drags.
+    /// True if window has an active animation.
     public func isAnimating(window: WindowID) -> Bool {
         animations.values.contains { $0[window] != nil }
     }
 
-    /// The frame a window's in-flight animation is heading to,
-    /// nil when idle. Lets an instant frame-set skip a window
-    /// already sliding to the same target (#207 exit slide).
+    /// In-flight target frame for window (#207).
     public func targetFrame(window: WindowID) -> CGRect? {
         for perWindow in animations.values {
             if let animation = perWindow[window] {
@@ -183,18 +96,7 @@ public final class AnimationEngine {
         )
     }
 
-    // MARK: - Public API
-
-    /// Animates a window to a target frame on a given screen.
-    ///
-    /// `sizing` is why the caller is animating (#593), and it
-    /// only ever loosens the shrink direction: `.mayInstantSize` (the
-    /// default) keeps the #45 first-frame snap, `.allSpringSized` lets a
-    /// shrinking axis follow the spring. It is deliberately NOT
-    /// derivable from `isNewWindow` — that flag marks the
-    /// *newly-opened* window and is consumed right here to pre-set
-    /// `heldSize`, while a make-room shrink hits the **siblings**,
-    /// which retile with `isNewWindow: false`.
+    /// Animates window to target frame on screen (#45, #593, #599).
     public func animate(
         window: WindowID,
         on screen: NSScreen,
@@ -203,13 +105,6 @@ public final class AnimationEngine {
         isNewWindow: Bool = false,
         sizing: BatchSizing = .mayInstantSize
     ) {
-        // A non-finite target can only come from garbage upstream
-        // (a NaN layout rect, a bad AX read), and it is worse than
-        // useless: the spring would never converge to it, and
-        // `FrameAnimation`'s non-finite net cannot recover — it
-        // assigns the target onto the position, so a NaN target
-        // reaches AX as a NaN frame. Refuse the animation and
-        // leave the window where it is (#599).
         guard Self.isRenderable(target) else {
             cancel(window: window)
             return
@@ -225,16 +120,6 @@ public final class AnimationEngine {
             return
         }
         if var existing = removeAnimation(for: window) {
-            // Taking on a promise the previous pass did not make
-            // re-seats the size springs onto what is actually on
-            // screen first: an unpromised shrink renders `target`
-            // from frame 1 while the springs travel on, so the
-            // promised step would read a stale, larger size and
-            // jump the window back up — #45 across batches.
-            // `reseatSize` argues it in full. The held size falls
-            // back to the rendered frame the way the tick loop's
-            // does, so a missing entry cannot silently skip the
-            // re-seat and let the jump through.
             if sizing == .allSpringSized,
                 existing.sizing == .mayInstantSize
             {
@@ -243,17 +128,11 @@ public final class AnimationEngine {
                         ?? Self.rounded(existing.frame).size
                 )
             }
-            // Newest promise wins: a pass that promises nothing,
-            // interrupting one that did, restores the snap (#593).
             existing.retarget(to: target, sizing: sizing)
             animations[display, default: [:]][window] = existing
         } else {
             onAnimationStart(window)
             if isNewWindow {
-                // Pre-set the target size at the current position
-                // so only position slides. The app resizes once
-                // at its spawn point, then moves smoothly — no
-                // visible mid-flight size snap.
                 heldSize[window] = target.size
                 apply(
                     window,
@@ -287,11 +166,7 @@ public final class AnimationEngine {
         startDriver(for: display, screen: screen)
     }
 
-    // MARK: - Internals
-
-    /// Drops all per-window bookkeeping for `id` (no-op skip cache,
-    /// held size, throttle accumulator). Shared by every teardown
-    /// path so a new per-window map can't be forgotten in one.
+    /// Clears per-window bookkeeping caches.
     func clearState(_ id: WindowID) {
         lastApplied[id] = nil
         heldSize[id] = nil
@@ -322,10 +197,7 @@ public final class AnimationEngine {
             ) { [weak self] dt in
                 self?.tick(display: display, dt: dt)
             }
-            // Redirected, not opted into: the driver reports
-            // by default, and this routes it to the engine's
-            // own sink so a starved clock lands beside the two
-            // force-settle nets (#1084, input-and-animation.md).
+            // Route driver warnings to engine's sink (#1084).
             driver.onLog = { [weak self] in self?.onLog($0) }
             drivers[display] = driver
         }

--- a/Sources/KiwiDeskCore/Animation/FrameAnimation.swift
+++ b/Sources/KiwiDeskCore/Animation/FrameAnimation.swift
@@ -1,55 +1,29 @@
 import CoreGraphics
 import Foundation
 
-/// One in-flight window frame animation.
-///
-/// Four independent springs (x, y, width, height). Retargeting
-/// keeps the current position and velocity, so an interrupted
-/// animation redirects smoothly instead of jumping.
+/// In-flight 4D window frame animation (x, y, width, height springs).
 public struct FrameAnimation: Sendable {
     public private(set) var current: [Double]
     public private(set) var velocity: [Double]
     public private(set) var target: [Double]
     public let spring: Spring
 
-    /// What the pass that started this animation promised about
-    /// its sizing (#593) — read every tick by `SizeStep` to decide
-    /// whether a shrinking axis may follow the spring. Stored per
-    /// animation rather than as an engine-wide flag "for the
-    /// duration of a retile": `animate` **retargets** a window
-    /// already in flight, so an engine flag would let one pass's
-    /// promise cover a later pass that never made it.
-    /// `retarget(to:sizing:)` makes that an explicit decision
-    /// instead, and the newest promise wins — a pass that promises
-    /// nothing must restore the snap.
+    /// Sizing promise for this animation pass (#593).
     public private(set) var sizing: BatchSizing
 
-    /// Settled when within this distance at negligible speed.
-    /// Sub-pixel tails are invisible but cost real AX calls,
-    /// so half a point is close enough (the final frame snaps
-    /// to the exact target anyway).
+    /// Epsilon threshold for settling distance and velocity (0.5 pt).
     private static let epsilon = 0.5
 
-    /// Total distance at start (or last retarget); yardstick
-    /// for `pastHalfway`.
+    /// Initial distance to target for halfway calculation.
     private var initialDistance: Double
 
-    /// Simulated seconds spent stepping toward the *current*
-    /// target — the settle watchdog's clock. Simulated rather
-    /// than wall-clock so a stalled `DisplayLink` cannot age an
-    /// animation that was not running; the bound it feeds lives
-    /// in `FrameAnimation+Watchdog` (#611).
+    /// Simulated seconds spent stepping towards current target (#611).
     private(set) var age: TimeInterval = 0
 
-    /// Raised by the non-finite net, drained by
-    /// `takeNonFiniteNotice()` in `FrameAnimation+Watchdog`. A
-    /// value type has no log seam of its own, so the net leaves a
-    /// mark the tick loop collects on its way past (#611).
+    /// Flag set by non-finite recovery net (#611).
     var pendingRescueNotice = false
 
-    /// `sizing` defaults to `.mayInstantSize` — today's first-frame
-    /// shrink snap — so a construction site that has no opinion
-    /// gets the fail-safe one (#593).
+    /// Initializes animation with optional sizing promise (#593).
     public init(
         from: CGRect,
         to: CGRect,
@@ -67,84 +41,21 @@ public struct FrameAnimation: Sendable {
         )
     }
 
-    /// Redirects the animation to a new target mid-flight. The
-    /// sizing is **required**, not defaulted: an interrupt is
-    /// exactly where a stale promise would go unnoticed, and the
-    /// newest one wins (#593).
+    /// Retargets animation mid-flight with a new sizing promise (#593, #611).
     public mutating func retarget(
         to frame: CGRect,
         sizing: BatchSizing
     ) {
         let next = Self.vector(frame)
-        // A genuinely new target is a new journey, so the settle
-        // watchdog's clock restarts with it (#611): a live
-        // make-room drag retargets its siblings for as long as the
-        // user holds the mouse, and a watchdog that fires on
-        // healthy motion is worse than none.
-        //
-        // Only on a *changed* target, though. A retile loop that
-        // re-issues an identical rect would otherwise reset the
-        // clock forever and blind the watchdog to the one wedge it
-        // could plausibly meet in production — an echo/retile
-        // feedback loop, which is far more reachable than the
-        // pathological spring the bound is written against. The
-        // comparison is exact, so a loop whose rect wobbles by a
-        // point (an app-enforced minimum bouncing the placement)
-        // still resets; see the accepted hole in the rule file.
-        //
-        // Keyed on the target alone, not on `sizing`: a pass that
-        // changes only its sizing promise has not moved the window
-        // anywhere new, so it has not restarted the journey.
         if next != target {
             age = 0
         }
         target = next
         self.sizing = sizing
-        // Outside the branch deliberately, though it is journey
-        // state too. Rebasing it on an identical target is the
-        // pre-existing behaviour of the `.midSlide` size policy's
-        // halfway yardstick (#45/#47), which has no coverage of
-        // its own; changing it here would be an unrelated,
-        // untested change to the size channel. The shipped
-        // `.throttledSmooth` never reads `pastHalfway`, so this
-        // is inert today.
         initialDistance = Self.distance(current, target)
     }
 
-    /// Re-seats the two SIZE springs onto a known on-screen size,
-    /// with zero size velocity. Position is untouched.
-    ///
-    /// The size springs integrate on every animation, but under
-    /// `.mayInstantSize` a shrinking axis does not *render* them —
-    /// `SizeStep` pins the emitted size to the target from frame
-    /// 1 while the spring keeps travelling down from the start
-    /// size. So mid-flight the spring and the screen diverge by
-    /// up to the whole shrink delta, and the spring is simply not
-    /// a claim about the window any more.
-    ///
-    /// `.allSpringSized` reads that spring *as* the on-screen
-    /// size. Switch into it mid-shrink without re-seating and the
-    /// window jumps back up by the divergence on the next frame —
-    /// and if the interrupted flight was a make-room shrink, the
-    /// sibling springing back up re-overlaps the newcomer that
-    /// `animate(isNewWindow:)` already painted at full size. That
-    /// is #45, reintroduced *across* batches rather than inside
-    /// one.
-    ///
-    /// **Per axis, and only where the two actually disagree** —
-    /// the staleness is a property of one axis, not of the
-    /// animation. A *growing* axis emits the spring on every due
-    /// tick, so it already agrees and must be left alone: zeroing
-    /// its velocity would stall a grow that was travelling
-    /// correctly (26 pt lost on the first frame after an
-    /// interrupt, still 17 pt behind eight frames later — measured
-    /// in review). The equality test is what separates them, and
-    /// it stays honest under a throttle, where a grow axis does
-    /// lag its last emitted size and is reseated too.
-    ///
-    /// Velocity goes to zero on a reseated axis rather than
-    /// carrying over: that axis was not moving on screen — it
-    /// snapped once and held — so there is no rate to preserve.
+    /// Re-seats size springs onto current on-screen size per axis (#45).
     public mutating func reseatSize(_ size: CGSize) {
         let onScreen = [Double(size.width), Double(size.height)]
         for (offset, value) in onScreen.enumerated() {
@@ -153,29 +64,16 @@ public struct FrameAnimation: Sendable {
             current[i] = value
             velocity[i] = 0
         }
-        // Dead in the one production call site (the `retarget`
-        // that follows recomputes it), kept so a public mutating
-        // method cannot leave the struct inconsistent on its own.
         initialDistance = Self.distance(current, target)
     }
 
-    /// True once at least half the distance is covered. A
-    /// growing window switches to its target size here, where
-    /// the ongoing slide masks the single-frame size jump and
-    /// the window already sits near its final origin.
+    /// True once at least half the distance is covered (#45, #47).
     public var pastHalfway: Bool {
         Self.distance(current, target) * 2 <= initialDistance
     }
 
-    /// Advances by `dt`; returns true when settled.
-    ///
-    /// A caller that wants the non-finite net's diagnostics must
-    /// drain `takeNonFiniteNotice()` after each call — the notice
-    /// is raised here and reported by whoever is driving.
+    /// Advances simulation by `dt`; returns true when settled (#599, #611).
     public mutating func step(dt: Double) -> Bool {
-        // Simulated time, not wall-clock, and deliberately not
-        // gated on whether the spring below actually integrated —
-        // see `FrameAnimation+Watchdog`.
         age += Spring.integratedSpan(dt)
         var settled = true
         for i in 0..<4 {
@@ -185,17 +83,7 @@ public struct FrameAnimation: Sendable {
                 target: target[i],
                 dt: dt
             )
-            // Backstop under the substepping (#599): a component
-            // that stops being finite can never come back, since
-            // `abs(inf - target)` is never within epsilon — so
-            // force it home rather than let it run forever. With
-            // the substepping in place a finite input cannot
-            // produce a non-finite output, so the live trigger is
-            // a non-finite START (a garbage AX read); check there
-            // first if this fires, and the engine logs it (#611)
-            // so there will be a symptom to check. A non-finite
-            // TARGET is refused upstream in `animate` instead —
-            // this recovery would hand the NaN straight to AX.
+            // Non-finite recovery net (#599, #611).
             if !current[i].isFinite || !velocity[i].isFinite {
                 current[i] = target[i]
                 velocity[i] = 0
@@ -213,10 +101,7 @@ public struct FrameAnimation: Sendable {
         return settled
     }
 
-    /// Snaps to the exact target and stops dead. The single
-    /// recovery shape: a clean settle, the non-finite net and the
-    /// age watchdog all end here, and the caller then runs its
-    /// ordinary settled handling.
+    /// Snaps current state directly to target with zero velocity.
     mutating func forceSettle() {
         current = target
         velocity = [0, 0, 0, 0]

--- a/Sources/KiwiDeskCore/Animation/FrameAnimation.swift
+++ b/Sources/KiwiDeskCore/Animation/FrameAnimation.swift
@@ -41,7 +41,13 @@ public struct FrameAnimation: Sendable {
         )
     }
 
-    /// Retargets animation mid-flight with a new sizing promise (#593, #611).
+    /// Retargets animation mid-flight with a new sizing promise
+    /// (#593). The watchdog clock restarts only on a CHANGED
+    /// target (#611): an echo/retile loop re-issuing an identical
+    /// rect must not reset the clock forever and blind the
+    /// watchdog to the one wedge it can meet in production. Keyed
+    /// on the target alone — a pass changing only its sizing
+    /// promise has not restarted the journey.
     public mutating func retarget(
         to frame: CGRect,
         sizing: BatchSizing
@@ -55,7 +61,14 @@ public struct FrameAnimation: Sendable {
         initialDistance = Self.distance(current, target)
     }
 
-    /// Re-seats size springs onto current on-screen size per axis (#45).
+    /// Re-seats size springs onto the on-screen size, per axis and
+    /// only where spring and screen disagree (#45): under
+    /// `.mayInstantSize` a shrinking axis renders the target while
+    /// the spring travels on, so switching to `.allSpringSized`
+    /// without re-seating jumps the window back up by the
+    /// divergence — #45 reintroduced ACROSS batches. A growing
+    /// axis already agrees and must be left alone (zeroing its
+    /// velocity stalls a healthy grow — measured in review).
     public mutating func reseatSize(_ size: CGSize) {
         let onScreen = [Double(size.width), Double(size.height)]
         for (offset, value) in onScreen.enumerated() {
@@ -83,7 +96,12 @@ public struct FrameAnimation: Sendable {
                 target: target[i],
                 dt: dt
             )
-            // Non-finite recovery net (#599, #611).
+            // Non-finite recovery net (#599, #611): a component
+            // that stops being finite can never settle, so force
+            // it home. The live trigger is a non-finite START (a
+            // garbage AX read) — check there first if this fires.
+            // A non-finite TARGET is refused upstream in `animate`;
+            // this recovery would hand the NaN straight to AX.
             if !current[i].isFinite || !velocity[i].isFinite {
                 current[i] = target[i]
                 velocity[i] = 0

--- a/Sources/KiwiDeskCore/Animation/Spring.swift
+++ b/Sources/KiwiDeskCore/Animation/Spring.swift
@@ -1,73 +1,20 @@
 import CoreGraphics
 import Foundation
 
-/// Damped spring parameters, matching SwiftUI's
-/// `.spring(response:dampingFraction:)` semantics.
+/// Damped spring parameters matching SwiftUI `.spring` semantics.
 public struct Spring: Sendable, Equatable {
     public let stiffness: Double
     public let damping: Double
-    /// The response this spring was built with, after `init`'s
-    /// clamp. Kept rather than re-derived because the settle
-    /// watchdog's bound scales with it (#611) and it is consulted
-    /// once per animation per tick — and because the clamped value
-    /// is the honest one: a caller that passed garbage should be
-    /// aged against the spring that actually shipped.
+    /// Clamped response time for watchdog scaling (#611).
     public let response: Double
-    /// The largest step this spring may be integrated with
-    /// before semi-implicit Euler stops damping and starts
-    /// amplifying (#599). Precomputed alongside the two above —
-    /// it is a fixed property of the spring, not a per-tick
-    /// question.
-    ///
-    /// **The real stability condition is
-    /// `k·h² + 2·c·h < 4`**, closed form `ωh < 2(√(1+ζ²) − ζ)`.
-    /// Do not reason from either term alone: `k·h² < 4` is the
-    /// undamped (ζ = 0) special case, and `|1 − c·h| < 1` is a
-    /// necessary-but-not-sufficient Jury condition. At ζ = 0.85
-    /// the combined bound (ωh < 0.925) is what binds, and the
-    /// amplification factor at the two single-term bounds is
-    /// 1.9 and 5.8 — both already divergent.
-    ///
-    /// `1/max(ω, c)` is a deliberately conservative closed form
-    /// that satisfies the real condition for every ζ > 0.
-    /// **`SpringStabilityMarginTests` computes that margin** —
-    /// its floor, where the floor sits, and each shipped spring's
-    /// value — so read it there rather than from a number copied
-    /// into a comment (#614). The halving is load-bearing, not
-    /// slack, and the same suite proves it: the looser
-    /// `2/max(ω, c)` lands outside the real bound at the damping
-    /// the engine ships, which is #599 again.
-    ///
-    /// Both terms are kept because ζ below 0.5 flips which one
-    /// `max` selects, and that is not hypothetical — `DeadEndBump`
-    /// already ships ζ = 0.45.
-    ///
-    /// Concretely at ζ = 0.85: a 60 Hz tick is 16.7 ms, and the
-    /// 150 ms default allows 19.7 ms — one substep, so the
-    /// default is untouched. At the 50 ms floor it allows 6.6 ms
-    /// and the tick splits three ways. A 120 Hz display was
-    /// inside the bound across the whole range, which is why this
-    /// only ever bit some machines.
+    /// Maximum stable integration step (`1/max(ω, c)`, #599;
+    /// `SpringStabilityMarginTests`, #614).
     let maxStableStep: Double
 
     public init(
         response: Double = 0.35,
         dampingFraction: Double = 0.85
     ) {
-        // A non-finite `response` would propagate through `max`
-        // into `maxStableStep`, and `step` guards against that by
-        // returning — which would freeze the animation instead of
-        // crashing it: never settling, never leaving the engine,
-        // the #599 wedge through another door. Degrade to the
-        // default instead. `init` is public, so this is reachable.
-        // `dampingFraction` is deliberately left unclamped. It can
-        // reach the same standstill (it drives `damping`, and an
-        // infinite one zeroes `maxStableStep`), but that case is
-        // covered by the settle watchdog rather than refused here
-        // — and leaving the vector open is what keeps
-        // `aFrozenSpringIsStillRescued` a reachable test. Do not
-        // "finish the job" by clamping it; that deletes the only
-        // way to exercise the rescue.
         let clamped = response.isFinite ? max(response, 0.01) : 0.35
         let omega = 2 * .pi / clamped
         self.response = clamped
@@ -76,80 +23,25 @@ public struct Spring: Sendable, Equatable {
         self.maxStableStep = 1 / max(omega, self.damping)
     }
 
-    /// The most real time one `step` call will integrate,
-    /// however large its `dt` (#599). One 30 Hz frame, chosen to
-    /// match the floor of `DisplayLinkDriver`'s own clamp
-    /// (`max(nominal, 1/30)`). The two agree at 30 Hz and above,
-    /// which is every display this runs on in practice; below it
-    /// — a panel at a 24 Hz ProMotion floor — this truncates the
-    /// driver's longer interval, so the motion runs slightly slow
-    /// rather than integrating an unbounded span. That trade is
-    /// deliberate: a bounded loop matters more than exact pace on
-    /// a display that is already dropping frames.
+    /// Maximum time integrated in a single step (1/30s, #599).
     static let maxIntegratedStep = 1.0 / 30.0
 
-    /// The real time one `step` call actually integrates for a
-    /// caller's `dt` — the interval itself under the cap above,
-    /// and **zero** for an interval `step` refuses outright.
-    ///
-    /// Extracted so the settle watchdog can age an animation by
-    /// the same measure (#611). Ageing by simulated rather than
-    /// wall-clock time is the point: a `DisplayLink` that stalls
-    /// hands over one enormous `dt`, and an animation must age by
-    /// what it moved, not by how long the display slept.
-    ///
-    /// It answers a different question from `step`'s own guard,
-    /// which is why it refuses only the *interval*. This one asks
-    /// how much simulated time a `dt` represents; `step` asks
-    /// whether this spring can integrate at all. A spring that
-    /// cannot (an unusable `maxStableStep`, which a caller-built
-    /// spring can produce) stands still without ever settling, and
-    /// its animation must still age or nothing will ever rescue
-    /// it — see `aFrozenSpringIsStillRescued`.
+    /// Simulated time span integrated for `dt` (#611;
+    /// `aFrozenSpringIsStillRescued`).
     static func integratedSpan(_ dt: Double) -> Double {
         guard dt.isFinite, dt > 0 else { return 0 }
         return min(dt, maxIntegratedStep)
     }
 
-    /// Advances one scalar by `dt` seconds (semi-implicit
-    /// Euler). Mutates position and velocity in place.
-    ///
-    /// Substepped so the integration stays inside
-    /// `maxStableStep` whatever the caller's frame interval is.
-    /// Without it, a duration below ~80 ms on a 60 Hz display
-    /// diverges — the position runs away to infinity, and since
-    /// `FrameAnimation.step` only reports settled once it is
-    /// within epsilon of the target, that animation never settles
-    /// and never leaves the engine. Everything waiting on
-    /// `onAllAnimationsEnded` then stops for the rest of the
-    /// session: the deferred focus raise, the z-order restore and
-    /// the overlay re-sync (#599, #596).
-    ///
-    /// Substepping is the refresh-rate-independent fix, which
-    /// matters with one `DisplayLink` per monitor at mixed rates
-    /// — a per-duration clamp would have to know the display.
+    /// Integrates position and velocity with substepping (#599, #596).
     public func step(
         position: inout Double,
         velocity: inout Double,
         target: Double,
         dt: Double
     ) {
-        // Nothing meaningful to integrate, and `Int(.infinity)`
-        // traps — this is a public entry point, so a garbage
-        // interval must return rather than crash.
         guard maxStableStep.isFinite, maxStableStep > 0
         else { return }
-        // A stall (display sleep, a wedged main actor) can hand
-        // us an arbitrarily large interval. Integrating all of it
-        // is neither wanted nor affordable, so `integratedSpan`
-        // caps the span itself rather than the substep count:
-        // capping the count would silently push `h` back above
-        // `maxStableStep` — the exact amplifying regime this
-        // method exists to prevent. `DisplayLinkDriver` already
-        // clamps its own ticks the same way and for the same
-        // reason; this makes the guarantee hold for any caller, so
-        // `step` is unconditionally stable rather than stable
-        // given a well-behaved driver.
         let span = Self.integratedSpan(dt)
         guard span > 0 else { return }
         let count = max(1, Int((span / maxStableStep).rounded(.up)))

--- a/Sources/KiwiDeskCore/Animation/Spring.swift
+++ b/Sources/KiwiDeskCore/Animation/Spring.swift
@@ -7,14 +7,29 @@ public struct Spring: Sendable, Equatable {
     public let damping: Double
     /// Clamped response time for watchdog scaling (#611).
     public let response: Double
-    /// Maximum stable integration step (`1/max(ω, c)`, #599;
-    /// `SpringStabilityMarginTests`, #614).
+    /// Maximum stable integration step (#599). The REAL stability
+    /// condition is `k·h² + 2·c·h < 4` (closed form
+    /// `ωh < 2(√(1+ζ²) − ζ)`); never reason from either term alone
+    /// — `k·h² < 4` is the undamped special case and `|1 − c·h| < 1`
+    /// is necessary-but-not-sufficient. `1/max(ω, c)` is a
+    /// deliberately conservative form satisfying the condition for
+    /// every ζ > 0; the halving is load-bearing, not slack —
+    /// `SpringStabilityMarginTests` computes the margin, so read it
+    /// there rather than from a number in a comment (#614). Both
+    /// terms stay because ζ below 0.5 flips which one `max` picks,
+    /// and `DeadEndBump` already ships ζ = 0.45.
     let maxStableStep: Double
 
     public init(
         response: Double = 0.35,
         dampingFraction: Double = 0.85
     ) {
+        // A non-finite response would freeze the animation (never
+        // settling — the #599 wedge through another door), so it
+        // degrades to the default. `dampingFraction` is
+        // deliberately left unclamped: the settle watchdog covers
+        // it, and clamping would delete the only way to exercise
+        // `aFrozenSpringIsStillRescued`. Do not "finish the job".
         let clamped = response.isFinite ? max(response, 0.01) : 0.35
         let omega = 2 * .pi / clamped
         self.response = clamped
@@ -23,11 +38,17 @@ public struct Spring: Sendable, Equatable {
         self.maxStableStep = 1 / max(omega, self.damping)
     }
 
-    /// Maximum time integrated in a single step (1/30s, #599).
+    /// Maximum time integrated in a single step (#599): one 30 Hz
+    /// frame, matching `DisplayLinkDriver`'s own clamp floor —
+    /// below 30 Hz motion runs slightly slow rather than
+    /// integrating an unbounded span, a deliberate trade.
     static let maxIntegratedStep = 1.0 / 30.0
 
-    /// Simulated time span integrated for `dt` (#611;
-    /// `aFrozenSpringIsStillRescued`).
+    /// Simulated time span integrated for `dt` (#611). Ageing by
+    /// simulated rather than wall-clock time is the point: a
+    /// stalled `DisplayLink` hands over one enormous `dt`, and an
+    /// animation must age by what it moved
+    /// (`aFrozenSpringIsStillRescued`).
     static func integratedSpan(_ dt: Double) -> Double {
         guard dt.isFinite, dt > 0 else { return 0 }
         return min(dt, maxIntegratedStep)
@@ -42,6 +63,9 @@ public struct Spring: Sendable, Equatable {
     ) {
         guard maxStableStep.isFinite, maxStableStep > 0
         else { return }
+        // Caps the SPAN, not the substep count: capping the count
+        // would silently push `h` back above `maxStableStep` — the
+        // exact amplifying regime this method exists to prevent.
         let span = Self.integratedSpan(dt)
         guard span > 0 else { return }
         let count = max(1, Int((span / maxStableStep).rounded(.up)))

--- a/Sources/KiwiDeskCore/App/DeferredTasks.swift
+++ b/Sources/KiwiDeskCore/App/DeferredTasks.swift
@@ -20,25 +20,39 @@ final class DeferredTasks {
         case desktopSettle
         case desktopMoveReap
         /// Adopts window sent to hidden desktop by follow (#1023).
+        /// A separate slot from `desktopMoveReap` deliberately:
+        /// keys are cancel-and-replace and the two verbs are one
+        /// keystroke apart — whichever fired second would silently
+        /// drop the other's reap.
         case desktopFollowReap
         /// Verifies desktop switch dispatch (#1023).
         case desktopSwitchVerify
         case borderDropSettle
-        /// Re-syncs border and mark geometry after animations (#596).
+        /// Re-syncs border and mark geometry after animations
+        /// (#596). A separate slot from `borderDropSettle`
+        /// deliberately: different delays for different reasons,
+        /// and sharing one would let whichever landed second
+        /// cancel the other.
         case borderResync
         case floatRaise
         /// Adoption-heal sweep for unhandled windows (#675).
         case adoptionHeal
         /// Re-tracks windows dropped mid-launch (#675).
         case transientRetrack
+        /// Bar re-render on a drawn title change — the one slot
+        /// whose reschedule is the POINT: cancel-and-replace turns
+        /// a keystroke-rate burst into one refresh when it stops.
         case barTitleRefresh
     }
 
     private var tasks: [Key: Task<Void, Never>] = [:]
     private var burstStarts: [Key: ContinuousClock.Instant] = [:]
 
-    /// Schedules `body` after `delay` (bounded by `maxWait` across bursts,
-    /// #900).
+    /// Schedules `body` after `delay` (bounded by `maxWait` across
+    /// bursts, #900). Cancellation is checked once, after the
+    /// sleep — `body` is synchronous main-actor code, so a cancel
+    /// cannot interleave once it starts. `body` is retained until
+    /// it fires: capture the core weakly.
     func schedule(
         _ key: Key,
         after delay: Duration,
@@ -83,7 +97,10 @@ final class DeferredTasks {
         burstStarts[key] = nil
     }
 
-    /// Returns task stored for key (used for test assertions).
+    /// The task stored for a key — for pinning cancel-and-replace
+    /// claims. NOT a pending-check: a fired body leaves its
+    /// finished task in the slot, so this stays non-nil after
+    /// firing; only `cancel`/`cancelAll` clear it.
     func task(for key: Key) -> Task<Void, Never>? {
         tasks[key]
     }

--- a/Sources/KiwiDeskCore/App/DeferredTasks.swift
+++ b/Sources/KiwiDeskCore/App/DeferredTasks.swift
@@ -1,115 +1,44 @@
 import Foundation
 
-/// Owns KiwiCore's deferred one-shot settle tasks, keyed so a
-/// reschedule self-cancels the prior run and teardown can cancel
-/// everything at once instead of hand-listing fields (#49) — the
-/// hand-kept cancel list is how a missing cancel slipped through
-/// review once already (#48).
-///
-/// Only the store/cancel/sleep protocol lives here; the settle
-/// bodies stay closures at the call sites because their delays,
-/// guard predicates, and post-work genuinely differ (AGENTS.md
-/// §2.4). Bodies run on the main actor and should capture the
-/// core weakly, as the call sites do.
+/// Owns KiwiCore's deferred one-shot settle tasks with self-cancelling keys
+/// (#48, #49).
 @MainActor
 final class DeferredTasks {
-    /// One slot per deferred job; scheduling a key replaces
-    /// (cancels) whatever that key was still waiting on.
+    /// Distinct slots for deferred jobs (cancel-and-replace per slot).
     enum Key: Hashable, CaseIterable {
-        /// Deferred switch to a hidden window's Space
-        /// (`scheduleFocusFollow`).
         case focusFollow
-        /// One-shot startup sweep re-tracking windows the cold
-        /// AX scan missed (`scheduleStartupSweep`) — and, once it
-        /// has fired, each of its own chunks (#801): the pass is
-        /// one job, so re-using its slot is what makes
-        /// `cancelAll()` stop a sweep mid-flight.
+        /// One-shot startup sweep re-tracking windows
+        /// (`scheduleStartupSweep`, #801).
         case startupSweep
-        /// The next chunk of the startup scan (`driveBootScan`,
-        /// #801). The scan hands the run loop back between
-        /// chunks; this is what brings it back.
+        /// Chunked startup scan (`driveBootScan`, #801).
         case bootScan
-        /// The next app whose boot work a per-app budget cut
-        /// short (`drainDeferredBootApps`, #803) — one per turn,
-        /// so completing them cannot re-block the run loop.
+        /// Deferred app boot processing (`drainDeferredBootApps`, #803).
         case deferredBootApps
-        /// One-shot layout re-assert after a virtual-space
-        /// switch (`scheduleSpaceSettle`).
         case spaceSettle
-        /// One-shot focus re-assert after a no-follow
-        /// `move_to_space` (`scheduleMoveSettle`, #482/#483).
+        /// Focus re-assert after no-follow `move_to_space` (#482, #483).
         case moveSettle
-        /// Layout + focus re-assert after a native desktop
-        /// switch (`settleAfterDesktopSwitch`).
         case desktopSettle
-        /// Reaps the window a no-follow `move_to_desktop` sent
-        /// to another Desktop (`scheduleDesktopMoveReap`): no OS
-        /// switch follows such a move, so nothing else is
-        /// guaranteed to notice the window left.
         case desktopMoveReap
-        /// Adopts the window a FOLLOW sent to a hidden Desktop
-        /// once the reveal has composited it (`departEagerly`,
-        /// #1023). A separate slot from `desktopMoveReap`
-        /// deliberately: the keys are cancel-and-replace, the
-        /// two verbs are one keystroke apart, and whichever
-        /// fired second would silently drop the other's reap —
-        /// a stale slot for the no-follow, a permanently
-        /// unadopted window for the follow.
+        /// Adopts window sent to hidden desktop by follow (#1023).
         case desktopFollowReap
-        /// Re-queries the display's current space a beat after a
-        /// Desktop-switch dispatch and logs a pointer that never
-        /// moved (`scheduleDesktopSwitchVerify`, #1023) — the
-        /// write applies asynchronously, so the honest re-query
-        /// cannot be synchronous.
+        /// Verifies desktop switch dispatch (#1023).
         case desktopSwitchVerify
-        /// Re-asserts every desired focus ring's VISIBILITY and
-        /// stacking after a drag/drop or animated transition
-        /// (`scheduleBorderDropReconcile`) — early on purpose, and
-        /// geometry-free while a window animates.
         case borderDropSettle
-        /// Re-syncs ring AND mark GEOMETRY from real window state
-        /// a grace after the last animation ends
-        /// (`scheduleBorderResync`, #596). A separate slot from
-        /// `borderDropSettle` deliberately: they run at different
-        /// delays for different reasons, so sharing one would let
-        /// whichever landed second cancel the other — silently
-        /// dropping either the un-hide or the sticky mark's heal.
+        /// Re-syncs border and mark geometry after animations (#596).
         case borderResync
-        /// Coalesced re-raise of the float layer after focus lands
-        /// on a tiled window (`raiseFloatsAbove`) — a burst of focus
-        /// changes collapses to one raise for the final target.
         case floatRaise
-        /// Self-rearming adoption-heal sweep re-adopting windows
-        /// every event path missed (`scheduleAdoptionHeal`,
-        /// #675).
+        /// Adoption-heal sweep for unhandled windows (#675).
         case adoptionHeal
-        /// One-shot re-track of windows the transient filters
-        /// dropped mid-launch (`scheduleTransientRetrack`,
-        /// #675).
+        /// Re-tracks windows dropped mid-launch (#675).
         case transientRetrack
-        /// Re-render of the bars after a drawn window title
-        /// changed (`handleTitleChangedForBars`). The one slot
-        /// here whose reschedule is the POINT rather than a
-        /// correctness guard: a title event arrives as fast as a
-        /// keystroke, and cancel-and-replace is what turns a
-        /// burst into one refresh when it stops.
         case barTitleRefresh
     }
 
     private var tasks: [Key: Task<Void, Never>] = [:]
     private var burstStarts: [Key: ContinuousClock.Instant] = [:]
 
-    /// Runs `body` after `delay` unless the key is rescheduled
-    /// or cancelled first. Cancellation is checked once, after
-    /// the sleep: `body` is synchronous main-actor code, so a
-    /// cancel cannot interleave with it once it has started.
-    /// `body` is retained until it fires or is cancelled, so
-    /// capture the core weakly (see the type doc) — a strong
-    /// capture would pin it for the pending delay.
-    ///
-    /// When `maxWait` is provided, continuous reschedules within
-    /// a burst will not delay execution past `maxWait` from the
-    /// burst's initial schedule (#900).
+    /// Schedules `body` after `delay` (bounded by `maxWait` across bursts,
+    /// #900).
     func schedule(
         _ key: Key,
         after delay: Duration,
@@ -145,9 +74,7 @@ final class DeferredTasks {
         }
     }
 
-    /// Whether `key` has work pending — the seam a test reads to
-    /// prove a path ARMED its deferred work, without waiting the
-    /// delay out or letting the body reach the machine.
+    /// True if `key` has work scheduled.
     func isScheduled(_ key: Key) -> Bool { tasks[key] != nil }
 
     func cancel(_ key: Key) {
@@ -156,18 +83,12 @@ final class DeferredTasks {
         burstStarts[key] = nil
     }
 
-    /// The task currently stored for a key — lets tests pin the
-    /// cancel-and-replace claims (identity + `isCancelled`).
-    /// Not a pending-check: a fired body leaves its *finished*
-    /// task in the slot (bounded — one per key — and inert), so
-    /// this stays non-nil after firing; only `cancel`/`cancelAll`
-    /// clear the slot.
+    /// Returns task stored for key (used for test assertions).
     func task(for key: Key) -> Task<Void, Never>? {
         tasks[key]
     }
 
-    /// Cancels every pending task — the one call teardown makes,
-    /// so `stop()` cannot forget a newly added key.
+    /// Cancels all pending tasks on teardown.
     func cancelAll() {
         for task in tasks.values { task.cancel() }
         tasks.removeAll()

--- a/Sources/KiwiDeskCore/Appearance/PaletteStore.swift
+++ b/Sources/KiwiDeskCore/Appearance/PaletteStore.swift
@@ -1,60 +1,31 @@
 import Foundation
 
-/// The palette library (#375): the seven built-ins plus the user's
-/// saved palettes, persisted **globally** (not per-profile) in
-/// `<config>/palettes.json`. Built-ins are read-only — they can't
-/// be renamed, overwritten, or deleted; user palettes can. Names
-/// are values inside the JSON (not file names), so there's no
-/// path-traversal surface here.
-///
-/// Stateless and file-backed: every call reads or writes the file,
-/// so a palette saved in one place is seen everywhere without a
-/// cache to invalidate.
+/// Global palette library store managing `palettes.json` (#375, #945, #606).
 public final class PaletteStore {
     public enum StoreError: Error, Equatable {
-        /// A user palette may not take a built-in's name.
         case reservedName(String)
-        /// Rename/delete targeted a name no user palette has.
         case notFound(String)
-        /// A rename would collide with another user palette's name.
         case duplicateName(String)
-        /// The imported file wasn't a valid palette.
         case invalidFile
-        /// `palettes.json` exists but refuses to decode (a newer
-        /// format, or corrupt bytes). Distinct from an empty
-        /// library on purpose (#945 review): `save` is
-        /// read-append-write, so a downgraded build that mistook
-        /// refusal for empty would rewrite the newer build's
-        /// whole library with one palette.
+        /// Unreadable or newer-format library (#945 review).
         case unreadableLibrary
     }
 
     private let fileURL: URL
 
-    /// Where the library lives. Public so a backup can name the
-    /// file it replaces (#606) — this type is stateless, every
-    /// read hitting the file, so a second instance over the same
-    /// path is safe and is how Core reaches the library the GUI
-    /// otherwise owns.
+    /// URL to `palettes.json` (#606).
     public var url: URL { fileURL }
 
-    /// `directory` is the config dir (`~/.config/KiwiDesk`); the
-    /// library lives in `palettes.json` inside it.
     public init(directory: URL) {
         fileURL = directory.appendingPathComponent("palettes.json")
     }
 
-    // MARK: - Reads
-
-    /// The built-in palettes (default first) — read-only.
+    /// Read-only built-in palettes.
     public func builtins() -> [ColorPalette] {
         PaletteCatalog.bundled()
     }
 
-    /// The decoded library document — nil when no file exists,
-    /// throwing `unreadableLibrary` when one exists but refuses
-    /// to decode. Migrates legacy or older formats through
-    /// `ConfigMigration` and repairs the file in place.
+    /// Decodes document, running `ConfigMigration` if needed (#945).
     private func readDocument() throws -> PaletteDocument? {
         guard var data = try? Data(contentsOf: fileURL) else {
             return nil
@@ -72,37 +43,25 @@ public final class PaletteStore {
         return doc
     }
 
-    /// The user's saved palettes for the MUTATING paths and the
-    /// backup export: refusal stays loud here, where a silent
-    /// `[]` would clobber or silently empty a backup (#945
-    /// review). Pure queries read `userPalettes()` below.
+    /// User palettes for mutating paths (throws on unreadable library, #945).
     public func libraryPalettes() throws -> [ColorPalette] {
         try readDocument()?.palettes ?? []
     }
 
-    /// The user's saved palettes, in saved order — the
-    /// query-side read: an unreadable library shows as empty
-    /// here (a list the GUI renders), while every path that
-    /// WRITES from what it read goes through `libraryPalettes`.
+    /// User palettes for read queries (defaults to empty on error).
     public func userPalettes() -> [ColorPalette] {
         (try? libraryPalettes()) ?? []
     }
 
-    /// True if `name` belongs to a built-in (reserved).
     public func isBuiltinName(_ name: String) -> Bool {
         builtins().contains { $0.name == name }
     }
 
-    /// True if a user palette already has `name`.
     public func hasUserPalette(_ name: String) -> Bool {
         userPalettes().contains { $0.name == name }
     }
 
-    // MARK: - Writes (user palettes only)
-
-    /// Adds `palette`, or overwrites the existing user palette of
-    /// the same name (the caller confirms overwrite first). Throws
-    /// `reservedName` if the name is a built-in's.
+    /// Saves or updates a user palette.
     public func save(_ palette: ColorPalette) throws {
         guard !isBuiltinName(palette.name) else {
             throw StoreError.reservedName(palette.name)
@@ -118,34 +77,7 @@ public final class PaletteStore {
         try write(palettes)
     }
 
-    /// Replaces the whole user library — the restore half of a
-    /// backup (#606).
-    ///
-    /// **This is the type's one bulk entry point, and the only one
-    /// whose input is untrusted**, so it enforces every invariant
-    /// the single-item paths enforce rather than only the first
-    /// one a reviewer thought of. A backup is JSON on the user's
-    /// disk; a hand-edited one can carry anything.
-    ///
-    /// - a name a **built-in** owns is dropped, which `save`
-    ///   refuses one at a time (`reservedName`) — a shadow would
-    ///   be invisible until the built-in stopped resolving;
-    /// - a **duplicate** name is dropped, keeping the first, which
-    ///   `rename` refuses (`duplicateName`) — the shelf keys tiles
-    ///   by name, so twins are a collision rather than a
-    ///   preference;
-    /// - an **unknown colour key** is filtered out, exactly as
-    ///   `importPalette` filters a hand-supplied file, so a typo
-    ///   or a retired key cannot ride into the library.
-    ///
-    /// Dropping rather than throwing is deliberate: one bad entry
-    /// must not fail a whole restore the user has already
-    /// confirmed. The count says how many were refused.
-    /// It deliberately does NOT read the existing library
-    /// first: replacing an unreadable (newer-format) file is
-    /// exactly the restore the user just confirmed, so the
-    /// `unreadableLibrary` refusal the read-modify-write paths
-    /// take does not apply here.
+    /// Bulk replaces user palettes during backup restore (#606).
     @discardableResult
     public func replaceUserPalettes(
         with palettes: [ColorPalette]
@@ -170,7 +102,6 @@ public final class PaletteStore {
         return palettes.count - admissible.count
     }
 
-    /// Deletes the user palette named `name`.
     public func delete(_ name: String) throws {
         var palettes = try libraryPalettes()
         guard
@@ -184,14 +115,10 @@ public final class PaletteStore {
         try write(palettes)
     }
 
-    /// Renames a user palette. Throws `notFound` if `from` isn't a
-    /// user palette, `reservedName` if `to` is a built-in's name.
     public func rename(from: String, to: String) throws {
         guard !isBuiltinName(to) else {
             throw StoreError.reservedName(to)
         }
-        // A rename onto another user palette's name would create a
-        // duplicate — orphaning data and colliding the grid's id.
         guard to == from || !hasUserPalette(to) else {
             throw StoreError.duplicateName(to)
         }
@@ -207,9 +134,6 @@ public final class PaletteStore {
         try write(palettes)
     }
 
-    // MARK: - Export / import
-
-    /// Writes one palette to `url` (a Finder Save panel location).
     public func export(_ palette: ColorPalette, to url: URL) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [
@@ -218,18 +142,7 @@ public final class PaletteStore {
         try encoder.encode(palette).write(to: url)
     }
 
-    /// Reads one palette from `url` (a Finder Open panel location).
-    /// Filters the colors to known paths so an alien file can't
-    /// smuggle junk keys into the library.
-    ///
-    /// The sidecar (this and `export` above) is a BARE
-    /// `ColorPalette` — no envelope, no format, no shape marker
-    /// — and deliberately outside the migration census (#945
-    /// review): routing it would misroute (`targetFormat` has
-    /// no marker to key on), and like a backup an exported file
-    /// is never rewritten. The cost is recorded where it bites:
-    /// a breaking `ColorPalette` schema change must rule the
-    /// sidecar deliberately (profiles.md's bump paragraph).
+    /// Imports palette from file URL (#945 review).
     public func importPalette(from url: URL) throws -> ColorPalette {
         guard let data = try? Data(contentsOf: url),
             let raw = try? JSONDecoder().decode(
@@ -257,9 +170,6 @@ public final class PaletteStore {
             format: PaletteDocument.currentFormat,
             palettes: palettes
         )
-        // Atomic: a crash mid-flush must not truncate the library
-        // — a corrupt file decodes to [] and the next save would
-        // then rewrite it with only the new palette, losing it all.
         try encoder.encode(doc).write(
             to: fileURL,
             options: .atomic

--- a/Sources/KiwiDeskCore/Appearance/PaletteStore.swift
+++ b/Sources/KiwiDeskCore/Appearance/PaletteStore.swift
@@ -77,7 +77,15 @@ public final class PaletteStore {
         try write(palettes)
     }
 
-    /// Bulk replaces user palettes during backup restore (#606).
+    /// Bulk-replaces the user library on a backup restore (#606) —
+    /// the one entry point whose input is untrusted, so it
+    /// enforces every single-item invariant: a built-in's name is
+    /// dropped, a duplicate keeps the first, unknown colour keys
+    /// are filtered. Dropping rather than throwing — one bad entry
+    /// must not fail a confirmed restore; the count says how many
+    /// were refused. It deliberately does NOT read the existing
+    /// library first: replacing an unreadable newer-format file is
+    /// exactly the restore the user confirmed.
     @discardableResult
     public func replaceUserPalettes(
         with palettes: [ColorPalette]
@@ -142,7 +150,12 @@ public final class PaletteStore {
         try encoder.encode(palette).write(to: url)
     }
 
-    /// Imports palette from file URL (#945 review).
+    /// Imports a palette from a file URL, filtering colours to
+    /// known paths. The sidecar is a BARE `ColorPalette` — no
+    /// envelope, no format — and deliberately outside the
+    /// migration census (#945 review): a breaking `ColorPalette`
+    /// schema change must rule the sidecar deliberately
+    /// (profiles.md's bump paragraph).
     public func importPalette(from url: URL) throws -> ColorPalette {
         guard let data = try? Data(contentsOf: url),
             let raw = try? JSONDecoder().decode(
@@ -170,6 +183,9 @@ public final class PaletteStore {
             format: PaletteDocument.currentFormat,
             palettes: palettes
         )
+        // Atomic: a crash mid-flush must not truncate the library
+        // — a corrupt file decodes to [] and the next save would
+        // rewrite it with only the new palette, losing it all.
         try encoder.encode(doc).write(
             to: fileURL,
             options: .atomic

--- a/Sources/KiwiDeskCore/Bar/AppBarItemView+Layout.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarItemView+Layout.swift
@@ -140,8 +140,14 @@ extension AppBarItemView {
         )
     }
 
-    /// Vertical bar icon-only layout (QA 2026-07-19; tested in
-    /// `AppBarGlyphLayoutTests.verticalReuseHidesLabel`).
+    /// Vertical bar icon-only layout (QA 2026-07-19). This pass
+    /// hides the label ITSELF, and must: item views are reused
+    /// across renders, so one that laid out horizontally arrives
+    /// still showing a stale title — the hide looked redundant
+    /// from every horizontal fixture and was deleted once, a real
+    /// defect for one commit
+    /// (`AppBarGlyphLayoutTests.verticalReuseHidesLabel`). Hidden
+    /// BEFORE the `side` guard, which can return early.
     private func layoutVertical() {
         label.isHidden = true
         let pad = Self.contentPadding

--- a/Sources/KiwiDeskCore/Bar/AppBarItemView+Layout.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarItemView+Layout.swift
@@ -1,7 +1,6 @@
 import AppKit
 
-/// Slot layout: icon and name centered as one group, font
-/// scaled with the bar thickness, name-only truncation.
+/// Slot layout: icon and name centered as one group, scaled with thickness.
 extension AppBarItemView {
     override func layout() {
         super.layout()
@@ -15,15 +14,9 @@ extension AppBarItemView {
         layoutBadge()
     }
 
-    /// The group-count badge: a filled circle just after the
-    /// content, growing into a larger circle for multi-digit counts.
+    /// Group-count badge layout (QA 2026-07-19, owner 2026-07-20, #411).
     private func layoutBadge() {
         guard !badge.isHidden else { return }
-        // 0.32/9: same QA 2026-07-19 shrink decision as the
-        // Space Bar badge (whose numbers differ deliberately —
-        // it scales off the glyph cell, this off the slot) —
-        // the 0.38 ratio with a 10pt floor read oversized next
-        // to small icons.
         let baseHeight = min(
             max(
                 min(bounds.width, bounds.height) * 0.32,
@@ -35,15 +28,8 @@ extension AppBarItemView {
             ofSize: baseHeight * 0.9,
             weight: .bold
         )
-        // Ensure text fits centered; width must equal height
-        // to maintain a proper circle. We add minimal horizontal
-        // padding to keep the badge tight around the text.
         let textWidth = ceil(badge.cell?.cellSize.width ?? 0)
         let diameter = max(baseHeight, textWidth + 2)
-        // With a name shown, sit just after it at its top corner —
-        // not over it (overlapping text reads badly). Icon- or
-        // glyph-only: overlap the top-right corner like a
-        // notification badge (owner 2026-07-20). Clamped to the slot.
         let x: CGFloat
         let y: CGFloat
         if !label.isHidden, label.frame.width > 0 {
@@ -57,16 +43,6 @@ extension AppBarItemView {
             x = box.maxX - diameter / 2
             y = box.minY - diameter / 2
         }
-        // Keep the corner badge clear of the item's rounded corner
-        // (#411): the badge overlaps the top-trailing corner, and the
-        // rounding cuts it — hard under any glass finish (the item is
-        // the glass's clipped contentView), and off the rounded box
-        // otherwise. Inset it by the MINIMAL amount that nestles the
-        // circle tangent-inside the corner arc: for a badge radius r
-        // in a corner radius R, that's `(R - r)(1 - 1/√2)` off the
-        // top and trailing edges (0 when the badge already spans the
-        // arc). Every mode, so the placement stays consistent; square
-        // corners (radius 0) keep the flush overlap.
         let corner = style.resolvedCornerRadius(
             forThickness: crossThickness
         )
@@ -84,16 +60,10 @@ extension AppBarItemView {
         badge.layer?.cornerRadius = diameter / 2
     }
 
-    /// Shared with the overlay's natural-width measurement.
     nonisolated static let contentPadding: CGFloat = 4
-    /// The slot's own leading/trailing inset — a touch wider
-    /// than the inner content padding (manual QA 2026-07-18);
-    /// shared with the natural-width measurement so widening
-    /// it can never re-truncate the widest name.
+    /// Slot leading/trailing inset (manual QA 2026-07-18).
     nonisolated static let edgePadding: CGFloat = 6
 
-    /// The style's own ladder (`resolvedFontSize`), fed this
-    /// item's live cross dimension.
     private var effectiveFontSize: CGFloat {
         style.resolvedFontSize(
             forThickness: horizontal
@@ -101,9 +71,8 @@ extension AppBarItemView {
         )
     }
 
-    /// Icon and name sit centered in the slot as one group;
-    /// when space runs out, only the title shrinks — the icon
-    /// always survives.
+    /// Icon and name layout for horizontal bar (manual QA 2026-07-18,
+    /// owner 2026-07-20).
     private func layoutHorizontal() {
         let pad = Self.contentPadding
         let edge = Self.edgePadding
@@ -120,29 +89,15 @@ extension AppBarItemView {
                 min(bounds.height, bounds.width) - pad * 2,
                 0
             )
-        // Horizontal-only path, so the raw preference IS the
-        // rendered content here. One predicate for both the
-        // measurement and the layout below: they answered
-        // `== .icon` separately until a review found the pair
-        // (2026-08-20), which is two ways for a later text-free
-        // content to draw text into a slot measured without it.
         let showText = style.content.showsText
-        // The cell itself knows how much room the text needs;
-        // measuring the raw string undershoots the cell's own
-        // padding and truncates titles that would have fit.
         var textSize =
             showText
             ? (label.cell?.cellSize ?? .zero)
             : .zero
         textSize.width = ceil(textSize.width)
         textSize.height = ceil(textSize.height)
-        // Half a pad: the full pad read too airy between icon
-        // and text (manual QA 2026-07-18).
         var spacing: CGFloat =
             side > 0 && showText ? pad / 2 : 0
-        // A grouped item reserves room after the text for its count
-        // badge, so the badge sits beside the text instead of
-        // clamping over it (owner 2026-07-20).
         let badgeReserve: CGFloat =
             count >= 2 && showText
             ? min(max(min(bounds.height, bounds.width) * 0.32, 9), 14)
@@ -157,21 +112,10 @@ extension AppBarItemView {
             spacing = 0
         }
         label.isHidden = !showText || textSize.width == 0
-        // Fold the badge's own footprint (a 2 pt gap + the circle)
-        // into the centering so a grouped item's badge doesn't crowd
-        // the trailing edge — icon + name + badge center as one
-        // group, so the trailing gap matches the leading one (owner
-        // 2026-07-20). Only when the name shows: an icon-only badge
-        // overlaps the corner instead (see `layoutBadge`), and the
-        // slot already reserved this room (`badgeReserve`), so the
-        // shift never re-truncates the text.
         let badgeExtent: CGFloat =
             badgeReserve > 0 && textSize.width > 0
             ? badgeReserve - pad + 2
             : 0
-        // The edge floor exists for text; an icon-only item at
-        // the minimum slot keeps the tighter pad so its glyph
-        // box can't poke past the trailing border.
         var x = max(
             (bounds.width - side - spacing - textSize.width
                 - badgeExtent) / 2,
@@ -196,26 +140,8 @@ extension AppBarItemView {
         )
     }
 
-    /// Vertical bars render icon-only (QA 2026-07-19): titles
-    /// letter-stack terribly and rotated text is not native, so
-    /// `Content.rendered(horizontal:)` collapses the preference
-    /// to `.icon` and no title is drawn here.
-    ///
-    /// This pass hides the label ITSELF, and must: item views
-    /// are reused across renders (`AppBarOverlay` reconfigures
-    /// survivors in place), so a view that laid out horizontally
-    /// arrives here still showing a title, with a stale string
-    /// and a stale frame. `layoutHorizontal` is the only other
-    /// writer of `label.isHidden`, and it does not run on this
-    /// path. `configure` used to hide it too — a write that
-    /// looked redundant from every horizontal fixture and was
-    /// deleted as such, which is how this became a real defect
-    /// for one commit (`AppBarGlyphLayoutTests
-    /// .verticalReuseHidesLabel`).
-    ///
-    /// Hidden BEFORE the `side` guard: an item too small for an
-    /// icon slot returns early, and must not keep a title on the
-    /// way out.
+    /// Vertical bar icon-only layout (QA 2026-07-19; tested in
+    /// `AppBarGlyphLayoutTests.verticalReuseHidesLabel`).
     private func layoutVertical() {
         label.isHidden = true
         let pad = Self.contentPadding
@@ -246,10 +172,7 @@ extension AppBarItemView {
         }
     }
 
-    /// A boxed ring hugs the box (flush, same corner radius); a
-    /// plain ring insets a couple points and reads as a capsule
-    /// outline — a clean native selection mark that keeps `plain`
-    /// boxless (ui-designer 2026-07-14).
+    /// Outline selection ring (ui-designer 2026-07-14, owner 2026-07-20).
     private func layoutRing() {
         if style.hasBox {
             accent.frame = bounds
@@ -258,12 +181,6 @@ extension AppBarItemView {
                     forThickness: crossThickness
                 )
         } else {
-            // The plain ring tracks the shared plate's roundness
-            // and stays concentric with it: inner radius = the
-            // plate's resolved corner radius minus the ring inset
-            // (owner 2026-07-20). Deriving it from the ring's own
-            // shrunk frame only matched at max roundness and bowed
-            // off the corner below it.
             let inset = BarAccent.capsuleInset
             accent.frame = bounds.insetBy(dx: inset, dy: inset)
             accent.layer?.cornerRadius = max(
@@ -275,11 +192,7 @@ extension AppBarItemView {
         }
     }
 
-    /// A ~3pt bar spanning the slot's full window-facing edge
-    /// (flipped coordinates: y grows downward): a top bar faces
-    /// down, a bottom bar up, a left bar right, a right bar left.
-    /// Full-width, no corner inset — matching the Space Bar's mark
-    /// (owner call 2026-07-20).
+    /// Edge mark layout (owner call 2026-07-20).
     private func layoutEdgeMark() {
         accent.layer?.cornerRadius = 0
         let thickness: CGFloat = 3
@@ -314,5 +227,4 @@ extension AppBarItemView {
             )
         }
     }
-
 }

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Style.swift
@@ -1,15 +1,8 @@
 import AppKit
 
-/// State-dependent styling for one Space item (#293): the box,
-/// the two-accent identifier/glyph tints, the count and
-/// overflow badges, and the active indicator. Split from
-/// `SpaceBarItemView.swift` for the file ceiling.
+/// State-dependent styling for SpaceBarItemView (#293).
 extension SpaceBarItemView {
-
     func restyle() {
-        // The item does NOT clip (corner badges must stay whole);
-        // the box fill still rounds via cornerRadius, and the active
-        // mark clips through `accentClip` to the same corner.
         layer?.masksToBounds = false
         layer?.cornerRadius = cornerRadius
         layer?.backgroundColor = fillColor.cgColor
@@ -24,10 +17,7 @@ extension SpaceBarItemView {
         styleAccent()
     }
 
-    /// The identifier↔glyphs rule (QA 2026-07-19): structural
-    /// chrome, so it stays on the muted `itemColor` tier
-    /// regardless of state — a third state-driven color would
-    /// compete with the two accents rather than separate.
+    /// Structural divider between identifier and app glyphs (QA 2026-07-19).
     private func styleDivider() {
         identifierDivider.isHidden = apps.isEmpty
         identifierDivider.layer?.backgroundColor =
@@ -35,22 +25,13 @@ extension SpaceBarItemView {
             .cgColor
     }
 
-    /// Untinted content (emoji identifiers, native app images)
-    /// takes no state color, so it carried no inactive cue at
-    /// all (QA 2026-07-19). Alpha is the channel that respects
-    /// "never tint": half strength when inactive, full on the
-    /// active space and under the pointer — legible enough to
-    /// identify, clearly secondary.
+    /// Alpha for untinted elements (QA 2026-07-19).
     private var untintedAlpha: CGFloat {
         isActive || isHovered || isDragHovered
             ? 1 : style.dimFactor
     }
 
-    /// Count and overflow badges follow the space state (#293
-    /// verdict 5, amended): configured badge colors on the
-    /// active space, muted (derived from `itemColor`) on
-    /// inactive ones — a saturated badge on a muted space would
-    /// fight the two-accent hierarchy.
+    /// Styles count and overflow badges (#293).
     private func styleBadges() {
         for (index, app) in apps.enumerated() {
             guard index < badgeViews.count else { break }
@@ -65,11 +46,7 @@ extension SpaceBarItemView {
         styleStateBadges()
     }
 
-    /// The sticky / floating corner badges (#414): shown per
-    /// slot from the group aggregate ("at least one"), gated by
-    /// the Lua-only `space_bar.sticky_badge`, styled exactly
-    /// like the count badge (`applyBadge`) so all three corners
-    /// read as one badge family sitting inside the glyph.
+    /// Styles sticky / floating corner state badges (#414).
     private func styleStateBadges() {
         for (index, app) in apps.enumerated() {
             guard index < stickyBadgeViews.count,
@@ -90,14 +67,7 @@ extension SpaceBarItemView {
         }
     }
 
-    /// A state mark (#429): a filled disc like the count badge,
-    /// but tinted with the chosen state color and wearing an
-    /// auto-contrast glyph. Automatic (empty) falls back to the
-    /// count badge's own `groupBadgeColor` fill, so the default
-    /// sticky / floating / count trio stays one consistent family;
-    /// a picked color makes just that mark stand out. The glyph is
-    /// computed black/white so any fill keeps a legible mark — no
-    /// focused-accent switch; focus reads through the alpha tier.
+    /// State badge fill and contrast glyph (#429).
     private func applyStateBadge(
         _ badge: StateBadgeView,
         shown: Bool,
@@ -114,37 +84,8 @@ extension SpaceBarItemView {
         badge.alphaValue = untintedAppAlpha(focused: appFocused)
     }
 
-    /// A count / overflow badge follows the same 3-tier ladder as the
-    /// glyphs (owner 2026-07-20): the whole badge (fill AND text)
-    /// dims via `alphaValue` to the app's focus tier — full for the
-    /// focused app (or on hover), `activeUnfocusedAlpha` for an
-    /// unfocused app on the active space, `untintedAlpha` on an
-    /// inactive one.
-    ///
-    /// The **alpha** half of that ladder generalizes; the **ink**
-    /// half did not, and no longer applies here (#470,
-    /// ui-designer consult). Badge text stays
-    /// `groupBadgeTextColor` and never takes the focused accent,
-    /// because a glyph and a badge do not share a background: a
-    /// glyph's ink is contrast-tested against the bar plate, a
-    /// badge's against a second, independently chosen fill. The
-    /// focused accent was only ever safe against the one badge
-    /// fill it was eyeballed against, and #470's darkening took
-    /// that pair to 2.10:1 — below even the large-text floor.
-    /// Alpha is chip-color-agnostic, so it survives any fill, any
-    /// palette, any future accent retune.
-    ///
-    /// This also puts the badge back in line with its siblings
-    /// rather than carving an exception: the App Bar's own count
-    /// badge (`AppBarItemView.applyGroupBadge`) and the
-    /// sticky/floating state marks below both already leave the
-    /// ink alone and let alpha carry focus. Nothing is lost —
-    /// `untintedAppAlpha` already puts the focused app's badge
-    /// uniquely at full alpha, beside a glyph that *is* tinted.
-    /// It is also what macOS does: the system badge pairs one
-    /// ink with one fill unconditionally, with no focused
-    /// variant. (That fill is red; ours has been neutral grey
-    /// since #955 — the invariance generalizes, not the hue.)
+    /// Group badge styling with 3-tier alpha ladder
+    /// (#470, #955, owner 2026-07-20).
     private func applyBadge(_ badge: NSTextField, appFocused: Bool) {
         badge.layer?.backgroundColor =
             NSColor(kiwiHex: style.groupBadgeColor).cgColor
@@ -159,11 +100,7 @@ extension SpaceBarItemView {
         )
     }
 
-    /// Which corners `accentClip` rounds. Boxed clips all four (its
-    /// own box). Plain clips only the run's outer end — leading on
-    /// the first item, trailing on the last (when no front app
-    /// trails it) — so the mark cuts on the plate's curve there and
-    /// stays square between (owner 2026-07-20).
+    /// Corner masking for accent clip (owner 2026-07-20).
     private var maskedCorners: CACornerMask {
         let all: CACornerMask = [
             .layerMinXMinYCorner, .layerMaxXMinYCorner,
@@ -185,9 +122,6 @@ extension SpaceBarItemView {
     }
 
     private var fillColor: NSColor {
-        // Active wins over hover (matching `stateColor` and the
-        // mouseEntered guard): a click that activates the item
-        // under the pointer must not leave it hover-tinted.
         if isActive, style.hasBox {
             return NSColor(kiwiHex: style.fillColor)
         }
@@ -201,8 +135,6 @@ extension SpaceBarItemView {
         return NSColor(kiwiHex: style.fillColor)
     }
 
-    /// The state tier a tinted element takes: active space
-    /// accent, hover text, or the inactive tier.
     private var stateColor: NSColor {
         if isActive {
             return NSColor(kiwiHex: style.activeItemColor)
@@ -258,13 +190,7 @@ extension SpaceBarItemView {
         }
     }
 
-    /// Three-tier ladder for untinted app glyphs (QA
-    /// 2026-07-19): full for the focused app on the active
-    /// space, `activeUnfocusedAlpha` for its unfocused
-    /// siblings — without it a native icon carried no focus
-    /// cue at all — and `untintedAlpha` on inactive spaces.
-    /// Hover always lifts to full (explicit intent; one hover
-    /// rule, no fourth value).
+    /// Three-tier alpha ladder for untinted app glyphs (QA 2026-07-19).
     private func untintedAppAlpha(
         focused: Bool
     ) -> CGFloat {
@@ -285,12 +211,6 @@ extension SpaceBarItemView {
             accent.layer?.backgroundColor = nil
             accent.layer?.borderColor = highlight.cgColor
             accent.layer?.borderWidth = 2
-            // Plain/material: the ring tracks the shared plate's
-            // roundness and stays concentric — inner radius = the
-            // plate's resolved corner radius minus the ring inset
-            // (owner 2026-07-20). Bounds-derived (not `accent.frame`):
-            // restyle runs before layout places the accent, so the
-            // frame may be stale here.
             accent.layer?.cornerRadius =
                 style.hasBox
                 ? cornerRadius
@@ -300,16 +220,10 @@ extension SpaceBarItemView {
             accent.layer?.cornerRadius = 0
             accent.layer?.backgroundColor = highlight.cgColor
         case .gap:
-            // No shape marker: `gap` hides the App Bar's active
-            // item, which cannot apply to a space identifier —
-            // colors alone carry the state.
             accent.isHidden = true
         }
     }
 
-    /// Both sizes read `SpaceBarStyle`'s one ladder — the
-    /// front-app glyph reads the same one, so every glyph
-    /// renders an app at one size.
     var identifierFont: CGFloat {
         style.identifierFontSize(
             forDepth: horizontal ? bounds.height : bounds.width

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView.swift
@@ -1,65 +1,23 @@
 import AppKit
 
-/// One Space in the Space Bar (#293): the space's identifier
-/// glyph followed by a compact row (horizontal bar) or column
-/// (vertical bar) of app glyphs for the windows currently in
-/// that space. Click focuses the space; app glyphs are
-/// informational in v1 — never nested click targets.
-///
-/// Two-accent rendering: inactive spaces draw everything in
-/// `itemColor`; the active space draws identifier + glyphs in
-/// `activeItemColor`, and the focused window's glyph in
-/// `focusedItemColor`. Emoji identifiers and native app images
-/// stay untinted — shape (the active indicator) carries the
-/// active state there.
+/// Space item view in Space Bar with identifier and app glyphs (#293).
 final class SpaceBarItemView: NSView {
-    /// The space identifier, resolved by the driver.
+    /// Space identifier glyph representation.
     enum Identifier: Equatable {
-        /// A template SF Symbol, tinted by space state.
         case symbol(String)
-        /// Emoji or single character; emoji render untinted.
         case text(String, tinted: Bool)
     }
 
-    /// One app glyph in the space's row — one slot per
-    /// adjacent same-app run (#293 stage 2), wearing a count
-    /// badge when the run holds several windows. No
-    /// focused-inside expansion: glyphs aren't click targets,
-    /// so a group containing the focused window just takes the
-    /// focused accent.
+    /// App glyph run in space item (#293 stage 2, #294, #414, #445).
     struct App: Equatable {
         let name: String
-        /// The window title the FRONT SEGMENT draws, already
-        /// capped, or nil to fall back to `name`. Only the front
-        /// segment ever carries one: a Space item is a run of
-        /// app glyphs with no text at all, so its `App` values
-        /// leave this nil. Resolved by the driver
-        /// (`KiwiCore.frontApp`), like the glyph.
-        ///
-        /// Separate from `name` on purpose — `name` still
-        /// resolves the App Font glyph
-        /// (`appFont.glyph(forAppName:)`) and names the app for
-        /// accessibility, neither of which a title can do.
         var title: String?
         let icon: NSImage?
-        /// App Font ligature; non-nil replaces `icon` and
-        /// follows the text-color ladder (#294).
         let glyph: String?
         let focused: Bool
-        /// Windows behind this glyph; > 1 shows a count badge.
         let count: Int
-        /// State badges (#414): aggregates over the run — an
-        /// explicit "at least one" signal, honest for a group
-        /// (badge inheritance). Sticky wears the top-left
-        /// badge, floating the bottom-left; the group count
-        /// keeps top-right. Space Bar only — in the bar there
-        /// is otherwise no way to tell these states apart.
         var sticky = false
         var floating = false
-        /// The sticky SCOPE the badge glyph reflects (#445):
-        /// `.global` → `infinity`, `.display` → `pin.fill`. The
-        /// run's first sticky member wins (badge inheritance); a
-        /// mixed run is rare and either glyph reads as "sticky".
         var stickyScope: StickyScope = .none
     }
 
@@ -71,29 +29,15 @@ final class SpaceBarItemView: NSView {
         return tf
     }()
     var appViews: [NSView] = []
-    /// One count badge per glyph slot (hidden below 2).
     var badgeViews: [NSTextField] = []
-    /// Per-slot state badges (#414): sticky top-left, floating
-    /// bottom-left — the count badge's circular plate wearing a
-    /// symbol, so all three corners read as one badge family.
     var stickyBadgeViews: [StateBadgeView] = []
     var floatingBadgeViews: [StateBadgeView] = []
-    /// The "+n" overflow badge, its own trailing slot.
     let overflowBadge = SpaceBarItemView.makeBadge()
-    /// The identifier↔glyphs rule (QA 2026-07-19) — the front
-    /// segment's divider, reused inside the item. Hidden on
-    /// empty spaces (nothing to separate).
+    /// Divider between identifier and app glyphs (QA 2026-07-19).
     let identifierDivider = NSView()
     let accent = NSView()
-    /// Rounds/clips only the active mark to the item's corner
-    /// without clipping the item itself — so the mark cuts on the
-    /// curve while corner badges stay whole (owner 2026-07-20).
-    /// Flipped to match the item, so the accent's y math is unchanged.
+    /// Active mark corner clip (owner 2026-07-20).
     let accentClip = AppBarOverlay.FlippedView()
-    /// Whether this item sits at the run's leading / trailing end.
-    /// Under Plain the shared plate rounds only there. The trailing
-    /// end may be the front-app segment's, not the last item's, so
-    /// the overlay sets `isLastInRun` false when a front app trails.
     var isFirstInRun = false
     var isLastInRun = false
 
@@ -104,31 +48,20 @@ final class SpaceBarItemView: NSView {
     )
     private(set) var apps: [App] = []
     private(set) var overflow = 0
-    /// The focused window is hidden past the cap (its glyph isn't
-    /// visible) — the "+n" tints to signal focus is behind it (#376).
+    /// True if focused window is in overflow (#376).
     private(set) var focusInOverflow = false
     private(set) var isActive = false
     private(set) var isHovered = false
-    /// Synthetic hover during a window drag (#372). Tracking
-    /// areas stay silent while another app owns the drag loop,
-    /// so the driver sets this from the AX cursor position; it
-    /// routes through the same `hoverFillColor` path as `isHovered`.
-    /// Mutated via `setDragHover` (SpaceBarItemView+DragDrop).
+    /// Drag hover state (#372).
     var isDragHovered = false
-    /// The pending-spring sweep ring (#372): a stroke that fills
-    /// 0→1 over the dwell, layered on top of the hover tint.
+    /// Spring sweep ring (#372).
     let springRing = CAShapeLayer()
     var horizontal = true
     var style = SpaceBarStyle()
-    /// The sticky / floating badge tints (#429), resolved by
-    /// `KiwiCore`; the state badges' glyphs read these instead of
-    /// the count badge's `groupBadgeColor` family.
+    /// State mark colors (#429).
     var stateMarkColors = StateMarkColors(sticky: "", floating: "")
     var onSelect: (SpaceID) -> Void = { _ in }
 
-    /// Flipped so the identifier leads at the visual top on
-    /// vertical bars and glyphs read in flat-array order (same
-    /// convention as `AppBarOverlay.FlippedView`).
     override var isFlipped: Bool { true }
 
     override init(frame: CGRect) {
@@ -150,8 +83,7 @@ final class SpaceBarItemView: NSView {
         layer?.addSublayer(springRing)
     }
 
-    /// The App Bar's badge shape: a filled circle around a
-    /// bold centered count (`IndicatorBarBadgeCell`).
+    /// Creates badge label with circular indicator background.
     static func makeBadge() -> NSTextField {
         let tf = NSTextField(labelWithString: "")
         let cell = IndicatorBarBadgeCell(textCell: "")
@@ -167,16 +99,10 @@ final class SpaceBarItemView: NSView {
         return tf
     }
 
-    /// The floating badge's mark, read from the style that owns
-    /// it (`FloatingStyle.symbolName`) — the sticky mark is
-    /// shared with the on-window mark the same way, see
-    /// `StickyStyle.symbolName`.
     static let floatingSymbol = FloatingStyle.symbolName
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
-
-    // MARK: - Interaction
 
     override func mouseDown(with event: NSEvent) {
         guard !isActive else { return }
@@ -208,8 +134,6 @@ final class SpaceBarItemView: NSView {
         restyle()
     }
 
-    // MARK: - Configuration
-
     func configure(
         space: SpaceID,
         spaceGlyph: Identifier,
@@ -221,10 +145,6 @@ final class SpaceBarItemView: NSView {
         overflow: Int = 0,
         focusInOverflow: Bool = false
     ) {
-        // A pooled view reused for a different Space drops any
-        // drag-drop cues it was showing for the old one — a stale
-        // hover tint or half-swept spring ring would otherwise
-        // paint on the wrong item (#372, review).
         if self.space != space {
             cancelSpringSweep()
             isDragHovered = false
@@ -238,9 +158,6 @@ final class SpaceBarItemView: NSView {
         self.horizontal = horizontal
         self.style = style
         self.stateMarkColors = stateMarkColors
-        // Hover is NOT reset here: a retile under the pointer
-        // (focus changes are frequent) must not drop the tint —
-        // mouseExited still fires when the pointer leaves.
         syncAppViews()
         restyle()
         needsLayout = true
@@ -250,8 +167,6 @@ final class SpaceBarItemView: NSView {
     }
 
     private var axLabel: String {
-        // Windows, not visible slots: grouped and past-the-cap
-        // windows still count.
         let windows =
             apps.reduce(0) { $0 + $1.count } + overflow
         let name = L(
@@ -273,10 +188,6 @@ final class SpaceBarItemView: NSView {
             )
     }
 
-    /// One subview per app: a text field for App Font glyphs, an
-    /// image view otherwise. Recreating (not pooling) is
-    /// load-bearing: `styleApps` never re-sets an image view's
-    /// `image`, so naive reuse would show stale icons.
     private func syncAppViews() {
         appViews.forEach { $0.removeFromSuperview() }
         badgeViews.forEach { $0.removeFromSuperview() }
@@ -319,7 +230,4 @@ final class SpaceBarItemView: NSView {
             return badge
         }
     }
-
-    // Styling lives in SpaceBarItemView+Style.swift;
-    // layout in SpaceBarItemView+Layout.swift.
 }

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -41,7 +41,11 @@ public final class BorderManager {
     var triedEventSource = false
     var privateRuntimeStarted = false
     var skyLightActive = false
-    /// QA lever to disable WindowServer tracking path (#596).
+    /// QA lever forcing the AX-fallback path (#596): set from
+    /// `KIWIDESK_NO_WS_TRACKING` at wiring — the settle-tail
+    /// symptoms are AX-fallback-only and the WS stream is up on
+    /// every developer Mac, so without a lever they are
+    /// unobservable.
     var windowServerTrackingDisabled = false
     var reportedTrackingActive: Bool?
     var onLog: @MainActor (String) -> Void = CoreLog.write
@@ -58,7 +62,10 @@ public final class BorderManager {
     }
     /// WindowServer bounds reconcile tee for sticky marks (QA 2026-07-21).
     var onFrameReconciled: @MainActor (WindowID, CGRect) -> Void = { _, _ in }
-    /// WindowServer z-order reorder tee (owner QA 2026-07-21).
+    /// WindowServer z-order reorder tee (owner QA 2026-07-21): a
+    /// re-click on an ALREADY-focused window raises it above its
+    /// own mark yet fires no AX focus event, so the focus-driven
+    /// re-sync never runs — this is what reaches the mark instead.
     var onWindowReordered: @MainActor (WindowID) -> Void = { _ in }
     /// Windows tracked for sticky mark z-order without active rings.
     var stickyTracked: Set<WindowID> = []
@@ -137,7 +144,10 @@ public final class BorderManager {
         cornerRadii[id] = nil
     }
 
-    /// Returns existing or newly created overlay for steady-state sync.
+    /// The window's ring, creating one if needed — a mutating
+    /// getter only `sync` may call. The dead-end bounce routes
+    /// around it via `makeOverlay` into a separate store, so a
+    /// concurrent `sync` can never adopt or stomp its transient.
     func overlay(for window: WindowID) -> BorderOverlay {
         if let existing = overlays[window] { return existing }
         let overlay = makeOverlay(for: window)

--- a/Sources/KiwiDeskCore/Borders/BorderManager.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager.swift
@@ -1,32 +1,16 @@
 import AppKit
 
-/// Keeps focus-border overlays in sync with the windows that
-/// should wear a ring (#278). The driver (`KiwiCore.updateBorders`)
-/// computes the desired set; this manager creates, updates, and
-/// retires one `BorderOverlay` per window, keyed by `WindowID` —
-/// mirroring `AppBarManager`'s diff-sync.
-///
-/// The rendering paths — `sync` for steady state (create /
-/// recolor / destroy), `follow` for the animation hot path, and
-/// the unguarded `apply` — live in the `+Sync` extension; the
-/// WindowServer integration in `+SkyLight`; the dead-end bounce
-/// in `+DeadEnd`. This file owns the stores they share.
+/// Keeps focus-border overlays in sync with targeted windows (#278).
 @MainActor
 public final class BorderManager {
-    /// One window's desired ring. Frames are in AX coordinates,
-    /// taken from cached window state — never a live AX call.
+    /// One window's desired ring specification in AX coordinates.
     public struct Spec: Equatable {
         public let window: WindowID
         public let frame: CGRect
         public let colorHex: String
         public let width: CGFloat
         public let cornerStyle: BorderStyle.CornerStyle
-        /// The glow bloom's resolved blur radius, `0` = no glow
-        /// (#358/#551). Resolved by `BorderStyle.resolvedGlowBlur`
-        /// at spec build — one number arrives here, never the
-        /// style's raw knobs. Set only on the focused ring —
-        /// `borderSpecs` never glows an unfocused ring, so this
-        /// is `0` for every non-focused spec.
+        /// Resolved glow blur radius (0 = none, #358, #551).
         public let glowBlur: CGFloat
 
         public init(
@@ -46,122 +30,58 @@ public final class BorderManager {
         }
     }
 
-    // `overlays` and the SkyLight tracking state below are read and
-    // written by the WindowServer integration in the
-    // `BorderManager+SkyLight` extension (separate file), so they are
-    // internal rather than private.
     var overlays: [WindowID: BorderOverlay] = [:]
-    /// Transient rings spawned only to carry the dead-end bounce on
-    /// a window that has no steady-state ring (borders off). Kept
-    /// out of `overlays` so `sync` never sees them; torn down by the
-    /// bump animator's completion (`+DeadEnd`).
+    /// Transient rings spawned for dead-end bounces when borders are disabled.
     var bumpTransients: [WindowID: BorderOverlay] = [:]
-    /// Last synced spec per window, so the per-tick `follow` can
-    /// recompute geometry from a fresh frame while reusing the
-    /// window's color / width / corner style.
-    /// Internal, not private: the frame paths that read it
-    /// live in the `BorderManager+Sync` extension.
     var specs: [WindowID: Spec] = [:]
-    /// Each window's real corner radius, resolved once per window and
-    /// reused. A window's radius is a fixed OS attribute, and a query
-    /// that comes back empty (a square/borderless window reporting no
-    /// radius) is a permanent answer, not a transient one — so a
-    /// resolved default is cached too, never re-queried every sync.
-    /// Internal for the same reason as `specs` above: `sync`
-    /// retires a window's radius alongside its ring.
     var cornerRadii: [WindowID: CGFloat] = [:]
-    /// The draw order every ring is currently built for (#367).
-    /// Global, not per-window: flipping it retires all overlays so
-    /// each rebuilds for the new order at the next `sync`. Both
-    /// orders now prefer the SkyLight backend (below-order too);
-    /// AppKit is only the availability/failure fallback.
+    /// Global draw order (#367).
     private var activeOrder: BorderGeometry.Order = .below
     var eventSource: SkyLightWindowEvents?
     var triedEventSource = false
     var privateRuntimeStarted = false
     var skyLightActive = false
-    /// QA lever (#596): forces the WindowServer border-tracking
-    /// path off so `skyLightActive` stays false and the ring and
-    /// mark run the AX-fallback path on a healthy machine. Set
-    /// from `KIWIDESK_NO_WS_TRACKING` at wiring — the settle-tail
-    /// symptoms this issue chases are AX-fallback-only, and the
-    /// WS stream is up on every developer Mac, so without a lever
-    /// they are unobservable. Off by default: the flag is read
-    /// once and costs nothing after.
+    /// QA lever to disable WindowServer tracking path (#596).
     var windowServerTrackingDisabled = false
     var reportedTrackingActive: Bool?
     var onLog: @MainActor (String) -> Void = CoreLog.write
-    /// Whether OUR OWN animation currently drives this window
-    /// (#594). Wired to `AnimationEngine.isAnimating`; while
-    /// true, the per-tick commanded frame owns the ring — the
-    /// WS stream and the AX echo both trail it on slow-AX apps
-    /// — so `follow`'s echo path and the WS `reconcile` stand
-    /// down. A no-op default keeps the manager testable in
-    /// isolation.
+    /// True while local animation drives this window (#594).
     var isAnimating: @MainActor (WindowID) -> Bool = { _ in false }
 
-    /// The engine's just-commanded instant-set target while its
-    /// echo is pending, nil otherwise (#881) — the `commanded`
-    /// input `sync` hands `FollowSource.syncFrame`. Wired in
-    /// `KiwiCore+Bootstrap` beside `isAnimating`, one closure
-    /// shared with the mark manager.
+    /// Engine's commanded instant target while echo is pending (#881).
     var commandedFrame: @MainActor (WindowID) -> CGRect? = {
         _ in nil
     }
-    /// WindowServer bounds read behind `reconcile` — injectable
-    /// so tests can hand the manager deterministic bounds
-    /// without a live SkyLight connection.
+    /// WindowServer bounds query seam for testability.
     var readWindowBounds: @MainActor (WindowID) -> CGRect? = {
         SkyLight.windowBounds($0.raw)
     }
-    /// Tee of every WindowServer bounds re-read (`reconcile`) —
-    /// the live-tracking hot path AX echoes lag behind. Wired
-    /// to the sticky mark so it follows a dragged window at
-    /// WS event rate, exactly like the ring (QA 2026-07-21);
-    /// a no-op by default.
+    /// WindowServer bounds reconcile tee for sticky marks (QA 2026-07-21).
     var onFrameReconciled: @MainActor (WindowID, CGRect) -> Void = { _, _ in }
-    /// Tee of every WindowServer z-order change (`.reorder` /
-    /// `.level`). Wired to the sticky mark so it re-asserts its
-    /// stacking whenever the target raises — a re-click on an
-    /// ALREADY-focused window raises it above its own mark yet
-    /// fires no AX focus event, so the focus-driven re-sync never
-    /// runs (owner QA 2026-07-21). A no-op by default.
+    /// WindowServer z-order reorder tee (owner QA 2026-07-21).
     var onWindowReordered: @MainActor (WindowID) -> Void = { _ in }
-    /// Windows the sticky mark needs WS z-order events for, even
-    /// when they wear no ring (borders off / unfocused). Folded
-    /// into the WS watch set so the reorder tee reaches them.
+    /// Windows tracked for sticky mark z-order without active rings.
     var stickyTracked: Set<WindowID> = []
 
-    /// Drives the dead-end rubber-band (#436). Owned here because it
-    /// bumps the same overlays this manager holds, and spawns a
-    /// transient one when borders are off (see `+DeadEnd`).
+    /// Drives the dead-end rubber-band bounce (#436).
     let bumpAnimator = BorderBumpAnimator()
-    /// Overlay pill for minimum size refusal (#933).
+    /// Overlay pill for minimum size refusal cues (#933).
     let sizeLimitOverlay = SizeLimitOverlay()
 
-    /// Test observation seam for the resize refusal cues (#933):
-    /// the drawn cues are display-gated, so headless suites
-    /// observe refusals here. Production leaves the no-op.
+    /// Test observation seam for resize refusal cues (#933).
     var onResizeRefusal: (ResizeRefusal) -> Void = { _ in }
 
-    /// Tokens for the own-key-window notifications that
-    /// re-evaluate the ring set (#933 follow-up) — stored here
-    /// because `KiwiCore` sits at the file-size ceiling; wired
-    /// by `KiwiCore.wireOwnKeyWindowRefresh`.
+    /// Observers for key window transitions (#933).
     var ownKeyWindowObservers: [NSObjectProtocol] = []
 
     public init() {}
 
-    /// Enables the private WindowServer fast path once KiwiDesk's
-    /// application lifecycle has started. Keeping it dormant during
-    /// pure core construction prevents tests and previews from
-    /// registering process-global SkyLight callbacks.
+    /// Enables private WindowServer tracking after application startup.
     func start() {
         privateRuntimeStarted = true
     }
 
-    /// Retires every ring and disables private callbacks until the
-    /// next application start.
+    /// Retires all rings and disables private callbacks.
     func stop() {
         clear()
         privateRuntimeStarted = false
@@ -169,19 +89,12 @@ public final class BorderManager {
         reportedTrackingActive = nil
     }
 
-    /// Windows currently wearing a ring — the manager's contract
-    /// surface for tests and diagnostics.
+    /// Windows currently wearing a ring.
     public var borderedWindows: Set<WindowID> {
         Set(overlays.keys)
     }
 
-    /// Selects whether rings stack behind or in front of windows
-    /// (#367). A no-op when unchanged; a real flip retires every
-    /// live overlay so the next `sync` rebuilds it for the new
-    /// order. Both orders prefer the SkyLight backend (front =
-    /// above-order, behind = below-order); AppKit renders only when
-    /// SkyLight is unavailable. Per-window `specs` and cached radii
-    /// are kept — only the geometry/stacking changes.
+    /// Sets draw order (behind or in front of windows, #367).
     public func setDrawOrder(_ order: BorderStyle.DrawOrder) {
         let mapped: BorderGeometry.Order =
             order == .front ? .above : .below
@@ -191,10 +104,7 @@ public final class BorderManager {
         activeOrder = mapped
     }
 
-    /// The window's real corner radius so the ring's arc hugs it,
-    /// resolved once and cached (#357). Falls back to the shared
-    /// default when SkyLight reports none — that default is cached
-    /// too, so a radius-less window isn't re-queried on every sync.
+    /// Window corner radius from SkyLight or system fallback (#357).
     func cornerRadius(for id: WindowID) -> CGFloat {
         if let cached = cornerRadii[id] { return cached }
         let resolved =
@@ -204,9 +114,7 @@ public final class BorderManager {
         return resolved
     }
 
-    /// Retires every ring at once. Used on shutdown (`stop()`)
-    /// before the quit gather scatters windows; steady-state
-    /// retirement of individual rings goes through `sync`.
+    /// Retires all rings and resets tracking state.
     public func clear() {
         bumpAnimator.flushAll()
         for overlay in overlays.values { overlay.hide() }
@@ -219,29 +127,17 @@ public final class BorderManager {
         _ = eventSource?.watch([])
     }
 
-    /// Force-settles in-flight dead-end bounces on a display change:
-    /// a bump whose monitor was unplugged would otherwise stall (its
-    /// DisplayLink stops firing) and leak its transient overlay.
+    /// Settles in-flight bounces when displays change.
     func displaysChanged() {
         bumpAnimator.flushAll()
     }
 
-    /// Drops a window's cached corner radius. Narrow surface for the
-    /// dead-end cue's transient teardown (`+DeadEnd`) so a borders-off
-    /// window that only ever bounced doesn't keep a stale radius until
-    /// `clear()` — which would mis-round a later ring if the id is
-    /// recycled (#308). No-op'd when a steady ring still owns it.
+    /// Clears cached corner radius on transient teardown (#308).
     func forgetCornerRadius(_ id: WindowID) {
         cornerRadii[id] = nil
     }
 
-    /// The window's ring, CREATING and storing one if it has
-    /// none — a mutating getter, so only `sync` may call it (it
-    /// alone knows the window should have a ring). The dead-end
-    /// bounce deliberately routes around it via `makeOverlay`
-    /// into a separate store, so a concurrent `sync` can never
-    /// adopt or stomp its transient. Internal, not private:
-    /// `sync` lives in the `+Sync` extension.
+    /// Returns existing or newly created overlay for steady-state sync.
     func overlay(for window: WindowID) -> BorderOverlay {
         if let existing = overlays[window] { return existing }
         let overlay = makeOverlay(for: window)
@@ -249,26 +145,10 @@ public final class BorderManager {
         return overlay
     }
 
-    /// Builds a ring overlay for `window` without inserting it into
-    /// the steady-state `overlays` store. Used there via
-    /// `overlay(for:)`, and by the dead-end cue's transient overlay
-    /// (`+DeadEnd`), which lives in a separate store so a concurrent
-    /// `sync` can never adopt or stomp it (and vice-versa).
+    /// Builds a ring overlay for `window` (#361, #367).
     func makeOverlay(for window: WindowID) -> BorderOverlay {
         BorderOverlay(
             window: window.raw,
-            // Below-order stays the default (#361) and now prefers
-            // the space-pinned SkyLight path: Mission Control
-            // leaves a pinned ring behind instantly (jankyborders'
-            // model), and a below ring skips the above-order
-            // sub-level re-assertion that flickered under the
-            // per-keystroke compositor churn Firefox/Zen emit —
-            // the target itself occludes it. AppKit is now purely
-            // the fallback when the private surface is unavailable
-            // or fails. `border.set_draw_order("front")` opts into
-            // the SkyLight above-order path (#367); `activeOrder`
-            // carries that choice. WS geometry tracking is
-            // unaffected (see `usesWindowServerTracking`).
             order: activeOrder,
             onFallback: { [weak self] reason in
                 self?.onLog(
@@ -279,11 +159,7 @@ public final class BorderManager {
         )
     }
 
-    /// The screen a window's frame mostly sits on (for the ring's
-    /// pixel scale), or the main screen. Max visible-area overlap
-    /// (#449), not a center hit test: a frame hanging off an edge
-    /// (stash corner, mid-drag) keeps an offscreen center yet
-    /// still resolves its OWN display's scale.
+    /// Display containing majority of frame for pixel scaling (#449).
     func screen(for frame: CGRect) -> NSScreen? {
         TilingEngine.screen(containing: frame) ?? NSScreen.main
     }

--- a/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
@@ -1,6 +1,9 @@
 import AppKit
 
-/// Focus-ring backend protocol (#357, #533).
+/// Focus-ring backend protocol (#357, #533). The SkyLight
+/// implementation returns `false` after any private-API failure
+/// so the facade can retire it and replay the latest state
+/// through the mandatory AppKit fallback.
 @MainActor
 protocol BorderOverlayBackend: AnyObject {
     var orderMode: BorderGeometry.Order { get }
@@ -23,6 +26,10 @@ extension BorderOverlayBackend {
 @MainActor
 final class BorderOverlay {
     private var backend: any BorderOverlayBackend
+    /// The raw inputs of the last render, kept so a fallback swap
+    /// can rebuild geometry for the new backend's order mode — the
+    /// `above` SkyLight geometry cannot be reused by the `below`
+    /// AppKit panel (#357).
     private var lastFrame: CGRect?
     private var lastWidth: CGFloat = 0
     private var lastCornerStyle: BorderStyle.CornerStyle = .rounded
@@ -40,6 +47,10 @@ final class BorderOverlay {
     private let makePreferred:
         @MainActor (CGWindowID) -> (any BorderOverlayBackend)?
     private let onFallback: @MainActor (String) -> Void
+    /// True once SkyLight must never be re-attempted: after a real
+    /// failure, and after a nil init (static unavailability) —
+    /// otherwise every glow-off update on the apply hot path would
+    /// re-run the doomed init forever.
     private var skyLightRetired = false
 
     init(
@@ -53,6 +64,10 @@ final class BorderOverlay {
         makePreferred = {
             SkyLightBorderOverlay(targetWindow: $0, order: order)
         }
+        // Both orders prefer SkyLight: its window is space-pinned
+        // at creation, so Mission Control leaves the ring behind
+        // instantly; `above` keeps the sub-level path that makes
+        // it occlusion-correct (#357/#367).
         if let skyLight = SkyLightBorderOverlay(
             targetWindow: window,
             order: order
@@ -84,7 +99,11 @@ final class BorderOverlay {
         onFallback = { _ in }
     }
 
-    /// Dynamically swaps backend when glow is toggled (#533).
+    /// Swaps backend on the glow toggle (#533): the
+    /// WindowServer-backed SkyLight context drops every shadow
+    /// colour to a grey smear, so a glow ring always renders on a
+    /// backend that can bloom; plain rings stay on SkyLight for
+    /// its space pin. Two-way, except once SkyLight is retired.
     @discardableResult
     private func ensureBackend(glow: Bool) -> Bool {
         if glow, !backend.rendersGlow {
@@ -144,6 +163,10 @@ final class BorderOverlay {
             return
         }
         if swapped && !shouldRestore {
+            // Re-assert through the FACADE methods, so a failed
+            // op on a fresh SkyLight window follows the
+            // retire-and-fall-back discipline instead of leaving
+            // a drawn-but-unordered ring.
             if isHidden {
                 hide()
             } else {
@@ -164,7 +187,9 @@ final class BorderOverlay {
         }
     }
 
-    /// Renders rubber-band bump offset for dead-end cue (#436).
+    /// Renders the rubber-band bump offset for the dead-end cue
+    /// (#436). Pure overlay motion: it never touches the window —
+    /// no AX write, nothing for the frame authority to fight.
     func renderBump(offset: CGVector, colorHex: String? = nil) {
         guard lastFrame != nil else { return }
         bumpOffset = offset

--- a/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderOverlay.swift
@@ -1,23 +1,10 @@
 import AppKit
 
-/// One focus-ring renderer. The SkyLight implementation returns
-/// `false` after any private-API failure so the facade can retire it
-/// and replay the latest state through the mandatory AppKit fallback.
+/// Focus-ring backend protocol (#357, #533).
 @MainActor
 protocol BorderOverlayBackend: AnyObject {
-    /// Where this backend stacks its ring, which the facade needs
-    /// to build the matching geometry: `above` draws a visible
-    /// hairline overlap on the target, `below` masks the overlap
-    /// behind it. SkyLight renders either order; the AppKit
-    /// fallback is below-only. The facade recomputes geometry for
-    /// this mode on every render and after a fallback swap (#357).
     var orderMode: BorderGeometry.Order { get }
-    /// Whether this backend can render the glow bloom (#533).
-    /// The SkyLight surface cannot — its WindowServer context
-    /// drops every shadow colour — so the facade swaps a glow
-    /// ring to a backend that answers `true`. Defaults to `true`
-    /// (only SkyLight opts out); test fakes flip it to exercise
-    /// the swap.
+    /// True if backend supports glow rendering (AppKit only, #533).
     var rendersGlow: Bool { get }
     func update(
         geometry: BorderGeometry,
@@ -32,52 +19,27 @@ extension BorderOverlayBackend {
     var rendersGlow: Bool { true }
 }
 
-/// Per-ring backend facade (#285 Tier 2). SkyLight is attempted only
-/// after its drawing and event surfaces both initialized; a missing
-/// symbol or failed operation permanently moves this ring to AppKit.
+/// Per-ring backend facade managing SkyLight and AppKit fallback (#285, #357).
 @MainActor
 final class BorderOverlay {
     private var backend: any BorderOverlayBackend
-    /// The raw inputs of the last render, kept so a fallback swap can
-    /// rebuild geometry for the new backend's order mode — the
-    /// `above` SkyLight geometry cannot be reused by the `below`
-    /// AppKit panel (#357).
     private var lastFrame: CGRect?
     private var lastWidth: CGFloat = 0
     private var lastCornerStyle: BorderStyle.CornerStyle = .rounded
     private var lastColorHex = ""
-    /// The last render's resolved glow blur (`0` = no glow,
-    /// #358/#551). Kept alongside the other raw inputs so a
-    /// fallback swap or a dead-end bump rebuilds geometry with
-    /// the same glow state.
+    /// Resolved glow blur (`0` = no glow, #358, #551).
     private var lastGlowBlur: CGFloat = 0
     private weak var lastScreen: NSScreen?
     private var targetWindow: CGWindowID
-    /// The target's real corner radius, resolved by `BorderManager`
-    /// (which owns OS I/O) and passed in, so the facade stays a pure
-    /// backend assembler and the radius path is injectable (#357).
     private var lastCornerRadius: CGFloat =
         GeometryUtils.systemWindowCornerRadius
     private var isHidden = false
-    /// The dead-end rubber-band's live offset (#436), layered on top
-    /// of `lastFrame` when geometry is built. Held separately from
-    /// `lastFrame` so a steady-state `sync` mid-bump keeps the offset
-    /// instead of snapping the ring back to the un-shifted frame.
+    /// Dead-end rubber-band offset (#436).
     private var bumpOffset = CGVector.zero
     private let makeFallback: @MainActor () -> any BorderOverlayBackend
-    /// Rebuilds the preferred (SkyLight) backend for a glow-off
-    /// swap-back (#533). Injectable so the swap machinery is
-    /// testable through the same seam as `makeFallback`; `nil`
-    /// means the preferred backend is unavailable, which retires
-    /// it (see `skyLightRetired`).
     private let makePreferred:
         @MainActor (CGWindowID) -> (any BorderOverlayBackend)?
     private let onFallback: @MainActor (String) -> Void
-    /// True once the preferred SkyLight backend must never be
-    /// re-attempted: after a real failure, and after its init
-    /// returns nil (static unavailability) — otherwise every
-    /// glow-off update on the apply hot path would re-run the
-    /// doomed init forever.
     private var skyLightRetired = false
 
     init(
@@ -91,14 +53,6 @@ final class BorderOverlay {
         makePreferred = {
             SkyLightBorderOverlay(targetWindow: $0, order: order)
         }
-        // Both orders prefer the SkyLight transport: its window is
-        // space-pinned at creation, so Mission Control leaves the
-        // ring behind instantly — an NSPanel cannot be pinned and
-        // lingers until settle. `above` keeps the sub-level path
-        // that makes it occlusion-correct (#357/#367); `below`
-        // orders beneath the target with none of that churn.
-        // AppKit remains the fallback whenever the private surface
-        // is unavailable or an operation fails.
         if let skyLight = SkyLightBorderOverlay(
             targetWindow: window,
             order: order
@@ -106,20 +60,12 @@ final class BorderOverlay {
             backend = skyLight
         } else {
             backend = AppKitBorderOverlay()
-            // Retire, don't just report: availability is static,
-            // so a glow-off swap-back re-attempting the init on
-            // every update would fail identically forever.
             skyLightRetired = true
             onFallback("SLS renderer initialization failed")
         }
     }
 
-    /// Test seam for exercising facade behavior without creating a
-    /// real AppKit or SkyLight window.
-    /// `preferred` feeds glow-off swap-backs; omitting it
-    /// permanently disables swap-back from t0 (`skyLightRetired`
-    /// latches at init, so no hidden mid-test state transition)
-    /// — inject a factory to test swap-backs.
+    /// Test seam for mocking backends (#533).
     init(
         window: CGWindowID,
         backend: any BorderOverlayBackend,
@@ -138,18 +84,7 @@ final class BorderOverlay {
         onFallback = { _ in }
     }
 
-    /// A glow ring always renders on a backend that can bloom
-    /// (#533): the WindowServer-backed SkyLight context drops
-    /// any `setShadow` colour to default black-at-low-alpha (a
-    /// grey smear), and every painted-falloff substitute banded
-    /// or clipped on device — while the `CAShapeLayer` shadow
-    /// renders correctly. Plain rings stay on SkyLight for its
-    /// space pin (instant Mission Control hide). The swap is
-    /// two-way on the glow toggle, driven by the backend's own
-    /// `rendersGlow` capability, except once SkyLight is
-    /// retired. Swapping before the backend's first window
-    /// exists is free — the SkyLight surface is created lazily
-    /// on its first update.
+    /// Dynamically swaps backend when glow is toggled (#533).
     @discardableResult
     private func ensureBackend(glow: Bool) -> Bool {
         if glow, !backend.rendersGlow {
@@ -171,20 +106,13 @@ final class BorderOverlay {
         return false
     }
 
-    /// The last rendered frame — the manager's test seam for
-    /// proving the `follow` guards stood down (or didn't).
     var lastRenderedFrame: CGRect? { lastFrame }
 
-    /// The last rendered colour — its sibling seam, for proving
-    /// that a `sync` standing down on GEOMETRY still recolored
-    /// (#596): both ride the one `update` call, so a guard placed
-    /// a level too high would silently eat the recolor.
+    /// Last rendered color hex (tested for geometry-independent recolor,
+    /// #596).
     var lastRenderedColorHex: String { lastColorHex }
 
-    /// Renders the ring around `frame` (AX coords). Takes the raw
-    /// inputs, not a finished `BorderGeometry`, because the geometry
-    /// depends on the current backend's order mode — the facade owns
-    /// that choice and rebuilds it here and on any fallback swap.
+    /// Renders focus ring geometry around `frame` in AX coordinates.
     func update(
         frame: CGRect,
         width: CGFloat,
@@ -216,11 +144,6 @@ final class BorderOverlay {
             return
         }
         if swapped && !shouldRestore {
-            // The fresh backend's window has no stacking yet —
-            // re-assert what the old one had through the FACADE
-            // methods, so a failed op on a fresh SkyLight window
-            // follows the retire-and-fall-back discipline
-            // instead of leaving a drawn-but-unordered ring.
             if isHidden {
                 hide()
             } else {
@@ -241,13 +164,7 @@ final class BorderOverlay {
         }
     }
 
-    /// Rubber-bands the ring by `offset` from its last real frame for
-    /// the dead-end cue (#436), optionally overriding the stroke with
-    /// `colorHex` (a Reduce-Motion opacity dip). Pure overlay motion:
-    /// it re-renders geometry with implicit animation disabled and
-    /// never touches the window, so no AX write and nothing for the
-    /// tiling engine's frame authority to fight. A no-op before the
-    /// first real render (no `lastFrame` to shift).
+    /// Renders rubber-band bump offset for dead-end cue (#436).
     func renderBump(offset: CGVector, colorHex: String? = nil) {
         guard lastFrame != nil else { return }
         bumpOffset = offset
@@ -258,8 +175,6 @@ final class BorderOverlay {
         )
     }
 
-    /// Builds the ring geometry for a backend's order mode from the
-    /// last rendered inputs, plus any live dead-end bump offset.
     private func geometry(
         for backend: any BorderOverlayBackend
     ) -> BorderGeometry {

--- a/Sources/KiwiDeskCore/Borders/BorderStyle.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderStyle.swift
@@ -24,8 +24,17 @@ public struct BorderStyle: Sendable, Equatable {
 
     public var enabled = true
     /// Ring width in pt (clamped to `minWidth...maxWidth`).
+    /// Default 5: the largest width that still tiles cleanly with
+    /// unfocused rings on — each ring reaches `width` into the
+    /// 10 pt inner gap, so 2 × 5 fills it edge-to-edge; 6 would
+    /// overlap.
     public var width: CGFloat = 5
-    /// Focused ring color (#4A9816, #578; distinct from drag visual #511).
+    /// Focused ring colour (#578: shifted ~12° off the brand hue
+    /// to escape the moss cast while clearing the 3:1 floor both
+    /// ways; docs/lua-reference.md mirrors the default — change
+    /// both). The drag ghost deliberately is NOT this family
+    /// (#511: it must separate from the drop-zone amber under
+    /// red-green vision loss) — do not re-converge them.
     public var focusedColor = "#4A9816"
     public var unfocusedEnabled = false
     public var unfocusedColor = "#8E8E93CC"
@@ -56,6 +65,9 @@ public struct BorderStyle: Sendable, Equatable {
     }
 
     /// Computes gaps fitting border widths without overlap (#295).
+    /// A one-shot convenience: `remaining` is an action parameter,
+    /// never a persisted setting, and the layout math itself stays
+    /// free of any border coupling (AGENTS.md §5).
     public func fittingGaps(remaining: CGFloat = 0) -> Gaps {
         let reach = BorderGeometry.outwardReach(
             width: clampedWidth

--- a/Sources/KiwiDeskCore/Borders/BorderStyle.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderStyle.swift
@@ -1,129 +1,48 @@
 import CoreGraphics
 import Foundation
 
-/// The focused-window border look (#278), stored top-level as
-/// `border` in profile JSON and set from Lua via `border.set_*`.
-/// A thin ring KiwiDesk paints around the focused window (and,
-/// when `unfocusedEnabled`, every other managed window) so the
-/// active window is unmistakable in a gapped grid — the feedback
-/// loop keyboard-driven focus otherwise lacks.
-///
-/// The ring is a pure post-layout overlay: it never feeds back
-/// into layout math (no gap coupling). The stroke uses a
-/// hidden-overlap geometry — the configured width grows entirely
-/// outward, with an additional renderer-only overlap behind the
-/// target. The target masks that overlap, so a thick border cannot
-/// hide content (see `Borders/BorderGeometry`).
+/// The focused-window border look (#278), stored in profile JSON.
 public struct BorderStyle: Sendable, Equatable {
-    /// Rounded matches the real macOS window radius; Square
-    /// strokes with sharp corners (radius 0). Square is seamless
-    /// on already-square windows (Electron/utility) and shows an
-    /// intentional corner reveal on rounded ones.
+    /// Corner stroke styling (rounded system radius or sharp square).
     public enum CornerStyle: String, Sendable, Codable, CaseIterable {
         case rounded
         case square
     }
 
-    /// Where the focus ring stacks relative to windows. `behind`
-    /// (the default, #319/#361) uses the flicker-free below-order
-    /// AppKit path; `front` uses the crisp, shadowless above-order
-    /// SkyLight path — a power-user opt-in that can flicker under
-    /// the per-keystroke compositor churn Firefox/Zen emit, so it
-    /// stays a Lua-only setting with no GUI toggle (#367).
+    /// Focus ring stack placement (#319, #361, #367).
     public enum DrawOrder: String, Sendable, Codable, CaseIterable {
         case behind
         case front
     }
 
-    /// The narrowest and widest the width clamps to. The command
-    /// setter clamps to this exact range; the GUI slider offers
-    /// whole points 1–20 (sub-point widths stay a Lua fine-tune).
     public static let minWidth: CGFloat = 0.5
     public static let maxWidth: CGFloat = 20
 
-    /// The remaining-gap action range (#295), whole points —
-    /// one source for the `border.fit_gaps` argument clamp and
-    /// the GUI field, so the bounds cannot drift (the
-    /// `targetDepthRange` pattern).
+    /// Gap range for `border.fit_gaps` (#295).
     public static let remainingGapRange: ClosedRange<Double> =
         0...100
 
     public var enabled = true
-    /// Ring width (pt). Raw here; callers clamp to
-    /// `minWidth...maxWidth` (`clampedWidth`). Default 5 pt — thick
-    /// enough to actually read as a frame (2 pt was too faint), and
-    /// the largest width that still tiles cleanly when unfocused
-    /// rings are on: each ring reaches `width` into the 10 pt inner
-    /// gap, so `2 × 5 = 10` fills the gap edge-to-edge without
-    /// overlap; 6 pt would overlap. A thicker stroke also reads at a
-    /// brighter, more saturated color than a hairline can (see
-    /// `focusedColor`).
+    /// Ring width in pt (clamped to `minWidth...maxWidth`).
     public var width: CGFloat = 5
-    /// Kiwi green — a true-green ring (~96°). Deliberately shifted
-    /// *off* the 84° brand-accent hue that the bars use: at the low
-    /// lightness a thin stroke needs to clear the 3:1 floor, the
-    /// yellow-leaning 84° family reads as dull olive/moss no matter
-    /// the saturation, so the ring alone moves ~12° toward pure green
-    /// to escape that cast (#578 — the prior #588613 and even a
-    /// full-saturation same-hue #538A00 still read mossy on device).
-    /// Still darkened from the fill-only bright accent (#8DB354,
-    /// which vanishes as a ring over light content); this clears the
-    /// 3:1 floor on both near-white (~3.6:1) and near-black (~5.8:1).
-    /// The ~12° divergence from the bar accent is the accepted trade
-    /// for a legible non-moss ring — lightness had no room to give,
-    /// so hue did. May read low-contrast over window content that is
-    /// itself green (see docs/accepted-limitations.md, whose
-    /// mitigation is the 3:1 floor above — keep it if you retune).
-    /// Default mirrored in docs/lua-reference.md (border colors)
-    /// — change both. The drag ghost used to be this same family and
-    /// **deliberately isn't** (#511: it has to separate from the
-    /// drop-zone amber under red-green vision loss, which this hue
-    /// cannot do at this chroma — see `DragVisual.ghostDefault`). Do
-    /// not re-converge them; the ring is free to move here precisely
-    /// because it has no partner to separate from. The optional glow
-    /// blooms a brightened derivative of this
-    /// (`BorderStyle.glowColor(from:)`).
+    /// Focused ring color (#4A9816, #578; distinct from drag visual #511).
     public var focusedColor = "#4A9816"
     public var unfocusedEnabled = false
-    /// A subtle translucent grey — present without competing with
-    /// the focused ring for attention.
     public var unfocusedColor = "#8E8E93CC"
     public var cornerStyle: CornerStyle = .rounded
-    /// A soft colored bloom around the focused ring (#358) — the
-    /// JankyBorders `COLOR_STYLE_GLOW` look, a zero-offset blurred
-    /// halo in a brightened derivative of the ring's hue
-    /// (`glowColor(from:)` — a bloom is a fill, so it can be far more
-    /// vivid than the legibility-darkened stroke). A render trait
-    /// like width and corners, not a visibility toggle: it reuses
-    /// `focusedColor` (introducing no separate color knob),
-    /// introduces no color choice, and applies to the **focused
-    /// ring only** (a bloom on every unfocused ring would undercut
-    /// the focused one it is meant to make pop). Default OFF —
-    /// native-first, matching JankyBorders' own default; the flat
-    /// ring already reads clearly, glow is additive flourish.
+    /// Bloom halo around focused ring (#358).
     public var glow = false
-    /// The bloom's blur radius in points, `0` = automatic (#551):
-    /// the width-scaled formula (`glowBlur(for:)`). An explicit
-    /// value overrides the formula, clamped only to the
-    /// renderable cap — the GUI curates a tighter band, Lua is
-    /// open per AGENTS §2.7.
+    /// Glow blur radius in pt (0 = automatic, #551).
     public var glowSize: CGFloat = 0
-    /// Ring stacked behind windows (default) or in front. A niche
-    /// Lua-only preference with no GUI control (#367).
+    /// Stacking order (#367).
     public var drawOrder: DrawOrder = .behind
 
     public init() {}
 
-    /// The renderable ceiling for an explicit `glowSize` — past
-    /// this the overlay frame growth buys no legible bloom.
+    /// Maximum renderable glow size ceiling (40 pt).
     public static let maxGlowSize: CGFloat = 40
 
-    /// The blur the focused ring's bloom actually renders: `0`
-    /// while glow is off; otherwise the explicit `glowSize`
-    /// (capped) or, at the `0 = automatic` sentinel, the
-    /// width-scaled formula. Resolved HERE, before geometry —
-    /// `BorderGeometry.compute` takes the finished number, so
-    /// the geometry math stays free of style resolution.
+    /// Resolved blur radius for focused ring glow (#551).
     public var resolvedGlowBlur: CGFloat {
         guard glow else { return 0 }
         return glowSize > 0
@@ -131,24 +50,12 @@ public struct BorderStyle: Sendable, Equatable {
             : Self.glowBlur(for: clampedWidth)
     }
 
-    /// The width actually rendered — raw `width` clamped into
-    /// range so a hand-edited profile can't paint an absurd ring.
+    /// Width clamped to valid range.
     public var clampedWidth: CGFloat {
         min(Self.maxWidth, max(Self.minWidth, width))
     }
 
-    /// Layout gaps sized so rings never touch a neighbour: the
-    /// border's visible **outward reach** at the screen edge and
-    /// between windows, doubled between windows when both
-    /// neighbours are ringed (`unfocusedEnabled`), plus an
-    /// optional `remaining` gap of deliberate whitespace kept
-    /// after the reach on every edge and axis (#295). Uses
-    /// `BorderGeometry.outwardReach`, which deliberately excludes
-    /// the renderer's hidden overlap. Shared by the `border.fit_gaps`
-    /// command and the GUI action so they can't drift. A one-shot
-    /// convenience — `remaining` is an action parameter, never a
-    /// persisted setting, and the layout math itself stays free of
-    /// any border coupling (AGENTS.md §5).
+    /// Computes gaps fitting border widths without overlap (#295).
     public func fittingGaps(remaining: CGFloat = 0) -> Gaps {
         let reach = BorderGeometry.outwardReach(
             width: clampedWidth
@@ -169,14 +76,8 @@ public struct BorderStyle: Sendable, Equatable {
     }
 }
 
-// MARK: - Codable
-
 extension BorderStyle: Codable {
-    /// JSON keys are the Lua setters (`border.set_*`) minus the
-    /// `set_` verb — the `border` nesting carries the namespace.
-    /// `CaseIterable` is load-bearing: `BorderParityTests`
-    /// reflects over `allCases` to prove every field has a key —
-    /// do not drop it as "unused".
+    /// CodingKeys reflect over `allCases` in `BorderParityTests`.
     enum CodingKeys: String, CodingKey, CaseIterable {
         case enabled
         case width
@@ -189,8 +90,6 @@ extension BorderStyle: Codable {
         case drawOrder = "draw_order"
     }
 
-    /// Manual decoding: profiles saved before a field existed
-    /// must keep loading (missing keys fall back to defaults).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self

--- a/Sources/KiwiDeskCore/Borders/StickyMarkOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/StickyMarkOverlay.swift
@@ -1,40 +1,11 @@
 import AppKit
 
-/// The on-window sticky mark (#414): a small mark wearing the
-/// sticky symbol, hugging its window's top-RIGHT corner
-/// (top-left belongs to the traffic lights). A border sibling,
-/// deliberately independent of `border.enabled` — borders are
-/// optional and often off, but a sticky window's state is
-/// otherwise invisible.
-///
-/// AppKit only: a passive marker needs none of the border's
-/// SkyLight fast path. The panel stacks directly above its
-/// target window, so unrelated windows layered over the target
-/// still cover the mark (same band trick as the border's
-/// below-order, inverted).
-///
-/// On demand it expands into a PILL naming the window's home
-/// space (#421): the glyph stays pinned in the rightmost square
-/// (its screen position never moves) while the plate grows
-/// leftward to reveal the space name, then collapses back. Shown
-/// only at the friction moment — a tiled-sticky traveler snapping
-/// back on a foreign space — so nothing changes for the common
-/// case (ui-designer 2026-07-21).
+/// On-window sticky mark overlay (#414, #421, ui-designer 2026-07-21).
 @MainActor
 final class StickyMarkOverlay {
-    /// Collapsed mark square and its inset from the window
-    /// corner. Final size picked by eye (#414).
     static let size: CGFloat = StickyMarkPlate.size
     static let inset: CGFloat = 6
 
-    /// The pill's own HUD timings — expand settles in, holds long
-    /// enough to READ, collapses a touch snappier. Deliberately
-    /// FIXED, not bound to the window animation-duration setting (like
-    /// the border ring's timings and macOS's own volume/brightness
-    /// HUDs): the hold is a reading duration, and a user who slows
-    /// window tiling to watch it glide should not get a pill that
-    /// also crawls open. Only the snap-back `delay` (a `flash` arg)
-    /// tracks the setting, because it waits on a window animation.
     private static let expandDuration: TimeInterval = 0.22
     private static let holdDuration: TimeInterval = 1.6
     private static let collapseDuration: TimeInterval = 0.16
@@ -42,36 +13,18 @@ final class StickyMarkOverlay {
     private var panel: NSPanel?
     private let plate = StickyMarkPlate()
     private let target: CGWindowID
-    /// The scope glyph this mark currently wears (#445): `infinity`
-    /// (global) or `pin.fill` (display). Set every sync before
-    /// `update`, so a scope flip lands on the next retile.
+    /// Scope glyph (`infinity` or `pin.fill`, #445).
     private var symbolName = StickyStyle.symbolName
-    /// Current visual width of the mark — collapsed `size`, or the
-    /// expanded pill width. `update` re-corners against this so a
-    /// frame follow arriving mid-pill keeps the plate anchored.
     private var currentWidth: CGFloat = size
-    /// Deferred expand (after the snap-back settles) and auto-
-    /// collapse timers — both cancelled/restarted on a repeat flash
-    /// so a rapid series of rejected drags never flickers.
     private var expandWork: DispatchWorkItem?
     private var collapseWork: DispatchWorkItem?
-    /// The last window frame this mark positioned against (AX
-    /// coords) — the observable seam that lets the manager's
-    /// WS-tracking guard be tested (a suppressed `follow` leaves
-    /// this unchanged; `reposition` advances it).
     private(set) var lastFrame: CGRect?
 
     init(window: CGWindowID) {
         target = window
     }
 
-    /// Places the mark at `frame`'s top-right (AX coords), its
-    /// right edge fixed at the window corner so the glyph never
-    /// moves as the pill widens leftward. Position only —
-    /// stacking is `order()`'s job, asserted on sync, never per
-    /// tick: a WindowServer reorder per move event made the mark
-    /// visibly lag behind its window (the borders' one-order-per-
-    /// sync rule, owner QA 2026-07-21).
+    /// Positions mark at top-right corner of `frame` (owner QA 2026-07-21).
     func update(frame: CGRect) {
         lastFrame = frame
         let panel = self.panel ?? makePanel()
@@ -85,30 +38,23 @@ final class StickyMarkOverlay {
         }
     }
 
-    /// Stacks the mark directly above its target window. Called
-    /// on sync (steady state), not per follow tick.
+    /// Stacks mark above target window.
     func order() {
         panel?.order(.above, relativeTo: Int(target))
     }
 
-    /// Tints the mark's glyph (and, when expanded, the pill's
-    /// home-space name) to the sticky mark color (#429); empty =
-    /// "Automatic" (adaptive `.labelColor`). Set every sync before
-    /// `update`, so a color change lands on the next retile.
+    /// Tints mark glyph (#429).
     func setMarkColor(_ hex: String) {
         plate.setMarkColor(hex)
     }
 
-    /// Sets the mark's scope glyph (#445). Applied to the live
-    /// plate at once when the panel already exists; otherwise
-    /// `makePanel` reads `symbolName` on first show.
+    /// Sets scope glyph symbol name (#445).
     func setSymbol(_ name: String) {
         guard name != symbolName else { return }
         symbolName = name
         if panel != nil { applySymbol() }
     }
 
-    /// Loads `symbolName` into the plate's glyph image.
     private func applySymbol() {
         plate.symbol.image = NSImage(
             systemSymbolName: symbolName,
@@ -124,21 +70,12 @@ final class StickyMarkOverlay {
         expandWork = nil
         collapseWork?.cancel()
         collapseWork = nil
-        // Retire in the collapsed state so a later re-show (a
-        // `hide` not paired with a retire) can't resurrect the
-        // mark mid-pill.
         currentWidth = Self.size
         plate.setNameShown(false, animated: false, duration: 0)
         panel?.orderOut(nil)
     }
 
-    /// Waits `delay` for the snap-back animation to settle (so the
-    /// pill doesn't chase a still-moving window), then briefly
-    /// expands the mark into a pill showing `format` with `mark`
-    /// substituted, then auto-collapses (#421). `delay` tracks the
-    /// caller's relayout duration, so a slow/long snap-back holds
-    /// the pill back exactly as long as the window travels. A no-op
-    /// if the mark isn't shown.
+    /// Briefly expands mark into a pill after snap-back settles (#421).
     func flash(format: String, mark: SpaceMark, delay: TimeInterval) {
         guard panel != nil, lastFrame != nil else { return }
         expandWork?.cancel()
@@ -153,8 +90,6 @@ final class StickyMarkOverlay {
         )
     }
 
-    /// Expands to fit the content (clamped to the window so the
-    /// pill never overruns its own edge), holds, then collapses.
     private func expandThenHold(format: String, mark: SpaceMark) {
         guard let frame = lastFrame else { return }
         let width = min(
@@ -180,12 +115,6 @@ final class StickyMarkOverlay {
         )
     }
 
-    /// Animates plate width and the name/shape morph together.
-    /// `StickyMarkPlate.layout()` reflows the glyph and name
-    /// from the live bounds each animation step, so the glyph
-    /// holds its screen position; the plate owns the name fade and
-    /// corner radius (`setNameShown`). Reduce Motion swaps the
-    /// morph for an instant show/hide.
     private func setPill(
         width: CGFloat,
         nameShown: Bool,
@@ -218,17 +147,7 @@ final class StickyMarkOverlay {
         if nameShown { popEntrance() }
     }
 
-    /// A brief scale overshoot on every pill entrance. Its job is
-    /// the keyboard refusal, which has no snap-back motion of its own
-    /// so a keypress would otherwise feel dead (ui-designer
-    /// 2026-07-22); on the mouse-drag pill (#421) the snap-back
-    /// already acknowledges, so there the pop is just a small
-    /// entrance flourish — one behavior on both paths, no
-    /// per-caller gating. Deliberately the pill's own body, not the
-    /// ring rubber-band (#436): a third, smallest vocabulary bound to
-    /// the cue that explains, keeping "your move bounced" (ring) and
-    /// "here's why" (pill) distinct. Guarded by Reduce Motion via the
-    /// `setPill` caller, which skips this whole branch.
+    /// Entrance pop animation (#421, #436; ui-designer 2026-07-22).
     private func popEntrance() {
         guard let layer = plate.layer else { return }
         let pop = CAKeyframeAnimation(keyPath: "transform.scale")
@@ -247,8 +166,6 @@ final class StickyMarkOverlay {
             .accessibilityDisplayShouldReduceMotion
     }
 
-    /// The mark's screen rect for a window `frame`: right edge
-    /// pinned at the corner (`inset` in), `width` growing left.
     private func markRect(
         for frame: CGRect,
         width: CGFloat
@@ -281,15 +198,9 @@ final class StickyMarkOverlay {
         panel.backgroundColor = .clear
         panel.hasShadow = false
         panel.ignoresMouseEvents = true
-        // Normal level + relative order: the mark shares its
-        // target's band so windows above the target also cover
-        // the mark (the border panel's stacking, inverted).
         panel.level = .normal
         panel.isReleasedWhenClosed = false
         panel.animationBehavior = .none
-        // `.transient` hides this mark/pill overlay in Exposé and
-        // Mission Control at the compositor level, so it vanishes
-        // with the swipe and restores on exit with no handler lag.
         panel.collectionBehavior = [
             .transient,
             .fullScreenAuxiliary,

--- a/Sources/KiwiDeskCore/Borders/StickyMarkOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/StickyMarkOverlay.swift
@@ -6,6 +6,11 @@ final class StickyMarkOverlay {
     static let size: CGFloat = StickyMarkPlate.size
     static let inset: CGFloat = 6
 
+    /// The pill's HUD timings are deliberately FIXED, not bound to
+    /// the animation-duration setting (like macOS's own HUDs): the
+    /// hold is a reading duration, and slowing window tiling must
+    /// not make the pill crawl open. Only the snap-back `delay`
+    /// tracks the setting, because it waits on a window animation.
     private static let expandDuration: TimeInterval = 0.22
     private static let holdDuration: TimeInterval = 1.6
     private static let collapseDuration: TimeInterval = 0.16
@@ -70,6 +75,8 @@ final class StickyMarkOverlay {
         expandWork = nil
         collapseWork?.cancel()
         collapseWork = nil
+        // Retire in the collapsed state so a later re-show cannot
+        // resurrect the mark mid-pill.
         currentWidth = Self.size
         plate.setNameShown(false, animated: false, duration: 0)
         panel?.orderOut(nil)
@@ -201,6 +208,9 @@ final class StickyMarkOverlay {
         panel.level = .normal
         panel.isReleasedWhenClosed = false
         panel.animationBehavior = .none
+        // `.transient` hides the mark in Exposé/Mission Control at
+        // the compositor level — it vanishes with the swipe, no
+        // handler lag.
         panel.collectionBehavior = [
             .transient,
             .fullScreenAuxiliary,

--- a/Sources/KiwiDeskCore/Commands/ZOrderDrain.swift
+++ b/Sources/KiwiDeskCore/Commands/ZOrderDrain.swift
@@ -1,38 +1,7 @@
 import Foundation
 
-/// Runs a z-order raise sequence and verifies each raise LANDED
-/// before issuing the next (#684).
-///
-/// `AXUIElementPerformAction(kAXRaiseAction)` returns once the
-/// target app has accepted the action, not once it has performed
-/// it. Measured on an overflowing scrolling row (Obsidian,
-/// Telegram, Ghostty, Zen, ChatGPT, Notizen, Claude, on device
-/// 2026-08-02, macOS 26.6): the call returns in 0.4-3.8 ms and
-/// the window reaches its new stacking position 1-20 ms later.
-/// The whole sequence issues in ~10 ms, so every raise is still
-/// in flight when the next goes out and the
-/// apps land them in whatever order they get to them — the pile
-/// settled scrambled in 3 of 3 runs. The window raised FIRST
-/// suffers most, because every later raise has to beat it.
-///
-/// So the order cannot rest on the return. The drain reads the
-/// WindowServer's real stacking instead (one
-/// `CGWindowListCopyWindowInfo`, ~0.4 ms) and only issues the next
-/// raise once the last one is visibly above its predecessors. With
-/// that wait the same row settled correctly, the whole sequence
-/// costing ~55 ms. No raise was ever *lost* in measurement — the
-/// waits never timed out at a 400 ms cap — which is why a window
-/// that misses its landing is left to the next restore instead of
-/// being retried here (`run` carries that argument).
-///
-/// It also raises only what is out of place (`plan`): stacking is
-/// by distance from focus, so a short focus jump leaves most pairs
-/// already correctly ordered, and a needless raise is not free —
-/// it steals focus for an echo and drags a slow app back to the
-/// front of the pile.
-///
-/// Every machine effect is a seam, so the loop is unit-testable
-/// without a WindowServer or a running app.
+/// Runs a z-order raise sequence and verifies each raise landed before issuing
+/// the next (#684).
 struct ZOrderDrain: Sendable {
     /// Issues the bare AX raise (`AXHelper.raiseQuietly`).
     let raise: @Sendable (WindowID) -> Void
@@ -42,87 +11,29 @@ struct ZOrderDrain: Sendable {
     let now: @Sendable () -> TimeInterval
     /// Blocks the calling queue for that many seconds.
     let sleep: @Sendable (TimeInterval) -> Void
-    /// False once a newer raise sequence has superseded this one,
-    /// so a stale drain abandons the raises it has left instead of
-    /// finishing them and fighting the newer sequence.
+    /// False once a newer raise sequence has superseded this one.
     let isCurrent: @Sendable () -> Bool
-    /// Windows the sequence must land ABOVE but never raises — the
-    /// tiled plane under a float raise (#418).
-    ///
-    /// Without it the diff below is blind to the only thing that
-    /// raise is for: floats keep their order among themselves, so
-    /// a float layer buried under the tile `focusWindow` just
-    /// raised reads as "already correct" and nothing is re-raised.
-    /// The pile restores pass none — their members are ordered
-    /// against each other, and the focused window sits above them
-    /// by design. Required at every call site rather than
-    /// defaulted, so a new sequence has to decide.
+    /// Windows the sequence must land above but never raises (#418).
     let floor: [WindowID]
-    /// What this sequence may spend and what it does when that
-    /// is gone. Required, like `floor`: `ZOrderDrain.Policy`
-    /// carries the two shipped answers and why they differ.
+    /// Budget and exhaustion policy.
     let policy: Policy
 
-    /// How long one raise may be waited on before the drain gives
-    /// up on it and moves to the next — 6x the 20 ms worst case
-    /// measured. Per-window, so one wedged app cannot stall the
-    /// windows behind it in the sequence.
+    /// Max per-window landing wait (120ms).
     static let landingLimit: TimeInterval = 0.12
-    /// Poll interval while waiting for a raise to land. The read
-    /// costs ~0.4 ms, so this spends under a tenth of a core.
+    /// Poll interval while awaiting landing (5ms).
     static let pollInterval: TimeInterval = 0.005
-    /// Raises `order` — deepest first, each landing on top of the
-    /// last — and returns once every raise has been issued or the
-    /// budget is spent. Blocking: call it on `zOrderQueue`, never
-    /// on the main actor — with one exception, the teardown
-    /// restack, which runs on the main actor because by then
-    /// there is no live session left to block. The whole quit
-    /// gather is already synchronous AX IPC there, and its budget
-    /// is the thing bounding it (#688).
-    ///
-    /// **Exactly one pass, and never the same window twice.** A
-    /// retry pass for the windows that missed their landing was
-    /// built and removed on device evidence: the raise echo
-    /// ledger then consumed a window's stamp on its FIRST echo,
-    /// so a retried raise's second echo read as a deliberate
-    /// focus change — focus slid one slot after every restore
-    /// (owner QA, 2026-08-02). #689 retired consumption (a
-    /// stamp now expires by age, because lazy apps re-report a
-    /// raised window and the unstamped duplicate was honored),
-    /// which removes that specific hazard — but the one-pass
-    /// rule stands on the measurement alone: no raise was ever
-    /// LOST, only late, and a late one is put right by the next
-    /// restore, so a retry buys nothing.
-    ///
-    /// Returns the windows it actually raised, which is not the
-    /// whole order: the caller stamped every target in the raise
-    /// echo ledger, and a window that is never raised emits no
-    /// echo to consume its stamp — so the caller drops the rest
-    /// (`releaseZOrderStamps`).
+
+    /// Raises `order` deepest first; exactly one pass per window (owner QA,
+    /// 2026-08-02; architect review, 2026-08-02; #688, #689).
     func run(_ rawOrder: [WindowID]) -> [WindowID] {
         guard isCurrent() else { return [] }
         let deadline = now() + policy.budget
-        // Uniqued, because "never twice" must be a property of
-        // this loop rather than a hope about its input: a repeated
-        // id makes every tail check fail (a filtered observation
-        // can never reproduce a duplicate), so `plan` would return
-        // it twice and raise it twice — the focus slide above, via
-        // a caller's bug instead of ours. No caller can produce
-        // one today (code review, 2026-08-02).
+        // Uniqued to prevent duplicate raises on caller error
+        // (review 2026-08-02).
         var seenIDs = Set<WindowID>()
         let order = rawOrder.filter { seenIDs.insert($0).inserted }
         let targets = seenIDs
         let observed = stacking()
-        // An empty read is `CGWindowListCopyWindowInfo` answering
-        // with nothing at all — a nil return, since the list
-        // otherwise always carries the menu bar. It is never a
-        // screen with no windows: we are here to raise windows
-        // that exist. Diffing against it would drop every
-        // raise silently and permanently for as long as the read
-        // failed, which is the opposite of what the budget branch
-        // below argues: unverified is what every pile did before
-        // this drain, a dropped raise is a window left definitely
-        // in the wrong place (architect review, 2026-08-02).
         guard !observed.isEmpty else {
             order.forEach(raise)
             return order
@@ -135,21 +46,11 @@ struct ZOrderDrain: Sendable {
         )
         guard !plan.isEmpty else { return [] }
         let planned = Set(plan)
-        // The windows the plan left alone keep their observed
-        // order and belong below every raised one — that is
-        // what makes them safe to leave alone, so they are
-        // part of what each landing is checked against.
         let untouched = seen.filter { !planned.contains($0) }
         return issue(plan, over: untouched, deadline: deadline)
     }
 
-    /// Issues the plan, waiting for each raise to land before the
-    /// next. Every window here is raised exactly once — see `run`
-    /// — and every one of them comes back in the return value,
-    /// including the unverified tail: the caller keys the echo
-    /// ledger off this, and a raise left out of it would have its
-    /// stamp dropped while its echo was still in flight, which is
-    /// the focus jump all over again.
+    /// Issues the planned raises, awaiting verification per step.
     private func issue(
         _ plan: [WindowID],
         over untouched: [WindowID],
@@ -164,11 +65,7 @@ struct ZOrderDrain: Sendable {
                 guard policy.spendsBudgetOnUnverifiedTail else {
                     return raised
                 }
-                // Out of budget. Issue the rest without waiting
-                // rather than dropping them: unverified is the
-                // behavior every pile had before this drain, while
-                // a dropped raise is a window left definitely in
-                // the wrong place.
+                // Out of budget: issue remaining unverified.
                 let rest = plan.dropFirst(index + 1)
                 rest.forEach(raise)
                 return raised + rest
@@ -182,13 +79,7 @@ struct ZOrderDrain: Sendable {
         return raised
     }
 
-    /// Polls until the windows raised so far stand front-to-back
-    /// in the reverse of the order they were raised in, above the
-    /// ones this pass left alone and clear of the floor. Relative,
-    /// never "is it frontmost": the focused window sits above the
-    /// whole pile by design (it is re-asserted last), and a window
-    /// on another display is listed among these and can never be
-    /// beaten. Returns false on timeout — the drain then moves on.
+    /// Polls until raised windows stand in desired relative order above floor.
     private func awaitLanding(
         raised: [WindowID],
         over untouched: [WindowID],
@@ -210,9 +101,7 @@ struct ZOrderDrain: Sendable {
         }
     }
 
-    /// Whether every one of `raised` stands in front of the whole
-    /// floor. Vacuously true with no floor, which is every pile
-    /// restore.
+    /// Whether every raised window stands in front of the floor set.
     private static func clears(
         _ raised: [WindowID],
         floor: Set<WindowID>,
@@ -231,33 +120,13 @@ struct ZOrderDrain: Sendable {
         }
     }
 
-    /// The windows of `raiseOrder` that are actually out of place,
-    /// in raise order — the minimal set, because a raise always
-    /// goes to the front: raising a set S in order leaves S at the
-    /// front in reverse-raise order and everything else in the
-    /// order it already had. So the work is exactly the front
-    /// stretch of the desired order whose tail does not already
-    /// stand correctly, and the tail check only gets stricter as
-    /// it grows, which is why the scan can stop at the first miss.
-    ///
-    /// A window standing correctly among the targets but still
-    /// under the `floor` is out of place too — that is the whole
-    /// job of a float raise, and the only reason the floor is a
-    /// parameter here.
-    ///
-    /// A target the WindowServer does not list on screen —
-    /// minimized, or on another space — is dropped: it has no
-    /// stacking to fix and no landing that could ever be
-    /// verified. `observed` is the full front-to-back list, not
-    /// just the targets, because the floor's position is in it.
-    /// Pure math, unit-tested.
+    /// Computes minimal out-of-order window prefix to raise (#418).
     static func plan(
         raiseOrder: [WindowID],
         observed: [WindowID],
         above floor: [WindowID]
     ) -> [WindowID] {
         let onScreen = Set(observed)
-        // Desired front-to-back: the last raise lands on top.
         let desired = raiseOrder.reversed().filter {
             onScreen.contains($0)
         }

--- a/Sources/KiwiDeskCore/Commands/ZOrderDrain.swift
+++ b/Sources/KiwiDeskCore/Commands/ZOrderDrain.swift
@@ -18,13 +18,20 @@ struct ZOrderDrain: Sendable {
     /// Budget and exhaustion policy.
     let policy: Policy
 
-    /// Max per-window landing wait (120ms).
+    /// Max per-window landing wait — 6x the 20 ms worst case
+    /// measured; per-window so one wedged app cannot stall the
+    /// windows behind it.
     static let landingLimit: TimeInterval = 0.12
     /// Poll interval while awaiting landing (5ms).
     static let pollInterval: TimeInterval = 0.005
 
-    /// Raises `order` deepest first; exactly one pass per window (owner QA,
-    /// 2026-08-02; architect review, 2026-08-02; #688, #689).
+    /// Raises `order` deepest first; exactly one pass per window
+    /// (owner QA 2026-08-02; #688, #689). Blocking: call on
+    /// `zOrderQueue`, never the main actor — the one exception is
+    /// the teardown restack (#688), which has no live session left
+    /// to block. Returns the windows actually RAISED, and every
+    /// one of them: the caller keys the echo ledger off this and
+    /// drops the stamps of the rest (`releaseZOrderStamps`).
     func run(_ rawOrder: [WindowID]) -> [WindowID] {
         guard isCurrent() else { return [] }
         let deadline = now() + policy.budget
@@ -34,6 +41,11 @@ struct ZOrderDrain: Sendable {
         let order = rawOrder.filter { seenIDs.insert($0).inserted }
         let targets = seenIDs
         let observed = stacking()
+        // An empty read is `CGWindowListCopyWindowInfo` answering
+        // nothing at all (the list otherwise always carries the
+        // menu bar) — never a screen with no windows. Diffing
+        // against it would drop every raise silently for as long
+        // as the read failed (architect review, 2026-08-02).
         guard !observed.isEmpty else {
             order.forEach(raise)
             return order
@@ -51,6 +63,10 @@ struct ZOrderDrain: Sendable {
     }
 
     /// Issues the planned raises, awaiting verification per step.
+    /// Every window here comes back in the return value, the
+    /// unverified tail included — a raise left out would have its
+    /// echo-ledger stamp dropped while its echo was in flight,
+    /// which is the focus jump all over again.
     private func issue(
         _ plan: [WindowID],
         over untouched: [WindowID],
@@ -79,7 +95,10 @@ struct ZOrderDrain: Sendable {
         return raised
     }
 
-    /// Polls until raised windows stand in desired relative order above floor.
+    /// Polls until raised windows stand in desired relative order
+    /// above the floor. RELATIVE, never "is it frontmost": the
+    /// focused window sits above the whole pile by design, and a
+    /// window on another display can never be beaten.
     private func awaitLanding(
         raised: [WindowID],
         over untouched: [WindowID],

--- a/Sources/KiwiDeskCore/Config/ConfigMigration.swift
+++ b/Sources/KiwiDeskCore/Config/ConfigMigration.swift
@@ -1,96 +1,17 @@
 import Foundation
 
-/// One-shot rewrites of config files written by an older build.
-///
-/// A rename lands in this repo without a compatibility alias
-/// (AGENTS.md §5) — the config is re-edited instead. That rule
-/// rests on a premise, "pre-release, single user", and the
-/// premise expired: v0.9.7 shipped to other people. So a rename
-/// made after it needs a way across, and this is the shape that
-/// has an END, which an alias does not: the value is rewritten
-/// in the file, once, and then this code is dead by construction
-/// rather than by anyone remembering.
-///
-/// What it is NOT is a decode-time fold. A lenient decoder keeps
-/// accepting the retired spelling forever, because nothing ever
-/// signals that the last config carrying it is gone — which is
-/// exactly the shim §5 bans, and exactly what this branch
-/// removed twice before understanding why it kept coming back.
-///
-/// Deleting a migration is a decision with a format floor (#902).
-/// Both `Profile` and `GuiConfig` carry a format integer (with
-/// absent meaning format 0, the unversioned legacy format),
-/// matching `SetupBundle.currentFormat`.
-///
-/// Removing an old migration means advancing the minimum
-/// supported format floor: files below the floor are refused
-/// explicitly rather than failing silently on an upgrade.
-/// `init.lua` is deliberately out of scope. A hand-written
-/// `app_bar.set_content("icon_and_name")` now fails, but it fails
-/// as ONE line reporting `expected one of icon|title|
-/// icon_and_title` — the user's own script, which KiwiDesk does
-/// not own or rewrite, and a refusal that names the fix. The
-/// crossing exists for files this app WROTE, where the user made
-/// no choice that could be reported back to them.
-///
-/// A SECOND Lua store sits inside that carve-out, and it is
-/// worth naming because it is easy to miss: a keybinding's `lua`
-/// rides inside `gui.json` and inside every profile
-/// (`layers[].bindings[].lua`), so a file this app rewrites does
-/// carry user-authored Lua. A renamed VERB breaks such a binding
-/// — `animations.set_scroll_speed(300)` after #1020 — and is
-/// still not migrated, for `init.lua`'s reason exactly: the text
-/// is the user's own, the failure is LOUD at press time rather
-/// than silent, and AGENTS.md §5 rules a verb rename free of
-/// aliases. What this crosses is the config VOCABULARY around
-/// the script, never the script.
+/// One-shot rewrites of config files written by an older build
+/// (AGENTS.md §5).
+/// Format floors in `Profile`, `GuiConfig`, and `SetupBundle` (#902).
 public enum ConfigMigration {
-    /// The `app_bar.content` spellings retired when the bars
-    /// began naming the WINDOW rather than its app (owner ruling
-    /// 2026-08-19), mapped onto what this build reads.
-    ///
-    /// Both bar-content sites decode from the same vocabulary —
-    /// `AppBarStyle.content` and a layout's `LayoutAppBar`
-    /// override — which is why the walk below rewrites by KEY at
-    /// any depth instead of hardcoding a path per layout: an
-    /// override sits one level down from the global style, and a
-    /// migration that reached only the global one would leave the
-    /// file just as undecodable.
-    ///
-    /// That breadth is bounded by this map, not by the walk, so a
-    /// second `content` CodingKey anywhere in the config would
-    /// break the bound — and `readBackup` runs the walk across a
-    /// whole `SetupBundle`, so the reach is wider than the two
-    /// types this reasons about. Such a key owes the walk a path,
-    /// or this map a narrower home;
-    /// `ConfigMigrationRoutingTests` is what says so on arrival.
+    /// Retired `app_bar.content` spellings mapped to current names
+    /// (owner ruling 2026-08-19, `ConfigMigrationRoutingTests`).
     static let retiredBarContent = [
         "name": "title",
         "icon_and_name": "icon_and_title",
     ]
 
-    /// Every migration, oldest first.
-    ///
-    /// The ORDERED list is the extension point, and the reason
-    /// the wired seam below is `migrated(_:)` rather than any one
-    /// migration's name: a reader names the seam, never a step,
-    /// so a new migration lands here instead of re-editing every
-    /// reader and re-asking which readers exist
-    /// (`ConfigMigrationRoutingTests` is the census). Each step
-    /// takes the bytes as they stand after the previous one.
-    ///
-    /// **A step added here is not yet a step that RUNS.**
-    /// `needsMigration` short-circuits on
-    /// `format >= targetFormat(for:)`, so a step owes a
-    /// `currentFormat` bump on EVERY shape it must reach — and
-    /// without one it is dead on arrival, silently, on exactly
-    /// the files it exists to rescue. #1020 is the worked
-    /// example: the rename it crosses would otherwise decode to
-    /// a DEFAULT rather than fail, so nothing anywhere would
-    /// report it. `ScrollDurationMigrationTests` pins that
-    /// rename against a `Profile.currentFormat - 1` fixture;
-    /// nothing pins the coupling itself, which is why it is
-    /// stated here, at the point where a step is added.
+    /// Ordered migrations (`ScrollDurationMigrationTests`, #1020).
     private static let steps: [@Sendable (Data) -> Data?] = [
         migratingLegacyPalettesArray,
         migratingRetiredBarContent,
@@ -115,12 +36,7 @@ public enum ConfigMigration {
         return GuiConfig.currentFormat
     }
 
-    /// Whether `data` is below the current format version for
-    /// its shape (#902).
-    ///
-    /// Formats at or above current format skip migrations
-    /// entirely — avoiding JSON parsing and key scans on every
-    /// config read once a file carries the format stamp.
+    /// Whether `data` is below current format version (#902).
     static func needsMigration(_ data: Data) -> Bool {
         guard
             let json = try? JSONSerialization.jsonObject(
@@ -135,13 +51,7 @@ public enum ConfigMigration {
         return format < targetFormat(for: root)
     }
 
-    /// `data` with every applicable migration applied, or nil
-    /// when none applied.
-    ///
-    /// Nil rather than the unchanged bytes, deliberately: a
-    /// caller writes back exactly when this returns non-nil, so
-    /// a config that needs nothing is never rewritten and its
-    /// mtime never moves.
+    /// Applies applicable migrations, returning modified data or nil (#938).
     public static func migrated(_ data: Data) -> Data? {
         guard needsMigration(data) else { return nil }
         var current = data
@@ -150,23 +60,11 @@ public enum ConfigMigration {
                 current = next
             }
         }
-        // A stale format whose bytes no step rewrites is still
-        // a crossing that must END (#938): stamp it anyway, or
-        // the file re-enters `needsMigration` on every read
-        // forever and the next floor advance (#902) refuses a
-        // valid file this app wrote. Nil only when the result
-        // is byte-identical, preserving the
-        // never-rewrite-untouched contract above.
         let result = stamped(current)
         return result == data ? nil : result
     }
 
-    /// `data` with every retired bar-content value rewritten, or
-    /// nil when there was nothing to rewrite.
-    ///
-    /// The envelope — gate, parse, surgical edit, verify, fall
-    /// back — is `surgicallyApplying`, which owns the argument
-    /// for all three steps. What is local here is the walk.
+    /// Rewrites retired bar-content values in data.
     @Sendable
     static func migratingRetiredBarContent(
         _ data: Data
@@ -179,13 +77,7 @@ public enum ConfigMigration {
         )
     }
 
-    /// `text` with each retired `content` VALUE replaced where it
-    /// is the value of a `content` key, leaving every other byte
-    /// exactly as it was.
-    ///
-    /// The pattern requires the opening quote, so
-    /// `"icon_and_name"` can never be matched by the `"name"`
-    /// entry and the two are order-independent.
+    /// Replaces retired content values in text.
     private static func surgicallyEdited(_ text: String) -> Data? {
         var out = text
         for (retired, mapped) in retiredBarContent {
@@ -198,8 +90,7 @@ public enum ConfigMigration {
         return out == text ? nil : out.data(using: .utf8)
     }
 
-    /// The tree with retired `content` values replaced, plus
-    /// whether anything changed.
+    /// Recursively replaces retired `content` values in JSON tree.
     private static func rewritten(_ node: Any) -> (Any, Bool) {
         if let dict = node as? [String: Any] {
             var out: [String: Any] = [:]

--- a/Sources/KiwiDeskCore/Config/ConfigMigration.swift
+++ b/Sources/KiwiDeskCore/Config/ConfigMigration.swift
@@ -1,17 +1,36 @@
 import Foundation
 
 /// One-shot rewrites of config files written by an older build
-/// (AGENTS.md §5).
-/// Format floors in `Profile`, `GuiConfig`, and `SetupBundle` (#902).
+/// (AGENTS.md §5); format floors in `Profile`, `GuiConfig` and
+/// `SetupBundle` (#902).
+///
+/// `init.lua` is deliberately out of scope — the user's own
+/// script fails LOUDLY with a refusal naming the fix. That
+/// carve-out also covers the Lua riding INSIDE files this app
+/// rewrites (`layers[].bindings[].lua` in gui.json and every
+/// profile): a renamed VERB breaks such a binding and is still
+/// not migrated — the crossing reaches the config VOCABULARY
+/// around the script, never the script (#1020).
 public enum ConfigMigration {
     /// Retired `app_bar.content` spellings mapped to current names
-    /// (owner ruling 2026-08-19, `ConfigMigrationRoutingTests`).
+    /// (owner ruling 2026-08-19). The walk rewrites by KEY at any
+    /// depth, so its breadth is bounded by THIS map: a second
+    /// `content` CodingKey anywhere in the config owes the walk a
+    /// path or this map a narrower home —
+    /// `ConfigMigrationRoutingTests` says so on arrival.
     static let retiredBarContent = [
         "name": "title",
         "icon_and_name": "icon_and_title",
     ]
 
-    /// Ordered migrations (`ScrollDurationMigrationTests`, #1020).
+    /// Ordered migrations, oldest first; each step takes the bytes
+    /// as they stand after the previous one. **A step added here is
+    /// not yet a step that RUNS**: `needsMigration` short-circuits
+    /// on the format stamp, so a step owes a `currentFormat` bump
+    /// on EVERY shape it must reach — without one it is dead on
+    /// arrival, silently, on exactly the files it exists to rescue
+    /// (#1020, `ScrollDurationMigrationTests`). Nothing pins that
+    /// coupling, which is why it is stated here.
     private static let steps: [@Sendable (Data) -> Data?] = [
         migratingLegacyPalettesArray,
         migratingRetiredBarContent,
@@ -51,7 +70,12 @@ public enum ConfigMigration {
         return format < targetFormat(for: root)
     }
 
-    /// Applies applicable migrations, returning modified data or nil (#938).
+    /// Applies applicable migrations, returning modified data or
+    /// nil. Nil rather than the unchanged bytes, deliberately: a
+    /// caller writes back exactly when this returns non-nil, so an
+    /// untouched config is never rewritten and its mtime never
+    /// moves. A stale format whose bytes no step rewrites is still
+    /// stamped — a crossing must END (#938).
     public static func migrated(_ data: Data) -> Data? {
         guard needsMigration(data) else { return nil }
         var current = data

--- a/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
+++ b/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
@@ -79,7 +79,10 @@ public enum DefaultKeybindings {
         return rows
     }
 
-    /// ⌃⌥K row that opens Shortcuts panel (#602).
+    /// ⌃⌥K row that opens the Shortcuts panel (#602). Seeded into
+    /// the base mode here AND into every GUI-created mode
+    /// (`ShortcutsHeader.addMode`), so the cheat-sheet stays
+    /// keyboard-reachable in any mode.
     public static func showShortcutsRow() -> KeyBinding {
         KeyBinding(
             combo: "control+option+k",
@@ -128,7 +131,10 @@ public enum DefaultKeybindings {
         )
     }
 
-    /// Additive top-up of missing space digit rows without overwriting (#485).
+    /// Additive top-up of missing space digit rows (#485) — a
+    /// combo already bound is left untouched, so the top-up can
+    /// never overwrite. Combo identity is by parsed `KeyCombo`,
+    /// so a hand-authored alias (`ctrl+alt+6`) counts as taken.
     public static func digitTopUp(
         existing: [KeyBinding],
         spaces: [SpaceID]

--- a/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
+++ b/Sources/KiwiDeskCore/Config/DefaultKeybindings.swift
@@ -1,53 +1,8 @@
 import Foundation
 
-/// The first-run starter shortcuts (#91): the set seeded into
-/// the base `default` mode when no binding exists anywhere —
-/// a fresh install, or a config whose Lua declares none — so a
-/// new user can focus, move, and navigate windows immediately.
-///
-/// Modifier scheme (#270, amended by #1075): the **positional**
-/// defaults are built on **Control+Option**, escalating ⌃⌥ (act
-/// on the focus) → ⌃⌥⇧ (act on the window) → ⌃⌥⌘ (both), so
-/// `⌘` there means exactly one thing: "and follow". **Size takes a
-/// base of its own, ⌥⌘**, because it is not a positional verb —
-/// it changes a weight or a scroll-slot domain rather than a
-/// place in the flat array — and because it is the one verb a
-/// user HOLDS (#1056), which ⌥⌘ takes as a single thumb roll and
-/// ⌃⌥⌘ does not.
-///
-/// Bare Option is the macOS special-character (AltGr) modifier,
-/// so a global `option+<key>` hotkey swallows characters on
-/// every Apple keyboard layout — which character depends on the
-/// layout (⌥L is ¬ on US, @ on German; measured in
-/// `docs/design-decisions.md`, do not quote one unlabelled);
-/// adding
-/// Control **or Command** suppresses that composition, which is
-/// what makes ⌥⌘ text-safe as well as ⌃⌥. Directions bind the
-/// **arrow keys**, which are layout-stable and never compose a
-/// character; size binds **digits**, which hold their physical
-/// position on every layout and are the only keys a numeric
-/// keypad will be able to repeat once #1074 lands.
-///
-/// The Lua and canonical labels mirror what
-/// `KeybindingCatalog` (GUI target) authors for the same
-/// spaces and resize step — byte-for-byte, or the import
-/// classifier would demote the rows to Custom (#4). That
-/// mirror is guarded by `DefaultSeedCatalogParityTests`
-/// (GUI tests), which iterates every seeded row and matches
-/// it against the catalog's output.
-///
-/// Per-space rows are position-based (`control+option+1` targets
-/// the FIRST space in display order, whatever its name),
-/// generated only for the spaces that exist at seed time and
-/// capped at ten — positions 1…9 then ⌃⌥0 for the tenth (#466) —
-/// so no dead row targeting a nonexistent space is ever authored
-/// (#91).
+/// First-run starter keyboard shortcuts (#91, #270, #1075, #1056).
+/// Parity guarded by `DefaultSeedCatalogParityTests`.
 public enum DefaultKeybindings {
-    /// Direction ↔ canonical label phrase, in the catalog's
-    /// order (left, down, up, right). The arrow key that drives
-    /// each binding is the direction itself — `control+option+
-    /// left` focuses left — so one token serves both the combo
-    /// and the Lua argument.
     private static let directions = [
         ("left", "to the left"),
         ("down", "below"),
@@ -55,13 +10,13 @@ public enum DefaultKeybindings {
         ("right", "to the right"),
     ]
 
-    /// The starter rows for the base `default` mode.
+    /// Starter keybindings for base `default` mode (#91, #466, #1094, #602).
     public static func bindings(
         spaces: [SpaceID],
         resizeStep: Int
     ) -> [KeyBinding] {
         var rows: [KeyBinding] = []
-        // Tier 1 — ⌃⌥: focus a window, go to a space.
+        // Tier 1 — ⌃⌥: focus window / space
         for (dir, phrase) in directions {
             rows.append(
                 KeyBinding(
@@ -75,7 +30,7 @@ public enum DefaultKeybindings {
         for (digit, space) in numbered(spaces) {
             rows.append(focusSpaceRow(digit: digit, space: space))
         }
-        // Tier 2 — ⌃⌥⇧: swap a window, move it to a space.
+        // Tier 2 — ⌃⌥⇧: swap window / move to space
         for (dir, phrase) in directions {
             rows.append(
                 KeyBinding(
@@ -89,24 +44,13 @@ public enum DefaultKeybindings {
         for (digit, space) in numbered(spaces) {
             rows.append(moveSpaceRow(digit: digit, space: space))
         }
-        // Tier 3 — ⌃⌥⌘: move-to-space-and-follow.
+        // Tier 3 — ⌃⌥⌘: move to space and follow
         for (digit, space) in numbered(spaces) {
             rows.append(followSpaceRow(digit: digit, space: space))
         }
-        // Size — ⌥⌘, a base of its own rather than a rung on the
-        // positional ladder (#1075).
+        // Size — ⌥⌘ (#1075)
         rows.append(contentsOf: resizeRows(step: resizeStep))
-        // Toggles — mnemonic letters, and NO `⇧` among them
-        // (#1094). The ladder above spends `⇧` on "act on the
-        // window"; the retired `⌃⌥⇧S` spent it on "a broader
-        // scope", which is the one chord in the seed a user who
-        // learned the ladder would have read wrong.
-        //
-        // Which letter each sticky scope takes, and why `P`
-        // names the mark rather than the label, is argued in
-        // `docs/design-decisions.md` ▸ "Size is not a positional
-        // verb" — not restated here (the sibling
-        // `DefaultKeybindings+Size.swift` sets that shape).
+        // Toggles — ⌃⌥ (#1094)
         rows.append(
             KeyBinding(
                 combo: "control+option+f",
@@ -131,24 +75,11 @@ public enum DefaultKeybindings {
                 label: "Toggle display sticky"
             )
         )
-        // General — open the read-only Shortcuts panel. App
-        // chrome, not a workspace verb, so it comes last (#602).
         rows.append(showShortcutsRow())
         return rows
     }
 
-    /// The ⌃⌥K row that opens the read-only Shortcuts panel
-    /// (#602) — a GUI/app action, not a workspace verb. "K = Keys"
-    /// names a shortcuts cheat-sheet; ⌃⌥H was avoided because
-    /// `⌘H` = Hide reads as *Hide* first to a Mac user. Seeded
-    /// into the base mode (here) and into every mode created in
-    /// the GUI (`ShortcutsHeader.addMode`), so the cheat-sheet is
-    /// reachable from the keyboard in any mode — editable or
-    /// deletable per mode like any default, with the menu bar's
-    /// "View Shortcuts…" as the mode-independent fallback. Its Lua
-    /// and label mirror `KeybindingCatalog.showShortcuts`
-    /// byte-for-byte (guarded by `DefaultSeedCatalogParityTests`),
-    /// so an imported copy classifies back to `.navigation`.
+    /// ⌃⌥K row that opens Shortcuts panel (#602).
     public static func showShortcutsRow() -> KeyBinding {
         KeyBinding(
             combo: "control+option+k",
@@ -158,9 +89,6 @@ public enum DefaultKeybindings {
         )
     }
 
-    // MARK: - Per-space rows (one per tier, shared with top-up)
-
-    /// Tier 1 — ⌃⌥ + digit: focus (go to) a space.
     private static func focusSpaceRow(
         digit: String,
         space: SpaceID
@@ -174,7 +102,6 @@ public enum DefaultKeybindings {
         )
     }
 
-    /// Tier 2 — ⌃⌥⇧ + digit: move the window to a space.
     private static func moveSpaceRow(
         digit: String,
         space: SpaceID
@@ -188,7 +115,6 @@ public enum DefaultKeybindings {
         )
     }
 
-    /// Tier 3 — ⌃⌥⌘ + digit: move the window and follow it.
     private static func followSpaceRow(
         digit: String,
         space: SpaceID
@@ -202,16 +128,7 @@ public enum DefaultKeybindings {
         )
     }
 
-    /// The per-space digit rows MISSING from `existing` for the
-    /// live `spaces` — the additive top-up when a display change
-    /// grows the space count past the digits seeded on first run
-    /// (#485). Strictly additive: a digit whose combo is already
-    /// bound (a seeded default OR a user's custom chord) is left
-    /// untouched, so the top-up can never overwrite a binding. The
-    /// same position → digit mapping and ten-cap as `bindings`
-    /// (`numbered`), so a space past the tenth still ships unbound.
-    /// Combo identity is by parsed `KeyCombo`, so an equivalent
-    /// hand-authored alias (`ctrl+alt+6`) counts as taken.
+    /// Additive top-up of missing space digit rows without overwriting (#485).
     public static func digitTopUp(
         existing: [KeyBinding],
         spaces: [SpaceID]
@@ -239,20 +156,9 @@ public enum DefaultKeybindings {
         return rows
     }
 
-    /// How many spaces can carry a default digit shortcut: the
-    /// number row, `1`…`9` then `0`. Public because it is the
-    /// reason the starter setup's own budget stops where it does
-    /// — we run out of keys before we run out of spaces — and a
-    /// second copy of the number over there would be a restated
-    /// constant rather than a derived one.
+    /// Maximum spaces with default digit shortcuts (1...9, 0) (#466).
     public static let digitCapacity = 10
 
-    /// The first ten spaces paired with the digit key each
-    /// per-space combo uses: positions 1…9 map to `"1"`…`"9"`, and
-    /// the tenth to `"0"` (⌃⌥0 = space 10, the top-row order). Ten
-    /// is the hard cap — the number row has no eleventh digit — so
-    /// spaces past the tenth ship unbound by default (#466);
-    /// they stay bindable in the Keybindings editor.
     private static func numbered(
         _ spaces: [SpaceID]
     ) -> [(String, SpaceID)] {

--- a/Sources/KiwiDeskCore/Config/GuiConfig.swift
+++ b/Sources/KiwiDeskCore/Config/GuiConfig.swift
@@ -1,93 +1,47 @@
 import Foundation
 
-/// The GUI's complete editable configuration.
-/// Split along the profile boundary (#36):
-/// - **Global fields** (spaces, app/float/ignore rules, profile
-///   bindings, keybindings) persist in `gui.json` and apply
-///   directly on reload (#55) — `init.lua` is never generated.
-/// - **Profile-scoped fields** (tiling settings, space modes,
-///   monitor pins, Main role) are held in memory for editing
-///   and persist into the active profile's JSON — never into
-///   the sidecar or `init.lua`, so the two files can't drift.
-///
-/// `init.lua` is the user's own hooks-only Lua; code touching
-/// managed vocabulary flips the raw editor (`ManagedConfig`).
+/// The GUI's editable configuration split across global `gui.json` and
+/// active profile JSON (#36, #55).
 public struct GuiConfig: Codable, Equatable, Sendable {
-    /// Format version of the gui.json schema (#902).
-    /// Format 0 = unversioned legacy.
-    ///
-    /// **Deliberately NOT bumped by the scroll-duration rename
-    /// (#1020)**, though `settings` sits on this type and looks
-    /// like it would carry the renamed key. It does not reach the
-    /// file: `settings` is absent from `CodingKeys`, so it is
-    /// neither encoded nor decoded, and the class doc above says
-    /// why — tiling settings are profile-scoped and persist into
-    /// the active profile's JSON, never into the sidecar. A bump
-    /// here would rewrite every existing `gui.json` for nothing
-    /// and make the previous release refuse one this build wrote.
+    /// Format version of gui.json schema (#902, #1020).
+    /// Format 0 = unversioned.
     public static let currentFormat = 1
 
     public var format: Int = GuiConfig.currentFormat
-    /// Tunable tiling parameters (gaps, per-layout params,
-    /// drag visuals). Mirrors the running `tiler.settings`;
-    /// profile-scoped.
+    /// Active profile tiling parameters.
     public var settings = TilingSettings()
-    /// The Spaces the user has defined, in display
-    /// order. Drives the space lists across the GUI (layouts,
-    /// navigation shortcuts, app assignment). A space can be
-    /// listed with the default `bsp` mode and no other config.
+    /// User-defined Spaces in display order.
     public var spaces: [SpaceID] = []
-    /// Layout mode per Space (`set_mode`);
-    /// profile-scoped.
+    /// Layout mode per Space (profile-scoped).
     public var spaceModes: [SpaceID: LayoutMode] = [:]
     /// App -> space assignment (`app_rules`).
     public var appRules: [String: SpaceID] = [:]
-    /// Space -> monitor fingerprint pin for the *live*
-    /// arrangement; profile-scoped (stored per monitor set).
+    /// Space -> monitor fingerprint pin (profile-scoped).
     public var spacePins: [SpaceID: String] = [:]
-    /// Spaces assigned the Main role (they follow the current
-    /// main display); profile-scoped, stored once per profile.
+    /// Spaces following the main display (profile-scoped).
     public var mainSpaces: Set<SpaceID> = []
-    /// The explicitly designated rehome target (#68): where
-    /// windows land when a profile switch drops their space.
-    /// Profile-scoped (rides the profile JSON, like the pins);
-    /// nil falls back to the order's first surviving space.
+    /// Explicit fallback space when a profile switch drops spaces (#68).
     public var fallbackSpace: SpaceID?
     /// Windows that never tile (`float_rules`).
     public var floatRules: [String] = []
-    /// Apps never managed (`ignore_rules`); no GUI control (#176).
+    /// Apps never managed (`ignore_rules`, #176).
     public var ignoreRules: [String] = []
-    /// Profile bound per native macOS Space (Mission Control
-    /// number -> profile name).
+    /// Mission Control space number -> profile name.
     public var profileBindings: [Int: String] = [:]
-    /// Keybinding modes; the first is always the default mode.
+    /// Keybinding modes; first is default mode.
     public var layers: [KeyLayer] = [KeyLayer.defaultLayer]
 
     public init() {}
 
-    /// Renames a space everywhere it is referenced (#13): the
-    /// `spaces` list, `spaceModes`, `appRules`, the monitor pin
-    /// and Main-role maps, the fallback-space reference, every
-    /// per-space settings map (`TilingSettings.renameSpace` —
-    /// gaps, placement, icons, layout overrides), and the
-    /// space-targeting Lua inside every
-    /// keybinding. A no-op returning `false` when `from` is
-    /// unknown or `to` already exists (the caller keeps the old
-    /// name); renaming to the same id succeeds trivially.
+    /// Renames a space across all references, overrides, and keybindings
+    /// (#13).
     @discardableResult
     public mutating func renameSpace(
         from: SpaceID,
         to: SpaceID
     ) -> Bool {
         guard from != to else { return true }
-        // An empty name is never a valid space (it would emit a
-        // `[""]` key); reject it as a rename target.
         guard !to.raw.isEmpty else { return false }
-        // `spaces` is the authoritative membership set; the caller's
-        // collision check mirrors this guard. A `to` that lingers as
-        // a key in another surface (hand-edited sidecar) is rare and
-        // gets overwritten below — acceptable given `spaces` gates
-        // what the GUI ever offers.
         guard spaces.contains(from), !spaces.contains(to) else {
             return false
         }
@@ -122,16 +76,7 @@ public struct GuiConfig: Codable, Equatable, Sendable {
         return true
     }
 
-    /// Deletes a space and every profile-scoped reference it
-    /// holds (#68): the list entry, its mode, monitor pin,
-    /// Main role, fallback designation, and all per-space
-    /// settings maps (`TilingSettings.removeSpace`). Without
-    /// this, a pin or override left behind keeps the space in
-    /// `Profile.declaredSpaces` and the next authoritative
-    /// profile load resurrects it. Deliberately does NOT touch
-    /// `appRules` (unlike `renameSpace`): app rules are
-    /// global, and another profile may still declare a space
-    /// of this name — a per-profile delete must not drop them.
+    /// Deletes a space and all profile-scoped overrides (#68).
     public mutating func removeSpace(_ space: SpaceID) {
         spaces.removeAll { $0 == space }
         spaceModes[space] = nil
@@ -141,15 +86,7 @@ public struct GuiConfig: Codable, Equatable, Sendable {
         settings.removeSpace(space)
     }
 
-    /// Whether deleting `space` would silently drop non-trivial
-    /// per-space work — the destructive-delete confirm gate
-    /// (#205). Counts a monitor pin, the Main role, the fallback
-    /// designation, and any per-space settings override (gap,
-    /// placement, icon, or a layout's own override map). The
-    /// bare layout mode is core identity, not "override work",
-    /// so it is not counted. The settings half probes by
-    /// mutating a copy and comparing, so it can never drift from
-    /// `TilingSettings.removeSpace`'s reflection-guarded map list.
+    /// True if deleting space would drop custom overrides (#205).
     public func carriesOverrides(_ space: SpaceID) -> Bool {
         if spacePins[space] != nil { return true }
         if mainSpaces.contains(space) { return true }
@@ -159,9 +96,6 @@ public struct GuiConfig: Codable, Equatable, Sendable {
         return probe != settings
     }
 
-    /// Only the global fields persist in the sidecar — the
-    /// profile-scoped ones (settings, modes, pins) round-trip
-    /// through the profile JSON instead (#36).
     private enum CodingKeys: String, CodingKey {
         case format
         case spaces
@@ -172,9 +106,6 @@ public struct GuiConfig: Codable, Equatable, Sendable {
         case layers
     }
 
-    /// Lenient decoding: a field missing from an older sidecar
-    /// falls back to its default (same policy as profiles).
-    /// Legacy tiling keys in an old sidecar are simply ignored.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self
@@ -216,11 +147,6 @@ public struct GuiConfig: Codable, Equatable, Sendable {
             ) ?? []
         profileBindings =
             try decodeProfileBindings(from: container)
-        // Normalized like the spaces below: a hand-edited
-        // sidecar can carry duplicate mode names or an icon on
-        // the default mode (#31) — cleaned here so invalid
-        // entries never reach the loader or the GUI. Empty
-        // input falls back to [KeyLayer.defaultLayer] as before.
         layers = KeyLayer.normalized(
             full: try container.decodeIfPresent(
                 [KeyLayer].self,
@@ -230,21 +156,11 @@ public struct GuiConfig: Codable, Equatable, Sendable {
         dropEmptyNamedSpaces()
     }
 
-    /// Empty space names are blocked at every GUI entry point
-    /// (`SpacesTab` add/rename); this drops any that slipped in
-    /// through a hand-edited sidecar so a `[""]` key never reaches
-    /// the writer. Glyph/symbol names are unaffected.
     private mutating func dropEmptyNamedSpaces() {
-        // ONE definition of the reference sites (removeSpace)
-        // instead of a third hand-mirror of the list; only the
-        // appRules *value* filter stays separate — decode-time
-        // sanitization removeSpace rightly skips.
         removeSpace(SpaceID(""))
         appRules = appRules.filter { !$0.value.raw.isEmpty }
     }
 
-    /// JSON object keys are strings; native-space numbers are
-    /// stored as `{"2": "Studio"}`.
     private func decodeProfileBindings(
         from container: KeyedDecodingContainer<CodingKeys>
     ) throws -> [Int: String] {

--- a/Sources/KiwiDeskCore/Config/GuiConfig.swift
+++ b/Sources/KiwiDeskCore/Config/GuiConfig.swift
@@ -3,8 +3,13 @@ import Foundation
 /// The GUI's editable configuration split across global `gui.json` and
 /// active profile JSON (#36, #55).
 public struct GuiConfig: Codable, Equatable, Sendable {
-    /// Format version of gui.json schema (#902, #1020).
-    /// Format 0 = unversioned.
+    /// Format version of the gui.json schema (#902); 0 =
+    /// unversioned legacy. **Deliberately NOT bumped by the
+    /// scroll-duration rename (#1020)**: `settings` is absent from
+    /// `CodingKeys`, so the renamed key never reaches this file —
+    /// a bump would rewrite every gui.json for nothing and make
+    /// the previous release refuse one this build wrote. That note
+    /// is the ruling `SetupBundle.currentFormat` cites.
     public static let currentFormat = 1
 
     public var format: Int = GuiConfig.currentFormat
@@ -76,7 +81,12 @@ public struct GuiConfig: Codable, Equatable, Sendable {
         return true
     }
 
-    /// Deletes a space and all profile-scoped overrides (#68).
+    /// Deletes a space and all profile-scoped overrides (#68) — a
+    /// pin left behind keeps the space in `Profile.declaredSpaces`
+    /// and the next authoritative load resurrects it. Deliberately
+    /// does NOT touch `appRules` (unlike `renameSpace`): app rules
+    /// are global, and another profile may still declare a space
+    /// of this name.
     public mutating func removeSpace(_ space: SpaceID) {
         spaces.removeAll { $0 == space }
         spaceModes[space] = nil
@@ -87,6 +97,9 @@ public struct GuiConfig: Codable, Equatable, Sendable {
     }
 
     /// True if deleting space would drop custom overrides (#205).
+    /// The settings half probes by mutating a copy and comparing,
+    /// so it can never drift from `TilingSettings.removeSpace`'s
+    /// reflection-guarded map list.
     public func carriesOverrides(_ space: SpaceID) -> Bool {
         if spacePins[space] != nil { return true }
         if mainSpaces.contains(space) { return true }
@@ -96,6 +109,10 @@ public struct GuiConfig: Codable, Equatable, Sendable {
         return probe != settings
     }
 
+    /// Only the global fields persist in the sidecar — the
+    /// profile-scoped ones round-trip through the profile JSON
+    /// instead (#36), which is what lets the two files never
+    /// drift.
     private enum CodingKeys: String, CodingKey {
         case format
         case spaces
@@ -147,6 +164,9 @@ public struct GuiConfig: Codable, Equatable, Sendable {
             ) ?? []
         profileBindings =
             try decodeProfileBindings(from: container)
+        // A hand-edited sidecar can carry duplicate mode names or
+        // an icon on the default mode (#31) — normalized here so
+        // invalid entries never reach the loader or the GUI.
         layers = KeyLayer.normalized(
             full: try container.decodeIfPresent(
                 [KeyLayer].self,
@@ -157,6 +177,9 @@ public struct GuiConfig: Codable, Equatable, Sendable {
     }
 
     private mutating func dropEmptyNamedSpaces() {
+        // ONE definition of the reference sites (removeSpace)
+        // rather than a third hand-mirror; only the appRules VALUE
+        // filter stays separate.
         removeSpace(SpaceID(""))
         appRules = appRules.filter { !$0.value.raw.isEmpty }
     }

--- a/Sources/KiwiDeskCore/Config/KeyLayerOverride.swift
+++ b/Sources/KiwiDeskCore/Config/KeyLayerOverride.swift
@@ -13,13 +13,20 @@ public struct KeyLayerOverride: Sendable, Equatable {
     /// True when no layer diverges.
     public var isEmpty: Bool { layers.isEmpty }
 
-    /// Count of divergent layers and bindings (#678 turn 13a).
+    /// Count of things this override overrides (#678 turn 13a).
+    /// Not `flatMap(\.bindings).count`: `diff` emits a layer with
+    /// NO bindings when only its icon diverges, so a diverging
+    /// layer contributes at least itself. The invariant to keep is
+    /// `isEmpty == (overrideCount == 0)`.
     public var overrideCount: Int {
         layers.reduce(0) { $0 + max($1.bindings.count, 1) }
     }
 
-    /// Merges this override onto `base` layer list (distinct from
-    /// `KeybindingMerge`).
+    /// Merges this override onto `base` (O4 soft: override wins
+    /// per combo IN PLACE, unmentioned base combos and layers
+    /// survive). `KeybindingMerge` folds by the same key with the
+    /// OPPOSITE icon precedence — both are correct for their
+    /// direction, do not unify them.
     public func resolved(
         onto base: [KeyLayer]
     ) -> [KeyLayer] {
@@ -35,6 +42,9 @@ public struct KeyLayerOverride: Sendable, Equatable {
                 result.append(baseLayer)
                 continue
             }
+            // EVERY matching base row is replaced — a hand-edited
+            // duplicate base combo must not let a stale copy
+            // outlive the override (registration is last-wins).
             var merged = baseLayer.bindings
             for row in over.bindings {
                 var replaced = false
@@ -65,7 +75,11 @@ public struct KeyLayerOverride: Sendable, Equatable {
 }
 
 extension KeyLayerOverride {
-    /// Produces sparse override diff from base to edited (nil if identical).
+    /// Inverse of `resolved(onto:)` — nil when nothing diverges.
+    /// DELETIONS are not expressible (O4 soft: unmentioned base
+    /// rows always survive): the editor treats deleting an
+    /// inherited row as revert, never removal — rebind to a no-op
+    /// to disable a combo in one profile. No tombstones.
     public static func diff(
         base: [KeyLayer],
         edited: [KeyLayer]

--- a/Sources/KiwiDeskCore/Config/KeyLayerOverride.swift
+++ b/Sources/KiwiDeskCore/Config/KeyLayerOverride.swift
@@ -1,20 +1,7 @@
 import Foundation
 
-// MARK: - KeyLayerOverride
-
-/// Sparse per-profile keybinding override (#55). nil (absent)
-/// inherits the base `layers` (gui.json) entirely; present, it
-/// shadows the base by layer name then by combo — the override's
-/// binding for a combo wins, base combos it does not mention
-/// survive (the switch-key-trap safeguard, O4 soft). A layer the
-/// base lacks is appended. Every base layer the override does not
-/// mention passes through unchanged, so the default layer and any
-/// profile-switch binding are never dropped.
-///
-/// Keyed merge (layer name × combo), NOT a struct field-mirror —
-/// so no reflection parity net applies (AGENTS.md §5); guarded
-/// instead by a round-trip + resolve + default-layer-invariant
-/// test in `KeyLayerOverrideTests`.
+/// Sparse per-profile keybinding override (#55; tested in
+/// `KeyLayerOverrideTests`).
 public struct KeyLayerOverride: Sendable, Equatable {
     /// Sparse: only layers that diverge from the base.
     public var layers: [KeyLayer]
@@ -23,52 +10,20 @@ public struct KeyLayerOverride: Sendable, Equatable {
         self.layers = layers
     }
 
-    /// True when no layer diverges — a fully-inherited profile
-    /// needs no stored override (drives sparse encoding).
+    /// True when no layer diverges.
     public var isEmpty: Bool { layers.isEmpty }
 
-    /// How many things this override actually overrides, for the
-    /// GUI's per-profile count (#678 turn 13a).
-    ///
-    /// Not `layers.flatMap(\.bindings).count`: `diff` emits a
-    /// layer with NO bindings when only its icon diverges, so
-    /// summing bindings returns 0 for an override that
-    /// `isEmpty` calls non-empty — and a profile row that then
-    /// drops its "N shortcut overrides" segment tells the user
-    /// the profile owns nothing here, which is the one reading
-    /// that count exists to prevent. So a diverging layer
-    /// contributes at least itself. The invariant to keep is
-    /// `isEmpty == (overrideCount == 0)`; anything that can
-    /// diverge without a binding must keep counting.
+    /// Count of divergent layers and bindings (#678 turn 13a).
     public var overrideCount: Int {
         layers.reduce(0) { $0 + max($1.bindings.count, 1) }
     }
 
-    /// Resolves this override onto `base`, producing the merged
-    /// layer list. Returns `base` unchanged when empty.
-    ///
-    /// Merge rule (O4 soft base layer):
-    /// - For each override layer matching a base layer by `name`:
-    ///   per-combo merge (override wins IN PLACE, so the base
-    ///   row order survives for GUI rendering; base combos not
-    ///   in the override survive). Override `icon` wins when
-    ///   non-nil; otherwise the base icon is kept.
-    /// - An override layer absent from `base` is appended.
-    /// - Base layers not in the override pass through unchanged
-    ///   (default layer and switch-key bindings always survive).
-    ///
-    /// Sibling keyed merge: `KeybindingMerge` (GUI shortcut
-    /// import) folds by the same name×combo key but with the
-    /// OPPOSITE icon precedence (existing-wins). Both are
-    /// correct for their direction — do not unify them.
+    /// Merges this override onto `base` layer list (distinct from
+    /// `KeybindingMerge`).
     public func resolved(
         onto base: [KeyLayer]
     ) -> [KeyLayer] {
         guard !isEmpty else { return base }
-        // Index override layers by name for O(n) lookup. The
-        // assignment is last-wins, but duplicate names cannot
-        // reach here: decode sanitizes them FIRST-wins
-        // (`KeyLayer.normalized`), and `diff` keys by name.
         var overrideByName: [String: KeyLayer] = [:]
         for layer in layers {
             overrideByName[layer.name] = layer
@@ -77,17 +32,9 @@ public struct KeyLayerOverride: Sendable, Equatable {
         var consumed: Set<String> = []
         for baseLayer in base {
             guard let over = overrideByName[baseLayer.name] else {
-                // Not in override — pass through unchanged.
                 result.append(baseLayer)
                 continue
             }
-            // Merge bindings in base order: an overridden
-            // combo replaces its base row in place (the GUI
-            // renders resolved layers — rows must not jump);
-            // combos new to the layer append at the end. EVERY
-            // matching base row is replaced — a hand-edited
-            // duplicate base combo must not let a stale copy
-            // outlive the override (registration is last-wins).
             var merged = baseLayer.bindings
             for row in over.bindings {
                 var replaced = false
@@ -109,7 +56,6 @@ public struct KeyLayerOverride: Sendable, Equatable {
             )
             consumed.insert(baseLayer.name)
         }
-        // Append override layers absent from base.
         for layer in layers
         where !consumed.contains(layer.name) {
             result.append(layer)
@@ -118,29 +64,8 @@ public struct KeyLayerOverride: Sendable, Equatable {
     }
 }
 
-// MARK: - Diff (inverse of resolved)
-
 extension KeyLayerOverride {
-    /// Inverse of `resolved(onto:)`: the sparse override that,
-    /// resolved onto `base`, yields `edited`. Rows matching a
-    /// base row SEMANTICALLY (`sameAction`: combo + lua —
-    /// display-only kind/label differences from the GUI
-    /// classifier never read as divergence) are inherited and
-    /// omitted; a row whose combo is absent from base or whose
-    /// action diverges is included. A layer absent from base is
-    /// included whole. An edited icon differing from the base
-    /// icon is carried (nil inherits — CLEARING a base icon
-    /// per profile is therefore not expressible; it reverts,
-    /// like row deletion). Returns nil when nothing diverges —
-    /// a fully-inherited profile stores no override (O3
-    /// sparse; an empty override is never persisted).
-    ///
-    /// DELETIONS are not expressible (O4 soft: base rows the
-    /// override does not mention always survive) — a base row
-    /// missing from `edited` is simply absent from the diff
-    /// and reappears on resolve. The editor treats deleting an
-    /// inherited row as revert, never removal; rebind to a
-    /// no-op to disable a combo in one profile. No tombstones.
+    /// Produces sparse override diff from base to edited (nil if identical).
     public static func diff(
         base: [KeyLayer],
         edited: [KeyLayer]
@@ -152,7 +77,6 @@ extension KeyLayerOverride {
         var layers: [KeyLayer] = []
         for layer in edited {
             guard let baseLayer = baseByName[layer.name] else {
-                // New layer: carried whole.
                 layers.append(layer)
                 continue
             }
@@ -182,16 +106,8 @@ extension KeyLayerOverride {
     }
 }
 
-// MARK: - Codable
-
 extension KeyLayerOverride: Codable {
-    /// Transparent to [KeyLayer]: encode/decode as a bare JSON
-    /// array, matching the `GuiConfig.layers` shape so both
-    /// surfaces share one vocabulary (AGENTS.md §5).
-    /// Decoded input is untrusted (hand-edited profile JSON,
-    /// #31): duplicate names and a default-layer icon are
-    /// normalized away. Sparse flavor — a default entry is
-    /// never inserted (absence means inherit).
+    /// Decodes normalized sparse layer list (#31).
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         layers = KeyLayer.normalized(
@@ -205,17 +121,9 @@ extension KeyLayerOverride: Codable {
     }
 }
 
-// MARK: - ConfigResolver
-
-/// Thin resolver composing the base and profile keybinding
-/// tiers (O1, AGENTS.md §5). Tiling tiers are unchanged:
-/// `apply()` replaces base, `TilingSettings.resolvedX(for:)`
-/// handles per-space — those are not re-implemented here.
+/// Resolver composing base and profile keybinding tiers.
 public enum ConfigResolver {
-    /// Returns the effective layer list: `base` (from gui.json)
-    /// when `profile` is nil or empty; keyed name×combo merge
-    /// otherwise. Mirrors `reapplyActiveProfileState` ordering
-    /// — declarative Lua is the seed, profile wins.
+    /// Returns effective layers merging `profile` onto `base`.
     public static func resolvedLayers(
         base: [KeyLayer],
         profile: KeyLayerOverride?

--- a/Sources/KiwiDeskCore/Config/ManagedConfig.swift
+++ b/Sources/KiwiDeskCore/Config/ManagedConfig.swift
@@ -3,7 +3,13 @@ import Foundation
 /// Classifies `init.lua` by whether it touches GUI-managed vocabulary
 /// (#55, #116).
 public enum ManagedConfig {
-    /// Tokens matched against non-comment lines that force the raw Lua editor.
+    /// Tokens matched against non-comment lines that force the raw
+    /// Lua editor. Known limitation: receiver aliasing
+    /// (`local K = KiwiDesk; K.bind(…)`) escapes this token scan —
+    /// a deliberate tradeoff, and the stakes are why bindings stay
+    /// in ONE home (O7): an evading bind is registered by
+    /// init.lua, then silently unregistered when the structured
+    /// loader resets.
     public static let managedTokens: [String] = [
         "app_rules",
         "float_rules",
@@ -23,7 +29,10 @@ public enum ManagedConfig {
         classify(source).custom
     }
 
-    /// Whether config declares any managed setting, gating seed (#354).
+    /// Whether the config declares any managed SETTING — the
+    /// first-launch seed gate (#354): a hand-written config using
+    /// `set_*` verbs is Lua-owned and must never be seeded over,
+    /// while a hooks-only file still earns the GUI defaults.
     public static func declaresManagedSettings(
         _ source: String
     ) -> Bool {

--- a/Sources/KiwiDeskCore/Config/ManagedConfig.swift
+++ b/Sources/KiwiDeskCore/Config/ManagedConfig.swift
@@ -1,50 +1,9 @@
 import Foundation
 
-/// Classifies `init.lua` by whether its code touches the GUI's
-/// managed vocabulary (#55: the app loads `gui.json` and profiles
-/// directly and treats `init.lua` as hooks-only — it neither
-/// generates nor recognizes a managed block).
-///
-/// The GUI falls back to the raw Lua editor only when the code
-/// touches the managed vocabulary — verbs the GUI owns in
-/// `gui.json`. Harmless custom Lua (print calls, debug hooks,
-/// sketchybar integrations) coexists with the visual editor; it
-/// shows an informational banner instead of locking the user out.
-///
-/// Pre-release, the marker-block recognition that used to keep a
-/// stale pre-#55 block "app-owned" was removed (#116): such a block
-/// is now scanned like any other code, so a bind or rule inside it
-/// reads as foreign — the file becomes Lua-owned (raw editor, never
-/// seeded over), the safe direction. Re-saving is the migration.
+/// Classifies `init.lua` by whether it touches GUI-managed vocabulary
+/// (#55, #116).
 public enum ManagedConfig {
-    // MARK: - Managed vocabulary
-
-    /// Tokens matched against non-comment, non-blank lines of the
-    /// source (see `touchesManagedVocabulary`).
-    /// A match forces the raw editor because the GUI cannot
-    /// safely co-own that vocabulary — it owns app rules,
-    /// float/ignore rules, keybindings, and profile bindings in
-    /// `gui.json` (#55). Harmless custom Lua (no matching
-    /// token) coexists with the visual editor.
-    ///
-    /// Matching rules (see `lineMatchesToken`):
-    /// - Tokens ending with `(` (method calls): optional
-    ///   whitespace before `(` is collapsed first, so
-    ///   `KiwiDesk.bind (` also matches `KiwiDesk.bind(`.
-    /// - Bare-identifier tokens (`app_rules`, `float_rules`,
-    ///   `ignore_rules`):
-    ///   require a word boundary and `\s*=` after the token
-    ///   so a substring inside a longer identifier
-    ///   (`app_rules_count`) or a string literal
-    ///   (`"app_rules"`) does not match.
-    ///
-    /// Known limitation: receiver aliasing
-    /// (`local K = KiwiDesk; K.bind(…)`) escapes detection.
-    /// Token-based scanning (not full Lua parsing) is a
-    /// deliberate pre-release tradeoff. Post-#55 the stakes:
-    /// an evading bind is registered by `init.lua`, then
-    /// silently unregistered when the structured loader
-    /// resets — keep bindings in ONE home (O7).
+    /// Tokens matched against non-comment lines that force the raw Lua editor.
     public static let managedTokens: [String] = [
         "app_rules",
         "float_rules",
@@ -54,65 +13,25 @@ public enum ManagedConfig {
         "KiwiDesk.bind_profile_to_desktop(",
     ]
 
-    // `adopt` and its selective-comment machinery live in
-    // `ManagedConfig+Adopt.swift` (file-size split, §2).
-
-    // MARK: - Foreign-code detection
-
-    /// Whether the code touches the GUI's managed vocabulary —
-    /// verbs the GUI itself owns in `gui.json` (`app_rules`,
-    /// `float_rules`, `ignore_rules`, `KiwiDesk.bind(`,
-    /// etc.). When `true` the visual editor cannot safely co-own
-    /// those constructs, so it yields to the raw Lua editor.
-    ///
-    /// Harmless custom Lua that does NOT touch any managed token
-    /// returns `false` here (the visual editor stays active) and
-    /// `true` from `hasCustomCode(_:)` (a banner is shown).
+    /// True if code touches GUI-managed vocabulary (`gui.json` ownership).
     public static func hasForeignCode(_ source: String) -> Bool {
         classify(source).foreign
     }
 
-    /// Whether any non-blank, non-comment Lua exists in the file.
-    /// This includes harmless code that does NOT
-    /// touch the managed vocabulary. Used by the GUI to show an
-    /// informational banner while keeping the visual editor
-    /// active.
-    ///
-    /// When `hasForeignCode(_:)` is `true`, this is also `true`
-    /// — every file that forces the raw editor also has custom
-    /// code — but the converse does not hold.
+    /// True if non-blank, non-comment Lua code exists in source.
     public static func hasCustomCode(_ source: String) -> Bool {
         classify(source).custom
     }
 
-    /// Whether the config declares any managed **setting** — the
-    /// signal that gates the first-launch `gui.json` seed (#354).
-    ///
-    /// A *superset* of `hasForeignCode`: on top of the foreign
-    /// tokens (rules/binds/modes) it also catches the `set_*`
-    /// setting verbs — `KiwiDesk.set_gap_global`, and crucially the
-    /// **namespaced** layout verbs (`bsp.set_ratio_h`,
-    /// `stack.set_master_ratio`, …) — that the editor-fallback
-    /// check deliberately ignores. Those verbs configure tiling
-    /// directly, so a hand-written config using them is Lua-owned
-    /// and must never be seeded over (the GUI defaults would
-    /// silently overwrite the user's Lua settings, #354). Harmless
-    /// custom Lua — event hooks (`KiwiDesk.on`/`KiwiDesk.exec`),
-    /// `print`, control flow — matches nothing and returns `false`,
-    /// so a hooks-only file still earns the GUI defaults.
+    /// Whether config declares any managed setting, gating seed (#354).
     public static func declaresManagedSettings(
         _ source: String
     ) -> Bool {
         classify(source).foreign || hasLiveSettingVerb(source)
     }
 
-    /// A live (non-comment) call to a `set_*` settings verb, on the
-    /// `KiwiDesk` table or any layout namespace. The namespace set
-    /// is `APIReference.namespaces` — the authoritative registry —
-    /// so this can't drift as sub-APIs (`bsp`, `stack`, `scroll`,
-    /// …) or their verbs are added. Anchoring to those known table
-    /// names avoids false positives from an unrelated
-    /// `foo.set_bar()`.
+    /// Live call to any `set_*` settings verb on KiwiDesk or layout
+    /// namespaces.
     private static func hasLiveSettingVerb(
         _ source: String
     ) -> Bool {
@@ -126,18 +45,10 @@ public enum ManagedConfig {
         return false
     }
 
-    /// Whether one line calls a `set_*` settings verb (on the
-    /// `KiwiDesk` table or a layout namespace) or `border.fit_gaps`.
-    /// The **single** definition of the setting-verb vocabulary,
-    /// shared by the file-level `hasLiveSettingVerb` and the
-    /// per-line `lineDeclaresManaged`, so the two can't drift as
-    /// verbs are added (§5 hand-mirrored-list rule).
+    /// Single definition of setting-verb vocabulary across namespaces.
     static func lineHasSettingVerb(_ line: String) -> Bool {
         if line.contains("KiwiDesk.set_") { return true }
-        // `border.fit_gaps` is the one config-writing verb without
-        // a `set_` name — it rewrites the global gap from the
-        // border width (`KiwiCore+BorderCommands`), so a config
-        // tuning gaps that way must not be seeded over.
+        // `border.fit_gaps` rewrites global gap from border width.
         if line.contains("border.fit_gaps") { return true }
         for ns in APIReference.namespaces.keys
         where line.contains("\(ns).set_") {
@@ -146,11 +57,7 @@ public enum ManagedConfig {
         return false
     }
 
-    /// Whether one line opens a **foreign** construct — a
-    /// `managedTokens` match (`KiwiDesk.bind(`, `app_rules =`, …).
-    /// The per-line half of `touchesManagedVocabulary`, shared so
-    /// the file-level foreign scan and `lineDeclaresManaged` use
-    /// one matcher.
+    /// Whether line opens a foreign construct matching `managedTokens`.
     static func lineMatchesForeignToken(_ line: String) -> Bool {
         for token in managedTokens
         where lineMatchesToken(line, token: token) {
@@ -159,29 +66,12 @@ public enum ManagedConfig {
         return false
     }
 
-    /// Whether a single trimmed, non-comment `line` opens a
-    /// **managed** construct — a foreign token or a `set_*` setting
-    /// verb — i.e. a statement `adopt` comments out because
-    /// `gui.json` now owns it. The per-line union of the two
-    /// vocabularies above; harmless custom Lua (hooks, `print`,
-    /// helpers) matches nothing (#355). Used to classify a
-    /// statement by its head line so a hook that *contains* an
-    /// inner `set_` still reads as custom.
+    /// Whether line opens a managed construct commented out on adopt (#355).
     static func lineDeclaresManaged(_ line: String) -> Bool {
         lineMatchesForeignToken(line) || lineHasSettingVerb(line)
     }
 
-    /// Classifies a config source in a single scan: returns
-    /// both `foreign` and `custom` flags without reading the
-    /// file twice. `foreign` implies `custom` by construction.
-    ///
-    /// This is the **single definition** of the foreign/custom
-    /// signal; `hasForeignCode`/`hasCustomCode` are thin
-    /// wrappers over it, so the "one ownership predicate"
-    /// invariant (AGENTS.md §5) holds structurally — there is
-    /// no second composition to keep in lockstep. Prefer
-    /// calling this directly when the source is already in
-    /// memory (e.g. `SettingsModel.reload()`).
+    /// Single-pass classifier returning (foreign, custom) flags.
     public static func classify(
         _ source: String
     ) -> (foreign: Bool, custom: Bool) {
@@ -190,16 +80,8 @@ public enum ManagedConfig {
         return (foreign: foreign, custom: custom)
     }
 
-    // MARK: - Internals
-
-    /// True if `text` holds a line that is not blank and not a
-    /// full-line Lua comment (lines starting with `--`).
-    ///
-    /// Known limitation: `--[[ … ]]` block comment interior
-    /// lines that don't start with `--` are treated as code
-    /// by this line-by-line scan. The behavior is
-    /// over-conservative (not dangerous); it is pinned by
-    /// `ManagedConfigTests.blockCommentInteriorIsTreatedAsCode`.
+    /// True if text contains non-comment code lines
+    /// (`ManagedConfigTests.blockCommentInteriorIsTreatedAsCode`).
     private static func isCode(_ text: String) -> Bool {
         for line in text.components(separatedBy: "\n") {
             let t = line.trimmed
@@ -209,9 +91,7 @@ public enum ManagedConfig {
         return false
     }
 
-    /// True if any non-blank, non-comment line in `text`
-    /// contains a managed-vocabulary token (matched via
-    /// `lineMatchesToken` for token-type-aware rules).
+    /// True if any active line matches managed vocabulary tokens.
     private static func touchesManagedVocabulary(
         _ text: String
     ) -> Bool {
@@ -224,25 +104,13 @@ public enum ManagedConfig {
         return false
     }
 
-    /// Matches `line` against `token` with token-type-aware
-    /// rules:
-    /// - Tokens ending with `(` (method calls): optional
-    ///   whitespace before `(` is collapsed first so that
-    ///   `KiwiDesk.bind ("alt+h", …)` matches the token
-    ///   `KiwiDesk.bind(`.
-    /// - Bare-identifier tokens (`app_rules`, `float_rules`,
-    ///   `ignore_rules`):
-    ///   a word boundary followed by `\s*=` is required so
-    ///   that a substring inside a longer identifier
-    ///   (`app_rules_count`) or inside a string literal
-    ///   (`"app_rules"`) does not produce a false positive.
+    /// Matches line against token taking method parentheses and word
+    /// boundaries.
     private static func lineMatchesToken(
         _ line: String,
         token: String
     ) -> Bool {
         if token.hasSuffix("(") {
-            // Collapse whitespace immediately before ( so
-            // `KiwiDesk.bind (` also matches `KiwiDesk.bind(`.
             let norm = line.replacingOccurrences(
                 of: #"\s+\("#,
                 with: "(",
@@ -250,8 +118,6 @@ public enum ManagedConfig {
             )
             return norm.contains(token)
         }
-        // Bare-identifier tokens: require word boundary + =
-        // so app_rules_count and "app_rules" don't match.
         let pat =
             #"\b"#
             + NSRegularExpression.escapedPattern(for: token)
@@ -264,8 +130,7 @@ public enum ManagedConfig {
 }
 
 extension StringProtocol {
-    /// Trims spaces, tabs, and line terminators (`\r`) so the
-    /// foreign-code scan survives CRLF files.
+    /// Trims whitespaces and newlines across CRLF line endings.
     fileprivate var trimmed: String {
         trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/KiwiDeskCore/Config/SetupBundle.swift
+++ b/Sources/KiwiDeskCore/Config/SetupBundle.swift
@@ -1,105 +1,21 @@
 import Foundation
 
-/// Everything a KiwiDesk backup carries, as one document (#606).
-///
-/// **One JSON file, not a zip.** Every piece that travels is
-/// already JSON, so an archive would add a packing step, a
-/// partial-extract failure mode and a temporary directory to buy
-/// nothing: this decodes and validates whole before anything on
-/// the destination Mac is touched.
-///
-/// **The contents are an allow-list, never a directory sweep.**
-/// `~/.config/KiwiDesk` also holds the IPC socket, the instance
-/// lock (`SingleInstanceLock`) and the remembered window
-/// arrangement (`CrashRecovery`'s `.state_snapshot` and its
-/// session file). None of that describes how the user likes their
-/// desk, and the snapshots are actively machine-specific. What
-/// travels:
-///
-/// **Carried:** `gui.json`'s contents, every profile, and the
-/// saved palette library.
-///
-/// **Left behind, each for its own reason:** `init.lua`, because
-/// it is user-authored code and a backup that quietly restored it
-/// would claim ownership of a file KiwiDesk deliberately does not
-/// manage; the arrangement snapshots, because a remembered
-/// arrangement is this Mac's session rather than a setting; and
-/// the socket and the lock file, which are runtime.
-///
-/// An earlier draft of this list also named `.bak-*` directories
-/// "a past reset left behind". Nothing in the tree writes one —
-/// `resetAllSettings` trashes, it does not copy aside — so the
-/// entry described a file that has never existed. Add an entry
-/// here only for a path something actually creates.
-///
-/// Palettes are here because they do **not** ride inside
-/// `gui.json`: applying a palette writes its colours into the
-/// settings, so the current *look* travels with the config while
-/// the user's saved *library* lives in `palettes.json` and would
-/// otherwise be left behind — the one thing a person moving Macs
-/// would most notice missing.
+/// Everything a KiwiDesk backup carries as one JSON document (#606).
+/// Carries `gui.json`, profiles, and saved palette library (`palettes.json`).
 public struct SetupBundle: Codable, Sendable, Equatable {
-    /// The format this build writes and is willing to read.
-    ///
-    /// **Not a compatibility shim**, which AGENTS.md §5 rules out
-    /// pre-release. It is a refusal signal, and it earns its place
-    /// because this is the one artifact that legitimately outlives
-    /// the running build: it is written to a file, carried to
-    /// another Mac and read back by whatever version is installed
-    /// there. `JSONDecoder` is lenient, so a bundle from a future
-    /// format would decode "successfully" with unknown fields
-    /// dropped — a restore that reports success having silently
-    /// lost data. One integer turns that into a refusal.
-    ///
-    /// **2** since the bar-content rename (owner ruling
-    /// 2026-08-19): `Profile` is bundle payload, and
-    /// `AppBarStyle.Content`'s raw values changed under it, which
-    /// is exactly the "breaks the decoded shape of anything the
-    /// bundle carries" case `profiles.md` says must bump this.
-    /// A v0.9.7 install then REFUSES a bundle written here
-    /// instead of restoring profiles whose bar setting it cannot
-    /// read; the other direction — a format-1 bundle read here —
-    /// stays readable and is migrated on the way in
-    /// (`KiwiCore+Backup.readBackup`).
-    ///
-    /// **3** since the scroll-duration rename (#1020), on
-    /// `[Profile]` ALONE: `Profile.settings` changed decoded
-    /// shape, which is the same "breaks the decoded shape of
-    /// anything the bundle carries" case as the bump above. The
-    /// `config:` payload did NOT — `GuiConfig.settings` is
-    /// absent from its `CodingKeys` and never reaches the file,
-    /// which is why `GuiConfig.currentFormat` was deliberately
-    /// left alone; that note is the ruling.
+    /// Supported bundle format version (format 2: bar-content rename, owner
+    /// ruling 2026-08-19; format 3: scroll-duration rename on Profile, #1020).
     public static let currentFormat = 3
 
     public let format: Int
 
-    /// The top-level key `ConfigMigration.targetFormat` routes a
-    /// bundle on — a constant HERE, beside the synthesized
-    /// CodingKey it mirrors (`writtenBy` below), so the marker
-    /// moves with the property or not at all;
-    /// `ConfigMigrationTests.shapeMarkersMatchEncodedShapes`
-    /// ties it to the real encoder output.
+    /// Top-level key `ConfigMigration.targetFormat` routes a bundle on
+    /// (`ConfigMigrationTests.shapeMarkersMatchEncodedShapes`).
     static let shapeMarker = "writtenBy"
 
-    /// The version that wrote it — informational, for a human
-    /// looking at a file they were mailed. Nothing branches on it;
-    /// `format` is the only compatibility question.
+    /// Informational version string of the writing KiwiDesk build.
     public let writtenBy: String
-    /// The GUI-managed settings, or nil.
-    ///
-    /// Nil has **two** causes and only one of them is benign:
-    /// there is no sidecar (a Lua-owned config, a legitimate
-    /// backup whose profiles and palettes still travel), or there
-    /// is one and it would not decode. `GuiConfigStore.load`
-    /// answers nil to both, so an export from a Mac with a corrupt
-    /// `gui.json` silently produces a settings-less backup and
-    /// reports success (`code-reviewer`, 2026-08-17).
-    ///
-    /// `exportSetup` therefore checks `guiConfigStore.exists`
-    /// rather than trusting the nil, and refuses the second case:
-    /// a backup is the one artifact a user makes precisely because
-    /// they are about to need it.
+    /// GUI-managed settings, or nil if unmanaged (code-reviewer 2026-08-17).
     public let config: GuiConfig?
     public let profiles: [Profile]
     public let palettes: [ColorPalette]
@@ -118,31 +34,13 @@ public struct SetupBundle: Codable, Sendable, Equatable {
         self.palettes = palettes
     }
 
-    /// Whether this build can read it.
+    /// Whether this build can read the bundle format.
     public var isReadable: Bool {
         format <= SetupBundle.currentFormat
     }
 
-    /// Whether this bundle replaces `artifact` — and the
-    /// distinction is **absent, not empty**.
-    ///
-    /// An empty `profiles` or `palettes` array is not an absence:
-    /// the export always writes both keys, so `[]` means *the
-    /// source Mac had none*, and replacing with none is exactly
-    /// what `docs/design-decisions.md` ▸ "A restore replaces; it
-    /// never merges" promises — "the destination holds exactly
-    /// what the source held, so a user can confirm it by looking".
-    /// Only `config == nil` is a true absence, and only because a
-    /// Lua-owned source has no sidecar to carry.
-    ///
-    /// An earlier cut put this on `ConfigArtifact` and answered
-    /// `!isEmpty` for all three, which turned a documented replace
-    /// into a merge in two dimensions and pinned it with a test:
-    /// restoring a backup from a Mac with no palettes left the
-    /// destination's library standing, against both the ruling and
-    /// the confirm dialog's own copy. Writing it from the FILE's
-    /// point of view is what got it wrong; the truth is entirely a
-    /// property of the payload (`architect-reviewer`, 2026-08-17).
+    /// Whether this bundle replaces `artifact`
+    /// (architect-reviewer 2026-08-17).
     public func replaces(_ artifact: ConfigArtifact) -> Bool {
         switch artifact {
         case .guiConfig: return config != nil
@@ -150,36 +48,18 @@ public struct SetupBundle: Codable, Sendable, Equatable {
         }
     }
 
-    /// True when the bundle would restore nothing at all — no
-    /// settings, no profiles, no palettes.
-    ///
-    /// Exporting one is legitimate (a fresh install has little to
-    /// say), but restoring one is almost certainly a mistake the
-    /// user should be told about rather than a wipe they asked
-    /// for.
+    /// True when bundle carries no settings, profiles, or palettes.
     public var isEmpty: Bool {
         config == nil && profiles.isEmpty && palettes.isEmpty
     }
 }
 
-/// What a restore did that the user did not ask for.
-///
-/// Structure rather than a log line, for the same reason every
-/// other condition in this feature is (#96): a restore that wrote
-/// three of five profiles and dropped two palettes used to report
-/// unqualified success, while this feature's own export path
-/// argues that a backup which silently did not happen is worse
-/// than one that says so (`architect-reviewer`, 2026-08-17).
-///
-/// Empty means a clean restore, which is the overwhelmingly common
-/// case — every value here needs a hand-edited bundle to reach.
+/// Structural outcome of a backup restore
+/// (#96, architect-reviewer 2026-08-17).
 public struct RestoreOutcome: Equatable, Sendable {
-    /// Profiles the bundle carried that could not be written —
-    /// a name `ProfileManager` rejects, reachable from a
-    /// hand-edited file.
+    /// Profiles that could not be written.
     public let skippedProfiles: [String]
-    /// Palettes dropped for shadowing a built-in, duplicating
-    /// another, or carrying no admissible colours.
+    /// Palettes dropped for shadowing built-ins or duplicate names.
     public let refusedPalettes: Int
 
     public var isClean: Bool {
@@ -187,49 +67,22 @@ public struct RestoreOutcome: Equatable, Sendable {
     }
 }
 
-/// What can go wrong reading or writing a backup.
-///
-/// Structure, never a sentence: Core names the condition and the
-/// GUI renders the copy at its own boundary (#96,
-/// `core-boundaries.md`). A pre-rendered English string here would
-/// be invisible to `scripts/extract-keys` and untranslatable in
-/// every catalog.
+/// Structured error cases for backup read/write operations (#96).
 public enum SetupBundleError: Error, Equatable, Sendable {
-    /// The file could not be read at all — gone, unreadable, or
-    /// not JSON.
+    /// The file could not be read or is not JSON.
     case unreadable
     /// Valid JSON that is not a KiwiDesk backup.
     case notABackup
-    /// Written by a newer KiwiDesk than this one.
+    /// Written by a newer KiwiDesk format.
     case newerFormat(found: Int, supported: Int)
-    /// A backup that would restore nothing.
+    /// A backup that contains no restoreable items.
     case empty
-    /// Writing failed, naming the file that did not land.
+    /// Writing failed, naming the target file.
     case couldNotWrite(name: String)
-    /// This Mac has a `gui.json` that will not decode, so an
-    /// export would silently omit every setting.
-    ///
-    /// Distinguished from "no sidecar at all" by
-    /// `GuiConfigStore.exists`, because the two look identical
-    /// through `load()` and only one of them is a backup worth
-    /// making.
+    /// Existing `gui.json` failed to decode during export.
     case unreadableSettings
-    /// This Mac's `palettes.json` exists but will not decode
-    /// (a newer KiwiDesk wrote it, or it is corrupt), so an
-    /// export would silently back up an empty library (#945
-    /// review). The gui.json twin of `unreadableSettings`,
-    /// one line up.
+    /// Existing `palettes.json` failed to decode during export (#945).
     case unreadablePalettes
-    /// The backup carries settings, but this Mac's `init.lua`
-    /// owns the configuration, so the settings half could not be
-    /// applied.
-    ///
-    /// `isGuiManaged` is the one ownership predicate
-    /// (`profiles.md`), and on a Lua-owned destination
-    /// `loadConfig` takes the `applyConfigGlobals` branch: the
-    /// restored rules and keybindings in the written `gui.json`
-    /// are never read, while the profile-scoped half applies
-    /// anyway. That is a half-landed restore, and reporting
-    /// success for it is the failure this case exists to prevent.
+    /// Target Mac is Lua-managed so GUI settings cannot apply.
     case luaOwnsThisMac
 }

--- a/Sources/KiwiDeskCore/Config/SetupBundle.swift
+++ b/Sources/KiwiDeskCore/Config/SetupBundle.swift
@@ -1,10 +1,22 @@
 import Foundation
 
-/// Everything a KiwiDesk backup carries as one JSON document (#606).
-/// Carries `gui.json`, profiles, and saved palette library (`palettes.json`).
+/// Everything a KiwiDesk backup carries as one JSON document
+/// (#606): `gui.json`, profiles, and the saved palette library.
+/// The contents are an ALLOW-LIST, never a directory sweep —
+/// `init.lua` stays behind (user-authored code a backup must not
+/// claim), as do the arrangement snapshots (this Mac's session)
+/// and the socket/lock (runtime). Add an entry only for a path
+/// something actually creates.
 public struct SetupBundle: Codable, Sendable, Equatable {
-    /// Supported bundle format version (format 2: bar-content rename, owner
-    /// ruling 2026-08-19; format 3: scroll-duration rename on Profile, #1020).
+    /// Supported bundle format version. Not a compatibility shim —
+    /// a refusal signal: this is the one artifact that legitimately
+    /// outlives the build, and `JSONDecoder` is lenient, so a
+    /// future-format bundle would decode "successfully" with data
+    /// silently dropped. One integer turns that into a refusal.
+    /// 2 = the bar-content rename (owner ruling 2026-08-19);
+    /// 3 = the scroll-duration rename, on `[Profile]` alone
+    /// (#1020 — `GuiConfig.currentFormat` carries why its half
+    /// deliberately did not move).
     public static let currentFormat = 3
 
     public let format: Int
@@ -15,7 +27,12 @@ public struct SetupBundle: Codable, Sendable, Equatable {
 
     /// Informational version string of the writing KiwiDesk build.
     public let writtenBy: String
-    /// GUI-managed settings, or nil if unmanaged (code-reviewer 2026-08-17).
+    /// GUI-managed settings, or nil. Nil has TWO causes and only
+    /// one is benign — no sidecar at all, or one that would not
+    /// decode — so `exportSetup` checks `guiConfigStore.exists`
+    /// rather than trusting the nil (code-reviewer 2026-08-17): a
+    /// backup is the artifact a user makes because they are about
+    /// to need it.
     public let config: GuiConfig?
     public let profiles: [Profile]
     public let palettes: [ColorPalette]
@@ -39,7 +56,11 @@ public struct SetupBundle: Codable, Sendable, Equatable {
         format <= SetupBundle.currentFormat
     }
 
-    /// Whether this bundle replaces `artifact`
+    /// Whether this bundle replaces `artifact` — and the
+    /// distinction is ABSENT, not empty: the export always writes
+    /// both arrays, so `[]` means the source Mac had none, and
+    /// replacing with none is what "a restore replaces; it never
+    /// merges" promises. Only `config == nil` is a true absence
     /// (architect-reviewer 2026-08-17).
     public func replaces(_ artifact: ConfigArtifact) -> Bool {
         switch artifact {
@@ -83,6 +104,10 @@ public enum SetupBundleError: Error, Equatable, Sendable {
     case unreadableSettings
     /// Existing `palettes.json` failed to decode during export (#945).
     case unreadablePalettes
-    /// Target Mac is Lua-managed so GUI settings cannot apply.
+    /// Target Mac is Lua-owned, so the settings half could not
+    /// apply: `loadConfig` never reads the restored rules and
+    /// keybindings there while the profile-scoped half applies
+    /// anyway — a half-landed restore, and reporting success for
+    /// it is the failure this case exists to prevent.
     case luaOwnsThisMac
 }

--- a/Sources/KiwiDeskCore/Events/MouseTracker.swift
+++ b/Sources/KiwiDeskCore/Events/MouseTracker.swift
@@ -1,44 +1,17 @@
 import AppKit
 
-/// Remembers the most recent left-button press via event
-/// monitors, and re-emits each press through `onLeftMouseDown`
-/// for consumers that react to a click's location (the #446
-/// display-focus follow).
-///
-/// The press is needed to classify the trailing AX resize event
-/// of a fast mouse gesture: it arrives after the button release,
-/// so "is the button down?" alone would drop it. Only clicks are
-/// observed (two event types, a handful per interaction) — never
-/// mouse movement — so the cost is negligible.
-///
-/// **Two monitors, deliberately asymmetric (#953).** A global
-/// monitor never sees an event routed to our OWN windows, so a
-/// press on the tiled Settings window's resize border went
-/// unrecorded and its gesture could not be classified. The
-/// local arm closes that, gated on the tiling mark and
-/// recording the press only — it never fires
-/// `onLeftMouseDown`. The argument for both halves of that
-/// sentence lives once, in
-/// `.claude/rules/input-and-animation.md` under #953; do not
-/// reproduce it here.
+/// Tracks left-button mouse presses for gesture classification and display
+/// focus (#446, #953).
 @MainActor
 public final class MouseTracker {
     public struct Press {
-        /// Which monitor arm opened this press. The two
-        /// arms answer disjoint worlds — a global monitor
-        /// never sees an event routed to our own windows —
-        /// so the arm IS the provenance, and it is what the
-        /// release and the click fan-out both reason from
-        /// rather than re-deriving anything from the event.
+        /// Monitor origin of press (global vs local, #953).
         public enum Origin: Sendable {
-            /// Any other application's window.
             case otherApp
-            /// The one own window that tiles (#953). Every
-            /// other own window records no press at all.
+            /// Single own window that tiles (#953, #678 item 18).
             case ownWindow
         }
 
-        /// Where the button went down, in AX coordinates.
         public let location: CGPoint
         public let downAt: Date
         public let origin: Origin
@@ -48,18 +21,7 @@ public final class MouseTracker {
     public private(set) var press: Press?
     private var monitors: [Any] = []
 
-    /// Fired on every left-button press, with the press location
-    /// in Cocoa screen coordinates (bottom-left origin) — the
-    /// space the `NSScreen` frames live in. Drives the
-    /// display-focus follow (#446): a bare click on another
-    /// monitor's empty desktop moves the "focused display". Only
-    /// clicks reach here (never mouse movement), so it is cheap.
-    ///
-    /// **Only a `.otherApp` press reaches it** — the consumers
-    /// are built on a global monitor's blindness to our own
-    /// windows (#446, #496, #687, #951), so the stand-down is
-    /// argued from the press's own provenance rather than from
-    /// which closure happened to call `recordDown`.
+    /// Fired on left-mouse-down for other apps in Cocoa screen space (#446).
     public var onLeftMouseDown: ((CGPoint) -> Void)?
 
     public init() {}
@@ -81,15 +43,7 @@ public final class MouseTracker {
                 self?.recordUp(from: .otherApp)
             }
         }
-        // Our own windows' presses, which the global pair
-        // never sees (#953). AppKit dispatches a local monitor
-        // from the main thread's own event dispatch and wants
-        // the event handed back synchronously, so the AppKit
-        // read happens inline under `assumeIsolated` — but the
-        // STORE is enqueued exactly like the global arms', so
-        // one scheduling discipline orders all four writes and
-        // a queued `up` can never stamp a press recorded after
-        // it.
+        // Local monitor arm for own tiled window presses (#953).
         let localDown = NSEvent.addLocalMonitorForEvents(
             matching: .leftMouseDown
         ) { [weak self] event in
@@ -106,17 +60,6 @@ public final class MouseTracker {
             }
             return event
         }
-        // The release closes a press its OWN arm opened, and
-        // that is provenance, not the mark: `press` outlives
-        // every gesture (only `stop()` clears it), so an
-        // ungated release re-stamps `upAt` on whatever press
-        // is still sitting there — after the down half started
-        // discriminating, a click on a bar item would refresh
-        // a third-party press recorded minutes earlier and
-        // hand `isResizeGesture` a stale location it reads as
-        // fresh. Provenance also survives an up delivered with
-        // no window at the end of a frame-resize tracking
-        // loop, which a mark-gated release would drop.
         let localUp = NSEvent.addLocalMonitorForEvents(
             matching: .leftMouseUp
         ) { [weak self] event in
@@ -129,9 +72,6 @@ public final class MouseTracker {
             .compactMap { $0 }
     }
 
-    /// The press location to record for a local event, or nil
-    /// when it is not one this tracker remembers. The AppKit
-    /// read; `ownPressLocation` is the decision.
     private static func tilingWindowPress(
         of event: NSEvent
     ) -> CGPoint? {
@@ -142,27 +82,8 @@ public final class MouseTracker {
         )
     }
 
-    /// Whether a press on one of our own windows is one the
-    /// gesture classifiers may reason from, and where it
-    /// landed in Cocoa screen space — the pure half, so both
-    /// answers are testable without a real `NSEvent`.
-    ///
-    /// **Per WINDOW, never per process (#678 item 18).** Only
-    /// the one own window carrying `OwnWindowTiling.identifier`
-    /// takes a layout slot, so only its presses can belong to a
-    /// tiled gesture. Every other own window — the bars' item
-    /// views take `mouseDown`, and so do the tour, Config
-    /// Issues and each `NSOpenPanel` — would otherwise
-    /// overwrite the single press slot that `isResizeGesture`
-    /// and the resize-vs-move ghost gate read, with a click the
-    /// user aimed at chrome.
-    ///
-    /// A local monitor's event carries WINDOW coordinates when
-    /// it has a window (a global monitor's never does, which is
-    /// why the global pair reads `locationInWindow` as a screen
-    /// point). Converting through the window's own frame origin
-    /// is `NSWindow.convertPoint(toScreen:)`'s definition and
-    /// keeps this half free of AppKit.
+    /// Resolves press location in Cocoa screen space for own tiled window
+    /// (#678).
     static func ownPressLocation(
         identifier: String?,
         locationInWindow: CGPoint,
@@ -185,10 +106,7 @@ public final class MouseTracker {
         press = nil
     }
 
-    /// Both feeders hand this Cocoa screen coordinates — the
-    /// global arm's events carry them directly (no window), and
-    /// the local arm's are converted by `ownPressLocation`.
-    /// Flip into AX space.
+    /// Records mouse down in AX space; notifies if otherApp (#446, #953).
     func recordDown(
         at location: CGPoint,
         from origin: Press.Origin
@@ -202,43 +120,14 @@ public final class MouseTracker {
         onLeftMouseDown?(location)
     }
 
-    /// Closes the OPEN press, if this arm is the one that
-    /// opened it. Both clauses guard the same thing from
-    /// different sides, and a release that satisfies neither is
-    /// not an error — it is a release with nothing of its own
-    /// to close.
-    ///
-    /// Dropping it is the safe direction: `isResizeGesture`
-    /// reads the press only through `guard let up = press.upAt`,
-    /// so a press left open is inert while one closed by the
-    /// wrong release is read as a gesture that just ended.
-    ///
-    /// **Openness is not implied by provenance.** `press`
-    /// outlives its gesture — only `stop()` clears it — so a
-    /// press stays there CLOSED after a real resize, and
-    /// re-stamping it would push its stale location back inside
-    /// `isResizeGesture`'s one-second freshness window. Without
-    /// this clause every later release of the same origin does
-    /// exactly that: a click on a bar item records no press
-    /// (the down arm is gated on the mark) and still reopens the
-    /// Settings window's own last one — and a Space Bar click is
-    /// itself a retile, which is the resize the pipeline would
-    /// then believe in.
+    /// Closes active press matching origin (#953).
     func recordUp(from origin: Press.Origin) {
         guard press?.origin == origin, press?.upAt == nil
         else { return }
         press?.upAt = Date()
     }
 
-    /// Test seam: seeds the last press directly (already in AX
-    /// coordinates), standing in for either mouse-down
-    /// monitor — neither fires under unit tests.
-    ///
-    /// Deliberately NOT `recordDown`: it skips the flip (the
-    /// point is already AX) and so also skips the fan-out. It
-    /// seeds `.otherApp`, which is the arm a `recordUp` must
-    /// then name to close it — seed here and release with
-    /// `.ownWindow` and nothing closes, correctly.
+    /// Test seam: seeds press in AX coordinates directly.
     func seedPress(at location: CGPoint) {
         press = Press(
             location: location,

--- a/Sources/KiwiDeskCore/Events/MouseTracker.swift
+++ b/Sources/KiwiDeskCore/Events/MouseTracker.swift
@@ -21,7 +21,11 @@ public final class MouseTracker {
     public private(set) var press: Press?
     private var monitors: [Any] = []
 
-    /// Fired on left-mouse-down for other apps in Cocoa screen space (#446).
+    /// Fired on left-mouse-down in Cocoa screen space (#446).
+    /// **Only a `.otherApp` press reaches it** — the consumers are
+    /// built on a global monitor's blindness to our own windows
+    /// (#446, #496, #687, #951), so the stand-down is argued from
+    /// the press's own provenance.
     public var onLeftMouseDown: ((CGPoint) -> Void)?
 
     public init() {}
@@ -44,6 +48,11 @@ public final class MouseTracker {
             }
         }
         // Local monitor arm for own tiled window presses (#953).
+        // The AppKit read happens inline (the event must be handed
+        // back synchronously) but the STORE is enqueued exactly
+        // like the global arms' — one scheduling discipline orders
+        // all four writes, so a queued `up` can never stamp a
+        // press recorded after it.
         let localDown = NSEvent.addLocalMonitorForEvents(
             matching: .leftMouseDown
         ) { [weak self] event in
@@ -82,8 +91,12 @@ public final class MouseTracker {
         )
     }
 
-    /// Resolves press location in Cocoa screen space for own tiled window
-    /// (#678).
+    /// Resolves press location for an own window — per WINDOW,
+    /// never per process (#678 item 18): only the one window
+    /// carrying `OwnWindowTiling.identifier` takes a layout slot,
+    /// and every other own window (bars, tour, panels) would
+    /// otherwise overwrite the single press slot with a click the
+    /// user aimed at chrome.
     static func ownPressLocation(
         identifier: String?,
         locationInWindow: CGPoint,
@@ -120,7 +133,14 @@ public final class MouseTracker {
         onLeftMouseDown?(location)
     }
 
-    /// Closes active press matching origin (#953).
+    /// Closes the OPEN press, if this arm opened it (#953).
+    /// Openness is not implied by provenance: `press` outlives its
+    /// gesture (only `stop()` clears it), so re-stamping a CLOSED
+    /// press would push its stale location back inside
+    /// `isResizeGesture`'s freshness window — a Space Bar click is
+    /// itself a retile, which is the resize the pipeline would
+    /// then believe in. Dropping an unmatched release is the safe
+    /// direction.
     func recordUp(from origin: Press.Origin) {
         guard press?.origin == origin, press?.upAt == nil
         else { return }
@@ -128,6 +148,9 @@ public final class MouseTracker {
     }
 
     /// Test seam: seeds press in AX coordinates directly.
+    /// Deliberately NOT `recordDown` — it skips the flip and the
+    /// fan-out, and seeds `.otherApp`, which a `recordUp` must
+    /// then name to close.
     func seedPress(at location: CGPoint) {
         press = Press(
             location: location,

--- a/Sources/KiwiDeskCore/Keys/HoldGlide+Ramp.swift
+++ b/Sources/KiwiDeskCore/Keys/HoldGlide+Ramp.swift
@@ -1,149 +1,25 @@
 import Foundation
 
-/// The velocity ramp of a held resize (#1082, owner ruling
-/// 2026-08-29), replacing #1056's interval acceleration. A hold
-/// does not re-fire on a timer — it GLIDES: one step per display
-/// frame, each moving `glideSteps(elapsed:) × dt` of the press's
-/// own delta.
-///
-/// **Speed is counted in steps per second, not points.** The
-/// press's delta is the user's unit of intent, and an absolute
-/// points-per-second glide is discontinuous with it at both ends
-/// (owner ruling, 2026-08-29): someone who binds a 10 pt
-/// precision step would have it overridden by an
-/// eighteen-of-their-steps-per-second glide the moment they
-/// hold, and someone on a 200 pt step would find the hold
-/// SLOWER than tapping — 180 pt/s is under one of their steps
-/// per second. Scaling the press's own delta makes the glide
-/// continuous with the tap by construction, at every setting of
-/// `resize.step` (which the decoder clamps to 1…10000 points, a
-/// four-decade range no absolute speed can serve).
-///
-/// **Why the tick is a display frame and the amount rides `dt`.**
-/// What the eye judges is displacement per RENDERED frame, and
-/// the display draws when it draws: ticking faster than the
-/// refresh produces no extra frames, only more accumulated
-/// movement in each one. So a shorter interval buys speed, never
-/// smoothness — they are one dial, which is why #1056's shrinking
-/// interval could not fix the chunkiness it was aimed at. Pinning
-/// the tick to the frame and scaling by that frame's own `dt`
-/// makes the ramp refresh-rate independent: 60 Hz, 120 Hz and a
-/// ProMotion panel changing rate mid-hold all travel at the same
-/// steps per second, with a faster panel spending its extra
-/// frames on finer motion instead of going quicker.
-///
-/// That fineness has a floor, and it is not this file's: the
-/// resize retile is deliberately UN-forced, so a computed frame
-/// within the engine's ±2 pt tolerance is not applied. The STORE
-/// still advances every frame — the tolerance can only delay a
-/// sub-tolerance step, never lose it (`KiwiCore.resize` argues
-/// the un-forced choice) — so the travel is unchanged and a
-/// panel fast enough to ask for sub-2 pt frames simply lands
-/// them every second or third frame instead. Refresh-rate
-/// independence is a claim about SPEED, which holds exactly;
-/// read the smoothness claim as bounded by that quantum rather
-/// than unlimited.
-///
-/// The constants below are feel, retuned at the machine.
-/// `HoldGlideRampTests` pins only the SHAPE (flat start, monotone
-/// ramp, clamped ceiling), derived from these values, so a retune
-/// reds nothing.
+/// Velocity ramp of a held resize (#1082, owner ruling 2026-08-29; replacing
+/// #1056). Speed is counted in steps/s (scaled by delta and frame `dt`).
+/// Shape pinned in `HoldGlideRampTests`.
 extension HoldGlide {
-    /// Steps per second at the glide's first frame. Bounded from
-    /// BELOW by two things rather than chosen for feel (designer
-    /// round, 2026-08-29):
-    ///
-    /// - It must clear the fineness floor, which is
-    ///   `2 pt ÷ step × refresh`: 2.4 steps/s at 60 Hz and 4.8 at
-    ///   120 Hz for the default 50 pt step. Below it the glide
-    ///   asks for frames the un-forced retile's ±2 pt tolerance
-    ///   does not apply, so a ProMotion panel spends its extra
-    ///   refreshes on nothing. The first cut shipped 3.5, under
-    ///   the 120 Hz floor.
-    ///
-    /// Bounded from ABOVE by overshoot: a release reaction of
-    /// ~150 ms should cost at most one step — the unit of intent,
-    /// and the amount one tap the other way undoes — which is
-    /// ≈6.7 steps/s.
-    ///
-    /// A third consideration was dropped rather than kept as
-    /// decoration (docs review, 2026-08-29): "it must beat
-    /// mashing the chord by hand" reads like a bound but names
-    /// no measured rate, so it constrained nothing and 6.0 is
-    /// not derived from it. The two above already bracket the
-    /// value to [4.8, 6.7]. If someone measures a sustained
-    /// mash rate on a three-modifier chord, it becomes a real
-    /// lower bound and belongs back here WITH the number.
-    ///
-    /// Deliberately NOT justified as "fine adjustment": that is
-    /// what a small configured step is for. The tap owns
-    /// precision and the glide owns travel, so a start speed
-    /// duplicating the tap's job taxes the glide's.
+    /// Steps per second at first frame. Lower bound: clears 120 Hz ±2pt floor
+    /// (4.8 steps/s for 50pt step). Upper bound: <=1 step overshoot at 150ms
+    /// reaction (6.7 steps/s). Designer round 2026-08-29;
+    /// docs review 2026-08-29.
     static let glideStartSteps = 6.0
 
-    /// Steps per second once the ramp is complete. The
-    /// "powerful on demand" end, deliberately uncapped-feeling:
-    /// it costs ~2.7 steps of overshoot at a 150 ms reaction,
-    /// which is only acceptable in a regime where the user has
-    /// declared they are travelling — and it is the RAMP that
-    /// establishes that, not the ceiling. Lowering this to buy
-    /// back overshoot would make the long haul permanently worse
-    /// to protect a case the ramp duration already protects.
+    /// Steps per second once ramp completes (18.0 steps/s; ~2.7 steps
+    /// overshoot at 150ms reaction).
     static let glideMaxSteps = 18.0
 
-    /// Seconds from the glide's first frame to `glideMaxSteps`.
-    ///
-    /// Owner-ruled on device at 1.8 s (2026-08-29), OVERRIDING a
-    /// derivation that said 2.5 — recorded rather than quietly
-    /// replaced, because the derivation is still the reasoning a
-    /// future retune should start from.
-    ///
-    /// The derivation: the ceiling should arrive at about one
-    /// screen-span of travel at the default step, which at a mean
-    /// 12 steps/s and 30 steps to cross ~1500 pt is 2.5 s. The
-    /// first cut shipped 1.5 s, reaching the ceiling at ~800 pt,
-    /// so the ordinary adjustment ended at top speed — where
-    /// overshoot is worst. Both of those still hold.
-    ///
-    /// What the device said: 2.5 s read as "a bit slow", and it
-    /// is the only constant that got slower between the two
-    /// builds tried — the start went 3.5 → 6.0 in the same
-    /// change, so a hold that felt slower could only be slower to
-    /// ACCELERATE. 1.8 s reaches the ceiling at ~1080 pt, about
-    /// two thirds of a span: it keeps most of the plateau the
-    /// long ramp bought (the speed still moves only ~2 steps/s
-    /// across the first 300 ms, so a short hold stays a
-    /// learnable, near-constant rate) while cutting the wait for
-    /// top speed by a third.
-    ///
-    /// Do NOT read the derivation as settled against the device.
-    /// Feel outranks it here: the whole constant exists to be
-    /// judged by hand, and the same hands caught the two errors
-    /// this feature's design turned on.
+    /// Seconds to reach `glideMaxSteps`. Owner-ruled on device at 1.8s
+    /// (2026-08-29), reaching max speed at ~1080pt travel on default step.
     static let glideRampSeconds: TimeInterval = 1.8
 
-    /// The ramp: linear in elapsed glide time, clamped at both
-    /// ends.
-    ///
-    /// Linear because **displacement is what the user controls,
-    /// and displacement is the integral**. A velocity linear in
-    /// time already makes distance quadratic in hold duration; an
-    /// ease-IN makes it cubic and unlearnable, and an ease-OUT is
-    /// a plateau wearing a curve — reachable by moving the two
-    /// endpoints above, which a guard can pin, where a curve is a
-    /// fifth free parameter nothing can. (The first cut argued
-    /// this as "an eased curve makes the same hold duration mean
-    /// different speeds depending on where in the ease it lands",
-    /// which is true of a linear ramp too and so defended
-    /// nothing — a wrong reason in a docstring is how the next
-    /// retune goes wrong.)
-    /// The `elapsed > 0` arm is DEFENSIVE, not a protected
-    /// invariant (code review, 2026-08-29): `glideElapsed` starts
-    /// at zero and only accumulates a `dt` the driver has already
-    /// proved positive, and zero returns `glideStartSteps`
-    /// through the arithmetic anyway. It is kept because the
-    /// function is `static` and reachable from anywhere, not
-    /// because a caller can reach it.
+    /// Linear velocity ramp clamped to [glideStartSteps, glideMaxSteps]
+    /// (code review 2026-08-29).
     static func glideSteps(elapsed: TimeInterval) -> Double {
         guard elapsed > 0 else { return glideStartSteps }
         let progress = min(1.0, elapsed / glideRampSeconds)

--- a/Sources/KiwiDeskCore/Keys/HoldGlide+Ramp.swift
+++ b/Sources/KiwiDeskCore/Keys/HoldGlide+Ramp.swift
@@ -10,16 +10,27 @@ extension HoldGlide {
     /// docs review 2026-08-29.
     static let glideStartSteps = 6.0
 
-    /// Steps per second once ramp completes (18.0 steps/s; ~2.7 steps
-    /// overshoot at 150ms reaction).
+    /// Steps per second once the ramp completes (~2.7 steps of
+    /// overshoot at a 150 ms reaction — acceptable only in a
+    /// regime the RAMP establishes). Lowering this to buy back
+    /// overshoot makes the long haul permanently worse to protect
+    /// a case the ramp duration already protects.
     static let glideMaxSteps = 18.0
 
-    /// Seconds to reach `glideMaxSteps`. Owner-ruled on device at 1.8s
-    /// (2026-08-29), reaching max speed at ~1080pt travel on default step.
+    /// Seconds to reach `glideMaxSteps`. Owner-ruled on device at
+    /// 1.8 s (2026-08-29), OVERRIDING a derivation that said 2.5
+    /// (ceiling at ~one screen-span of travel) — recorded because
+    /// the derivation is still where a future retune should start,
+    /// but feel outranks it: the whole constant exists to be
+    /// judged by hand. 1.8 reaches the ceiling at ~1080 pt.
     static let glideRampSeconds: TimeInterval = 1.8
 
-    /// Linear velocity ramp clamped to [glideStartSteps, glideMaxSteps]
-    /// (code review 2026-08-29).
+    /// Linear velocity ramp, clamped at both ends. Linear because
+    /// displacement is the integral of what the user controls: an
+    /// ease-IN makes distance cubic in hold time and unlearnable,
+    /// an ease-OUT is a plateau reachable by moving the two
+    /// endpoints — which a guard can pin, where a curve is a fifth
+    /// free parameter nothing can (code review 2026-08-29).
     static func glideSteps(elapsed: TimeInterval) -> Double {
         guard elapsed > 0 else { return glideStartSteps }
         let progress = min(1.0, elapsed / glideRampSeconds)

--- a/Sources/KiwiDeskCore/Keys/HoldGlide.swift
+++ b/Sources/KiwiDeskCore/Keys/HoldGlide.swift
@@ -1,117 +1,43 @@
 import AppKit
 import Foundation
 
-/// Hold-to-glide for keyboard resize (#1056, retimed by #1082):
-/// a held resize chord keeps applying — the press's own full
-/// step, then, after the system's initial delay, a GLIDE that
-/// moves a fraction of that step every display frame. A Carbon
-/// hot key delivers exactly one press and one release per
-/// physical hold and never auto-repeats, so both halves are ours
-/// to drive.
-///
-/// Eligibility is decided by what the press FIRE actually did:
-/// exactly one command executed, it was in `glidableCommands`,
-/// and it succeeded — a binding's body is opaque Lua, so the
-/// tally is the one honest signal. The #933/#1055 size-limit
-/// cues end a run through `noteRefusal()`, so a held resize
-/// parked on a limit cues ONCE and stops. Why those are the
-/// rules — and why `resize` alone glides — is argued in
-/// `docs/design-decisions.md` ▸ "A held resize chord glides";
-/// widen `glidableCommands` only with a ruling of that shape.
-///
-/// **The glide re-issues the COMMAND, never the binding** (owner
-/// ruling, 2026-08-29). The press's `resize` arguments are
-/// captured from the tally and re-issued with a scaled delta, so
-/// the Lua body runs once, on the press. Re-running an opaque
-/// body sixty to a hundred and twenty times a second would
-/// repeat whatever else it does — and the single-command tally
-/// already refuses to arm on such a body, so this is what makes
-/// the arming rule and the run agree rather than a new licence.
-/// Re-issuing through `KiwiCore.execute` keeps the capped
-/// writers, the refusal cues and the command contract exactly as
-/// a keypress has them. `HoldGlide+Ramp.swift` owns the ramp
-/// and why speed is counted in steps per second.
-///
-/// Pure state machine over injected seams — the frame clock, the
-/// initial delay, the scheduler and the apply are all closures —
-/// so the ladder is unit-testable with no timers and no
-/// `CADisplayLink` (`HoldGlideTests`).
+/// Hold-to-glide for keyboard resize (#1056, retimed by #1082). A held resize
+/// chord glides after initial key-repeat delay. Re-issues the command (never
+/// binding, owner ruling 2026-08-29) with scaled delta (`HoldGlideTests`).
+/// Refusal cues stop run (#933, #1055).
 @MainActor
 final class HoldGlide {
-    /// The verbs a held chord may GLIDE. `resize` alone by
-    /// ruling; see the type doc before widening. Members must
-    /// name real commands — `HoldGlideEligibilitySeamTests` holds the set
-    /// against the API census so a §5 verb rename reds here.
+    /// The verbs a held chord may glide (only `resize`). Checked in
+    /// `HoldGlideEligibilitySeamTests` against the API census (#614).
     static let glidableCommands: Set<String> = ["resize"]
 
-    /// A glide that outlives this much accumulated FRAME time is
-    /// force-ended (`onOverrun`). The stop signal is one Carbon
-    /// release event, and a lost one (a Mission Control switch
-    /// mid-hold, a swallowed key-up) would otherwise glide for
-    /// the rest of the session — the #611 force-settle shape, one
-    /// subsystem over. No deliberate resize hold approaches the
-    /// bound: at the ramp's top speed it is many screens of
-    /// travel.
+    /// Force-end bound if release event is lost (#611).
     static let maxRunSeconds: TimeInterval = 30
 
-    /// One glide step: the press's captured command NAME, its
-    /// arguments, and the factor to scale its delta by. The name
-    /// travels because `glidableCommands` is the declared
-    /// owner of what may glide and the rule file contemplates
-    /// widening it — a wiring that hardcodes `"resize"` would
-    /// then re-issue `resize` for a press that ran a different
-    /// verb, with every suite green (architect review,
-    /// 2026-08-29).
-    ///
-    /// Returns whether the command succeeded — a failure ends the
-    /// glide, so a resize that starts failing (a mode change, a
-    /// focus loss) stops rather than hammering the dispatcher
-    /// every frame. Inert by default and wired live in
-    /// `KiwiCore+HoldGlide`.
+    /// One glide step: command name, args, delta factor (architect review,
+    /// 2026-08-29). Returns success. Inert by default; wired in KiwiCore.
     var applyGlideStep: @MainActor (String, [JSONValue], Double) -> Bool = {
         _,
         _,
         _ in false
     }
 
-    /// Starts the frame clock, returning its stop. Inert by
-    /// default and wired live in `KiwiCore+HoldGlide`: the live
-    /// object is a `CADisplayLink` on a real screen, so a live
-    /// default would build one in every suite that arms a hold —
-    /// the inverted-seam shape tests.md rules, which owes a guard
-    /// from BOTH sides (`HoldGlideSeamTests`), so deleting the
-    /// wiring reds exactly as loudly as duplicating it.
+    /// Starts the frame clock; returns stop closure (`HoldGlideSeamTests`).
     var startFrames:
         @MainActor (@escaping @MainActor (TimeInterval) -> Void)
             -> () -> Void = { _ in {} }
 
-    /// A run hit `maxRunSeconds` and was force-ended — wired to
-    /// the manager's log seam so the rescue is visible, never
-    /// silent (the #611 reporting rule).
+    /// Fired on `maxRunSeconds` overrun (#611).
     var onOverrun: @MainActor () -> Void = {}
 
-    /// A physical press has begun, before its binding body runs.
-    /// Fires once per press whatever that press turns out to do,
-    /// which is what makes it — and never `onGlideEnd` below —
-    /// the place to retire a press-scoped record (#1090). Inert
-    /// by default and wired live in
-    /// `KiwiCore+HoldGlide.wireFireBegan`, which carries the two
-    /// ways the glide-end seam fails at that job.
+    /// Fires once on physical press start to retire press-scoped records
+    /// (#1090).
     var onFireBegan: @MainActor () -> Void = {}
 
-    /// A glide that was RUNNING has ended, however it ended
-    /// (release, refusal, failing step, teardown, overrun). Fires
-    /// once per glide and never for a hold that never began
-    /// gliding. It exists so work a glide frame stands down can
-    /// be paid exactly once at the end — the #674 z-order arm is
-    /// the first taker (`KiwiCore+HoldGlide`).
+    /// Fires once when a running glide ends (e.g. #674 z-order restore).
     var onGlideEnd: @MainActor () -> Void = {}
 
-    /// Schedules `work` after `delay`; returns a cancel. This
-    /// drives the ONE pre-glide wait and never the glide itself,
-    /// which rides the frame clock. The production wiring is
-    /// `DispatchQueue.main.asyncAfter`; tests substitute a
-    /// captured slot they fire by hand.
+    /// Schedules `work` after `delay`; returns cancel closure.
     var schedule:
         @MainActor (
             TimeInterval, @escaping @MainActor () -> Void
@@ -124,23 +50,15 @@ final class HoldGlide {
             return { item.cancel() }
         }
 
-    /// The system's own key-repeat delay, read once per run at
-    /// the arming press: a tap moves exactly one step, and only a
-    /// hold past this glides. A Settings change applies to the
-    /// next hold, so the wait cannot shift mid-run.
+    /// System key-repeat delay, read once per hold.
     var initialDelay: @MainActor () -> TimeInterval = {
         NSEvent.keyRepeatDelay
     }
 
-    /// Whether the registrar can deliver releases at all
-    /// (`HotkeyReleaseReporting`). False forbids arming — a glide
-    /// with no stop channel would never end.
+    /// Whether registrar delivers releases (`HotkeyReleaseReporting`).
     var releaseCapable = false
 
-    /// One fire's tally, so a nested fire (a Lua body that pumps
-    /// a run loop and delivers a second press — the case
-    /// `KeybindingManager.fire`'s `wasFiring` exists for) can
-    /// save the outer fire's counts and hand them back.
+    /// Preserves outer tally across nested fires.
     struct TallySnapshot {
         let commands: Int
         let glidableSucceeded: Bool
@@ -152,75 +70,30 @@ final class HoldGlide {
     private var commandsInFire = 0
     private var glidableSucceeded = false
     private var refused = false
-    /// The repeatable command the press ran, and the arguments
-    /// it ran with. The glide re-issues this verb and scales its
-    /// delta rather than inventing either
-    /// (`HoldGlide+Ramp.swift`).
+    /// Repeatable command and arguments run on press (`HoldGlide+Ramp.swift`).
     private var fireCommand = ""
     private var fireArgs: [JSONValue] = []
 
     /// The registration id currently held.
     private(set) var heldID: UInt32?
 
-    /// True from the moment the frame clock starts until the run
-    /// ends — the hold's LIFETIME. Its one reader is the refusal
-    /// gate, which is a lifetime question: a size-limit cue
-    /// raised anywhere in the hold ends it, and
-    /// `KeybindingManager.isFiring` is false outside the press
-    /// fire. Anything asking "does THIS WRITE belong to the
-    /// glide?" takes `isApplyingGlideStep` below instead — that
-    /// property's doc argues why a lifetime bit answers the
-    /// per-write question wrongly, and fails open.
-    // `private(set)` would not let `HoldGlide+Run` set it —
-    // Swift access control is file-scoped — so the setter is
-    // internal and the type's own files are its only writers.
+    /// True from frame-clock start until run end.
     var isGliding = false
 
-    /// True for the duration of ONE glide frame's write, set
-    /// around the apply in `HoldGlide+Run` and cleared by
-    /// `defer` on every exit.
-    ///
-    /// Separate from `isGliding` deliberately (code review,
-    /// 2026-08-29). A geometry path asking "does THIS WRITE
-    /// belong to the glide?" must not read the hold's lifetime:
-    /// that answers wrongly in both directions — an unrelated
-    /// Lua, CLI or IPC `resize` arriving during a hold would
-    /// silently lose its animation, and a hold whose frame clock
-    /// dies (display sleep or disconnect mid-hold) would leave
-    /// the bit stuck true for the session, making every later
-    /// resize instant. This one cannot outlive the write it
-    /// describes, and it is owned by the state machine rather
-    /// than by the wiring so a re-wiring cannot forget it.
-    ///
-    /// Read through `KeybindingManager.isApplyingGlideStep`, the
-    /// `keys.isFiring` precedent one screen up in
-    /// `KiwiCore+Resize`. Who may read it is pinned by count in
-    /// `HoldGlideSeamTests`, since "there is one reader" is
-    /// otherwise the state claim #614 bans.
+    /// True during one glide step write (review 2026-08-29,
+    /// `HoldGlideSeamTests`).
     var isApplyingGlideStep = false
 
-    // Internal, not private: the run machinery lives in
-    // `HoldGlide+Run.swift`, split at the file ceiling, and
-    // Swift `private` does not cross files (the
-    // `SizeBoundLearner+Invalidation` precedent).
     var cancelPending: (() -> Void)?
     var stopFrames: (() -> Void)?
     var glideArgs: [JSONValue] = []
     var glideCommand = ""
     /// Cancels the wall-clock backstop in `HoldGlide+Run`.
     var cancelBackstop: (() -> Void)?
-    /// Frame time the glide has accumulated: its ramp clock AND
-    /// its age, both simulated from the frames actually
-    /// delivered — never wall clock (the #611 idiom), so a
-    /// starved main queue cannot age a glide it never ticked, and
-    /// the ramp cannot jump a stall's worth of speed.
+    /// Accumulated simulated frame time for ramp (#611).
     var glideElapsed: TimeInterval = 0
 
-    // MARK: - Fed by KiwiCore during a fire
-
-    /// Every `execute` inside a hotkey fire reports here; the
-    /// press-fire's tally decides eligibility and carries the
-    /// arguments the glide re-issues.
+    /// Records executed command tally for eligibility and re-issue.
     func noteCommand(
         _ name: String,
         args: [JSONValue],
@@ -234,20 +107,13 @@ final class HoldGlide {
         }
     }
 
-    /// A size-limit refusal cue fired (#933/#1055): the run stops
-    /// so the pill flashes once per hold, and the press that hit
-    /// the wall arms nothing.
+    /// Stops run on size-limit refusal cue (#933, #1055).
     func noteRefusal() {
         refused = true
         cancelRun()
     }
 
-    // MARK: - Driven by KeybindingManager
-
-    /// Opens one binding fire's tally, returning the previous
-    /// tally for the caller to `restoreTally` afterwards — a
-    /// no-op pair except in the nested-fire case the snapshot's
-    /// doc names.
+    /// Opens a press fire tally, returning the previous snapshot.
     func beginFire() -> TallySnapshot {
         onFireBegan()
         let saved = TallySnapshot(
@@ -273,19 +139,14 @@ final class HoldGlide {
         fireArgs = saved.args
     }
 
-    /// Closes the fire `beginFire` opened and lets the ladder act
-    /// on its tally. Only a physical key-down reaches here — the
-    /// glide re-issues the command itself and never opens a fire,
-    /// so there is no tick-fire case left to judge.
+    /// Evaluates press tally and schedules glide if eligible.
     func endFire(id: UInt32) {
         let eligible =
             releaseCapable
             && commandsInFire == 1
             && glidableSucceeded
             && !refused
-        // A new press always ends any previous run — one active
-        // hold at a time, latest wins — and does so before the
-        // eligibility verdict, unconditionally.
+        // New press ends any active run before judging eligibility.
         let command = fireCommand
         let args = fireArgs
         cancelRun()
@@ -293,12 +154,7 @@ final class HoldGlide {
         heldID = id
         glideCommand = command
         glideArgs = args
-        // Each press restarts the ramp, deliberately: repeated
-        // short holds must never accumulate speed. A ramp that
-        // carried across quick re-holds makes the third nudge in
-        // a row lurch, which is the classic defect in this family
-        // — so this is not a warm-start waiting to be optimised
-        // in (designer round, 2026-08-29).
+        // Ramp restarts per press; no speed carryover (designer, 2026-08-29).
         glideElapsed = 0
         cancelPending = schedule(initialDelay()) { [weak self] in
             self?.cancelPending = nil
@@ -306,17 +162,13 @@ final class HoldGlide {
         }
     }
 
-    /// The physical release for `id` — from the registrar's
-    /// release channel. A stale id (a run already replaced or
-    /// cancelled) is ignored.
+    /// Releases matching held ID; ignores stale IDs.
     func released(id: UInt32) {
         guard heldID == id else { return }
         cancelRun()
     }
 
-    /// Any registration teardown (layer switch, suspend, reset):
-    /// the ids are gone, so the run is too — an unregistered hot
-    /// key delivers no release to stop on.
+    /// Cancels current run and active timers/frames on teardown.
     func cancelRun() {
         cancelPending?()
         cancelPending = nil
@@ -329,9 +181,7 @@ final class HoldGlide {
         heldID = nil
         glideArgs = []
         glideCommand = ""
-        // Last, and only for a glide that actually ran: the
-        // consumer re-enters the command layer, so every field
-        // above must already read as ended.
+        // Notify onGlideEnd only if the glide actually ran, after state reset.
         if wasGliding { onGlideEnd() }
     }
 }

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Abstraction over Carbon hotkey registration for test isolation.
+/// Abstraction over Carbon hotkey registration for test
+/// isolation. An implementor never fires the handler of a FAILED
+/// registration — the hold-to-glide press path leans on it
+/// (`RegistrationBox` carries a nil id for exactly that handler).
 @MainActor
 public protocol HotkeyRegistrar: AnyObject {
     func register(
@@ -27,14 +30,24 @@ public final class KeybindingManager {
     }
 
     public private(set) var currentLayer = defaultLayer
-    /// True while executing Lua hotkey handler (#184).
+    /// True while a hotkey's Lua callback runs (#184): failure
+    /// cues key off this, so the same command from CLI/IPC stays
+    /// silent. Deliberately synchronous-only — deferred work runs
+    /// with the flag off and never cues. Save/restore (not
+    /// set/clear) in `fire`, so a callback pumping a nested run
+    /// loop cannot clear the outer fire's flag.
     public private(set) var isFiring = false
     /// Combos rejected during activation (#123).
     public internal(set) var activationFailures: Set<KeyCombo> =
         []
     private var layers: [String: [KeyCombo: Int32]] = [:]
     private var layerIcons: [String: String] = [:]
-    /// Live registrations mapped by id (#1056, #1082).
+    /// Live registrations by id — the ONE home for "what is
+    /// registered right now" (#1056/#1082): the unregister loop
+    /// and the glide's arm check both read it, and the arm check
+    /// is an EXISTENCE question, never a re-derivation of which
+    /// binding to act on. A second id list beside it would be two
+    /// homes drifting in opposite failure modes.
     var activeBindings: [UInt32: LiveBinding] = [:]
 
     struct LiveBinding {

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager.swift
@@ -1,13 +1,6 @@
 import Foundation
 
-/// Abstraction over Carbon hotkey registration so the manager
-/// is testable without touching the real event system.
-///
-/// An implementor never fires the handler of a registration
-/// that FAILED (`register` returned nil) — the hold-to-glide
-/// press path leans on it (`RegistrationBox` carries a nil id
-/// for exactly that handler), and Carbon holds it for free
-/// since a failed registration installs nothing.
+/// Abstraction over Carbon hotkey registration for test isolation.
 @MainActor
 public protocol HotkeyRegistrar: AnyObject {
     func register(
@@ -20,81 +13,42 @@ public protocol HotkeyRegistrar: AnyObject {
 
 extension CarbonHotkeyCenter: HotkeyRegistrar {}
 
-/// Modal keybindings: named layers hold
-/// their own bindings; exactly one layer is active. The default
-/// layer holds `KiwiDesk.bind(...)` registrations.
+/// Modal keybinding manager with named layers and hold-to-glide
+/// support (#1056, #1082).
 @MainActor
 public final class KeybindingManager {
     public static let defaultLayer = "default"
 
     public var lua: LuaInterpreter?
     public var onLog: @MainActor (String) -> Void = CoreLog.write
-    /// GUI indicator hook (layer name).
+    /// Layer change callback for GUI indicators.
     public var onLayerChange: @MainActor (String) -> Void = {
         _ in
     }
 
     public private(set) var currentLayer = defaultLayer
-    /// True while a hotkey's Lua callback runs (#184): commands
-    /// executing inside a fire are keyboard-interactive, so
-    /// failure cues (the unsupported-resize beep) key off this —
-    /// the same command from CLI/IPC or init.lua stays silent.
-    /// Deliberately synchronous-only: work a hotkey body defers
-    /// (an `ExecLauncher` completion, a `Task`) runs with the
-    /// flag off and never cues. Save/restore (not set/clear) in
-    /// `fire`, so a callback that pumps a nested run loop and
-    /// delivers a second fire can't clear the outer fire's flag.
+    /// True while executing Lua hotkey handler (#184).
     public private(set) var isFiring = false
-    /// Combos the system declined in the most recent
-    /// activation (`RegisterEventHotKey` returned no id — e.g.
-    /// a reserved system shortcut). Rebuilt on every
-    /// activation; the GUI's live-apply (#123) reads it to
-    /// branch its feedback caption ("Active now" vs "the
-    /// system didn't grant it").
+    /// Combos rejected during activation (#123).
     public internal(set) var activationFailures: Set<KeyCombo> =
         []
     private var layers: [String: [KeyCombo: Int32]] = [:]
-    /// Menu bar indicator per layer (SF Symbol name or emoji),
-    /// set via `define_layer(name, bindings, { icon = ... })`.
     private var layerIcons: [String: String] = [:]
-    /// The live registrations by id — the ONE home for "what is
-    /// registered right now": `deactivate`'s unregister loop and
-    /// the hold-to-glide engine's arm check and release routing
-    /// (#1056/#1082) both read it. The arm check is an EXISTENCE
-    /// question — does the id that will deliver the release still
-    /// exist — never a re-derivation of which binding to act on;
-    /// `KeybindingManager+HoldGlide.pressFire` argues it. Written
-    /// only by `activate`/`deactivate` (both in
-    /// `KeybindingManager+Activation.swift`, which is why the
-    /// setter is internal rather than private); a second id
-    /// list beside it would
-    /// be two homes for one fact, drifting in opposite failure
-    /// modes (a leaked live chord vs a tick against a dead id).
+    /// Live registrations mapped by id (#1056, #1082).
     var activeBindings: [UInt32: LiveBinding] = [:]
 
-    /// One live registration: the Lua ref and the combo it is
-    /// registered under.
     struct LiveBinding {
         var ref: Int32
         var combo: KeyCombo
     }
 
-    /// Hands a registration handler its own id (#1056): the
-    /// closure is built before `register` returns the id, so
-    /// the id travels through this box, filled immediately
-    /// after. Nil only for a handler whose registration failed
-    /// — which `HotkeyRegistrar`'s contract says never fires.
+    /// Box holding assigned registration id for handler closure (#1056).
     final class RegistrationBox {
         var id: UInt32?
     }
-    /// Hold-to-glide (#1056/#1082). Internal so `KiwiCore.execute`
-    /// and the size-limit cues can feed it through the
-    /// `noteCommand` / `noteResizeRefusal` passthroughs below.
+
+    /// Hold-to-glide engine (#1056, #1082).
     let holdGlide = HoldGlide()
-    /// True while a Settings recorder is armed (#213): all our
-    /// hotkeys are unregistered so testing an existing shortcut
-    /// mid-capture can't fire its action. Table/layer edits still
-    /// apply but skip registration until `resume()`.
     private var suspended = false
     let registrar: HotkeyRegistrar
 
@@ -105,17 +59,14 @@ public final class KeybindingManager {
         wireHoldGlideChannels(registrar: registrar)
     }
 
-    /// Bindings of one layer (exposed for the GUI editor).
+    /// Bindings for specified layer name.
     public func bindings(
         for layer: String
     ) -> [KeyCombo: Int32] {
         layers[layer] ?? [:]
     }
 
-    /// Every defined layer name, the default first and the rest
-    /// sorted, so the GUI import (#4) can enumerate them in a
-    /// stable order. The default is always present even with no
-    /// bindings, matching the always-present GUI default layer.
+    /// Defined layer names in stable order for GUI import (#4).
     public var definedLayers: [String] {
         let others = layers.keys
             .filter { $0 != Self.defaultLayer }
@@ -123,11 +74,7 @@ public final class KeybindingManager {
         return [Self.defaultLayer] + others
     }
 
-    // MARK: - Registration (from Lua)
-
-    /// `KiwiDesk.bind(combo, fn)` — default layer. A rebound
-    /// combo's displaced ref is released (registry slots must
-    /// not leak between resets).
+    /// Binds combo to Lua ref in default layer.
     public func bind(_ combo: KeyCombo, ref: Int32) {
         let old = layers[Self.defaultLayer, default: [:]]
             .updateValue(ref, forKey: combo)
@@ -139,10 +86,7 @@ public final class KeybindingManager {
         }
     }
 
-    /// `KiwiDesk.define_layer(name, { key = fn, ... }, opts)`.
-    /// Redefining an existing layer releases the displaced
-    /// refs — a duplicate layer name in hand-edited config must
-    /// not leak registry slots until the next reload.
+    /// Defines layer with given bindings and optional icon.
     public func defineLayer(
         _ name: String,
         bindings: [KeyCombo: Int32],
@@ -165,12 +109,10 @@ public final class KeybindingManager {
         }
     }
 
-    /// The menu bar indicator for a layer, if one was set.
     public func icon(for layer: String) -> String? {
         layerIcons[layer]
     }
 
-    /// `KiwiDesk.switch_layer(name)`.
     public func switchLayer(_ name: String) {
         guard name == Self.defaultLayer || layers[name] != nil
         else {
@@ -182,10 +124,7 @@ public final class KeybindingManager {
         onLayerChange(name)
     }
 
-    /// Clears everything (config reload / profile apply).
-    /// Falling back to the default layer notifies
-    /// `onLayerChange` — the menu-bar indicator must not keep
-    /// showing a layer whose bindings just went away.
+    /// Resets all layers and releases Lua references on config reload.
     public func reset() {
         deactivate()
         if let lua {
@@ -204,15 +143,7 @@ public final class KeybindingManager {
         }
     }
 
-    /// Atomically replaces every layer prepared by the
-    /// structured-config bridge. Preparation happens before
-    /// this call, so the old table remains callable until one
-    /// swap; Carbon registration then runs once for the chosen
-    /// layer instead of once per growing default-layer prefix.
-    ///
-    /// `preferredLayer` preserves a recorder session's active
-    /// layer when it still exists. Profile/config applies pass
-    /// `default`, retaining their settled reset semantics.
+    /// Atomically replaces layers from structured config.
     func replaceLayers(
         _ replacements: [String: [KeyCombo: Int32]],
         icons: [String: String],
@@ -249,25 +180,17 @@ public final class KeybindingManager {
         }
     }
 
-    // MARK: - Recorder suspension (#213)
-
-    /// True while suspended by an armed Settings recorder.
+    /// True while hotkeys are suspended by Settings shortcut recorder (#213).
     public var isSuspended: Bool { suspended }
 
-    /// Unregisters every hotkey while a Settings recorder is
-    /// armed, so pressing an existing KiwiDesk shortcut to test
-    /// it can't trigger its action. Idempotent. Only touches our
-    /// own Carbon registrations — macOS/system shortcuts are the
-    /// OS's and stay live.
+    /// Suspends hotkey registration during recorder capture (#213).
     public func suspend() {
         guard !suspended else { return }
         suspended = true
         deactivate()
     }
 
-    /// Restores the hotkeys suspended by `suspend()`, registering
-    /// whatever layer is current now — a layer/table change made
-    /// during suspension is honored. Idempotent.
+    /// Resumes hotkeys after recorder capture (#213).
     public func resume() {
         guard suspended else { return }
         suspended = false
@@ -281,7 +204,6 @@ public final class KeybindingManager {
         defer { isFiring = wasFiring }
         if case .failure(let error) = lua.call(ref: ref) {
             onLog("keybinding disabled: \(error)")
-            // Disable the faulty callback (sandbox rules).
             for (layer, var bindings) in layers {
                 if bindings[combo] == ref {
                     bindings[combo] = nil

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle+Enums.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle+Enums.swift
@@ -3,7 +3,10 @@ import Foundation
 
 /// App bar nested option vocabularies (split from `AppBarStyle.swift`).
 extension AppBarStyle {
-    /// Minimum bar thickness in pt (QA 2026-07-19).
+    /// Minimum bar thickness in pt (QA 2026-07-19): below it the
+    /// plate stroke and glyph run collide. Every entry point
+    /// clamps to it — profile decode, the Lua/CLI setter, and the
+    /// GUI slider's lower bound.
     public static let minThickness: CGFloat = 20
 
     /// True if platform supports Liquid Glass (macOS 26+, #390).
@@ -44,7 +47,12 @@ extension AppBarStyle {
             horizontal ? self : .icon
         }
 
-        /// True if content displays text.
+        /// True if content displays text. A consumer deciding for
+        /// a PAINTED bar asks `AppBarStyle.renderedContent`, which
+        /// folds in the vertical collapse; the two sites reading
+        /// raw `content` are legal only because each stands on a
+        /// horizontal-only path — moving either off it owes it
+        /// `renderedContent` (#937).
         public var showsText: Bool { self != .icon }
     }
 

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle+Enums.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle+Enums.swift
@@ -1,138 +1,54 @@
 import CoreGraphics
 import Foundation
 
-/// The bar's nested option vocabularies, split from
-/// AppBarStyle.swift (file-size ceiling). Same types, same
-/// JSON spellings; the Codable conformance stays with the
-/// struct (synthesized `encode` requires same-file).
+/// App bar nested option vocabularies (split from `AppBarStyle.swift`).
 extension AppBarStyle {
-    /// The floor for `thickness` (pt), shared by both bars. Below
-    /// this the plate/border stroke and the glyph run collide and
-    /// the bar reads broken (QA 2026-07-19), so every entry point
-    /// clamps to it: profile decode, the Lua/CLI setter, and the
-    /// GUI slider's lower bound.
+    /// Minimum bar thickness in pt (QA 2026-07-19).
     public static let minThickness: CGFloat = 20
 
-    /// True when this platform can render Liquid Glass (macOS 26+).
-    /// Gates the `liquidGlass` finish everywhere: rendering falls
-    /// back to the solid shape below 26, and the GUI hides the
-    /// toggle there (#390).
+    /// True if platform supports Liquid Glass (macOS 26+, #390).
     public static var glassAvailable: Bool {
         if #available(macOS 26, *) { return true }
         return false
     }
 
-    /// WHERE the background is drawn — orthogonal both to
-    /// `activeIndicator` (which marks only the active item) and to
-    /// the `liquidGlass` finish (a colorless glass material laid
-    /// over either shape on macOS 26). Boxed = a box per item
-    /// (honors `cornerRoundness`); Plain = one shared strip.
+    /// Background drawing style.
     public enum BackgroundStyle: String, Sendable, Codable, CaseIterable {
-        /// A box per item, honoring `cornerRoundness`
-        /// (roundness 0 = square).
         case boxed
-        /// No per-item box; the items sit on one shared
-        /// translucent strip.
         case plain
     }
 
-    /// How big the shared background plate is (QA 2026-07-19).
-    /// Orthogonal to `BackgroundStyle` — "where is it drawn"
-    /// vs "how far does it reach": `plain` draws one shared plate
-    /// and honors this; `boxed` draws no shared plate, so the
-    /// setting is inert there (the GUI greys it).
+    /// Background plate fit (QA 2026-07-19).
     public enum BackgroundFit: String, Sendable, Codable, CaseIterable {
-        /// The plate spans the whole strip edge-to-edge.
         case full
-        /// The plate wraps the content run plus one item gap of
-        /// breathing room per end — the Dock's read; falls back
-        /// to `full` once the run overflows and scrolls
-        /// (content fills the strip there, nothing to hug).
         case hug
     }
 
-    /// How the active item is marked. Orthogonal to
-    /// `backgroundStyle`: works on any background.
+    /// Active item indicator style.
     public enum ActiveIndicator: String, Sendable, Codable, CaseIterable {
-        /// An outline around the active item, tracing its shape at
-        /// the bar's roundness (a capsule at max, square at 0).
         case outline
-        /// An accent bar on the window-facing edge of the
-        /// active item.
         case edgeMark = "edge_mark"
-        /// The active item's slot is left empty — an empty slot
-        /// marks the focused window.
         case gap
     }
 
-    /// What an item draws. The text is the window's own
-    /// **title**, never its app name: a bar of five Finder
-    /// windows reading "Finder" five times names nothing the
-    /// icon did not already say, while "Downloads" / "KiwiCall"
-    /// tells them apart (owner 2026-08-19). The app name
-    /// survives as the fallback in the two places a title
-    /// cannot speak — an empty one (lazy-title apps, #160) and
-    /// a collapsed group, whose members have several titles and
-    /// no one of them is true. Both fallbacks are resolved by
-    /// the driver, in `KiwiCore.barItemText`.
-    /// `CaseIterable` is load-bearing:
-    /// `BarTitleCapTests.showsTextIsExhaustive` asserts the case
-    /// COUNT, so adding a case reds that test and forces a
-    /// ruling on whether the new one draws text — do not drop
-    /// it as "unused".
+    /// Content drawn per item (owner 2026-08-19, #160).
+    /// `CaseIterable` guarded by `BarTitleCapTests.showsTextIsExhaustive`.
     public enum Content: String, Sendable, Codable, CaseIterable {
         case icon
         case title
-        /// Truncation only ever eats the title; the icon
-        /// always survives.
         case iconAndTitle = "icon_and_title"
 
-        /// The content actually drawn: vertical bars render
-        /// icon-only — letter-stacked titles read terribly and
-        /// rotated text is not native (QA 2026-07-19; the Space
-        /// Bar settled the same rule for its front segment).
-        /// The stored preference round-trips, mirroring
-        /// `BackgroundStyle.rendered(glassAvailable:)`.
+        /// Content actually rendered, collapsing vertical to `.icon`
+        /// (QA 2026-07-19).
         public func rendered(horizontal: Bool) -> Content {
             horizontal ? self : .icon
         }
 
-        /// Whether the drawn content carries text at all. Ask
-        /// this rather than re-spelling `!= .icon`, so a later
-        /// text-free case cannot be missed at a call site;
-        /// `BarTitleCapTests.showsTextIsExhaustive` asserts the
-        /// case COUNT, so a new one reds it and has to be ruled
-        /// on here.
-        ///
-        /// A consumer deciding for a PAINTED bar asks it of
-        /// `AppBarStyle.renderedContent`, which folds in the
-        /// vertical collapse. No such consumer remains: the
-        /// title-refresh gate left in #937 (announced titles
-        /// made every item a consumer) and the GUI's title-cap
-        /// grey-out followed it out (same corollary — the cap
-        /// binds the announced title too).
-        ///
-        /// Two sites ask the raw `content` instead, and may only
-        /// because each already stands on a horizontal-only
-        /// path: `AppBarOverlay+Sizing`'s text measurement,
-        /// behind its own `guard horizontal`, and
-        /// `layoutHorizontal`, which by name never runs on a
-        /// vertical bar. Moving either off that path owes it
-        /// `renderedContent` — the collapse is the whole reason
-        /// the gate exists.
+        /// True if content displays text.
         public var showsText: Bool { self != .icon }
     }
 
-    /// Where the item group sits along the bar's long axis
-    /// (#293 QA). Values are edge-relative (`start`/`end`),
-    /// never `left`/`right` — the same reasoning that made
-    /// `edge` absolute: correct across all four edges without
-    /// a per-edge remap. A left bar's `start` is its top; a
-    /// top bar's `start` is its left. Shared by both bars
-    /// (`SpaceBarStyle.Alignment` aliases this). Once an App
-    /// Bar group overflows and scrolls, the three collapse to
-    /// the same visual (the group starts at the scroll
-    /// offset).
+    /// Item group alignment along the bar's axis (#293 QA).
     public enum BarAlignment: String, Sendable, Codable,
         CaseIterable
     {

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
@@ -34,7 +34,9 @@ public struct AppBarStyle: Sendable, Equatable {
     public var cornerRoundness: CGFloat = 50
     /// Dim opacity for untinted inactive items (`BarAccent.untintedAlpha`).
     public var dimFactor: CGFloat = BarAccent.untintedAlpha
-    /// Inactive item text and glyph color.
+    /// Inactive item text and glyph colour. The colour defaults
+    /// here are mirrored as examples in docs/lua-reference.md —
+    /// change both.
     public var itemColor = "#EAF3EE"
     /// Background fill color (#14201CB3, #660, retuned by #755;
     /// `PaletteBarFillTests`).
@@ -73,7 +75,11 @@ public struct AppBarStyle: Sendable, Equatable {
         backgroundStyle == .boxed && !glassEnabled
     }
 
-    /// True if plate spans edge-to-edge.
+    /// True if the plate spans edge-to-edge — the SETTINGS
+    /// PREVIEWS' one copy of the spans rule; the live bars resolve
+    /// one layer down in `BarPlate.frame` (which adds the hug→full
+    /// overflow fallback), so a retune touches this and `BarPlate`
+    /// together. `SpaceBarStyle.plateSpans` is the twin.
     public var plateSpans: Bool {
         !hasBox && backgroundFit == .full
     }

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
@@ -1,199 +1,83 @@
 import CoreGraphics
 import Foundation
 
-/// The app bar's global look, shared by every layout that
-/// shows a bar (monocle, scrolling). Stored top-level as
-/// `app_bar` in profile JSON, set from Lua via `app_bar.set_*`.
-/// A layout may
-/// override any of these fields for itself (see `LayoutAppBar`);
-/// what isn't overridden inherits from here.
-///
-/// Two things deliberately live *outside* this type because they
-/// are layout-specific, not looks: whether the bar is shown
-/// (`LayoutAppBar.enabled`) and the focus/scroll axis
-/// (`MonocleParams.orientation` / `ScrollingParams.orientation`).
+/// Global look and behavior for app bars (monocle, scrolling).
 public struct AppBarStyle: Sendable, Equatable {
-    /// The absolute screen edge the bar occupies (#293) — no
-    /// longer derived from the layout's axis.
-    ///
-    /// Bottom by default (#660), mirroring the Dock, while the
-    /// Space Bar takes the top beside the menu bar. The two
-    /// persistent strips land where macOS has already taught the
-    /// eye to look for one.
+    /// Screen edge occupied by the bar (bottom by default, #293, #660).
     public var edge: AppBarEdge = .bottom
-    /// Item-group placement along the bar; center matches the
-    /// pre-#293-QA shipped behavior.
+    /// Item group alignment along the bar (center by default).
     public var alignment: BarAlignment = .center
     /// Depth of the reserved strip (pt).
     public var thickness: CGFloat = 32
-    /// Plain by default (#660): one shared plate reads as a
-    /// system strip the way the menu bar and Dock do, where a
-    /// box per item reads as a widget laid over the desktop.
+    /// Background plate style (plain by default, #660).
     public var backgroundStyle: BackgroundStyle = .plain
-    /// Liquid Glass finish (macOS 26+), orthogonal to the shape:
-    /// a colorless glass material laid over the Boxed boxes or the
-    /// Plain plate. Ignored below macOS 26 (`glassEnabled`). Fill
-    /// is still forwarded as the glass tint, though the tint reads
-    /// near-colorless on current macOS (#390).
+    /// Liquid Glass material (macOS 26+, #390).
     public var liquidGlass: Bool = false
-    /// Hug by default: a tight plate reads calmer than an
-    /// edge-to-edge strip (ui-designer, QA 2026-07-19).
+    /// Background fit (hug by default, QA 2026-07-19).
     public var backgroundFit: BackgroundFit = .hug
     public var activeIndicator: ActiveIndicator = .outline
-    /// Item length along the bar (pt) — every item is the
-    /// same size. 0 (default) = a standard length per
-    /// `content`: a compact square for icon-only, wider once
-    /// text is shown. Clamped at layout time between the icon
-    /// square (icons never clip) and a quarter of the bar;
-    /// items that overflow anyway scroll instead of shrinking.
+    /// Item length along the bar in pt (0 = auto per content).
     public var itemSize: CGFloat = 0
-    /// Spacing between boxes (pt); 0 = touching.
+    /// Spacing between item boxes in pt.
     public var itemGap: CGFloat = 6
     public var content: Content = .iconAndTitle
-    /// Longest title an item draws, in characters; longer ones
-    /// tail-truncate to it with an ellipsis. Read through
-    /// `resolvedTitleCap`, which clamps to `titleCapRange`.
-    ///
-    /// Not cosmetic. Slots are uniform and auto-sized to the
-    /// WIDEST item (`AppBarOverlay.autoSlotWidth`), so one long
-    /// title widens every slot until `slotLength`'s quarter-bar
-    /// clamp bites and the rest of the bar scrolls — and because
-    /// the measurement re-runs per render, an uncapped bar also
-    /// breathes on every keystroke in an editor. Titles observed
-    /// on a real desktop ran to 57 characters (owner 2026-08-19)
-    /// against app names of 6–20, which is the whole reason this
-    /// knob exists and `item_size` alone does not answer it.
-    /// Tail truncation, deliberately: the apps that do repeat
-    /// their own name in the title append it ("… — Obsidian
-    /// 1.13.7"), so the tail is the byte worth losing first.
+    /// Longest title drawn per item before tail-truncation. Default 25
+    /// (owner 2026-08-19).
     public var titleCap = 25
-    /// Where app icons come from: the native app image, or a
-    /// monochrome SketchyBar App Font glyph that follows the
-    /// bar's text colors (#294). Apps without a glyph keep
-    /// their image.
+    /// App icon source: native image or SketchyBar App Font glyph (#294).
     public var iconSource: BarAppIconSource = .appImage
-    /// Adjacent windows of the same app collapse into one
-    /// item wearing a count badge. Clicking the group
-    /// focuses its first member, which expands the group
-    /// into individual items; focus leaving the group
-    /// collapses it again. Non-adjacent windows of the same
-    /// app stay separate items.
+    /// Group adjacent windows of the same app with a count badge.
     public var groupAdjacentWindows = true
-    /// 0 (default) = auto: the text scales with the bar
-    /// thickness. Any positive value pins the size.
+    /// Font size (0 = auto scale with thickness).
     public var fontSize: CGFloat = 0
-    /// Corner rounding as a percentage (0–100) of the maximum:
-    /// 100 = a full capsule (radius = thickness/2), 0 = square.
-    /// Resolved to a concrete radius in
-    /// `resolvedCornerRadius(forThickness:)`. Percentage, not
-    /// pt, so it can't exceed thickness/2 (which rendered items
-    /// as pointed hexagons) and self-adapts to any thickness.
+    /// Corner rounding percentage (0–100) of thickness / 2.
     public var cornerRoundness: CGFloat = 50
-    /// Opacity of an inactive item's untinted icon (0.05–1). The dim
-    /// carries "not focused" for content that takes no state color.
-    /// Lua-only power knob (`set_dim_factor`, no GUI); the default
-    /// matches `BarAccent.untintedAlpha`. Clamped in `resolvedDim`.
+    /// Dim opacity for untinted inactive items (`BarAccent.untintedAlpha`).
     public var dimFactor: CGFloat = BarAccent.untintedAlpha
-    /// KiwiCanopy theme: ink-on-dark item text, a translucent
-    /// cool-dark surface fill (box, plate, or glass tint), a
-    /// kiwi-green active accent. Bars own their backdrop, so the
-    /// fill-only brand green is legible here; content overlays
-    /// (focus ring, drag ghost) paint over arbitrary windows and
-    /// are decoupled to a contrast-tuned teal — see BorderStyle
-    /// and DragVisual. Defaults here are mirrored as examples in
-    /// docs/lua-reference.md (App Bar colors) — change both.
+    /// Inactive item text and glyph color.
     public var itemColor = "#EAF3EE"
-    /// The fill under the items — a box per item (Boxed), one
-    /// shared plate (Plain), or the Liquid Glass tint
-    /// (Material). One knob, three renders.
-    ///
-    /// 70% opaque (#755, retuning #660's 80%). #660's argument
-    /// stands whole: the old 40% was legible over a dark
-    /// wallpaper and a guess anywhere else, and which wallpaper
-    /// a user has is not something a default can know — so the
-    /// default takes the reading that holds over all of them and
-    /// leaves the translucent look to anyone who wants it. Only
-    /// the number moved, once all nine bundled palettes could be
-    /// read side by side: bar legibility is not a per-theme
-    /// preference, so every bar fill KiwiDesk ships is the same
-    /// alpha, and 70% is where the readable ones had converged.
-    /// `PaletteBarFillTests` holds this and the eight authored
-    /// palettes to it.
+    /// Background fill color (#14201CB3, #660, retuned by #755;
+    /// `PaletteBarFillTests`).
     public var fillColor = "#14201CB3"
     public var activeItemColor = "#8DB354"
     public var highlightColor = "#8DB354"
-    /// Hover feedback on clickable (non-active) items: a
-    /// lighter, translucent kiwi green, deliberately a shade
-    /// off the highlight so hover and active never read as
-    /// the same state.
+    /// Hover fill color on non-active items.
     public var hoverFillColor = "#AACB5D80"
-    /// Item text/glyph while hovered; defaults to the normal
-    /// item color (the hover tint is translucent, so the text
-    /// stays readable through it) — the knob exists for themes
-    /// whose hover tint needs darker text.
+    /// Hover item text/glyph color.
     public var hoverItemColor = "#EAF3EE"
-    /// The count badge on grouped items. Neutral grey, not the
-    /// notification red it shipped as until #955: a count of
-    /// windows is state, not news, and an alert hue on every
-    /// grouped item at rest reads as urgency that is not there.
-    /// A theme is free to pick a hue; the DEFAULT is not.
+    /// Grouped window count badge colors (#955).
     public var groupBadgeColor = "#636366"
     public var groupBadgeTextColor = "#FFFFFF"
 
     public init() {}
 
-    /// The concrete corner radius (pt) for an item/strip of the
-    /// given cross dimension: `cornerRoundness`% of its half —
-    /// 100% is a capsule, 0% square. One resolution site shared
-    /// by the item box, the shared strip, the scroll arrows, and
-    /// the GUI preview so they can't drift.
+    /// Concrete corner radius in pt for a given thickness.
     public func resolvedCornerRadius(
         forThickness thickness: CGFloat
     ) -> CGFloat {
         max(0, min(cornerRoundness, 100)) / 100 * (thickness / 2)
     }
 
-    /// Guards a dim factor to a legible, sane range — the only
-    /// restriction on the Lua-only knob (a fully invisible or >1
-    /// alpha is a bug, not a preference). No ordering is enforced
-    /// across the Space Bar's two factors: Lua users may set what
-    /// they want; the GUI is the curated gate, Lua the open one.
+    /// Clamps dim factor to valid range [0.05, 1.0].
     public static func clampDim(_ value: CGFloat) -> CGFloat {
         max(0.05, min(value, 1))
     }
 
-    /// The Liquid Glass finish is painted only where the platform
-    /// can render it — false below macOS 26 even if `liquidGlass`
-    /// is stored true, so a glass profile opened on older macOS
-    /// shows the solid shape (the toggle is hidden there too).
+    /// True if Liquid Glass is enabled and supported on this platform.
     public var glassEnabled: Bool {
         liquidGlass && Self.glassAvailable
     }
 
-    /// An item paints its own box: the Boxed shape without the
-    /// glass finish. Plain (shared plate) and any glass finish
-    /// draw no per-item box, so item fill/accent geometry that
-    /// keyed on "boxed" keys on this instead.
+    /// True if item paints its own boxed background without glass.
     public var hasBox: Bool {
         backgroundStyle == .boxed && !glassEnabled
     }
 
-    /// Whether the shared plate spans its whole strip
-    /// edge-to-edge (`background_fit: full` on a style that
-    /// draws a shared plate at all). The SETTINGS PREVIEWS'
-    /// one copy of the spans rule — both strip mocks and the
-    /// fused scene consult it. The LIVE bars resolve fit one
-    /// layer further down (`BarPlate.frame`, which adds the
-    /// hug→full fallback on overflow), so a retune of the
-    /// rule touches this and `BarPlate` together.
-    /// `SpaceBarStyle.plateSpans` is the same rule on the
-    /// twin struct.
+    /// True if plate spans edge-to-edge.
     public var plateSpans: Bool {
         !hasBox && backgroundFit == .full
     }
 }
-
-// MARK: - Codable
 
 extension AppBarStyle: Codable {
 }

--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout+Offset.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout+Offset.swift
@@ -1,36 +1,10 @@
 import CoreGraphics
 
-/// The viewport-offset half of `ScrollingLayout`, split at the
-/// file ceiling: the anchor dispatch and the clamps that keep a
-/// row from revealing empty margin past its ends. Pure maths —
-/// `calculateGeometry` and `viewportRest` (in
-/// `ScrollingLayout+Viewport`) both resolve through it, and so
-/// does the Settings preview (#776).
+/// Viewport offset computation and anchor dispatch for `ScrollingLayout`
+/// (#776).
 extension ScrollingLayout {
-    /// The viewport offset for `focus` at `focusedPos`, given the
-    /// rest from the last tile (`previous`).
-    ///
-    /// Dispatches on `anchor`, not on whether the space has
-    /// scrolled before (#239): `center`/`start`/`end` compute a
-    /// fixed resting position on *every* focus, then clamp it to
-    /// keep the focused slot fully visible. `follow` instead pans
-    /// the minimum needed to reveal the focused slot from where
-    /// the viewport already was (#66) — the only anchor that
-    /// reads `previous`; a `follow` space that has never scrolled
-    /// seeds at the row start. When `focusedPos` is nil (a
-    /// floating window, or nothing focused) there is no slot to
-    /// place, so the viewport holds its previous offset (#141).
-    /// The result is finally clamped so the row never reveals
-    /// empty margin past its ends.
-    ///
-    /// "Where the viewport already was" is the half `follow` has
-    /// to read carefully, which is why `previous` carries the
-    /// slot it was measured against (#966): see `heldBase`.
-    ///
-    /// Public because the Settings preview asks it for the same
-    /// resting position it draws (#776): the schematic's anchor
-    /// arms re-implemented this switch without the clamps and
-    /// drew a leading margin the engine cannot produce.
+    /// Computes viewport offset for `focus` at `focusedPos`
+    /// (#239, #66, #141, #966).
     public static func offset(
         anchor: ScrollingParams.Anchor,
         previous: ScrollRest?,
@@ -42,17 +16,10 @@ extension ScrollingLayout {
     ) -> CGFloat {
         var target: CGFloat
         if let focusedPos {
-            // The range of offsets that keep the focused slot
-            // fully inside the viewport: sliding it any further
-            // would clip its leading or trailing edge.
             let visibleMin = -focusedPos
             let visibleMax = along - size - focusedPos
             switch anchor {
             case .follow:
-                // Scroll-into-view (#66): hold where the viewport
-                // was, pan only enough to reveal the focused
-                // slot. A never-scrolled space seeds at the row
-                // start.
                 let base =
                     heldBase(
                         previous: previous,
@@ -63,7 +30,6 @@ extension ScrollingLayout {
                     ) ?? visibleMin
                 target = min(max(base, visibleMin), visibleMax)
             case .center, .start, .end:
-                // Fixed resting position, recomputed every focus.
                 let resting = anchorOffset(
                     anchor: anchor,
                     along: along,
@@ -73,58 +39,14 @@ extension ScrollingLayout {
                 target = min(max(resting, visibleMin), visibleMax)
             }
         } else {
-            // The focused window has no slot in the row (a
-            // floating window, or nothing focused): there is
-            // nothing to scroll into view, so the viewport
-            // stays put instead of snapping home (#141).
             target = previous?.offset ?? 0
         }
 
-        // Boundary awareness: never reveal empty margin past the
-        // row ends.
         guard rowLength > along else { return 0 }
         return min(max(target, along - rowLength), 0)
     }
 
-    /// The offset `follow` pans from — nil for a space that has
-    /// never scrolled, which seeds at the row start instead.
-    ///
-    /// Two things can put the focused slot somewhere new, and
-    /// `follow` owes them opposite answers (#966):
-    ///
-    /// - **The focus moved.** Nothing else changed, so holding
-    ///   the recorded offset is exactly what makes the pan read
-    ///   as scroll-into-view: the side you came from stays open
-    ///   (#66).
-    /// - **Every slot moved underneath an unchanged focus** — a
-    ///   slot resize (one size serves the whole row, so a resize
-    ///   re-positions every slot), a `swap` that re-seats the
-    ///   focus in the array, a neighbour opening or closing ahead
-    ///   of it, a #677 bound re-packing the row. Here the
-    ///   recorded offset points at a different place than it did
-    ///   when it was recorded, and holding it slides the window
-    ///   the user is acting on toward the leading edge. Shift it
-    ///   by however far the slot moved instead, so that slot
-    ///   keeps its place on screen and the row rearranges around
-    ///   it — except where the slot was resting flush against
-    ///   the trailing border, where the edge is what it keeps.
-    ///   Otherwise a shrink tears the slot off a border it was
-    ///   sitting on and opens a gap the row then fills from
-    ///   behind, which is the one shape that reads as broken
-    ///   rather than merely different (device QA, 2026-08-27).
-    ///   A slot that is last in its row already behaved this
-    ///   way, because the boundary clamp refuses to reveal
-    ///   margin past the row end — so this is also what stops
-    ///   two identical-looking situations answering
-    ///   differently.
-    ///
-    /// The recorded slot is what tells them apart: it names the
-    /// focus the offset was measured against and where that slot
-    /// sat at the time. No slot recorded — a hand-seeded rest, or
-    /// a space that has never placed one — reads as the first
-    /// case. A pass that places no slot does not produce that
-    /// state: it carries the previous measurement through with
-    /// the offset it is also carrying (`ScrollRest`).
+    /// Offset from which `follow` pans (#966, #677; device QA, 2026-08-27).
     private static func heldBase(
         previous: ScrollRest?,
         focus: WindowID?,
@@ -135,31 +57,13 @@ extension ScrollingLayout {
         guard let previous else { return nil }
         guard let slot = previous.slot, slot.window == focus
         else { return previous.offset }
-        // Resting against the TRAILING border: hold that edge,
-        // so the slot gives its space back on the side that is
-        // open rather than tearing away from the border with a
-        // hidden neighbour behind it. The verdict was reached
-        // when the offset was measured (`ScrollRest.Slot`), so
-        // a slot that filled the viewport already reads
-        // `.leading` and falls through — the precedence is not
-        // re-decided here.
-        //
-        // The value returned is the visibility clamp's own upper
-        // bound, which is what "flush at the trailing edge"
-        // means in offsets; the clamp below therefore keeps it
-        // unchanged rather than fighting it.
         if slot.restingOn == .trailing {
             return along - focusedSpan - focusedPos
         }
         return previous.offset + (slot.position - focusedPos)
     }
 
-    /// A fixed anchor's resting offset for a focused slot, before
-    /// visibility/boundary clamping. `start`/`end` are
-    /// axis-relative: the `along` coordinate already runs along
-    /// the scroll axis (x horizontal, y vertical), so `start` is
-    /// the leading edge (left / top) and `end` the trailing edge
-    /// (right / bottom) on both orientations — no per-axis branch.
+    /// Axis-relative fixed resting offset for focused slot.
     private static func anchorOffset(
         anchor: ScrollingParams.Anchor,
         along: CGFloat,
@@ -174,8 +78,6 @@ extension ScrollingLayout {
         case .end:
             return along - size - focusedPos
         case .follow:
-            // Unreachable: `follow` is resolved from `previous`
-            // in `offset`, never as a fixed resting position.
             return -focusedPos
         }
     }

--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout+Offset.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout+Offset.swift
@@ -46,7 +46,15 @@ extension ScrollingLayout {
         return min(max(target, along - rowLength), 0)
     }
 
-    /// Offset from which `follow` pans (#966, #677; device QA, 2026-08-27).
+    /// Offset from which `follow` pans — nil for a never-scrolled
+    /// space (#966). Two things move the focused slot and they owe
+    /// opposite answers: the FOCUS moved (hold the recorded offset
+    /// — scroll-into-view, #66), or every slot moved underneath an
+    /// unchanged focus (a resize, swap, neighbour change, #677
+    /// re-pack — shift by how far the slot moved so it keeps its
+    /// place on screen). The recorded slot tells them apart;
+    /// except when it rested flush at the trailing border, the
+    /// edge is what it keeps (device QA, 2026-08-27).
     private static func heldBase(
         previous: ScrollRest?,
         focus: WindowID?,
@@ -57,6 +65,10 @@ extension ScrollingLayout {
         guard let previous else { return nil }
         guard let slot = previous.slot, slot.window == focus
         else { return previous.offset }
+        // The trailing verdict was reached when the offset was
+        // measured (`ScrollRest.Slot`) — never re-decided here;
+        // the value returned is the visibility clamp's own upper
+        // bound, so the clamp keeps it unchanged.
         if slot.restingOn == .trailing {
             return along - focusedSpan - focusedPos
         }

--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
@@ -1,50 +1,8 @@
 import CoreGraphics
 
-/// Niri/PaperWM-style scrolling columns.
-///
-/// Windows sit in an infinite row (horizontal orientation) or
-/// column (vertical) of fixed-size slots. The **focus anchor**
-/// decides where the focused slot rests, applied on *every* focus
-/// change (#239): `center`/`start`/`end` re-seat it at a fixed
-/// resting position (centred, or flush against the leading
-/// left/top or trailing right/bottom edge — `start`/`end` are
-/// relative to the scroll axis), then clamp so no empty
-/// margin shows past the row ends; `follow` (the default) pans
-/// the minimum to reveal the focus from where the viewport
-/// already was (#66) — up/down mirror, an already-visible slot
-/// doesn't move, the side you came from stays open — and when
-/// the row moves underneath an unchanged focus instead (a slot
-/// resize re-positions every slot), it holds that slot's place
-/// on screen rather than its own number (#966,
-/// `ScrollingLayout+Offset.heldBase`). Ends snap to the screen
-/// edge. With the indicator bar enabled its strip is carved out
-/// of the usable area first, so windows and bar never overlap.
-///
-/// macOS constrains what frames it will apply, so materialized
-/// frames pin while the viewport *offset* stays the ideal,
-/// unpinned value (keeping the up/down scroll math symmetric).
-/// The clamp form is chosen **per edge** (#878): a *blocked*
-/// edge — one with another screen beyond it
-/// (`LayoutContext.screenNeighbors`), or the vertical top,
-/// which macOS walls off itself (#139, an accepted OS-blocked
-/// limitation, see docs/design-decisions.md) — is a hard stop,
-/// where a scrolled-out slot stops flush at the border, fully
-/// on its own screen, and stacks behind the viewport; frames
-/// are global and macOS cannot clip another app's window, so
-/// an overhang there would render on the neighbor screen. An
-/// *open* edge lets the slot overhang into the void with an
-/// `edgePeek` sliver still visible, because macOS clamps fully
-/// offscreen frames to its own undocumented minimum anyway
-/// (#142) — pinning above that minimum keeps every target
-/// achievable. Neither form ever resizes a slot.
+/// Scrolling column/row layout (#239, #66, #966, #878, #139, #142).
 public struct ScrollingLayout: LayoutSystem {
-    /// Visible sliver of a slot scrolled far past a screen edge
-    /// (#142): the WindowServer's clamp floor plus this
-    /// sliver's own margin (see
-    /// `WindowServerFacts.visibilityFloor`). Sitting safely
-    /// above the floor keeps every pinned target achievable,
-    /// so the retile tolerance can settle instead of
-    /// re-issuing unreachable frames forever.
+    /// Visible sliver of a slot scrolled past screen edge (#142).
     static let edgePeek: CGFloat =
         WindowServerFacts.visibilityFloor + 8
 
@@ -56,7 +14,6 @@ public struct ScrollingLayout: LayoutSystem {
     ) -> [WindowID: CGRect] {
         guard !windows.isEmpty else { return [:] }
 
-        // The area left for windows after the bar strip.
         let area = context.scrolling.windowFrame(
             in: context.usable,
             inner: context.gaps.inner,
@@ -64,11 +21,6 @@ public struct ScrollingLayout: LayoutSystem {
         )
         let horizontal = context.scrolling.axisIsHorizontal
 
-        // A single window always fills the whole window area —
-        // unless its app refuses that size (#677): a lone
-        // window has no neighbors to re-pack against, so the
-        // answered size is CENTERED instead (the monocle
-        // treatment; a symmetric gap reads deliberate).
         if windows.count == 1, let only = windows.first {
             return [
                 only: context.sizeBounds[only]?
@@ -106,16 +58,8 @@ public struct ScrollingLayout: LayoutSystem {
         )
     }
 
-    /// The row geometry shared by `calculateGeometry` and
-    /// `viewportRest`: per-slot spans and positions, total
-    /// row length, and the focused slot's position along the
-    /// scroll axis — nil when the focused window has no slot in
-    /// the row (a floating window, or nothing focused), so the
-    /// offset math knows there is nothing to scroll into view
-    /// (#141). `size` is the uniform ask; a slot's span differs
-    /// from it only where a confirmed app bound consumed the
-    /// ask (#677), which is what re-packs the row so neighbors
-    /// close a refusal's gap.
+    /// Row geometry shared between layout calculation and viewport rest
+    /// (#141, #677).
     struct Metrics {
         let along: CGFloat
         let size: CGFloat
@@ -141,18 +85,7 @@ public struct ScrollingLayout: LayoutSystem {
             along: along,
             horizontal: horizontal
         )
-        // Honour the global floor: a scrolling slot never resolves
-        // below minWindowSize, but never wider than the axis — so a
-        // small fraction (e.g. 5% of a narrow display) falls back to
-        // minWindowSize. Note BSP/Stack/Grid use minWindowSize as a
-        // *trigger* to spill into an OverlapStack pile; scrolling has
-        // no pile (its overflow is the scroll itself), so it floors
-        // the slot instead.
         let size = min(along, max(resolved, context.minWindowSize))
-        // Per-slot span: the learned answer where the app has
-        // refused exactly this ask (#677), the uniform size
-        // everywhere else — only the scroll axis re-packs; the
-        // cross axis keeps asking the full extent.
         let spans = windows.map { window -> CGFloat in
             let bound = context.sizeBounds[window]
             let generalizing = !context.probesBeyondBounds
@@ -200,12 +133,6 @@ public struct ScrollingLayout: LayoutSystem {
         neighbors: ScreenNeighbors
     ) -> [WindowID: CGRect] {
         let along = metrics.along
-        // A blocked edge — another screen beyond it, or the
-        // vertical top, which macOS itself walls off (#139) — is
-        // a hard stop (#878): the scrolled-out slot stops flush
-        // at the border, fully on its own screen, and stacks
-        // behind the viewport (the #150 pile, relocated). An
-        // open edge keeps the overhang-with-sliver pin below.
         let leadingBlocked =
             horizontal ? neighbors.left : true
         let trailingBlocked =
@@ -214,21 +141,6 @@ public struct ScrollingLayout: LayoutSystem {
         for (index, window) in windows.enumerated() {
             let span = metrics.spans[index]
             var lead = offset + metrics.positions[index]
-            // On an open edge, pin what macOS would refuse
-            // anyway (#142): (almost) fully offscreen frames
-            // clamp to its own title-bar minimum. An unreachable
-            // target makes every retile re-issue the frame past
-            // the ±2pt tolerance, so far slots keep `edgePeek`
-            // visible at the edge. The peek caps at the slot's
-            // own span: a slot smaller than `edgePeek` (possible
-            // via `.fraction`, whose 5% floor has no point
-            // minimum) pins fully visible instead of displacing
-            // already-visible slots — with the cap, the focused
-            // slot is provably never touched: the offset clamps
-            // already hold its lead in [0, along - focusedSpan]
-            // using the slot's OWN span, which is exactly the
-            // hard stop's bound here, and the open form's is
-            // looser still (peek ≤ span on both ends).
             let peek = min(Self.edgePeek, span)
             lead = min(
                 lead,

--- a/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/ScrollingLayout.swift
@@ -21,6 +21,10 @@ public struct ScrollingLayout: LayoutSystem {
         )
         let horizontal = context.scrolling.axisIsHorizontal
 
+        // A single window fills the whole area — unless its app
+        // refuses that size (#677): with no neighbors to re-pack
+        // against, the answered size is CENTERED (the monocle
+        // treatment; a symmetric gap reads deliberate).
         if windows.count == 1, let only = windows.first {
             return [
                 only: context.sizeBounds[only]?
@@ -85,6 +89,9 @@ public struct ScrollingLayout: LayoutSystem {
             along: along,
             horizontal: horizontal
         )
+        // BSP/Stack/Grid use minWindowSize as a TRIGGER to spill
+        // into a pile; scrolling has no pile (its overflow is the
+        // scroll itself), so it floors the slot instead.
         let size = min(along, max(resolved, context.minWindowSize))
         let spans = windows.map { window -> CGFloat in
             let bound = context.sizeBounds[window]
@@ -133,6 +140,14 @@ public struct ScrollingLayout: LayoutSystem {
         neighbors: ScreenNeighbors
     ) -> [WindowID: CGRect] {
         let along = metrics.along
+        // A blocked edge — another screen beyond it, or the
+        // vertical top macOS walls off itself (#139) — is a hard
+        // stop (#878): frames are global and macOS cannot clip
+        // another app's window, so an overhang there would render
+        // on the neighbor screen — the scrolled-out slot stops
+        // flush and stacks behind the viewport (the #150 pile,
+        // relocated). An open edge keeps the
+        // overhang-with-sliver pin below.
         let leadingBlocked =
             horizontal ? neighbors.left : true
         let trailingBlocked =
@@ -141,6 +156,13 @@ public struct ScrollingLayout: LayoutSystem {
         for (index, window) in windows.enumerated() {
             let span = metrics.spans[index]
             var lead = offset + metrics.positions[index]
+            // On an open edge, pin what macOS would refuse anyway
+            // (#142): an unreachable target makes every retile
+            // re-issue the frame past the ±2 pt tolerance. The
+            // peek caps at the slot's own span so a tiny
+            // `.fraction` slot pins fully visible; the focused
+            // slot is provably never touched — the offset clamps
+            // already bound its lead with the same span.
             let peek = min(Self.edgePeek, span)
             lead = min(
                 lead,

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
@@ -90,6 +90,10 @@ public struct SpaceBarStyle: Sendable, Equatable {
 
 }
 
-/// Synthesized Codable conformance must stay in type's own file; backed by
-/// `SpaceBarParityTests` and `SettingsCodingTests`.
+/// Synthesized Codable conformance must stay in the type's own
+/// file (cross-file conformances get no synthesized `encode`,
+/// forcing the mirrored list parity-tests.md bans). The OPPOSITE
+/// placement from `TilingSettings+Coding` is deliberate — do not
+/// harmonize; `SpaceBarParityTests` and `SettingsCodingTests`
+/// backstop the residual hazard.
 extension SpaceBarStyle: Codable {}

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
@@ -1,21 +1,8 @@
 import CoreGraphics
 import Foundation
 
-/// The Space Bar's look and behavior (#293): one bar per display
-/// listing that display's Spaces, layout-independent. Stored
-/// top-level as `space_bar` in profile JSON, set from Lua via
-/// `space_bar.set_*`.
-///
-/// Deliberately **global-only** — the bar exists outside every
-/// layout, so there is no per-layout override mirror (and no
-/// parity surface for one). `enabled` lives here for the same
-/// reason: no layout owns the bar.
-///
-/// The two-accent model is the bar's signature: `itemColor`
-/// paints inactive spaces, `activeItemColor` the active space's
-/// identifier and glyphs, and `focusedItemColor` the focused
-/// window — its glyph inside the active space AND the front-app
-/// segment (spaces.lua's `space_focused_window`).
+/// The Space Bar's look and behavior (#293): global per-display bar listing
+/// that display's Spaces. Stored as `space_bar` in profile JSON.
 public struct SpaceBarStyle: Sendable, Equatable {
     public typealias BackgroundStyle = AppBarStyle.BackgroundStyle
     public typealias BackgroundFit =
@@ -23,155 +10,70 @@ public struct SpaceBarStyle: Sendable, Equatable {
     public typealias ActiveIndicator = AppBarStyle.ActiveIndicator
     public typealias Alignment = AppBarStyle.BarAlignment
 
-    /// On by default (QA 2026-07-19): the bar is the only
-    /// surface where KiwiDesk's Spaces are visible at
-    /// all — without it a new user may never discover the
-    /// concept. macOS's own Spaces have Mission Control; ours
-    /// have only this.
+    /// On by default (QA 2026-07-19) to surface Spaces discoverability.
     public var enabled = true
-    /// The absolute screen edge the bar occupies. When it
-    /// matches the App Bar's edge, the Space Bar is always
-    /// screen-facing and the App Bar window-facing (space-first
-    /// reservation) — never a conflict.
-    ///
-    /// Top by default (#660), under the menu bar, with the App
-    /// Bar on the bottom beside the Dock.
+    /// Absolute screen edge occupied (top by default, #660).
     public var edge: AppBarEdge = .top
-    /// Item-group placement along the bar (#293 QA); one
-    /// shared default with the App Bar — the bar's pre-QA
-    /// de-facto start anchoring was an omission, not a
-    /// decision.
+    /// Item-group placement along the bar (center by default, #293 QA).
     public var alignment: Alignment = .center
-    /// Depth of the reserved strip (pt); aligned with the App
-    /// Bar default.
+    /// Depth of the reserved strip (pt).
     public var thickness: CGFloat = 32
-    /// Box length along the bar (pt); 0 (default) = auto.
+    /// Box length along the bar (pt); 0 = auto.
     public var itemSize: CGFloat = 0
     /// Spacing between space boxes (pt).
     public var itemGap: CGFloat = 6
-    /// 0 (default) = auto: text scales with the bar thickness.
+    /// Font size (pt); 0 = auto scale with thickness.
     public var fontSize: CGFloat = 0
-    /// Max app-group glyphs rendered per Space item (#376);
-    /// grouping runs first, then this cap, and any further groups
-    /// fold into the trailing "+n" badge. Read through
-    /// `resolvedGlyphCap`, which clamps to `glyphCapRange`.
-    /// Default 5 (the shipped #293 value).
+    /// Max app-group glyphs per Space item before "+n" badge (#376).
+    /// Default 5.
     public var glyphCap = 5
-    /// How app glyphs are drawn (#294): the native app image or
-    /// a monochrome App Font glyph following the bar's text
-    /// colors. Apps without a resolvable image fall back to the
-    /// App Font `Default` glyph either way.
+    /// App icon rendering mode: native image or App Font glyph (#294).
     public var iconSource: BarAppIconSource = .appImage
-    /// Plain by default, like the App Bar (#660).
+    /// Plain by default, matching App Bar (#660).
     public var backgroundStyle: BackgroundStyle = .plain
-    /// Liquid Glass finish (macOS 26+), orthogonal to the shape —
-    /// see `AppBarStyle.liquidGlass`. Ignored below 26.
+    /// Liquid Glass finish (macOS 26+). Ignored on older versions.
     public var liquidGlass: Bool = false
-    /// Hug by default, like the App Bar (QA 2026-07-19).
+    /// Background fit (hug by default, QA 2026-07-19).
     public var backgroundFit: BackgroundFit = .hug
     public var activeIndicator: ActiveIndicator = .outline
-    /// Corner rounding as a percentage (0–100) of thickness/2,
-    /// like the App Bar.
+    /// Corner rounding percentage (0–100) of thickness / 2.
     public var cornerRoundness: CGFloat = 50
-    /// Opacity (0.05–1) of everything on an INACTIVE space — the
-    /// outer dim tier. Lua-only (`set_dim_factor`, no GUI); default
-    /// = `BarAccent.untintedAlpha`.
+    /// Opacity (0.05–1) on inactive spaces (`BarAccent.untintedAlpha`).
     public var dimFactor: CGFloat = BarAccent.untintedAlpha
-    /// Opacity (0.05–1) of an UNFOCUSED window's glyph on the
-    /// ACTIVE space — the middle dim tier. Lua-only
-    /// (`set_active_dim_factor`); default =
-    /// `BarAccent.activeUnfocusedAlpha`. Independent of `dimFactor`
-    /// (Lua may invert the ladder; the GUI is the curated gate).
+    /// Opacity (0.05–1) of unfocused glyph on active space.
     public var activeDimFactor: CGFloat =
         BarAccent.activeUnfocusedAlpha
-    /// Trailing `| <front app>` segment (spaces.lua's front_app);
-    /// off by default (ui-designer verdict 6).
+    /// Trailing front-app segment; off by default (ui-designer verdict 6).
     public var showFrontApp = false
-    /// Longest front-segment title drawn, in characters; read
-    /// through `resolvedTitleCap`, which clamps to
-    /// `AppBarStyle.titleCapRange` (the shared range, aliased
-    /// rather than re-declared like `BackgroundStyle` above).
-    ///
-    /// The segment cannot CLIP without it — `layoutFrontName`
-    /// already tail-truncates to the remaining viewport. The cap
-    /// exists because the render pass folds the segment's
-    /// estimated length into its alignment total
-    /// (`SpaceBarOverlay+Render`), so under `center` or `end` a
-    /// growing title slides the whole Space run sideways, and a
-    /// title grows on every keystroke.
+    /// Front-segment character limit to prevent layout shifts. Default 25.
     public var titleCap = 25
-    /// Hides empty spaces except the current one (verdict 4);
-    /// off by default.
+    /// Hides empty spaces except current; off by default (verdict 4).
     public var hideEmpty = false
-    /// Sticky/floating state badges on space items (#414):
-    /// sticky top-left, floating bottom-left (top-right stays
-    /// the group count). On by default and Lua-only
-    /// (`set_sticky_badge`, no GUI toggle) — in the bar there
-    /// is otherwise no way to tell tiled from floating, and a
-    /// sticky window is invisible state. Space Bar only; the
-    /// App Bar shows no state badges.
+    /// Sticky/floating state badges on space items (#414). Default true.
     public var stickyBadge = true
-    /// Drag-drop spring dwell (#372): how long a dragged window
-    /// must hover a Space item before the visible space springs
-    /// to it, in milliseconds. Read through `resolvedSpringDelay`,
-    /// which clamps to `springDelayRange`. Default 1500 (1.5 s).
-    /// (Named without the `MS` suffix so the reflected field name
-    /// snakes to the `spring_delay` key the parity guard expects.)
+    /// Drag-drop hover dwell before space spring switch (ms, #372).
+    /// Default 1500.
     public var springDelay = 1500
-    /// Inactive spaces: identifier + glyphs (muted tier).
-    /// KiwiCanopy theme; defaults mirrored as examples in
-    /// docs/lua-reference.md (Space Bar colors) — change both.
+    /// Inactive spaces accent color (#EAF3EE66).
     public var itemColor = "#EAF3EE66"
-    /// The active space's accent (identifier + its glyphs).
+    /// Active space accent color (#8DB354).
     public var activeItemColor = "#8DB354"
-    /// The focused window's accent, on two surfaces: its glyph
-    /// inside the active space, and the front-app segment (glyph
-    /// + name). Deliberately NOT the group-count badge's text —
-    /// that is ink on an independently chosen chip rather than on
-    /// the bar plate, so it keeps `groupBadgeTextColor` and lets
-    /// the alpha ladder carry focus (#470). A
-    /// genuinely different hue, not a tint of the active-space
-    /// color, so the two states read apart (QA 2026-07-19).
-    ///
-    /// Converged onto the palette in #470 by reusing the amber
-    /// the rebrand had *already* ratified for the drag drop-zone
-    /// (`DragVisual.dropZoneDefault`) rather than inventing a
-    /// hue: same H36 as the old `#E8A33D`, dropped L57% → L40%.
-    /// Here the **lightness** is load-bearing, not the hue: an
-    /// amber against a green primary is the axis red-green vision
-    /// loss erases, so keep that gap if this is retuned — a
-    /// lighter amber loses it. What survives the loss generally is
-    /// lightness *or* blue↔yellow, and #511's Kiwi Neon takes the
-    /// second road (green primary → cyan focused, near-equal
-    /// lightness); that road is closed here only because the
-    /// default's amber is fixed by the drag drop-zone above.
-    /// (`SpaceBarAccentSeparationTests` pins the floor,
-    /// docs/design-decisions.md carries the numbers.) Accepted
-    /// trade: focused now reads darker than the active green, not
-    /// brighter. Default mirrored in docs/lua-reference.md.
+    /// Focused window accent color on space bar and front-app segment (#470,
+    /// #511, QA 2026-07-19; `SpaceBarAccentSeparationTests`).
     public var focusedItemColor = "#C2790A"
     /// Hover tint on non-active space items.
     public var hoverFillColor = "#AACB5D80"
     public var hoverItemColor = "#EAF3EE"
-    /// The fill under the items — a box per Space (Boxed), one
-    /// shared plate (Plain), or the Liquid Glass tint (Material).
-    /// A cool-dark surface under the kiwi accent, 70% opaque to
-    /// match the App Bar (#660, retuned by #755 — the argument
-    /// is on `AppBarStyle.fillColor`).
+    /// Plate background fill (#14201CB3, #660, retuned by #755).
     public var fillColor = "#14201CB3"
     public var highlightColor = "#8DB354"
-    /// Count badges (grouped duplicates and the "+n" overflow),
-    /// shown in these colors on the active space and muted from
-    /// `itemColor` on inactive ones. Neutral grey by default for
-    /// the reason `AppBarStyle.groupBadgeColor` carries (#955) —
-    /// the two bars' badges are one idiom and move together.
+    /// Group count badge colors (#955).
     public var groupBadgeColor = "#636366"
     public var groupBadgeTextColor = "#FFFFFF"
 
     public init() {}
 
-    /// Liquid Glass paints only where the platform renders it —
-    /// false below macOS 26 even if `liquidGlass` is stored true.
+    /// True if Liquid Glass is enabled and supported on this platform.
     public var glassEnabled: Bool {
         liquidGlass && AppBarStyle.glassAvailable
     }
@@ -181,35 +83,13 @@ public struct SpaceBarStyle: Sendable, Equatable {
         backgroundStyle == .boxed && !glassEnabled
     }
 
-    /// `AppBarStyle.plateSpans`' twin — same rule, same
-    /// consult set (the Settings previews; the live bar
-    /// resolves through `BarPlate.frame`). Kept per struct
-    /// because each preview reads the style it draws.
+    /// Whether plate background spans entire screen width.
     public var plateSpans: Bool {
         !hasBox && backgroundFit == .full
     }
 
 }
 
-// MARK: - Codable
-
-/// The conformance is declared here, in the type's own file,
-/// because Swift only synthesizes `encode(to:)` where the
-/// conformance sits — a cross-file `extension … : Codable` would
-/// force a hand-written encode, i.e. exactly the mirrored field
-/// list `.claude/rules/parity-tests.md` says to avoid. The keys
-/// and the sparse decode live in `SpaceBarStyle+Coding.swift`.
-///
-/// This is the **opposite** placement from
-/// `TilingSettings+Coding.swift`, deliberately, and the two
-/// should not be "harmonized": that type hand-writes its encode,
-/// so it can keep the conformance next to the implementation and
-/// warns against a gutted extension re-synthesizing camelCase.
-/// `SpaceBarStyle` relies on synthesis instead, so its
-/// conformance has to stay here. The residual hazard — deleting
-/// or renaming `CodingKeys` in the other file would let both
-/// sides silently re-synthesize camelCase — is backstopped by
-/// `SpaceBarParityTests` (which references
-/// `CodingKeys.allCases`, so it stops compiling) and
-/// `SettingsCodingTests` (which pins the snake_case keys).
+/// Synthesized Codable conformance must stay in type's own file; backed by
+/// `SpaceBarParityTests` and `SettingsCodingTests`.
 extension SpaceBarStyle: Codable {}

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+Domain.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+Domain.swift
@@ -145,6 +145,9 @@ extension TrackLayout {
         let overflows =
             markerCount > normalCap || markerCount > geoCap
         guard overflows else { return (markerCount, false) }
+        // Auto (`normalCap == .max`) caps at the fit count; the
+        // branch also sidesteps `.max + 1`, which would overflow
+        // `Int`.
         let cap = min(
             normalCap == .max ? geoCap : normalCap + 1,
             geoCap

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+Domain.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+Domain.swift
@@ -1,30 +1,15 @@
 import CoreGraphics
 import Foundation
 
-/// The track layout's shared domain rules (#128), split from
-/// `TrackLayout` for file size (AGENTS.md §2): the break-marker
-/// partition and the slice arithmetic consumed by the layout
-/// math, the resize/navigate commands, and the state maintenance
-/// — single authorities so no two sites can disagree on where a
-/// track begins (the stack-domain parity precedent).
+/// Shared domain rules, break-marker partition, and capacity for Track
+/// layout (#128).
 extension TrackLayout {
-    /// The weight domain is shared with the stack layout (#67):
-    /// track weights and in-track window shares use the same
-    /// floor, store clamp and min-size cap, so `resize` steps
-    /// feel identical across both layouts and the formulas
-    /// cannot drift apart.
+    /// Shared weight domain with stack layout (#67).
     public static let weightFloor = StackLayout.weightFloor
     public static let weightRange = StackLayout.weightRange
 
-    /// The authoritative partition of a tiled window list: a
-    /// new track starts at index 0 and at every window carrying
-    /// a break marker (`Space.trackBreaks`); tracks past a
-    /// positive `cap` merge into the last allowed one. Break
-    /// markers are keyed by window, so a floating window (not
-    /// in `tiled`) simply does not split — no positional state
-    /// to reconcile. No markers means one track holding
-    /// everything (mode entry seeds every window as its own
-    /// track instead).
+    /// Partition of tiled windows into tracks via break markers
+    /// (`Space.trackBreaks`).
     public static func counts(
         of tiled: [WindowID],
         breaks: Set<WindowID>,
@@ -45,17 +30,7 @@ extension TrackLayout {
         return merged
     }
 
-    /// How many `minSize` tracks fit across `crossSpan` with
-    /// `gap` between them (#192): the read-time geometric cap
-    /// that forms the overflow track. `n` tracks need
-    /// `n·minSize + (n-1)·gap ≤ crossSpan`, so
-    /// `n = ⌊(crossSpan + gap) / (minSize + gap)⌋`. `minSize ≤ 0`
-    /// means no floor (unlimited), matching
-    /// `StackLayout.maxColumnTotal`; a span too small for even
-    /// one track returns 0 (the caller clamps to a single
-    /// overflow track, which then degenerates to the whole-space
-    /// cascade). Purely geometric — the surplus beyond this many
-    /// tracks folds into the last slot via `counts(cap:)`.
+    /// Geometric capacity of tracks fitting across `crossSpan` (#192).
     public static func fitCap(
         crossSpan: CGFloat,
         minSize: CGFloat,
@@ -66,8 +41,7 @@ extension TrackLayout {
         return Int((crossSpan + gap) / (minSize + gap))
     }
 
-    /// The consecutive index ranges the counts carve out of the
-    /// tiled window list.
+    /// Index ranges carved out by track counts.
     public static func ranges(of counts: [Int]) -> [Range<Int>] {
         var start = 0
         return counts.map { count in
@@ -76,8 +50,7 @@ extension TrackLayout {
         }
     }
 
-    /// Which track holds the window at tiled index `index`, or
-    /// nil when the index is outside the partition.
+    /// Track index containing the window at `index`.
     public static func trackIndex(
         ofWindowIndex index: Int,
         counts: [Int]
@@ -85,10 +58,7 @@ extension TrackLayout {
         ranges(of: counts).firstIndex { $0.contains(index) }
     }
 
-    /// A track's size weight: the head window's entry in
-    /// `Space.trackWeights` (absent = 1, an even share). The
-    /// head is the slice's first window — where `remove` and
-    /// `swap` keep the marker and its weight.
+    /// Track size weight from head window in `Space.trackWeights`.
     public static func weight(
         ofTrack range: Range<Int>,
         tiled: [WindowID],
@@ -97,13 +67,7 @@ extension TrackLayout {
         max(weights[tiled[range.lowerBound]] ?? 1, weightFloor)
     }
 
-    /// How many tracks physically fit in `context`'s usable
-    /// area (#192): the geometric cap that forms the overflow
-    /// track, from the cross-axis span, `min_window_size`, and
-    /// the inner gap. `max(1, …)` so a span too small for even
-    /// one track still yields a single (degenerate) track.
-    /// Shared by the layout math and `track.swap`'s guard (#198)
-    /// so neither can disagree on when the far-edge slot folds.
+    /// Number of tracks physically fitting in context (#192, #198).
     public static func geometricCap(
         for context: LayoutContext
     ) -> Int {
@@ -125,22 +89,7 @@ extension TrackLayout {
         )
     }
 
-    /// How many min-size windows fit stacked inside ONE track
-    /// along its in-track axis (#437, fill-then-spill): the
-    /// orthogonal of `geometricCap` (which caps how many *tracks*
-    /// fit across the cross-axis). A vertical track (column)
-    /// stacks its windows down `usable.height` with the vertical
-    /// inner gap; a horizontal track (row) runs them along
-    /// `usable.width`. Independent of the track count — every
-    /// track spans the full in-track axis — so it is a stable
-    /// per-display capacity. At equal track weights it matches the
-    /// count at which `trackFrames` starts piling (both go through
-    /// `StackLayout.maxColumnTotal` / `fitCap`), so a spawn spills
-    /// about when the render would otherwise cascade — a min-size
-    /// heuristic, since a resized (non-uniform) track can diverge by
-    /// a window. At least
-    /// 1 (a track always holds one window before spilling);
-    /// `.max` when there is no minimum.
+    /// In-track capacity for windows stacked in one track (#437).
     public static func trackCapacity(
         for context: LayoutContext
     ) -> Int {
@@ -160,13 +109,7 @@ extension TrackLayout {
         return cap == .max ? .max : max(1, cap)
     }
 
-    /// The break-marker seed that packs a tiled window list into
-    /// tracks of `capacity` each (#437): a break every `capacity`
-    /// windows, so entering track mode under fill-then-spill lays
-    /// the existing windows out as filled tracks — what
-    /// window-by-window spawning would have built — instead of one
-    /// column each. `capacity <= 0` (no minimum) is one track
-    /// holding everything, matching the seed's "no markers" case.
+    /// Break-marker seed for fill-then-spill packing (#437).
     public static func fillSeed(
         tiled: [WindowID],
         capacity: Int
@@ -180,21 +123,8 @@ extension TrackLayout {
         return breaks
     }
 
-    /// Whether the next window into the focused track opens a NEW
-    /// track beside it instead of joining — fill-then-spill
-    /// (#437). True when the focused track already holds as many
-    /// windows as fit at `min_window_size` (`spillCapacity`) AND
-    /// another track fits under `trackCap` (0 = unlimited, the
-    /// `auto_tracks` case). A nil `spillCapacity` disables the
-    /// spill entirely: the explicit-placement path, which must
-    /// join-and-pile rather than relocate a traveler.
-    ///
-    /// Single authority, for the same reason `overflowCap` is one
-    /// (#198): `insertIntoTrack` decides a real spawn with it and
-    /// the Layout Defaults preview draws its Track schematic from
-    /// it (#708). A preview that re-spelled this condition beside
-    /// its drawing would be right the day it was written and drift
-    /// the day the rule moved — which is the whole of #702.
+    /// Whether next window into focused track opens a new track
+    /// (#437, #708, #702).
     public static func spillsToNewTrack(
         focusedTrackCount: Int,
         trackCount: Int,
@@ -206,14 +136,7 @@ extension TrackLayout {
             && (trackCap == 0 || trackCount < trackCap)
     }
 
-    /// Resolves the marker-track count against the two caps the
-    /// layout applies — `normalCap` (the fixed `count`, or
-    /// `.max` when `auto_tracks` is on) and `geoCap` (how many
-    /// tracks fit) — into the effective render cap and whether a
-    /// far-edge overflow track exists (#192/#198). The cap is
-    /// what `counts(cap:)` folds the surplus into; not
-    /// overflowing leaves every marker track standing. Single
-    /// authority so the layout and the swap guard fold alike.
+    /// Resolves effective render cap and overflow status (#192, #198).
     public static func overflowCap(
         markerCount: Int,
         normalCap: Int,
@@ -222,10 +145,6 @@ extension TrackLayout {
         let overflows =
             markerCount > normalCap || markerCount > geoCap
         guard overflows else { return (markerCount, false) }
-        // Auto on (`normalCap == .max`) caps at the fit count;
-        // a fixed limit adds ONE overflow track past it, but
-        // never more than fits. `.max + 1` is sidestepped by the
-        // branch — it would overflow `Int`.
         let cap = min(
             normalCap == .max ? geoCap : normalCap + 1,
             geoCap
@@ -233,18 +152,8 @@ extension TrackLayout {
         return (cap, true)
     }
 
-    /// Whether `track.swap` must refuse because the swap would
-    /// disturb the folded overflow track (#198). The far-edge
-    /// slot folds ≥2 marker tracks — none keeping its marker
-    /// identity — whenever `markerCount` exceeds the effective
-    /// render cap, under BOTH a fixed limit AND geometric
-    /// pressure (`auto_tracks` on, a small display). Exchanging
-    /// that slot re-derives a different composition (windows
-    /// leak between tracks; #182 review H1), so a swap that
-    /// touches it — the focused window's own track or its
-    /// target — is rejected. A lone N+1th track folds nothing
-    /// and swaps freely, as do two normal tracks while an
-    /// overflow exists elsewhere.
+    /// Whether swap must be refused due to folded overflow track
+    /// (#198, #182, #944).
     public static func overflowSwapBlocked(
         tiled: [WindowID],
         breaks: Set<WindowID>,
@@ -253,18 +162,12 @@ extension TrackLayout {
         normalCap: Int,
         geoCap: Int
     ) -> Bool {
-        // The one fold assembly (`foldedPartition`): a hand
-        // copy here made swap refusals divergeable from the
-        // render on a fold-rule change (#944 review round 3).
         let partition = foldedPartition(
             of: tiled,
             breaks: breaks,
             normalCap: normalCap,
             geoCap: geoCap
         )
-        // A fold of ≥2 marker tracks, not merely an N+1th
-        // overflow slot: only a real merge loses marker
-        // identity.
         guard let folded = partition.overflowTrack,
             partition.markers > partition.cap
         else { return false }

--- a/Sources/KiwiDeskCore/Layouts/TrackParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackParams.swift
@@ -1,125 +1,48 @@
 import Foundation
 
-/// Track layout tuning (#128): axis, track cap, where a new
-/// window's track comes from, and the focus-wrap toggle. In its
-/// own file like `GridParams` (file size).
-///
-/// The track layout is #67's stack model promoted to first
-/// class: windows stay in the flat per-space array, and break
-/// markers (`Space.trackBreaks`) partition the tiled list into
-/// consecutive slices — the tracks. `masterCount` generalized
-/// from one number to a partition; never a tree.
+/// Track layout parameters (#128, #67; partitions via `Space.trackBreaks`).
 public struct TrackParams: Sendable, Equatable, Codable {
-    /// Which way a track runs. Vertical tracks are columns
-    /// side by side (windows stack vertically inside one);
-    /// horizontal tracks are rows (scrolling's axis
-    /// precedent).
     public enum Axis: String, Sendable, Codable, CaseIterable {
         case vertical
         case horizontal
     }
 
-    /// Whether a new window fills the focused track (spilling into
-    /// a new one when it is full) or opens its own track (#128,
-    /// redefined #437). Where within that choice it lands is the
-    /// orthogonal `newWindowPosition`.
+    /// Placement policy for newly spawned windows (#128, #437).
     public enum NewWindowTrack: String, Sendable, Codable, CaseIterable {
-        /// The window opens its own new track; `newWindowPosition`
-        /// places that track among the others. Falls back to
-        /// joining once the track cap is reached. The "one
-        /// full-width app per column" (ultrawide) choice.
         case ownTrack = "own_track"
-        /// Fill-then-spill (#437, the default): the window joins
-        /// the focused window's track, and `newWindowPosition`
-        /// places it among that track's windows — until the track
-        /// can't fit another window at `min_window_size`, when the
-        /// window instead spills into a NEW track beside the
-        /// focused one (focus follows it, so the next window fills
-        /// that track and spills again). With no other track to
-        /// spill to — a fixed `count` cap with no room, or a
-        /// traveler dropped by `move_to_space` — it piles in the
-        /// focused track instead (the overflow fallback).
         case focusedTrack = "focused_track"
     }
 
     public var axis: Axis = .vertical
-    /// Whether the track limit is managed automatically (#178):
-    /// on (the default), tracks open and collapse as windows come
-    /// and go — no cap. Off pins the cap to `limit`. The
-    /// carousel-vs-grid twin of `GridParams.autoSize`. The layout
-    /// reads `limit` directly for the normal/overflow split
-    /// (#192); spawn, navigation, and swap read `trackCap`
-    /// (= `limit + 1`, the overflow track included).
+    /// Dynamic track limit management (#178).
     public var autoTracks = true
-    /// The fixed maximum number of tracks used when `autoTracks`
-    /// is off (the remembered magnitude, so toggling auto off
-    /// restores it instead of resetting). A *cap* that automatic
-    /// tracks overrides, not a count of what exists — hence
-    /// `limit`, matching the GUI's own "Track limit" (R6/#406).
-    /// Ignored while `autoTracks` is on. The live partition is
-    /// session state (`Space.trackBreaks`), like `stackWeights`.
+    /// Fixed maximum number of tracks when `autoTracks` is false (R6/#406).
     public var limit: Int = 2
     public var newWindow: NewWindowTrack = .focusedTrack
-    /// Where a new window lands within the `newWindow` choice,
-    /// reusing the shared `SpawnPlacement` vocabulary. For
-    /// `own_track` it positions the new track among the others
-    /// (`first` = leftmost column / topmost row, `last` = the
-    /// far edge, `before`/`after_focused` = beside the focused
-    /// track); for `focused_track` it positions the window among
-    /// that track's windows. `.first` by default so a new window
-    /// is never buried in the overflow. Per-layout, not
-    /// per-space: excluded from `TrackOverride` like `newWindow`.
+    /// Position of new window within target track.
     public var newWindowPosition: SpawnPlacement = .first
-    /// How the **overflow track** renders (#192): the far-edge
-    /// track that collects the surplus when more tracks exist
-    /// than fit side by side at `min_window_size`. The same
-    /// `cascade_overflow` / `cascade_all` choice as stack, but
-    /// track defaults to **`cascade_all`** — its windows stack
-    /// from the top as a clean title-bar pile. Applies ONLY to
-    /// the overflow track; every normal track's own overflow is
-    /// always `cascade_overflow`. Per-space via `TrackOverride`.
+    /// Rendering style for overflow track (#192).
     public var overflowStyle: StackParams.OverflowStyle =
         .cascadeAll
-    /// Whether stepping `focus` past an end wraps to the far
-    /// end (#168 twin): along the axis it wraps within the
-    /// focused track, across it wraps last <-> first track.
-    /// OFF by default; `swap` and `move_to_track` never wrap.
-    /// Per-layout, not per-space: excluded from
-    /// `TrackOverride` like `newWindow`.
+    /// Wraps focus navigation past ends (#168).
     public var wrapFocus = false
-    /// Per-space overrides (`layout.track.override[space_id]`),
-    /// resolved via `TilingSettings.resolvedTrack(for:)`.
+    /// Per-space overrides.
     public var override: [SpaceID: TrackOverride] = [:]
 
     public init() {}
 
-    /// The hard cap on **marker** tracks that spawn, navigation,
-    /// and swap enforce: 0 (unlimited, dynamic) while `autoTracks`
-    /// is on, otherwise `limit + 1` (#192) — the fixed `limit`
-    /// **normal** tracks plus the one extra **overflow track**
-    /// that catches the surplus. A new `own_track` window past
-    /// `limit` therefore opens the overflow track rather than
-    /// joining an existing one. The layout reads `limit` directly
-    /// for the normal/overflow split; everything that moves
-    /// windows between tracks reads this so none can disagree on
-    /// where the last track is.
+    /// Hard cap on tracks (0 = unlimited, otherwise limit + 1 for overflow,
+    /// #192).
     public var trackCap: Int {
         autoTracks ? 0 : max(1, limit) + 1
     }
 
-    /// The **normal**-track capacity the render and every
-    /// overflow-fold guard gauge against (#192/#198): `.max`
-    /// (geometry alone caps) while `auto_tracks` is on, else the
-    /// fixed `limit`. The `.max` sentinel is the contract
-    /// `TrackLayout.overflowCap` reads (`normalCap == .max` = no
-    /// limit fold). Sibling of `trackCap`; both live here so no
-    /// site re-derives the fixed-cap rule and drifts from the
-    /// layout (the shared-authority precedent that #198 closed).
+    /// Normal track capacity before overflow fold (#192, #198; read by
+    /// `TrackLayout.overflowCap`).
     public var normalCap: Int {
         autoTracks ? .max : max(1, limit)
     }
 
-    /// JSON keys follow the Lua setters (`track.set_axis`).
     private enum CodingKeys: String, CodingKey {
         case axis
         case autoTracks = "auto_tracks"
@@ -131,8 +54,6 @@ public struct TrackParams: Sendable, Equatable, Codable {
         case override
     }
 
-    /// Manual decoding: profiles saved before a field existed
-    /// must keep loading (missing keys fall back to defaults).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self
@@ -179,8 +100,6 @@ public struct TrackParams: Sendable, Equatable, Codable {
             ) ?? [:]
     }
 
-    /// Manual encode so the per-space override map stays sparse
-    /// (absent when empty), unlike the synthesized encode.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(axis, forKey: .axis)

--- a/Sources/KiwiDeskCore/Models/SpaceModel.swift
+++ b/Sources/KiwiDeskCore/Models/SpaceModel.swift
@@ -207,6 +207,10 @@ public struct Space: Sendable, Equatable {
         windows.removeAll { $0 == window }
         stackWeights[window] = nil
         if focused == window {
+            // The neighbor that slid into the removed slot — not
+            // `windows.last` unconditionally, which yanked focus
+            // across the whole scrolling row when a middle window
+            // closed.
             focused =
                 removedIndex.flatMap {
                     windows.indices.contains($0) ? windows[$0] : nil
@@ -231,6 +235,8 @@ public struct Space: Sendable, Equatable {
                 trackBreaks.insert(a)
             }
         }
+        // Index 0 is an IMPLICIT head, so its weight stays at the
+        // slot even though it may carry no explicit marker.
         if aBreak || bBreak || i == 0 || j == 0 {
             let weight = trackWeights[a]
             trackWeights[a] = trackWeights[b]

--- a/Sources/KiwiDeskCore/Models/SpaceModel.swift
+++ b/Sources/KiwiDeskCore/Models/SpaceModel.swift
@@ -1,11 +1,7 @@
 import CoreGraphics
 import Foundation
 
-/// Identifier of a Space (space).
-///
-/// Spaces support arbitrary string identifiers ("mail", "α", "🎵").
-/// Identifiers are case-sensitive, but numeric strings and plain
-/// integers are equivalent: `SpaceID("1") == SpaceID(1)`.
+/// Identifier of a Space (case-sensitive strings, integer-canonicalized).
 public struct SpaceID: Hashable, Sendable, Codable,
     CustomStringConvertible, ExpressibleByStringLiteral,
     ExpressibleByIntegerLiteral
@@ -13,8 +9,6 @@ public struct SpaceID: Hashable, Sendable, Codable,
     public let raw: String
 
     public init(_ raw: String) {
-        // Canonicalize integer-valued strings ("01" -> "1") so
-        // numeric strings and integers compare as equal.
         if let n = Int(raw) {
             self.raw = String(n)
         } else {
@@ -36,12 +30,6 @@ public struct SpaceID: Hashable, Sendable, Codable,
 
     public var description: String { raw }
 
-    // MARK: - Codable
-
-    /// Encodes as its bare string ("1", "mail") — never as a
-    /// keyed `{"raw": ...}` object — so ids read naturally in
-    /// profile JSON. Decoding accepts strings and integers
-    /// (hand-edited files may write `1` for `"1"`).
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let number = try? container.decode(Int.self) {
@@ -57,15 +45,8 @@ public struct SpaceID: Hashable, Sendable, Codable,
     }
 }
 
-// MARK: - Ordering helpers
-
 extension SpaceID {
-    /// Sorts space IDs: numeric ids ascending, then named ids
-    /// alphabetically. Stable within equal-valued elements.
-    ///
-    /// Shared by `Profile.orderedSpaces` and
-    /// `GuiConfig` sort helpers — the single canonical
-    /// numeric-then-lexical comparator for space lists.
+    /// Sorts space IDs: numeric IDs ascending, then named IDs alphabetically.
     public static func numericLexicalSorted(
         _ ids: [SpaceID]
     ) -> [SpaceID] {
@@ -80,9 +61,6 @@ extension SpaceID {
     }
 
     /// Order-preserving de-duplication: first occurrence wins.
-    ///
-    /// Shared by `Profile` and `GuiConfig` — the single
-    /// canonical dedup helper for space ID arrays.
     public static func deduplicated(
         _ ids: [SpaceID]
     ) -> [SpaceID] {
@@ -91,8 +69,6 @@ extension SpaceID {
     }
 }
 
-/// Dictionaries keyed by SpaceID serialize as JSON objects
-/// (`{"2": ...}`) instead of flattened key/value arrays.
 extension SpaceID: CodingKeyRepresentable {
     struct RawKey: CodingKey {
         let stringValue: String
@@ -126,80 +102,34 @@ public enum LayoutMode: String, Sendable, Codable, CaseIterable {
     case track
     case floating
 
-    /// Whether the layout's output depends on which window
-    /// is focused, requiring a retile on focus changes.
+    /// True if layout output depends on focused window.
     public var isFocusDriven: Bool {
         self == .scrolling || self == .monocle
     }
 
-    /// Whether a focus move defers its AX raise until the
-    /// focus retile's animations settle (#143). Scrolling
-    /// only: raising first pops a top-pinned row over the
-    /// screen before the pan starts. Monocle must stay
-    /// raise-first — all its windows share one frame, so the
-    /// raise IS the visible focus change. Must stay a subset
-    /// of `isFocusDriven`: the deferred raise is armed on the
-    /// focus retile that predicate gates.
+    /// True if focus move defers AX raise until animations settle (#143).
     public var defersFocusRaise: Bool {
         self == .scrolling
     }
 }
 
-/// A Space holding its windows as a flat 1D array.
-///
-/// This is the core KiwiDesk idea: no trees, no containers. Layout
-/// algorithms are pure functions over `windows`.
+/// Space holding windows as a flat 1D array.
 public struct Space: Sendable, Equatable {
     public let id: SpaceID
     public var mode: LayoutMode
     public var windows: [WindowID]
     public var focused: WindowID?
-    /// Per-window vertical share of a stack column (#67):
-    /// absent = 1.0 = an even share; `resize("y")` bumps the
-    /// focused window's entry. A parallel map next to the flat
-    /// array — never a tree. Ephemeral by design: WindowIDs
-    /// are OS handles, unstable across relaunch, so there is
-    /// nothing to persist the weights against (see
-    /// docs/design-decisions.md); pruned when a window leaves
-    /// the space.
+    /// Per-window vertical share in stack column (#67).
     public var stackWeights: [WindowID: Double]
-    /// The scrolling layout's last-computed viewport rest (#66)
-    /// — the offset and the slot it was measured against (#966,
-    /// `ScrollRest`). `nil` means "never scrolled yet" (fresh
-    /// space or mode switch), so the layout falls back to
-    /// centering on the anchor instead of scrolling minimally
-    /// from a stale position. Ephemeral like `stackWeights` —
-    /// never persisted, cleared only on an actual mode change
-    /// (`setMode`). An emptied space keeps its last value;
-    /// harmless, every consumer re-clamps it against the live
-    /// row.
+    /// Scrolling layout last-computed viewport rest
+    /// (#66, #966, `ScrollRest`).
     public var scrollRest: ScrollRest?
-    /// The track layout's boundaries (#128): a window in this
-    /// set STARTS a new track; the partition of the tiled
-    /// window list falls out of the flat array order plus these
-    /// markers (`TrackLayout.counts`) — `masterCount`
-    /// generalized, never a tree. Keyed by WindowID like
-    /// `stackWeights` (not positional) so floating windows drop
-    /// out of the partition with zero maintenance and removal
-    /// prunes naturally; a dying head hands its break to its
-    /// successor (`remove`), and `swap` keeps boundaries at the
-    /// slot, not on the traveling window. Ephemeral: what
-    /// persists is the *rule* (`layout.track.limit`/`axis`).
-    /// Seeded to all windows on mode entry, cleared on leave.
+    /// Track layout track boundary markers (#128, `TrackLayout.counts`).
     public var trackBreaks: Set<WindowID>
-    /// Per-track size weight, keyed by the track's head window
-    /// (#128): absent = 1.0 = an even share; `resize` across
-    /// the axis bumps the focused window's track entry.
-    /// Session-only like `stackWeights`; travels with the break
-    /// marker.
+    /// Per-track weight keyed by head window (#128).
     public var trackWeights: [WindowID: Double]
-    /// Interactive-resize ratio layer (#458): the value a
-    /// resize wrote for THIS space when no config override of
-    /// the field exists — so resizing a no-override space no
-    /// longer moves every other no-override space through the
-    /// global. Session-only like `stackWeights` (never
-    /// persisted); cleared on an actual mode change and on
-    /// config reload. See `SessionRatios`.
+    /// Session-only interactive resize ratio overrides
+    /// (#458, `SessionRatios`).
     public var sessionRatios: SessionRatios
 
     public init(
@@ -224,15 +154,13 @@ public struct Space: Sendable, Equatable {
         self.sessionRatios = sessionRatios
     }
 
-    /// Appends a window if it is not already present.
+    /// Appends window if not already present.
     public mutating func append(_ window: WindowID) {
         guard !windows.contains(window) else { return }
         windows.append(window)
     }
 
-    /// Inserts a window right after another one (BSP: a new
-    /// window splits the FOCUSED window's region). Falls back
-    /// to appending when the anchor is unknown.
+    /// Inserts window immediately after anchor or appends if anchor missing.
     public mutating func insert(
         _ window: WindowID,
         after anchor: WindowID?
@@ -247,10 +175,7 @@ public struct Space: Sendable, Equatable {
         }
     }
 
-    /// Inserts a window per the layout's spawn placement rule
-    /// (`new_window_placement`); the focused window anchors
-    /// the relative placements, falling back to appending
-    /// when there is none.
+    /// Inserts window per layout spawn placement rule.
     public mutating func insert(
         _ window: WindowID,
         placement: SpawnPlacement
@@ -274,25 +199,14 @@ public struct Space: Sendable, Equatable {
         }
     }
 
-    /// Removes a window; hands focus to the spatial neighbor if
-    /// it was focused, and prunes its stack weight (#67).
+    /// Removes window, updating track heads (#128) and neighbor focus (#67).
     public mutating func remove(_ window: WindowID) {
         let removedIndex = windows.firstIndex(of: window)
-        // A departing track head hands its break (and the
-        // track's weight) to its successor, so closing the
-        // first window of a track does not merge that track
-        // away (#128).
         handTrackBreakToSuccessor(of: window)
         trackWeights[window] = nil
         windows.removeAll { $0 == window }
         stackWeights[window] = nil
         if focused == window {
-            // Fall back to the window that slid into the removed
-            // slot (the neighbor further along the array), or the
-            // new last window when the removed one was at the end.
-            // Not `windows.last` unconditionally — that yanked
-            // focus across the whole scrolling row when a middle
-            // window closed, panning every window to the far end.
             focused =
                 removedIndex.flatMap {
                     windows.indices.contains($0) ? windows[$0] : nil
@@ -300,13 +214,7 @@ public struct Space: Sendable, Equatable {
         }
     }
 
-    /// Swaps the positions of two windows in the flat array.
-    /// Track boundaries are positional: a break marker (and the
-    /// head weight riding it) stays at the slot, not on the
-    /// traveling window, so swapping two windows never moves a
-    /// track boundary (#128). Index 0 is an *implicit* head, so
-    /// its weight must stay at the slot too even though it may
-    /// carry no explicit marker.
+    /// Swaps positions of two windows preserving track boundary slots (#128).
     public mutating func swap(_ a: WindowID, _ b: WindowID) {
         guard let i = windows.firstIndex(of: a),
             let j = windows.firstIndex(of: b)
@@ -315,8 +223,6 @@ public struct Space: Sendable, Equatable {
         let aBreak = trackBreaks.contains(a)
         let bBreak = trackBreaks.contains(b)
         if aBreak != bBreak {
-            // Move the explicit marker to the window that now
-            // holds the head slot.
             if aBreak {
                 trackBreaks.remove(a)
                 trackBreaks.insert(b)
@@ -325,10 +231,6 @@ public struct Space: Sendable, Equatable {
                 trackBreaks.insert(a)
             }
         }
-        // Swap the head weight whenever either slot is a head —
-        // an explicit marker OR index 0 (the implicit first
-        // head), so an index-0 head's weight can't travel with
-        // the moved window.
         if aBreak || bBreak || i == 0 || j == 0 {
             let weight = trackWeights[a]
             trackWeights[a] = trackWeights[b]
@@ -336,7 +238,7 @@ public struct Space: Sendable, Equatable {
         }
     }
 
-    /// Moves a window to a new index, clamped to valid bounds.
+    /// Moves window to clamped target index.
     public mutating func move(_ window: WindowID, to index: Int) {
         guard let from = windows.firstIndex(of: window) else {
             return

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -71,6 +71,9 @@ public final class ExecLauncher {
 
         let key = ObjectIdentifier(process)
 
+        // Install before run(): a fast child may exit before
+        // launch() returns, and a handler set after the fact would
+        // never fire.
         process.terminationHandler = { [weak self] child in
             let code = child.terminationStatus
             let deliver: @Sendable (String, String) -> Void = {
@@ -172,7 +175,13 @@ public final class ExecLauncher {
         UInt64(max(0, seconds) * 1_000_000_000)
     }
 
-    /// Cancels timeout watchdogs on teardown without killing children.
+    /// Cancels timeout watchdogs on teardown without killing
+    /// children — a `timeout` armed before a mid-session stop must
+    /// not SIGTERM after management tore down. Accepted trade: a
+    /// child ALREADY stuck at that instant leaks its `running`
+    /// entry for the process life (its command stays
+    /// dedup-blocked); clearing here would be worse — a later EOF
+    /// reap would find no entry and leak its Lua callback ref.
     func cancelWatchdogs() {
         for key in Array(running.keys) {
             running[key]?.watchdog?.cancel()
@@ -187,6 +196,10 @@ public final class ExecLauncher {
         stdout: String,
         stderr: String
     ) {
+        // Idempotent: the EOF path and the timeout force-reap can
+        // both target the same child; whichever runs first wins,
+        // so `onExit` (which releases the Lua ref) fires exactly
+        // once.
         guard let child = running[key] else { return }
         child.watchdog?.cancel()
         running[key] = nil

--- a/Sources/KiwiDeskCore/OS/ExecLauncher.swift
+++ b/Sources/KiwiDeskCore/OS/ExecLauncher.swift
@@ -1,35 +1,8 @@
 import Foundation
 import os
 
-/// Launches external commands without ever blocking the main
-/// thread (issue #5): `KiwiDesk.exec` and the async
-/// `os.execute` replacement both funnel through here.
-///
-/// Each command runs as `/bin/sh -c <command>`. The launcher
-/// never waits for the child; the optional `onExit` closure is
-/// invoked back on the main actor once the child exits, with
-/// `(exit_code, stdout, stderr)`. Output pipes are only created
-/// when a closure exists, and they are drained via
-/// `readabilityHandler` — no thread is ever blocked waiting
-/// for a child. The main thread never touches a pipe, so even
-/// a child that leaves grandchildren holding the descriptors
-/// open can only delay its own callback, never stall the app.
-///
-/// **Child quit policy:** children are fire-and-forget.
-/// `KiwiCore.stop()` neither terminates nor waits for them —
-/// they re-parent to launchd and finish on their own. This is
-/// intentional: hooks like `sketchybar --notify` should
-/// complete even as KiwiDesk quits. Note `stop()` also runs
-/// mid-session on an AX-permission revoke (after which
-/// `start()` may reuse this same launcher), so it calls
-/// `cancelWatchdogs()` — a `timeout` armed before the stop must
-/// not SIGTERM a child once management has torn down. Use the
-/// optional `timeout` parameter for per-command control.
-///
-/// The launcher knows nothing about Lua: callers bind their
-/// own callback lifetime into `onExit` (see
-/// `KiwiCore+ExecAPI`, which captures the owning interpreter
-/// weakly so a config reload drops pending callbacks).
+/// Launches external commands non-blockingly via `/bin/sh -c` (#5).
+/// Children are fire-and-forget; callbacks and timeouts run asynchronously.
 @MainActor
 public final class ExecLauncher {
     public typealias ExitHandler =
@@ -37,66 +10,31 @@ public final class ExecLauncher {
 
     public var onLog: @MainActor (String) -> Void = CoreLog.write
 
-    /// A launched child and its optional timeout watchdog, kept
-    /// together so the two can never desync — one table, one
-    /// count. The `Process` must stay alive until termination or
-    /// its handlers never fire. `command` is kept so the reap can
-    /// find and decrement this child's in-flight tally.
+    /// Launched child process, command string, and optional timeout watchdog.
     private struct Child {
         let process: Process
         let command: String
         var watchdog: Task<Void, Never>?
     }
 
-    /// Children we have launched and not yet reaped, keyed by
-    /// object identity (pids can be recycled).
+    /// Active children keyed by ObjectIdentifier (avoiding pid reuse).
     private var running: [ObjectIdentifier: Child] = [:]
 
-    /// In-flight count per exact command string, powering the
-    /// `dedup` skip (#467). A wedged receiver (e.g. a sketchybar
-    /// daemon that never answers) otherwise lets per-event hook
-    /// pokes pile up without bound; deduping caps it at one stuck
-    /// child per distinct command. Reference-counted so a
-    /// legitimately-parallel non-deduped launch of the same
-    /// command still tears down cleanly.
+    /// In-flight tally per command for `dedup` (#467).
     private var inFlight: [String: Int] = [:]
 
-    /// `runningCount` value at which `launch` warns that a hook
-    /// command may be hanging (#467). Discoverable without polling
-    /// `get_state.exec_running`.
+    /// Warning threshold for outstanding children (#467).
     private static let warnThreshold = 20
 
-    /// One-shot latch for the `warnThreshold` warning: set when the
-    /// outstanding count first reaches the threshold, re-armed once
-    /// it falls back below. Without it a monotonic pile-up (the
-    /// #467 scenario) would warn only on the single `== threshold`
-    /// launch and a count flapping across the line would re-warn
-    /// every crossing.
+    /// Latch for `warnThreshold` warning (#467).
     private var highWaterWarned = false
 
     public init() {}
 
-    /// Number of children that have been launched and not
-    /// yet reaped. Exposed in `get_state` as `exec_running`.
+    /// Number of children currently active and un-reaped (`exec_running`).
     public var runningCount: Int { running.count }
 
-    /// Starts `command` and returns its pid, or nil when the
-    /// child could not be spawned.
-    ///
-    /// If `timeout` is given (seconds), the child receives
-    /// SIGTERM after that interval if it has not already
-    /// exited; the `onExit` callback is still invoked with
-    /// the termination code.
-    ///
-    /// When `dedup` is true and an identical `command` string is
-    /// already in flight, the spawn is skipped and nil returned
-    /// (the caller releases any callback ref, as on a failed
-    /// spawn). For trigger-style pokes that just re-poke a
-    /// receiver this is correct semantics — a second poke while
-    /// one is pending adds nothing — and it bounds accumulation
-    /// against a wedged receiver (#467). `dedup` defaults to
-    /// `false` here (a raw, policy-free primitive); the opinionated
-    /// default-on lives at the Lua boundary in `KiwiCore+ExecAPI`.
+    /// Starts `command` returning child pid or nil on failure (#467, #489).
     @discardableResult
     public func launch(
         _ command: String,
@@ -125,28 +63,14 @@ public final class ExecLauncher {
             process.standardError = pipes.err
             capture = OutputCapture(pipes.out, pipes.err)
         } else {
-            // Fire-and-forget: nobody reads the output, so give
-            // the child the null device instead of letting it
-            // inherit ours. An inherited pipe outlives us in a
-            // long-lived child (a wedged `sketchybar --trigger`),
-            // and whoever reads our stdout then waits for an EOF
-            // that never comes — the #489 test-runner hang, where
-            // the child held the swiftpm runner's pipe hostage.
+            // Null device avoids holding test runner pipes open (#489).
             process.standardOutput = FileHandle.nullDevice
             process.standardError = FileHandle.nullDevice
             capture = nil
         }
 
-        // Compute the bookkeeping key before the handler so
-        // the handler can close over it directly rather than
-        // re-deriving it from the Process object.
         let key = ObjectIdentifier(process)
 
-        // Install before run(): a fast child may exit before
-        // launch() returns, and a handler set after the fact
-        // would never fire. The main-actor reap cannot race
-        // the bookkeeping below — it only runs once launch()
-        // has returned control to the main actor.
         process.terminationHandler = { [weak self] child in
             let code = child.terminationStatus
             let deliver: @Sendable (String, String) -> Void = {
@@ -201,17 +125,11 @@ public final class ExecLauncher {
         return process.processIdentifier
     }
 
-    /// Grace after SIGTERM for the normal EOF-driven reap to
-    /// land before the watchdog force-reaps (seconds).
+    /// Grace period after SIGTERM before force-reaping (seconds).
     private static let reapGrace: TimeInterval = 2
 
-    /// Builds a timeout watchdog: SIGTERM at `timeout`, then a
-    /// short grace for the normal EOF-driven reap to land. If the
-    /// child is still un-reaped after that — e.g. it left a
-    /// grandchild holding the output pipe open, so EOF never
-    /// arrives — force-reap with whatever was captured, so the
-    /// bookkeeping entry and any Lua callback ref are released
-    /// instead of leaking (#37 review).
+    /// Creates timeout watchdog sending SIGTERM and force-reaping on grace
+    /// (#37).
     private func makeWatchdog(
         key: ObjectIdentifier,
         command: String,
@@ -254,29 +172,8 @@ public final class ExecLauncher {
         UInt64(max(0, seconds) * 1_000_000_000)
     }
 
-    /// Cancels outstanding timeout watchdogs without disturbing
-    /// the children. Called from `KiwiCore.stop()`: a `timeout`
-    /// armed before a mid-session stop (AX-permission revoke,
-    /// which may `start()` again on this same launcher) must not
-    /// SIGTERM or force-reap a child after teardown. Children
-    /// stay fire-and-forget.
-    ///
-    /// Trade-off: this also voids the force-reap for a child that
-    /// is *already stuck* (grandchild holding the pipe, so EOF
-    /// never arrives) when the stop fires — its `running` entry
-    /// then leaks for the life of the process (`exec` outlives a
-    /// stop/start), inflating `runningCount` and (its `inFlight`
-    /// tally riding along) keeping that exact command deduped
-    /// away — even if the receiver later recovers, so a
-    /// transiently-wedged command can stay dedup-blocked for the
-    /// process life. Accepted (documented as a limitation): the
-    /// window is tiny (a stop must fire while a child holds the
-    /// pipe past EOF), and clearing the entries here would be
-    /// wrong — a later EOF `reap` of that child would then find no
-    /// entry and leak its Lua callback ref. Avoiding a
-    /// post-teardown SIGTERM outweighs the corner.
+    /// Cancels timeout watchdogs on teardown without killing children.
     func cancelWatchdogs() {
-        // Snapshot the keys: the loop mutates `running`.
         for key in Array(running.keys) {
             running[key]?.watchdog?.cancel()
             running[key]?.watchdog = nil
@@ -290,12 +187,6 @@ public final class ExecLauncher {
         stdout: String,
         stderr: String
     ) {
-        // Idempotent: the normal EOF path and the timeout
-        // force-reap can both target the same child. Whichever
-        // runs first wins; the other finds no entry and is a
-        // no-op — so `onExit` (which releases the Lua ref) fires
-        // exactly once. Both run on the main actor, so the
-        // check-and-clear can't interleave.
         guard let child = running[key] else { return }
         child.watchdog?.cancel()
         running[key] = nil
@@ -310,11 +201,7 @@ public final class ExecLauncher {
         onExit?(code, stdout, stderr)
     }
 
-    /// GUI apps inherit launchd's minimal PATH, not the
-    /// user's shell PATH — `sketchybar`, `borders`, etc. live
-    /// in the Homebrew prefix and would be "command not
-    /// found" in production while working in
-    /// terminal-launched dev runs.
+    /// Augments environment PATH with Homebrew directories.
     private static func childEnvironment() -> [String: String] {
         var env = ProcessInfo.processInfo.environment
         var parts = (env["PATH"] ?? "")

--- a/Sources/KiwiDeskCore/OS/NativeSpaces+Desktop.swift
+++ b/Sources/KiwiDeskCore/OS/NativeSpaces+Desktop.swift
@@ -45,7 +45,10 @@ public struct DesktopSnapshot: Sendable {
             .sorted()
     }
 
-    /// True if current space on display is a user space (#670).
+    /// True if the current space on the display is a user space
+    /// (#670). True for an unknown screen: standing down needs
+    /// positive evidence of a fullscreen/system space, never a
+    /// lookup miss.
     public func currentSpaceIsUser(on uuid: String?) -> Bool {
         guard let uuid, let id = currentSpaces[uuid] else {
             return true

--- a/Sources/KiwiDeskCore/OS/NativeSpaces+Desktop.swift
+++ b/Sources/KiwiDeskCore/OS/NativeSpaces+Desktop.swift
@@ -1,82 +1,33 @@
 import CoreGraphics
 import Foundation
 
-/// One switch's reading of the desktop topology (#888): the
-/// active-Desktop authority and every screen's current Space,
-/// taken from ONE `allSpaces()` snapshot.
-///
-/// One value rather than two reads, because the switch handler
-/// and the event emit ask the same question — *which screen
-/// switched, and to what* — and two readings taken moments apart
-/// can disagree (review, 2026-08-18). Whoever handles a switch
-/// reads this once and passes it on.
+/// Single snapshot of desktop topology across displays
+/// (#888, review 2026-08-18).
 public struct DesktopSnapshot: Sendable {
-    /// The Mission Control number of the MAIN screen's current
-    /// Desktop, or nil when that Desktop is a fullscreen/system
-    /// space, or without SkyLight (callers treat nil as
-    /// single-space, as with `activeSpaceNumber()`).
+    /// Mission Control number of main screen's desktop (nil if fullscreen).
     public let authority: Int?
-    /// UUID of the main screen, or nil when the topology cannot
-    /// name it (no SkyLight, no display-UUID symbol, or shared
-    /// mode's synthetic managed-display identifier).
+    /// UUID of the main screen.
     public let mainUUID: String?
-    /// Each screen's current Space, keyed by its display UUID
-    /// (SkyLight's own key name).
+    /// Each screen's current Space ID keyed by display UUID.
     public let currentSpaces: [String: SkyLight.SpaceID]
-    /// The spaces the snapshot was read from — so a consumer can
-    /// number a Space in the SAME topology the authority was
-    /// counted in.
+    /// Raw native spaces in this snapshot.
     public let spaces: [NativeSpace]
 
-    /// The Mission Control number of `space` in this snapshot.
+    /// Mission Control number of `space` in this snapshot.
     public func number(of space: SkyLight.SpaceID) -> Int? {
         NativeSpaces.number(of: space, in: spaces)
     }
 
-    /// The Desktop carrying Mission Control `number`, or nil
-    /// when no user Desktop has it.
-    ///
-    /// The INVERSE of `number(of:)`, and derived from it rather
-    /// than re-deriving the rule: #25's own note asks that bind
-    /// targets and move targets agree, and a second copy of
-    /// "filter `isUser`, take position n" is what would shift
-    /// which Desktop a number means when the numbering changes
-    /// (the collector's KV-identity item is queued to change
-    /// it). One authority, read both ways.
+    /// Returns Desktop carrying Mission Control `wanted` number (#25).
     public func space(numbered wanted: Int) -> NativeSpace? {
         spaces.first { number(of: $0.id) == wanted }
     }
 
-    /// The Mission Control numbers of the MAIN screen's user
-    /// Desktops, ascending — the Desktops a binding can fire on
-    /// in this arrangement (#888).
-    ///
-    /// **Numbers, never positions.** Mission Control counts
-    /// across every screen, and a binding keys on that global
-    /// number, so a consumer may narrow WHICH Desktops it offers
-    /// but must keep each one's number: depending on SkyLight's
-    /// screen order the main screen's Desktops can be 3 and 4.
-    ///
-    /// Every user Desktop when the main screen cannot be named
-    /// (no SkyLight, shared mode's synthetic managed-display
-    /// identifier) — in shared mode every Desktop IS the main
-    /// screen's, so the degenerate case answers exactly as it
-    /// did before this existed.
-    ///
-    /// **Not the only answer, and not the default one.** This
-    /// is what a *binding* can fire on; `userDesktops` is what
-    /// a Desktop *verb* can reach, which is every screen's. A
-    /// consumer picks by what it offers — the pair is stated on
-    /// both accessors because this is the one a caller already
-    /// reaches for, and the names do not contrast on the axis
-    /// that separates them.
+    /// Mission Control numbers of MAIN screen's user Desktops (#888).
     public var mainDisplayDesktops: [Int] {
         guard let mainUUID,
             spaces.contains(where: { $0.displayUUID == mainUUID })
         else {
-            // The degenerate answer IS every user Desktop, so
-            // it routes through the accessor that computes them
-            // rather than re-deriving the numbering beside it.
             return userDesktops
         }
         return
@@ -86,23 +37,7 @@ public struct DesktopSnapshot: Sendable {
             .sorted()
     }
 
-    /// The Mission Control numbers of EVERY user Desktop in
-    /// this snapshot, ascending — every screen's, not one
-    /// screen's.
-    ///
-    /// The peer of `mainDisplayDesktops`, and the two are not
-    /// interchangeable: that one narrows to the screen a
-    /// *binding* fires on (#888), while a Desktop VERB acts on
-    /// the screen the Desktop lives on, so a consumer offering
-    /// the verbs must offer them all — narrowing to the main
-    /// screen would put a second screen's Desktops out of reach
-    /// of every surface but hand-written Lua. Which of the two
-    /// a consumer takes is a statement about what it offers,
-    /// which is why both exist rather than one with a flag.
-    ///
-    /// Numbered through `number(of:)`, so a Desktop reads the
-    /// same here, in a binding and in `space(numbered:)` — the
-    /// one numbering authority, read a third way.
+    /// Mission Control numbers of all user Desktops in snapshot (#888).
     public var userDesktops: [Int] {
         spaces
             .filter(\.isUser)
@@ -110,11 +45,7 @@ public struct DesktopSnapshot: Sendable {
             .sorted()
     }
 
-    /// Whether the space now current on `uuid` is a user desktop
-    /// — the #670 verdict, per screen and inside this snapshot,
-    /// rather than a second live read. True for an unknown
-    /// screen: standing down needs positive evidence of a
-    /// fullscreen/system space, never a lookup miss.
+    /// True if current space on display is a user space (#670).
     public func currentSpaceIsUser(on uuid: String?) -> Bool {
         guard let uuid, let id = currentSpaces[uuid] else {
             return true
@@ -123,28 +54,9 @@ public struct DesktopSnapshot: Sendable {
     }
 }
 
-/// The active-Desktop authority (#888): which Mission Control
-/// desktop counts as "the" active one for Desktop→profile
-/// bindings and the per-Desktop Space memory.
-///
-/// The definition: **the MAIN screen's current Desktop**.
-/// KiwiDesk resolves one active profile for the whole setup, so
-/// one screen has to hold the authority, and the main screen
-/// (the one with the menu bar) is it — a secondary screen's
-/// swipe never changes this answer. With "Displays have separate
-/// Spaces" off, or with a single screen, the main screen's
-/// Desktop IS the global one, so the answer degenerates to
-/// `activeSpaceNumber()` exactly.
+/// Active-desktop authority and queries for Desktop bindings (#888).
 extension NativeSpaces {
-    /// UUID of the main screen (the one with the menu bar), or
-    /// nil when `CGDisplayCreateUUIDFromDisplayID` is
-    /// unavailable.
-    ///
-    /// The ONE main-screen seam this subsystem reads: the emit's
-    /// monitor numbering resolves its main screen from this
-    /// answer too, so a fixture pinning it cannot get a switch
-    /// attributed to one screen and numbered as another
-    /// (review, 2026-08-18).
+    /// UUID of the main display (with menu bar) (review 2026-08-18).
     public static func mainDisplayUUID() -> String? {
         #if DEBUG
             if let override = mainDisplayUUIDOverride {
@@ -154,14 +66,7 @@ extension NativeSpaces {
         return displayUUID(for: DisplayID(CGMainDisplayID()))
     }
 
-    /// Reads the topology once and answers the authority with it.
-    ///
-    /// When the main screen cannot be found in that snapshot (no
-    /// SkyLight, no display-UUID symbol, or macOS's shared mode,
-    /// whose managed display carries a synthetic identifier), the
-    /// global `activeSpaceNumber()` answers — the public-fallback
-    /// ladder os-private-apis.md requires, and in shared mode the
-    /// global number is exactly the main screen's.
+    /// Captures topology snapshot determining authority (#888).
     public static func desktopSnapshot() -> DesktopSnapshot {
         let spaces = allSpaces()
         let uuid = mainDisplayUUID()
@@ -190,14 +95,7 @@ extension NativeSpaces {
         )
     }
 
-    /// Mission Control number of the active Desktop: the MAIN
-    /// screen's current Desktop (#888).
-    ///
-    /// The convenience read, for a caller that wants the number
-    /// and nothing else (a diagnostics dump, a Settings refresh).
-    /// A caller HANDLING a switch takes `desktopSnapshot()`
-    /// instead, so its later questions are answered from the same
-    /// reading.
+    /// Mission Control number of the active main Desktop (#888).
     public static func activeDesktopNumber() -> Int? {
         #if DEBUG
             if let override = activeDesktopNumberOverride {

--- a/Sources/KiwiDeskCore/OS/WMBridge.swift
+++ b/Sources/KiwiDeskCore/OS/WMBridge.swift
@@ -1,73 +1,19 @@
 import Foundation
 import ObjectiveC
 
-/// Runtime bridge to SkyLight's window-management operation
-/// classes (`SLSBridged*Operation`) — the surface #884 found
-/// and #889 probed: moving windows between Desktops, switching
-/// the visible Desktop, Desktop lifecycle, sticky membership and
-/// the per-Desktop key/value store, all on stock macOS with SIP
-/// on. Which builds carry the classes is os-private-apis.md's
-/// dated fact; nothing here names a cutoff — the nil class
-/// lookup IS the version gate (#889 item 8).
-///
-/// The discipline is `SkyLight`'s, extended from C symbols to
-/// ObjC classes: every class is looked up by name at runtime
-/// (`NSClassFromString` after the framework's `dlopen`), and a
-/// class that does not resolve makes the capability ABSENT —
-/// every entry point answers nil or false, never traps (#889
-/// item 8: an absent class is a nil lookup, verified against
-/// three fake names with the real class as the control).
-///
-/// Three facts every caller has to carry (#889):
-///
-/// - **Performed is not applied.** An asynchronous operation
-///   returns nothing at all, and a synchronous one returns a
-///   result even when the WindowServer silently declined
-///   (edge reservation performed under every mask and moved
-///   nothing). A write is verified by a re-query or by state
-///   the caller owns — never by this API's return value.
-/// - **The bridge exists only while AppKit is genuinely loaded**
-///   (#884's bisection): its load-time init registers the
-///   delegate the operations dispatch to. Free in the app,
-///   binding on any harness — which is one reason tests reach
-///   this type only through `classResolverOverride`.
-/// - **No Accessibility trust is needed** for reads or writes;
-///   AppKit-loaded is the only gate.
-///
-/// The `SLSBridged` prefix is spelled ONCE, here, and the
-/// operation names are joined to it at lookup — so every
-/// bridge call in the tree goes through this file, which
-/// `WMBridgeSeamTests` pins by scanning for the prefix.
-///
-/// Main-actor, like every AppKit interaction (AGENTS.md §2.6):
-/// the operations dispatch through AppKit's registered delegate,
-/// #889 probed them on the main thread only, and the first
-/// `isAvailable` read is a live WindowServer round trip inside
-/// a once-initialiser — a hop to main from inside that lock
-/// while main waited on the same lock would deadlock.
+/// Runtime bridge to SkyLight's `SLSBridged*Operation` window-management
+/// classes (#884, #889). Tested via `WMBridgeSeamTests`.
 @MainActor
 public enum WMBridge {
     public typealias SpaceID = SkyLight.SpaceID
 
-    /// The one spelling of the class-name prefix (see the type
-    /// doc). Joined to an operation's short name at lookup.
+    /// Prefix joined to short operation names at runtime lookup.
     static let classPrefix = "SLSBridged"
 
-    /// Every custom key KiwiDesk writes into a Desktop's store
-    /// carries this prefix — the store is Apple's own dictionary
-    /// (`type`, `id64`, `WindowManagerInfo`, …) and a bare key
-    /// would sit beside theirs (#889 item 3). The wrapper owns
-    /// it: a caller passes BARE keys, `setValues` and
-    /// `createSpace` prefix them, `stamps(of:)` strips them — one
-    /// shape each way, so a caller never spells the prefix.
-    ///
-    /// A STORED value (AGENTS.md §5): the WindowServer persists
-    /// these keys across logout and mode flips, so a change to
-    /// this string owes a re-stamp crossing for every Desktop
-    /// carrying the old one — never a reader lenient to both.
+    /// Stored desktop store prefix (#889 item 3).
     public static let valueKeyPrefix = "kiwidesk."
 
-    /// `values` with every key under `valueKeyPrefix`.
+    /// Transforms dictionary keys under `valueKeyPrefix`.
     static func namespaced(_ values: [String: Any]) -> NSDictionary {
         var out: [String: Any] = [:]
         for (key, value) in values {
@@ -77,20 +23,11 @@ public enum WMBridge {
     }
 
     #if DEBUG
-        /// Test seam: answers every class lookup instead of the
-        /// ObjC runtime, so a suite can hand the plumbing fake
-        /// operation classes — or nil, to prove the absent
-        /// capability degrades rather than traps — without
-        /// touching the machine's WindowServer.
+        /// Test seam for injecting mocked operation classes.
         public static var classResolverOverride: ((String) -> AnyClass?)?
     #endif
 
-    /// Whether the bridge is usable in THIS process: the
-    /// framework loaded, the operation classes resolve, and a
-    /// synchronous read answers — which is what proves the
-    /// delegate is registered, i.e. that AppKit is really
-    /// loaded. A GUI surface offering a bridge feature gates on
-    /// this predicate and greys with a reason when it is false.
+    /// True if framework is loaded and operation classes resolve (#884, #889).
     public static var isAvailable: Bool {
         #if DEBUG
             if classResolverOverride != nil {
@@ -106,11 +43,7 @@ public enum WMBridge {
         managedDisplaySpaces() != nil
     }
 
-    // MARK: - Class resolution
-
-    /// The class for one operation, by its short name
-    /// (`"SpaceCreateOperation"`), or nil when the capability is
-    /// absent on this macOS.
+    /// Resolves class for operation short name, or nil if unavailable.
     static func resolve(_ operation: String) -> AnyClass? {
         #if DEBUG
             if let override = classResolverOverride {
@@ -121,14 +54,6 @@ public enum WMBridge {
         return NSClassFromString(classPrefix + operation)
     }
 
-    // MARK: - Message sending
-
-    /// `objc_msgSend`, typed per call below. The bridge's
-    /// initialisers take C scalars (`unsigned long long` space
-    /// ids, `unsigned int` option masks) that `perform(_:with:)`
-    /// cannot pass, and its asynchronous `perform…` returns
-    /// VOID — read through `perform(_:)` that is a stale
-    /// register, not a result.
     private nonisolated(unsafe) static let send: UnsafeMutableRawPointer? =
         dlsym(dlopen(nil, RTLD_LAZY), "objc_msgSend")
 
@@ -163,16 +88,11 @@ public enum WMBridge {
         "performWithWMBridgeDelegate"
     )
 
-    /// `objc_msgSend` as one of the signatures above.
     static func sender<T>(as type: T.Type) -> T? {
         send.map { unsafeBitCast($0, to: T.self) }
     }
 
-    /// Allocates and initialises one operation: `build` receives
-    /// the `+alloc`ed instance and the initialiser selector and
-    /// returns the initialised object (`-init…` consumes the
-    /// allocation, so the pair nets +1 and is taken retained).
-    /// Nil when the class or the runtime is unavailable.
+    /// Allocates and initializes operation object.
     static func make(
         _ operation: String,
         initializer: String,
@@ -188,10 +108,7 @@ public enum WMBridge {
         )?.takeRetainedValue()
     }
 
-    /// Performs a SYNCHRONOUS operation and returns its result
-    /// object (an `SLSBridgedWindowManagementOperation*Result`,
-    /// read by key), or nil when the delegate is absent — the
-    /// AppKit-not-loaded case, or a bridge that refused.
+    /// Executes synchronous operation returning result object.
     static func performSync(_ operation: AnyObject?) -> NSObject? {
         guard let operation,
             let perform = sender(as: SyncPerformFn.self)
@@ -200,8 +117,7 @@ public enum WMBridge {
             .takeUnretainedValue() as? NSObject
     }
 
-    /// Dispatches an ASYNCHRONOUS operation. True means it was
-    /// handed to the bridge — nothing more (see the type doc).
+    /// Dispatches asynchronous operation to bridge (#889).
     static func performAsync(_ operation: AnyObject?) -> Bool {
         guard let operation,
             let perform = sender(as: AsyncPerformFn.self)
@@ -210,12 +126,7 @@ public enum WMBridge {
         return true
     }
 
-    /// One typed field of a result object, by its declared
-    /// property name (`spaceID`, `numbers`, `string`, …). A
-    /// result that no longer declares the key answers nil — the
-    /// key is the same release-churn surface as the class, and
-    /// `value(forKey:)` on an unknown key raises an ObjC
-    /// exception Swift cannot catch, which is a trap.
+    /// Reads typed field from result object if selector is supported.
     static func field<T>(_ key: String, of result: NSObject?) -> T? {
         guard let result,
             result.responds(to: NSSelectorFromString(key))

--- a/Sources/KiwiDeskCore/OS/WMBridge.swift
+++ b/Sources/KiwiDeskCore/OS/WMBridge.swift
@@ -1,8 +1,14 @@
 import Foundation
 import ObjectiveC
 
-/// Runtime bridge to SkyLight's `SLSBridged*Operation` window-management
-/// classes (#884, #889). Tested via `WMBridgeSeamTests`.
+/// Runtime bridge to SkyLight's `SLSBridged*Operation`
+/// window-management classes (#884, #889); `WMBridgeSeamTests`
+/// pins that every bridge call routes through this file.
+/// Main-actor deliberately: #889 probed the operations on the
+/// main thread only, and the first `isAvailable` read is a live
+/// WindowServer round trip inside a once-initialiser — a hop to
+/// main from inside that lock while main waited on it would
+/// deadlock.
 @MainActor
 public enum WMBridge {
     public typealias SpaceID = SkyLight.SpaceID
@@ -10,7 +16,11 @@ public enum WMBridge {
     /// Prefix joined to short operation names at runtime lookup.
     static let classPrefix = "SLSBridged"
 
-    /// Stored desktop store prefix (#889 item 3).
+    /// Stored desktop-store key prefix (#889 item 3). A STORED
+    /// value (AGENTS.md §5): the WindowServer persists these keys
+    /// across logout, so a change to this string owes a re-stamp
+    /// crossing for every Desktop carrying the old one — never a
+    /// reader lenient to both.
     public static let valueKeyPrefix = "kiwidesk."
 
     /// Transforms dictionary keys under `valueKeyPrefix`.
@@ -54,6 +64,10 @@ public enum WMBridge {
         return NSClassFromString(classPrefix + operation)
     }
 
+    /// `objc_msgSend`, typed per call: the initialisers take C
+    /// scalars `perform(_:with:)` cannot pass, and the async
+    /// `perform…` returns VOID — read through `perform(_:)` that
+    /// is a stale register, not a result.
     private nonisolated(unsafe) static let send: UnsafeMutableRawPointer? =
         dlsym(dlopen(nil, RTLD_LAZY), "objc_msgSend")
 
@@ -126,7 +140,10 @@ public enum WMBridge {
         return true
     }
 
-    /// Reads typed field from result object if selector is supported.
+    /// Reads a typed field from a result object, only where the
+    /// selector is supported: `value(forKey:)` on an unknown key
+    /// raises an ObjC exception Swift cannot catch — a trap, and
+    /// the key is the same release-churn surface as the class.
     static func field<T>(_ key: String, of result: NSObject?) -> T? {
         guard let result,
             result.responds(to: NSSelectorFromString(key))

--- a/Sources/KiwiDeskCore/Power/SleepWakeManager.swift
+++ b/Sources/KiwiDeskCore/Power/SleepWakeManager.swift
@@ -16,8 +16,13 @@ public final class SleepWakeManager {
 
     public var onLog: @MainActor (String) -> Void = CoreLog.write
 
-    /// Display topology fingerprints; tested via `WakeFingerprintWiringTests`
-    /// (#633).
+    /// Display topology of a held snapshot, re-read when the
+    /// delayed restore fires — replaying onto changed geometry is
+    /// what scrambled wakes (#633). Compared as a sorted MULTISET,
+    /// never a `Set`: two identical monitors share one
+    /// fingerprint, and a `Set` would swallow the loss of one of
+    /// them — the most common matched-pair undock
+    /// (`WakeFingerprintWiringTests`).
     public var displayFingerprints: @MainActor () -> [String] = { [] }
 
     /// Diagnostic session presence (`WakeSessionPresenceWiringTests`, #835).
@@ -35,6 +40,11 @@ public final class SleepWakeManager {
     /// Identifies the transition leg for logging (#835).
     enum Leg: String {
         case sleep, wake, lock, unlock
+        /// Driven with no notification behind it — the tests. A
+        /// production trigger added later takes a case of its OWN:
+        /// an anonymous leg in the log is the evidence gap `Leg`
+        /// exists to close, and there is no default parameter so
+        /// the choice cannot be made by omission.
         case direct
 
         var isRest: Bool { self == .sleep || self == .lock }
@@ -86,7 +96,15 @@ public final class SleepWakeManager {
     /// True if a state snapshot is currently held.
     var holdsSnapshot: Bool { snapshot != nil }
 
-    /// Armed replay task for tests to await (#791).
+    /// The most recently ARMED replay, for a test to await instead
+    /// of polling — the one authority for why polling was wrong
+    /// here, which tests.md ▸ "Async tests" cites: swift-testing
+    /// starves the shared main actor under a full run (one 10 ms
+    /// sleep measured 65 s), so a wall-clock deadline decided by
+    /// which continuation drained first (#791). NOT an in-flight
+    /// predicate: the task is left uncleared deliberately (clearing
+    /// from inside would race a newer arm); `holdsSnapshot` is the
+    /// in-flight question. Production must not read either.
     var pendingReplay: Task<Void, Never>? { restoreTask }
 
     private func observe(

--- a/Sources/KiwiDeskCore/Power/SleepWakeManager.swift
+++ b/Sources/KiwiDeskCore/Power/SleepWakeManager.swift
@@ -1,73 +1,30 @@
 import AppKit
 import Foundation
 
-/// Preserves window state across sleep/wake and lock/unlock.
-///
-/// macOS tends to scramble window positions when displays go
-/// away during these transitions. This manager snapshots the
-/// state before the system sleeps or locks, and restores it
-/// after waking — delayed by `restoreDelayMS` so displays can
-/// finish reconnecting first.
+/// Preserves and restores window state across sleep/wake and lock/unlock.
 @MainActor
 public final class SleepWakeManager {
-    /// `enable_wake_restore`: master toggle.
     public var isEnabled = true
-
-    /// `wake_restore_delay_ms`: wait before restoring so the
-    /// display topology can settle. Default 1500 ms.
     public var restoreDelayMS = 1500
 
-    /// Captures the state to preserve (nil skips the cycle).
     public var captureState: @MainActor () -> StateSnapshot? = {
         nil
     }
 
-    /// Re-applies a previously captured state.
     public var restoreState: @MainActor (StateSnapshot) -> Void =
         { _ in }
 
     public var onLog: @MainActor (String) -> Void = CoreLog.write
 
-    /// The display topology a held snapshot belongs to,
-    /// captured beside it and re-read when the delayed restore
-    /// fires. If it changed while asleep/locked (undock,
-    /// monitor power-off), the snapshot's raw frames belong to
-    /// dead geometry and the monitor-change re-adopt that
-    /// already ran is the truth — replaying on top of it is
-    /// what scrambled wakes (#633). Compared as a sorted
-    /// multiset, never a `Set`: display *order* may shuffle
-    /// without meaning a topology change, but two identical
-    /// monitors share one fingerprint, and a `Set` would
-    /// swallow the loss of one of them — the most common
-    /// matched-pair undock. The unwired default (`[]` both
-    /// sides) compares equal, so the gate stays inert until
-    /// Bootstrap wires it; `WakeFingerprintWiringTests` probes
-    /// that wiring on a live core.
+    /// Display topology fingerprints; tested via `WakeFingerprintWiringTests`
+    /// (#633).
     public var displayFingerprints: @MainActor () -> [String] = { [] }
 
-    /// What macOS says about the login session, read where the
-    /// replay decides.
-    ///
-    /// **Diagnostic only — nothing branches on it (#835).** The
-    /// mechanism it exists to settle, and why BOTH of its facts
-    /// are recorded rather than the one the issue proposed, are
-    /// argued once on `SessionPresence`.
-    ///
-    /// Inert by default and wired in `KiwiCore+Bootstrap`, like
-    /// the three seams above it — never live-by-default. An
-    /// unwired live read would reach the host from every suite
-    /// that drives a return leg, which is a residue `tests.md`
-    /// does not carry; the inert default reports "unknown" on
-    /// every axis, which is an honest thing for a diagnostic to
-    /// say and a useless thing to ship, so the wiring is probed
-    /// on a live core by `WakeSessionPresenceWiringTests` — the
-    /// `displayFingerprints` precedent, and the same shipped-
-    /// inert-seam class the log-seam guards exist for.
+    /// Diagnostic session presence (`WakeSessionPresenceWiringTests`, #835).
     public var sessionPresence: @MainActor () -> SessionPresence =
         { SessionPresence(session: nil) }
 
     private var snapshot: StateSnapshot?
-    /// Sorted at capture; see `displayFingerprints`.
     private var snapshotFingerprints: [String] = []
     private var restoreTask: Task<Void, Never>?
     private var tokens: [(NotificationCenter, NSObjectProtocol)] =
@@ -75,26 +32,11 @@ public final class SleepWakeManager {
 
     public init() {}
 
-    /// Which notification drove a rest or a return.
-    ///
-    /// Carried into every log line so a lock → lid → unlock cycle
-    /// reads as the four events it is, rather than as two
-    /// anonymous pairs — which is the whole of what the #835 log
-    /// could not say.
+    /// Identifies the transition leg for logging (#835).
     enum Leg: String {
         case sleep, wake, lock, unlock
-        /// Driven with no notification behind it — the tests.
-        /// A production trigger added later takes a case of its
-        /// own rather than this one: an anonymous leg in the log
-        /// is the exact evidence gap `Leg` exists to close, and
-        /// the parameter carries no default so the choice cannot
-        /// be made by omission.
         case direct
 
-        /// Whether this leg captures (a rest) or replays (a
-        /// return). Derived from the leg rather than passed
-        /// beside it, so a leg added later cannot be wired to
-        /// the wrong half of the pair.
         var isRest: Bool { self == .sleep || self == .lock }
     }
 
@@ -133,10 +75,7 @@ public final class SleepWakeManager {
         restoreTask = nil
     }
 
-    /// Drops a snapshot held for a pending wake/unlock replay,
-    /// cancelling the replay — the tier-1 escape hatch's
-    /// in-flight half (#634). Observers stay armed; the next
-    /// rest/return cycle captures fresh.
+    /// Cancels pending wake/unlock restore and drops held snapshot (#634).
     public func dropHeldSnapshot() {
         restoreTask?.cancel()
         restoreTask = nil
@@ -144,46 +83,11 @@ public final class SleepWakeManager {
         snapshotFingerprints = []
     }
 
-    /// Whether a rest capture is currently held for replay.
-    /// Internal observability for the tier-1 discard pin — the
-    /// replay itself hides behind an awaited `Task`, so a test
-    /// asserting "nothing replayed" synchronously passes even
-    /// when the drop is broken; this reads the held state
-    /// directly. Production must not read it: the held
-    /// snapshot's one consumer is the return leg above.
+    /// True if a state snapshot is currently held.
     var holdsSnapshot: Bool { snapshot != nil }
 
-    /// The most recently ARMED replay, for a test to await
-    /// instead of polling for its effect.
-    ///
-    /// This is the one authority for why polling was wrong here;
-    /// `tests.md` ▸ "Async tests" and the two wake suites cite it
-    /// rather than restating the measurement. The poll it
-    /// replaces bounded a 30 s WALL-CLOCK deadline, and wall
-    /// clock is the wrong instrument: swift-testing runs suites
-    /// concurrently, so under a full run the shared main actor is
-    /// starved and one 10 ms `Task.sleep` resumption measured
-    /// 65 s. Past the deadline the loop exits without giving the
-    /// replay's continuation a turn, so the result came down to
-    /// which continuation drained first — which is why the
-    /// reported failure hit three tests of four rather than all
-    /// four, and why it looked like shared state with the running
-    /// app when it was CPU contention (#791).
-    ///
-    /// **Not an in-flight predicate.** The task is not cleared
-    /// when its body finishes, so a non-nil value means "one was
-    /// armed since the last `stop()` / `dropHeldSnapshot()`", and
-    /// awaiting after a return leg that early-returned awaits the
-    /// PREVIOUS cycle's finished task — vacuously. `holdsSnapshot`
-    /// is the in-flight question. It is left uncleared
-    /// deliberately: clearing from inside the task would race a
-    /// newer arm into dropping it.
-    ///
-    /// Production must not read it: the replay's one consumer is
-    /// the return leg that armed it.
+    /// Armed replay task for tests to await (#791).
     var pendingReplay: Task<Void, Never>? { restoreTask }
-
-    // MARK: - Internals
 
     private func observe(
         _ center: NotificationCenter,
@@ -206,9 +110,6 @@ public final class SleepWakeManager {
         tokens.append((center, token))
     }
 
-    /// Internal, not private: the notification observers above
-    /// are the production trigger, and tests drive the pair
-    /// directly instead of posting to the shared centers.
     func systemWillRest(_ leg: Leg) {
         guard isEnabled else { return }
         restoreTask?.cancel()
@@ -225,11 +126,6 @@ public final class SleepWakeManager {
 
     func systemDidReturn(_ leg: Leg) {
         guard isEnabled else { return }
-        // The silent arm the #835 log could not distinguish from
-        // a healthy cycle: if the wake leg's replay has already
-        // fired and cleared the capture, the unlock leg lands
-        // here with nothing left to do, and the log said nothing
-        // either way.
         guard let saved = snapshot else {
             onLog(
                 "wake restore: \(leg.rawValue) found no held "
@@ -247,9 +143,6 @@ public final class SleepWakeManager {
             let ns = UInt64(delay) * 1_000_000
             try? await Task.sleep(nanoseconds: ns)
             guard !Task.isCancelled, let self else { return }
-            // Re-read at fire time, not at wake: the delay
-            // exists precisely so the topology can finish
-            // settling first.
             let note =
                 "\(self.sessionPresence().summary), "
                 + self.age(of: saved)
@@ -257,10 +150,6 @@ public final class SleepWakeManager {
                 == self.snapshotFingerprints
             {
                 self.restoreState(saved)
-                // The positive line #835 asked for. Without it a
-                // silent log cannot tell "restored correctly"
-                // from "never restored", so no capture of a
-                // failing cycle could be decisive.
                 self.onLog(
                     "wake restore: \(leg.rawValue) replayed "
                         + self.describe(saved) + " (\(note))"
@@ -275,7 +164,6 @@ public final class SleepWakeManager {
         }
     }
 
-    /// `12 windows in 3 spaces`, or why there was nothing.
     private func describe(_ snapshot: StateSnapshot?) -> String {
         guard let snapshot else {
             return "nothing (capture returned no state)"
@@ -284,9 +172,6 @@ public final class SleepWakeManager {
             + "\(snapshot.spaces.count) spaces"
     }
 
-    /// How stale the replayed capture is. The mechanism under
-    /// suspicion needs the return to outlive `restoreDelayMS`,
-    /// so the gap between capture and replay is evidence.
     private func age(of snapshot: StateSnapshot) -> String {
         let seconds = Date().timeIntervalSince(snapshot.capturedAt)
         return String(format: "captured %.1fs ago", seconds)

--- a/Sources/KiwiDeskCore/Profiles/Profile+Screens.swift
+++ b/Sources/KiwiDeskCore/Profiles/Profile+Screens.swift
@@ -1,7 +1,13 @@
-/// Resolves opening layout modes per screen for saved profile preview
-/// cards (#789, #959).
-/// Precedence follows `SpacePlacement` (pin -> Main role -> fallback).
-/// Tested via `ProfileOpeningModesTests`.
+/// Resolves opening layout modes per screen for saved-profile
+/// preview cards (#789, #959) — the static shadow of
+/// `SpacePlacement`, answering its first two legs (pin, Main
+/// role) in the same order; a change to the precedence belongs in
+/// `SpacePlacement` first, and here second. Two accepted
+/// residues, pinned by `ProfileOpeningModesTests`: a space pinned
+/// to the MAIN display lets a blank secondary borrow Main's
+/// glyph, and a multi-set profile answers from
+/// `monitorSets.first`, which a screen blank there may contradict
+/// in another set.
 extension Profile {
     /// Opening layout mode for each screen in monitor order
     /// (nil if unassigned).
@@ -33,7 +39,12 @@ extension Profile {
         return blank.count == 1 ? blank.first : nil
     }
 
-    /// First ordered space assigned to Main role without display pin.
+    /// First ordered space assigned to the Main role WITHOUT a
+    /// pin: `SpacePlacement.resolve` gives the pin precedence, so
+    /// a space carrying both opens on the pinned screen — painting
+    /// the blank one with its mode would name a screen it never
+    /// reaches. The GUI writers clear one when they set the other;
+    /// a hand-edited profile can carry both.
     private func firstMainSpace(in set: MonitorSet) -> SpaceID? {
         let main = Set(mainSpaces)
         return orderedSpaces.first {
@@ -41,7 +52,10 @@ extension Profile {
         }
     }
 
-    /// First ordered space pinned to monitor fingerprint.
+    /// First ordered space pinned to the fingerprint — the
+    /// profile's own order decides "first", never the
+    /// dictionary's, which would pick differently between
+    /// launches.
     private func firstSpace(
         pinnedTo fingerprint: String,
         in set: MonitorSet

--- a/Sources/KiwiDeskCore/Profiles/Profile+Screens.swift
+++ b/Sources/KiwiDeskCore/Profiles/Profile+Screens.swift
@@ -1,83 +1,10 @@
-/// What a SAVED profile can say about its own screens (#789) —
-/// the stored-profile twin of
-/// `StandardLayout.openingMode(onScreen:screens:)`.
-///
-/// It exists so the Settings row and the preset card can draw
-/// ONE picture grammar. The saved rows drew featureless
-/// rectangles only because nothing answered this question, and
-/// the two surfaces then said the same thing — "what shape is
-/// this profile" — two ways, one scroll apart.
-///
-/// **A stored profile can answer less than a preset can, and
-/// this returns `nil` rather than guessing.** A preset plans
-/// positionally (`spaceScreens` names screen 0, 1, 2), so it
-/// always knows which screen a space is for. A stored profile
-/// pins spaces to *fingerprints* (`MonitorSet.spaceMonitorMap`)
-/// and leaves the rest to the Main role plus the positional
-/// default — and **which monitor is Main is resolved live, not
-/// stored** (`Profile.mainSpaces`' doc comment). So for a
-/// multi-screen profile whose spaces were never pinned, no
-/// stored fact says which screen opens in what, and inventing
-/// one would put a claim about behaviour on screen that loading
-/// the profile might not produce.
-///
-/// That is the same rule `PresetScreenCard.outlineView` already
-/// draws by: a screen with no answer gets its outline and no
-/// glyph.
-///
-/// **But "no fingerprint names Main" is not the same as "the
-/// profile does not say" (#959)**, so a sole unpinned screen is
-/// answered by elimination. The ruling and its argument are in
-/// `docs/design-decisions.md` ▸ Profiles; what this file owes is
-/// the seam and the two things elimination is NOT sure of.
-///
-/// **Residue 1 — a space pinned to the MAIN display.** The
-/// GUI's Monitors editor can pin a space onto the main display's
-/// own card (`SpaceAssignmentChip`, `DisplayCard`), and Lua's
-/// `pin_space_to_display` does the same. Then main carries a pin
-/// AND the follows-main spaces, so the sole blank screen is a
-/// SECONDARY one that holds nothing — and it borrows Main's
-/// glyph. Accepted rather than fixed: nothing stored tells the
-/// two apart (which fingerprint was Main is resolved live), and
-/// refusing the whole arm to avoid it would cost every ordinary
-/// two-screen profile the glyph #959 was filed about. The case
-/// is pinned by `ProfileOpeningModesTests` so it is a chosen
-/// answer rather than an accident.
-///
-/// **Residue 2 — a profile covering several arrangements**
-/// answers from `monitorSets.first`. That was harmless while the
-/// answer was a refusal; elimination makes it a positive claim
-/// about one arrangement, and the row carries no per-set label.
-/// A screen blank in the first set may be pinned in another.
-///
-/// Two blank screens stay blank in every case: there the
-/// unpinned spaces fit on either, and that IS the refusal above.
-///
-/// **This is the static shadow of `SpacePlacement`, not a
-/// second opinion.** That enum owns the one space→display
-/// precedence — pin → Main role → the positional plan → main —
-/// and this accessor answers the first two legs, in the same
-/// order, from the same two stored fields. It cannot answer the
-/// third: the plan is `ProfileComposition`'s, composed from the
-/// displays connected right now, and a saved profile stores no
-/// plan. That costs nothing on a profile any save produced,
-/// where every declared space is pinned or follows Main and the
-/// two legs are total (`adoptComposedPlacement` writes exactly
-/// those two sets). It is why a hand-edited profile carrying a
-/// space that is neither draws a bare outline rather than a
-/// guess: that space's screen is decided by hardware this file
-/// cannot see. A change to the precedence belongs in
-/// `SpacePlacement` first, and here second.
+/// Resolves opening layout modes per screen for saved profile preview
+/// cards (#789, #959).
+/// Precedence follows `SpacePlacement` (pin -> Main role -> fallback).
+/// Tested via `ProfileOpeningModesTests`.
 extension Profile {
-    /// One entry per screen this profile covers, in the stored
-    /// set's canonical monitor order — the mode that screen's
-    /// first space opens in, or `nil` where the profile does not
-    /// say.
-    ///
-    /// The single-screen case is exact and is the common one:
-    /// with one monitor every declared space is on it, so the
-    /// first ordered space IS what that screen opens in, pins or
-    /// no pins.
+    /// Opening layout mode for each screen in monitor order
+    /// (nil if unassigned).
     public func openingModes() -> [LayoutMode?] {
         let screens = monitorCount
         guard screens > 0 else { return [] }
@@ -98,13 +25,7 @@ extension Profile {
         return firsts.map { $0.flatMap { spaceModes[$0] } }
     }
 
-    /// The index of the one covered monitor carrying no pin —
-    /// nil unless there is exactly one.
-    ///
-    /// Exactly one is the whole condition: with two unpinned
-    /// monitors the follows-main spaces fit on either, so
-    /// attributing them to one would be the guess this accessor
-    /// exists to refuse.
+    /// Index of sole unpinned screen in set (nil if 0 or >1, #959).
     private func soleUnpinnedScreen(
         in firsts: [SpaceID?]
     ) -> Int? {
@@ -112,20 +33,7 @@ extension Profile {
         return blank.count == 1 ? blank.first : nil
     }
 
-    /// The profile's first ordered follows-main space.
-    ///
-    /// The profile's own order again, for the reason
-    /// `firstSpace(pinnedTo:in:)` states — `mainSpaces` is a
-    /// stored list, but it is a list of MEMBERS, and which of
-    /// them comes first is `orderedSpaces`' answer, not its own.
-    ///
-    /// A space carrying a pin is not a candidate even when
-    /// `main_spaces` also lists it: `SpacePlacement.resolve`
-    /// gives the pin precedence over the Main role, so such a
-    /// space opens on the pinned screen, and painting the blank
-    /// one with its mode would name a screen it never reaches.
-    /// The GUI writers clear one when they set the other; a
-    /// hand-edited profile is what can carry both.
+    /// First ordered space assigned to Main role without display pin.
     private func firstMainSpace(in set: MonitorSet) -> SpaceID? {
         let main = Set(mainSpaces)
         return orderedSpaces.first {
@@ -133,10 +41,7 @@ extension Profile {
         }
     }
 
-    /// The profile's own order decides which space is "first" on
-    /// a monitor, never the dictionary's — `spaceMonitorMap` is
-    /// a `[SpaceID: String]`, and iterating it would pick a
-    /// different space between launches for the same profile.
+    /// First ordered space pinned to monitor fingerprint.
     private func firstSpace(
         pinnedTo fingerprint: String,
         in set: MonitorSet

--- a/Sources/KiwiDeskCore/Profiles/StarterAllocation.swift
+++ b/Sources/KiwiDeskCore/Profiles/StarterAllocation.swift
@@ -1,44 +1,19 @@
 import CoreGraphics
 import Foundation
 
-/// How many spaces a starter setup creates, and which layout each
-/// one gets (#678 Phase 4 pass 11, turn 15b).
-///
-/// Pure arithmetic over screen SIZES in points — no `Display`, no
-/// state — so the whole rule is unit-testable and the seed and the
-/// preset face can both call it. `ScreenClass` owns which layouts
-/// a shape wants; this owns how many it gets and who places
-/// Floating.
-///
-/// The rule the numbers serve: **budget the total, then give each
-/// screen a share it fills from its own list.** Spaces belong to
-/// the profile and are merely assigned to a screen, so the count
-/// grows with screens sub-linearly — a laptop's 3 plus a 27"'s 5
-/// would be eight keys to learn on day one, most of them empty.
-/// The cost of a space is a key to bind and a name to recall, not
-/// screen area.
+/// Determines initial space counts and layout modes per screen (#678).
+/// Budgets total spaces sub-linearly, apportioning by width.
 public enum StarterAllocation {
-    /// Spaces for 1…5 screens. The second and third screen add
-    /// two each; every one after that adds one.
+    /// Spaces for 1…5 screens.
     static let ladder = [3, 5, 7, 8, 9]
-    /// Past ⌃⌥1–9 and ⌃⌥0 there are no default go-to keys left,
-    /// so the total stops growing here. We run out of keys, not
-    /// spaces — which is why this is DERIVED from the number
-    /// row's capacity rather than restating it: the two are one
-    /// fact, and `DefaultKeybindings` owns it.
+    /// Soft cap derived from default shortcut digit capacity.
     public static let softCap = DefaultKeybindings.digitCapacity
-    /// A screen with no space would have nowhere for a window to
-    /// resolve to, so this floor outranks `softCap`.
+    /// Floor outranking `softCap`: at least one space per screen.
     public static let minShare = 1
-    /// Screens four and five are almost always glanceable — logs,
-    /// chat, a stream — and want one space that is always the
-    /// same, not a set to switch between.
+    /// Upper bound share for a single screen.
     public static let maxShare = 3
 
-    /// Total spaces for a screen count. **Min-one-per-screen
-    /// always wins**: eleven displays gets eleven spaces, one
-    /// apiece, because the cap is on spaces and a screen without
-    /// one has nowhere to put a window.
+    /// Total space budget for `screenCount`; min 1 per screen always wins.
     public static func budget(screenCount: Int) -> Int {
         let count = max(1, screenCount)
         let budgeted =
@@ -48,16 +23,8 @@ public enum StarterAllocation {
         return max(budgeted, count)
     }
 
-    /// Each screen's share of the budget, proportional to its
-    /// width in points and clamped to `minShare...maxShare`.
-    ///
-    /// Largest-remainder apportionment, then a repair pass:
-    /// clamping can leave the shares off the budget in either
-    /// direction, and a share list that does not sum to the
-    /// budget is a space the allocator promised and never placed.
-    /// The repair can run out of eligible screens (every one at a
-    /// clamp), which is why each loop can `break` — the budget
-    /// yields to the clamps, never the other way round.
+    /// Apportions budget across screens proportionally by width in points,
+    /// clamped to `minShare...maxShare` (code review 2026-08-11).
     public static func shares(
         widths: [CGFloat],
         budget: Int
@@ -73,27 +40,12 @@ public enum StarterAllocation {
         var share = raw.map {
             min(maxShare, max(minShare, Int($0.rounded(.down))))
         }
-        // Remainder measured against the CLAMPED base, not the
-        // floor: a screen whose raw share was below one has
-        // already been given more than it earned by `minShare`,
-        // and ranking it on `raw - floor(raw)` handed it a second
-        // bonus on top — which inverted width order outright
-        // (a 1080 pt screen taking two spaces beside a 1440 pt
-        // one taking one). Zero means "already paid".
+        // Remainder measured against clamped base to prevent bonus inversion.
         let remainder = zip(raw, share).map {
             max(0, $0 - Double($1))
         }
         var deficit = budget - share.reduce(0, +)
-        // One unit per screen per PASS, in ranked order — not
-        // "give the top-ranked screen everything it can take".
-        // `remainder` is fixed, so re-ranking inside the loop
-        // returns the same head every time and a single screen
-        // absorbed the whole deficit: two identical 1080 pt
-        // screens beside a 1728 pt one apportioned [3, 1, 3],
-        // and a narrower screen could out-rank a wider one
-        // outright — both contradicting "proportional to its
-        // width" while still summing to the budget, which is all
-        // the tests checked (code review, 2026-08-11).
+        // One unit per pass in ranked order to prevent deficit absorption.
         while deficit > 0 {
             let eligible = rank(remainder, widths, ascending: false)
                 .filter { share[$0] < maxShare }
@@ -115,23 +67,7 @@ public enum StarterAllocation {
         return share
     }
 
-    /// The layouts for every screen, **positional order in,
-    /// positional order out** (index 0 = main).
-    ///
-    /// Three global rules ride on top of the per-screen lists.
-    /// Exactly one Floating space, on the largest screen that has
-    /// room beside it. No layout twice unless the budget forces
-    /// it, which is why the fill runs widest-first — the screen
-    /// that benefits most picks first. And every screen's FIRST
-    /// space is decided by `lead(_:of:)` before its own list is
-    /// read at all (#1018).
-    ///
-    /// That lead is the deliberate exception to the no-repeat
-    /// rule: Scrolling leads several screens on purpose, so it is
-    /// appended without consulting `used` — an accidental repeat
-    /// would be a bug, this one is the feature. It still JOINS
-    /// `used` afterwards, so no screen draws it twice from its
-    /// own list on top of leading with it.
+    /// Layouts per screen in positional order (index 0 = main, #1018).
     public static func modes(sizes: [CGSize]) -> [[LayoutMode]] {
         guard !sizes.isEmpty else { return [] }
         let widths = sizes.map(\.width)
@@ -161,10 +97,6 @@ public enum StarterAllocation {
                 used.insert(first)
                 quota -= 1
             }
-            // No filter: `ScreenClass.layouts` carries no
-            // `.floating` at all, because where the one Floating
-            // space goes is this type's rule, not a screen's
-            // preference.
             let list = shapes[index].layouts
             modes += take(
                 quota,
@@ -178,60 +110,18 @@ public enum StarterAllocation {
         return result
     }
 
-    /// The layout a screen OPENS in, whatever its shape wants
-    /// second (#1018).
-    ///
-    /// Scrolling everywhere but the smallest screen, which leads
-    /// Monocle. The argument is what a fresh install's first
-    /// Space teaches: Scrolling is the mode where nothing is
-    /// squashed — each window keeps a comfortable slot and the
-    /// neighbours wait one keystroke away — where a lead of Grid
-    /// or Track cuts the user's windows into halves or thirds on
-    /// sight, which is the impression that closes a tiling
-    /// manager on day one.
-    ///
-    /// Read by SIZE, never by which screen is main: the main
-    /// screen leads Scrolling like any other unless it is also
-    /// the narrowest. `StarterTuning` is the one that reads the
-    /// main screen, and that asymmetry is deliberate — a slot
-    /// FRACTION is profile-wide and has to be named by one
-    /// screen, while which layout a screen opens in is a fact
-    /// about that screen.
-    ///
-    /// The size rule is unconditional, so it can hand Monocle to
-    /// a screen whose own class would not have asked for it — a
-    /// 27" beside an ultrawide is "the smallest" and leads
-    /// Monocle, though `ScreenClass.desktop` lists none.
-    /// `StarterLeadTests` pins that case so it stays a decision
-    /// rather than a surprise.
+    /// Opening layout: smallest screen leads Monocle, others Scrolling
+    /// (#1018, `StarterLeadTests`).
     static func lead(_ index: Int, of smallest: Int?) -> LayoutMode {
         index == smallest ? .monocle : .scrolling
     }
 
-    /// The screen that leads Monocle, or nil when there is only
-    /// one — a solo screen leads Scrolling whatever its size, so
-    /// at least one Scrolling space always exists.
-    ///
-    /// Derived by reading `fillOrder` from the other END rather
-    /// than sorting again: one ordering, so the tie-break cannot
-    /// disagree with itself. That also settles two equal widths
-    /// the way the setup wants — `fillOrder` puts the earlier
-    /// index first among equals, so the LAST of them is the
-    /// later screen, and a main screen beside an identical twin
-    /// keeps Scrolling.
+    /// Screen index that leads Monocle, or nil if single display.
     static func smallestScreen(order: [Int]) -> Int? {
         order.count > 1 ? order.last : nil
     }
 
-    /// The screen that gets the one Floating space: the widest
-    /// with a share of at least two.
-    ///
-    /// The floor is what stops a wide setup's main screen from
-    /// being handed Floating and nothing else — at eleven
-    /// displays every share is one, every screen is doing a
-    /// single job, and there is no room for a space that tiles
-    /// nothing. Then there is no Floating space at all, which is
-    /// the honest answer rather than a stolen one.
+    /// Screen receiving the single Floating space (widest with share >= 2).
     static func floatingHost(
         widths: [CGFloat],
         shares: [Int]
@@ -246,7 +136,7 @@ public enum StarterAllocation {
             .first
     }
 
-    /// Widest first, ties by positional order.
+    /// Widest screen index first, ties broken by positional order.
     static func fillOrder(widths: [CGFloat]) -> [Int] {
         widths.indices.sorted { lhs, rhs in
             widths[lhs] != widths[rhs]
@@ -255,31 +145,7 @@ public enum StarterAllocation {
         }
     }
 
-    /// `quota` layouts off the top of `list`, skipping what
-    /// another screen already took. When the list runs dry the
-    /// budget has forced a repeat, so it refills from the top of
-    /// the same list — still this shape's best-first order.
-    ///
-    /// `beside` is what this screen has ALREADY been given — its
-    /// lead — and the refill prefers an entry the screen does not
-    /// hold yet, then rotates PAST it rather than restarting at
-    /// the top.
-    ///
-    /// Two different things are going on and only one of them is
-    /// avoidable. A screen with more spaces than its list has
-    /// entries must repeat something — a laptop list holds two
-    /// layouts, and three spaces cannot be three distinct ones.
-    /// What the rotation fixes is WHICH repeat: restarting the
-    /// cursor at `list[0]` handed the middle of three laptops
-    /// `[scrolling, monocle, monocle]`, two identical spaces
-    /// side by side, where rotating gives `[scrolling, monocle,
-    /// scrolling]` — the same unavoidable duplicate, spread.
-    ///
-    /// So the obligation is: **never repeat while this screen
-    /// still has an unheld entry, and when a repeat is forced,
-    /// do not put it adjacent to its twin.** Repeating across
-    /// SCREENS is a separate thing entirely — that is the budget
-    /// forcing a hand, and `used` is what governs it.
+    /// Takes `quota` layouts, avoiding repeats and rotating when exhausted.
     private static func take(
         _ quota: Int,
         from list: [LayoutMode],
@@ -309,8 +175,7 @@ public enum StarterAllocation {
         return picked
     }
 
-    /// Indices ordered by remainder, ties by width then by index,
-    /// so the repair pass is deterministic on identical screens.
+    /// Indices sorted by remainder, then width, then index.
     private static func rank(
         _ remainder: [Double],
         _ widths: [CGFloat],

--- a/Sources/KiwiDeskCore/Profiles/StarterAllocation.swift
+++ b/Sources/KiwiDeskCore/Profiles/StarterAllocation.swift
@@ -67,7 +67,11 @@ public enum StarterAllocation {
         return share
     }
 
-    /// Layouts per screen in positional order (index 0 = main, #1018).
+    /// Layouts per screen in positional order (index 0 = main).
+    /// Each screen's FIRST space is `lead(_:of:)`'s before its own
+    /// list is read (#1018) — the deliberate exception to the
+    /// no-repeat rule, appended without consulting `used` (it
+    /// still JOINS `used` after, so no screen draws it twice).
     public static func modes(sizes: [CGSize]) -> [[LayoutMode]] {
         guard !sizes.isEmpty else { return [] }
         let widths = sizes.map(\.width)
@@ -145,7 +149,10 @@ public enum StarterAllocation {
         }
     }
 
-    /// Takes `quota` layouts, avoiding repeats and rotating when exhausted.
+    /// Takes `quota` layouts off the list. The obligation: never
+    /// repeat while this screen still has an unheld entry, and
+    /// when the budget forces a repeat, rotate PAST the held one
+    /// so the duplicate is never adjacent to its twin.
     private static func take(
         _ quota: Int,
         from list: [LayoutMode],

--- a/Sources/KiwiDeskCore/Service/AutoStartManager.swift
+++ b/Sources/KiwiDeskCore/Service/AutoStartManager.swift
@@ -69,7 +69,13 @@ public enum AutoStartLevel: Equatable, Sendable, CaseIterable {
         self == .atLoginWithAutoRestart
     }
 
-    /// Resolves (login, restart) pair refusing invalid permutations (#678).
+    /// The level a (login, restart) pair means — and the ONE place
+    /// the impossible pair (login OFF + restart ON) is refused
+    /// (#678 item 16): with login off the restart flag is
+    /// DISCARDED. The Advanced row's grey is a courtesy; this is
+    /// the half that holds for a CLI verb, a restored preference
+    /// or a test that never passes the view. Do not re-derive the
+    /// pair anywhere else.
     public static func level(
         openAtLogin: Bool,
         restartOnCrash: Bool

--- a/Sources/KiwiDeskCore/Service/AutoStartManager.swift
+++ b/Sources/KiwiDeskCore/Service/AutoStartManager.swift
@@ -1,72 +1,15 @@
 import Foundation
 
-/// The **auto-start composition root** (#576): the one place that
-/// folds KiwiDesk's two independent launch mechanisms — the
-/// `SMAppService` login item (`LoginItemManager`) and the
-/// crash-supervising `kiwidesk service` LaunchAgent
-/// (`ServiceManager`) — into a single `AutoStartLevel`. It is the
-/// GUI-side analog of what `CLIMain.runService` is for the CLI:
-/// each subsystem stays decoupled (`ServiceManager` never imports
-/// `SMAppService`), and this facade owns the coupling instead of
-/// the view.
-///
-/// Why one merged level and not two independent flags: the
-/// service is `RunAtLoad` + `KeepAlive` as one indivisible unit,
-/// so "restart on crash" is a *superset* of "open at login", and
-/// the pair *Open at Login: OFF + Restart: ON* names no reachable
-/// state. #576 kept that honest by shipping one three-level
-/// picker.
-///
-/// **The GUI now draws two rows again (#678 item 16), and the
-/// constraint did not move with it.** What makes the pair
-/// impossible is no longer the shape of the control — a view can
-/// hold two toggles in any combination — but
-/// `AutoStartLevel.level(openAtLogin:restartOnCrash:)`, which
-/// discards the restart flag when login is off. Read that as the
-/// invariant's home: the Advanced row's greying is a courtesy to
-/// the reader, and this type is what a CLI verb, a restored
-/// preference or a test hits when no view is involved. Do not
-/// re-derive the pair anywhere else.
-///
-/// **Async discipline (architect-gated).** `ServiceManager`'s
-/// launchctl verbs are blocking `Process` spawns; running them in a
-/// SwiftUI `body`/`onAppear` on the main thread is an AGENTS.md
-/// violation. So `current()` / `set(_:)` are `async` and do their
-/// work on a detached background task — the GUI shows a transient
-/// pending state and publishes the result to `@State` on main.
-///
-/// **Read-through.** No cached bool: the level is always derived
-/// from a fresh dual read, and `set(_:)` re-reads after applying,
-/// exactly as `LoginItemManager.setEnabled` returns `current`. That
-/// one live source keeps the GUI and the `kiwidesk service` CLI in
-/// sync with no second store to drift.
-///
-/// Core returns *structure* (`AutoStartStatus`); the GUI narrates
-/// the level and any unavailable/approval caption at its own
-/// boundary (#96).
+/// Auto-start composition root folding `SMAppService` and LaunchAgent into
+/// `AutoStartLevel` (#576, #678, #1071, #96).
 public enum AutoStartManager {
-    /// The current level plus the availability/approval facts the
-    /// GUI needs, read off the main actor.
+    /// Current status and availability, detached off main actor.
     public static func current() async -> AutoStartStatus {
         await Task.detached(priority: .userInitiated) { read() }
             .value
     }
 
-    /// Applies a level (registering/unregistering the login item
-    /// and starting/stopping the service as that level demands),
-    /// then re-reads so the control adopts OS truth rather than the
-
-    /// Drives the LOGIN ITEM alone, leaving the service exactly
-    /// as it is, and re-reads the folded status (#1071).
-    ///
-    /// `set(_:)` takes a LEVEL, and the level ladder stops the
-    /// service on both `.off` and `.atLogin` — correct for a
-    /// caller choosing a level, wrong for the Settings switch,
-    /// which owns the login item and nothing else since #1071.
-    /// Routing the GUI here means it cannot unload a user's
-    /// supervision agent even from a stale read of the status,
-    /// because there is no code path from this function to
-    /// `ServiceManager`.
+    /// Drives the login item alone and returns updated status (#1071).
     public static func setLoginItem(
         _ enabled: Bool
     ) async -> AutoStartStatus {
@@ -76,11 +19,7 @@ public enum AutoStartManager {
         }.value
     }
 
-    // MARK: - Dual read & apply (blocking — call off main)
-
-    /// One fresh dual read: the live login-item state + the
-    /// service's launchd state, folded to a level. Blocking
-    /// (`currentStatus` spawns launchctl) — callers run it detached.
+    /// Blocking dual read combining login item and launchd service state.
     static func read() -> AutoStartStatus {
         status(
             login: LoginItemManager.current,
@@ -88,18 +27,7 @@ public enum AutoStartManager {
         )
     }
 
-    /// Drives the two mechanisms to match `level`. The service is
-    /// the superset, so the auto-restart level keeps the login item
-    /// on *and* loads the service; the plain login level stops the
-    /// service; off clears both. Results are discarded — the
-    /// following re-read reports what actually took (a launchctl or
-    /// `SMAppService` failure is logged by the callee and simply
-
-    // MARK: - Pure mapping (unit-tested)
-
-    /// Folds the two subsystem states into the GUI-facing status.
-    /// Pure over its inputs so the mapping is testable without
-    /// touching `SMAppService` or launchctl.
+    /// Pure mapping from subsystem states to GUI status.
     static func status(
         login: LoginItemState,
         service: ServiceStatus
@@ -114,11 +42,7 @@ public enum AutoStartManager {
         )
     }
 
-    /// The level the merged state reads as. A loaded service wins:
-    /// it sets `RunAtLoad` (so it launches at login) *and*
-    /// `KeepAlive` (so it restarts on crash), the auto-restart
-    /// level's exact promise. Otherwise the login item alone means
-    /// plain at-login, and neither means off.
+    /// Derives level from flags (service loaded > login item on > off).
     static func level(
         loginOn: Bool,
         serviceLoaded: Bool
@@ -128,48 +52,24 @@ public enum AutoStartManager {
     }
 }
 
-/// The three auto-start levels the folded control offers (#576),
-/// ordered off → most. `atLoginWithAutoRestart` is a superset of
-/// `atLogin` — it also relaunches KiwiDesk if it crashes.
+/// Three auto-start levels (#576), ordered off → most.
 public enum AutoStartLevel: Equatable, Sendable, CaseIterable {
-    /// Neither mechanism: KiwiDesk never starts itself.
+    /// Never start automatically.
     case off
-    /// Login item on: launches at login, no crash supervision.
+    /// Launch at login via login item.
     case atLogin
-    /// The `kiwidesk service` LaunchAgent: launches at login and
-    /// restarts on crash (`RunAtLoad` + `KeepAlive`).
+    /// Launch at login and supervise crash restarts via LaunchAgent.
     case atLoginWithAutoRestart
 
-    // MARK: - The two rows the GUI draws (#678 item 16)
-
-    /// Whether KiwiDesk starts itself at login.
+    /// Whether KiwiDesk starts at login.
     public var opensAtLogin: Bool { self != .off }
 
-    /// Whether it is also supervised and relaunched on a crash.
+    /// Whether KiwiDesk restarts on crash.
     public var restartsOnCrash: Bool {
         self == .atLoginWithAutoRestart
     }
 
-    /// The level a (login, restart) PAIR means — and the one place
-    /// the impossible pair is refused (#678 item 16).
-    ///
-    /// Turn 14b draws two rows where #576 shipped one three-level
-    /// picker. #576's reason has not gone away: the LaunchAgent
-    /// writes `RunAtLoad` and `KeepAlive` as one indivisible unit,
-    /// so "restart on crash" is a SUPERSET of "open at login" and
-    /// the pair *login OFF + restart ON* names no reachable
-    /// state. What changed is the presentation, not the
-    /// constraint.
-    ///
-    /// So the constraint moves here, where it is total: with
-    /// login off the restart flag is DISCARDED rather than
-    /// honoured, and no caller can express the contradiction
-    /// whatever its two toggles say. The Advanced row also greys
-    /// while login is off, but `gui.md` is explicit that a grey
-    /// is never the sole gate on a side effect — this is the
-    /// other half, and it is the half that holds when a future
-    /// caller (a CLI verb, a restored preference, a test) never
-    /// passes through the view at all.
+    /// Resolves (login, restart) pair refusing invalid permutations (#678).
     public static func level(
         openAtLogin: Bool,
         restartOnCrash: Bool
@@ -179,23 +79,10 @@ public enum AutoStartLevel: Equatable, Sendable, CaseIterable {
     }
 }
 
-/// The structure Core hands the GUI for the auto-start control: the
-/// current level plus the two facts that shape its rendering —
-/// whether the upper levels are unavailable (grey, don't hide), and
-/// whether the login item is awaiting the user's approval.
+/// Auto-start status for GUI rendering (#96).
 public struct AutoStartStatus: Equatable, Sendable {
-    /// The level the merged state currently reads as.
     public let level: AutoStartLevel
-    /// Set when the running copy can't register a login item — a
-    /// bare binary or a translocated download. Disables levels 2
-    /// *and* 3 (both need a stable `.app` path: level 2 is the
-    /// `SMAppService` item, level 3 a LaunchAgent that would point
-    /// at an ephemeral path), leaving only "Never" selectable. The
-    /// reason picks the caption, reusing the login-item strings.
     public let unavailable: LoginItemUnavailable?
-    /// The login item is registered but macOS needs the user to
-    /// confirm it in System Settings ▸ Login Items — surfaced as
-    /// the same jump the login toggle showed.
     public let requiresApproval: Bool
 
     public init(
@@ -208,7 +95,6 @@ public struct AutoStartStatus: Equatable, Sendable {
         self.requiresApproval = requiresApproval
     }
 
-    /// Whether the upper two levels are selectable — false when the
-    /// running copy can't register.
+    /// True if auto-start registration is supported in this environment.
     public var registerable: Bool { unavailable == nil }
 }

--- a/Sources/KiwiDeskCore/State/StateCoordinator+EffectiveMembers.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+EffectiveMembers.swift
@@ -67,7 +67,10 @@ extension StateCoordinator {
         }
     }
 
-    /// Display assigned to a window's home space (#445).
+    /// Display assigned to a window's home space (#445) — the one
+    /// primitive the "home display = display of home space"
+    /// invariant rests on, shared so `stickyRenderSpace`,
+    /// `stickyExemptFromStash` and the move guard cannot drift.
     func homeDisplay(of window: WindowID) -> DisplayID? {
         workspaces.space(of: window)
             .flatMap { workspaces.display(of: $0) }
@@ -91,8 +94,13 @@ extension StateCoordinator {
         }
     }
 
-    /// The window a focus-driven surface should treat as focused on `space`,
-    /// including frontmost sticky travelers (#431, #416, #292).
+    /// The window a focus-driven surface should treat as focused
+    /// on `space` (#431, #416, #292). Normally `space.focused`,
+    /// except when a sticky traveler is frontmost and can never BE
+    /// that slot (the membership guard keeps `space.focused` off
+    /// it). `lastFocused` is GLOBAL, so the anchor yields the
+    /// traveler until a real member is next focused — an inactive
+    /// space injects none and always yields its own focus.
     public func focusAnchor(
         of space: Space,
         tiled: [WindowID]
@@ -133,7 +141,11 @@ extension StateCoordinator {
         var result: [WindowID] = []
         var next = 0
         for id in space.windows {
-            // Fullscreen stickies stay home (#670).
+            // Fullscreen first (#670), BEFORE the sticky skip:
+            // absent from `injected`, the tiled cursor below would
+            // drain past it and duplicate every later member, and
+            // a fullscreen sticky travels nowhere — its one glyph
+            // stays home.
             if let window = windows[id], window.isFullscreen {
                 result.append(id)
                 continue

--- a/Sources/KiwiDeskCore/State/StateCoordinator+EffectiveMembers.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+EffectiveMembers.swift
@@ -1,29 +1,12 @@
 import Foundation
 
-// MARK: - Effective space membership (#414/#415)
-//
-// A sticky window is a real member of exactly ONE space — its
-// home (`Space.windows` holds it nowhere else). Presence on
-// every space is DERIVED here, never stored: a tiled-sticky
-// window is injected into the ACTIVE space's tiled member list
-// at a position computed from its home-space position (#414
-// v2), and the Space Bar's glyph membership travels alongside.
+// Sticky windows belong to one home space; presence on other spaces is derived
+// (#414, #415).
 
 extension StateCoordinator {
-    /// Ordered tiled members a space actually OWNS
-    /// (`space.windows` minus floating and native-fullscreen)
-    /// — no sticky injection. The derivation for anything that
-    /// writes positions back into `space.windows` (the App Bar
-    /// drag reorder), where an injected traveler with no local
-    /// slot would overwrite a real window's slot (#414 v2).
-    ///
-    /// Native-fullscreen exemption (#670): the window keeps
-    /// its slot in `space.windows` (fullscreen is not a
-    /// destroy — the design ruling `FullscreenStateTests`
-    /// pins), but macOS moved it to its own Space, so no
-    /// layout pass, navigation step, or z-order raise may
-    /// target it until it returns. The `.windowFullscreenChanged`
-    /// retile re-places it on exit.
+    /// Ordered tiled members a space owns (`space.windows` minus floating and
+    /// native-fullscreen, #414 v2). Fullscreen keeps its slot but leaves
+    /// tiling until return (#670, `FullscreenStateTests`).
     public func localTiledMembers(
         of space: Space
     ) -> [WindowID] {
@@ -33,46 +16,22 @@ extension StateCoordinator {
         }
     }
 
-    /// Ordered tiled members of a space for layout, navigation,
-    /// and z-order — the single authority replacing the
-    /// open-coded `space.windows.filter { !isFloating }` sites
-    /// (#415).
-    ///
-    /// #414 v2: on the ACTIVE space this additionally injects
-    /// every tiled-sticky window homed on another space, each
-    /// inserted at an index derived from its position among its
-    /// home space's own tiled members (clamped to the target
-    /// list, insertion — never overwrite, never stored).
-    /// Reordering a sticky on its HOME space therefore moves its
-    /// derived slot everywhere for free; reordering it on a
-    /// foreign space is a v2 non-goal (`Space.swap` membership
-    /// guards no-op on a non-member). Inactive spaces stay pure
-    /// local: only the space on screen tiles travelers.
+    /// Ordered tiled members for layout, navigation, and z-order (#415).
+    /// Injects tiled-sticky travelers on active space at home-derived indices
+    /// (#414 v2, #445).
     public func effectiveTiledMembers(
         of space: Space,
         activeSpace: SpaceID? = nil
     ) -> [WindowID] {
         let focused = activeSpace ?? workspaces.activeSpace
-        // A local sticky that RENDERS on another space has
-        // physically traveled away (#445: a global sticky follows
-        // the focused display; a display sticky follows its home
-        // monitor's shown space). Drop it from this space's layout
-        // so its home monitor reserves no phantom slot to fight the
-        // traveler frame on the render display. On the common
-        // single-monitor / home-active path its render space IS
-        // this space, so nothing is dropped.
+        // Local sticky rendering elsewhere drops from local layout (#445).
         var members = localTiledMembers(of: space).filter { id in
             guard let window = windows[id], window.isSticky
             else { return true }
             return stickyRenderSpace(of: window, focused: focused)
                 == space.id
         }
-        // Ascending (index, id) order, each insertion offset by
-        // the travelers already placed before it: earlier
-        // travelers occupy slots ahead of later home indexes,
-        // and the offset keeps the clamped (append) case in the
-        // same ascending order — a reversed insertion inverted
-        // ties whenever two travelers clamped to the end.
+        // Offset by already-placed travelers to preserve ascending order.
         for (placed, traveler)
             in tiledStickyTravelers(into: space, focused: focused)
             .enumerated()
@@ -88,25 +47,9 @@ extension StateCoordinator {
         return members
     }
 
-    /// The single space a sticky window RENDERS on right now —
-    /// where its one physical frame lands and its glyph shows
-    /// (#445). A sticky window is a real member of one home space
-    /// but is DERIVED onto others; with two scopes across several
-    /// monitors it can only physically be one place, so this names
-    /// it:
-    ///
-    /// - `.global`: the FOCUSED active space. One physical window
-    ///   follows the display the user is on — injected there as a
-    ///   traveler, or rendered in place when its home space IS the
-    ///   focused one.
-    /// - `.display`: the space currently shown on its HOME display
-    ///   (`activeSpace(on:)`). It never leaves that monitor; a
-    ///   cross-display `move_to_space` re-homes it first.
-    ///
-    /// Collapses to the focused active space when the home display
-    /// is unresolvable (single monitor, early boot, unit tests) —
-    /// there "one monitor" and "every monitor" coincide, so a
-    /// display sticky behaves exactly like a global one.
+    /// The single space a sticky window renders on currently (#445).
+    /// Global follows focused space; display follows home monitor's active
+    /// space.
     func stickyRenderSpace(
         of window: ManagedWindow,
         focused: SpaceID?
@@ -124,28 +67,14 @@ extension StateCoordinator {
         }
     }
 
-    /// The display a window's HOME space is assigned to — the one
-    /// primitive the "home display = display of home space"
-    /// invariant (#445) rests on, shared so `stickyRenderSpace`,
-    /// `stickyExemptFromStash`, and the move guard cannot drift on
-    /// how it is computed. Each caller keeps its own fallback for
-    /// the unresolvable (single-monitor / unassigned) case.
+    /// Display assigned to a window's home space (#445).
     func homeDisplay(of window: WindowID) -> DisplayID? {
         workspaces.space(of: window)
             .flatMap { workspaces.display(of: $0) }
     }
 
-    /// Whether a sticky window is exempt from the inactive-space
-    /// stash while `space` is being parked (#414/#445). A global
-    /// sticky is always exempt — present on every monitor. A
-    /// display sticky is exempt only on its OWN display's spaces:
-    /// parking a space on ANOTHER display must not keep it visible
-    /// there. Under the one-home-space invariant the window only
-    /// ever appears in the stash loop on its home display, so this
-    /// is exempt-in-practice; the display check states the
-    /// invariant explicitly and stays correct if that ever shifts.
-    /// Collapses to exempt when the home display is unresolvable
-    /// (single monitor), where display and global sticky coincide.
+    /// Whether sticky window is exempt from inactive stash on `space`
+    /// (#414, #445).
     func stickyExemptFromStash(
         _ window: ManagedWindow,
         onSpace space: SpaceID
@@ -162,47 +91,8 @@ extension StateCoordinator {
         }
     }
 
-    /// The window a focus-driven surface should treat as focused
-    /// on `space` — the target a Scrolling space pans to, a
-    /// Monocle space raises on top, and the App Bar highlights
-    /// (`KiwiCore.appBarFocused`). Normally its own `focused`
-    /// slot, except when
-    /// a tiled-sticky traveler is the frontmost window
-    /// (`lastFocused`) and can never BE that slot (#431). A
-    /// traveler is injected into the active space's row (present
-    /// in `tiled`) yet is a member only of its home space, so
-    /// `WorkspaceManager.focus`'s membership guard keeps
-    /// `space.focused` off it; without this the layout cannot
-    /// surface it — clicking its bar item, or navigating to it,
-    /// would leave it off-screen (Scrolling) or buried (Monocle).
-    ///
-    /// `lastFocused` is a **global** field, so the anchor tracks
-    /// the last-focused window across the whole workspace: it
-    /// yields the traveler until any real member is next focused,
-    /// not the instant a space is switched (a bare switch fires no
-    /// focus event). An inactive space injects no travelers
-    /// (`tiled` is local-only) so it always yields its own focus.
-    ///
-    /// A **floating** sticky traveler is never in `tiled`, so it
-    /// gets its own membership test (#416): when `lastFocused` is
-    /// a floating sticky that RENDERS on this space, it is the
-    /// window under the user's eyes — resolving past it to the
-    /// stale local slot made same-app implicit-focused verbs
-    /// (`toggle_sticky` pressed while looking at the sticky)
-    /// silently mutate the wrong window, and cross-app ones fail
-    /// the #292 pid check. The render space resolves against the
-    /// REAL active space (`focused: nil`), so an inactive space
-    /// keeps yielding its own focus — matching the one-arg
-    /// overload, whose traveler injection likewise uses the real
-    /// active space.
-    ///
-    /// - Parameters:
-    ///   - space: the space whose surface target is wanted.
-    ///   - tiled: the space's `effectiveTiledMembers`, passed in
-    ///     so the caller's already-computed list is reused rather
-    ///     than recomputed.
-    /// - Returns: the traveler to surface, or `space.focused` when
-    ///   no frontmost traveler applies (may itself be `nil`).
+    /// The window a focus-driven surface should treat as focused on `space`,
+    /// including frontmost sticky travelers (#431, #416, #292).
     public func focusAnchor(
         of space: Space,
         tiled: [WindowID]
@@ -221,15 +111,7 @@ extension StateCoordinator {
         return space.focused
     }
 
-    /// `focusAnchor` computing its own `tiled` — for the many
-    /// focused-command bodies that don't already hold the space's
-    /// `effectiveTiledMembers`. Travelers are injected against
-    /// the REAL active space (not the queried space as if it
-    /// were active, #416 review): a traveler physically renders
-    /// on one space, so an inactive space injects none and
-    /// collapses to `space.focused` — the same notion of
-    /// "active" the floating-sticky test uses, keeping the two
-    /// traveler branches in agreement.
+    /// Variant of `focusAnchor` computing its own `tiled` list (#416).
     public func focusAnchor(of space: Space) -> WindowID? {
         focusAnchor(
             of: space,
@@ -237,17 +119,8 @@ extension StateCoordinator {
         )
     }
 
-    /// The Space Bar's membership for a space: on the current
-    /// space, sticky windows homed elsewhere travel in — tiled
-    /// travelers at their injected layout position (so the bar
-    /// order matches the tiles on screen, #414 v2), floating
-    /// travelers appended id-sorted (they have no slot); on any
-    /// other space, its own sticky windows are pruned so each
-    /// glyph shows in exactly one place. Two client classes:
-    /// presentation (the bars) and, filtered to floats, the
-    /// float tier of directional focus
-    /// (`floatingFocusCandidates`, #488) — layout/z-order keep
-    /// using `effectiveTiledMembers`.
+    /// Space Bar membership including injected travelers and pruned stickies
+    /// (#414 v2, #488, #445). Fullscreen stickies stay home (#670).
     public func effectiveMembers(
         of space: Space,
         activeSpace: SpaceID? = nil
@@ -257,27 +130,10 @@ extension StateCoordinator {
             of: space,
             activeSpace: focused
         )
-        // Merge: local windows keep their flat-array positions
-        // (floating included); each tiled traveler lands before
-        // the local tiled member that follows it in the injected
-        // order. Locals appear in `injected` in their original
-        // relative order, so a single cursor suffices. A local
-        // sticky that renders on ANOTHER space (#445) is skipped —
-        // its glyph shows once, where it renders — and it is absent
-        // from `injected` too (dropped there), so the cursor stays
-        // aligned. This subsumes the old "prune own sticky on a
-        // non-active space" branch and additionally KEEPS a sticky
-        // that renders on a secondary display's shown space.
         var result: [WindowID] = []
         var next = 0
         for id in space.windows {
-            // Fullscreen first (#670): appended in place like a
-            // float — absent from `injected`, so the tiled
-            // cursor below would drain past it and duplicate
-            // every later member. Before the sticky skip: a
-            // fullscreen sticky travels nowhere (both
-            // injections exclude it), so its one glyph stays
-            // home instead of vanishing from every bar.
+            // Fullscreen stickies stay home (#670).
             if let window = windows[id], window.isFullscreen {
                 result.append(id)
                 continue
@@ -302,8 +158,6 @@ extension StateCoordinator {
         result.append(contentsOf: injected[next...])
         let floating = windows.all
             .filter {
-                // Fullscreen stickies stay home (loop above);
-                // appending here too would double the glyph.
                 $0.isSticky && $0.isFloating && !$0.isFullscreen
                     && !space.windows.contains($0.id)
                     && stickyRenderSpace(of: $0, focused: focused)
@@ -314,22 +168,13 @@ extension StateCoordinator {
         return result + floating
     }
 
-    /// Tiled-sticky windows homed on a space OTHER than
-    /// `space`, paired with their derived injection index — the
-    /// window's position among its home space's own tiled
-    /// members. Sorted by (index, id) so multiple stickies
-    /// insert in a stable order regardless of dictionary
-    /// ordering.
+    /// Tiled-sticky windows homed elsewhere with derived home index (#670).
     private func tiledStickyTravelers(
         into space: Space,
         focused: SpaceID?
     ) -> [(id: WindowID, homeIndex: Int)] {
         windows.all
             .filter {
-                // A fullscreen sticky travels nowhere (#670);
-                // the `firstIndex` below would drop it anyway
-                // (it has no local tiled slot), stated here so
-                // the exemption is deliberate, not incidental.
                 $0.isSticky && !$0.isFloating && !$0.isFullscreen
                     && !space.windows.contains($0.id)
                     && stickyRenderSpace(of: $0, focused: focused)

--- a/Sources/KiwiDeskCore/State/StateCoordinator.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator.swift
@@ -38,7 +38,10 @@ public struct StateCoordinator: Sendable {
     /// Explicit `make_floating` / `make_tiled` verdicts per window.
     var manualFloatOverrides: [WindowID: Bool] = [:]
 
-    /// Manual float intent remembered across window close/reopen (#160).
+    /// Manual float intent remembered across close/reopen (#160).
+    /// Keyed by app + title, not `WindowID`: a reopened window
+    /// gets a fresh id, and old ids can be recycled onto unrelated
+    /// windows. Last close wins, first reopen consumes.
     var rememberedFloating: [WindowIdentity: Bool] = [:]
 
     /// Sticky intent remembered across window close/reopen (#414, #445).
@@ -59,8 +62,14 @@ public struct StateCoordinator: Sendable {
         workspaces.ensureSpace(defaultSpace)
     }
 
-    /// Swaps a window ID across all ID-keyed maps for native tab switches
-    /// (#308, #673; `WindowRekeyParityTests`, `MinimizeOrderTests`).
+    /// Swaps a window ID across every ID-keyed map for native tab
+    /// switches (#308) — the hand-mirrored list §5 warns about, so
+    /// `WindowRekeyParityTests` discovers the containers by
+    /// reflection. `minimizeOrder`'s element is a struct the
+    /// reflection cannot see; the `String(describing:)` scan and
+    /// `MinimizeOrderTests` are its nets (#673).
+    /// `rememberedFloating` is keyed by app+title and deliberately
+    /// untouched.
     mutating func rekey(_ old: WindowID, to new: WindowID) {
         windows.rekey(old, to: new)
         workspaces.rekey(old, to: new)

--- a/Sources/KiwiDeskCore/State/StateCoordinator.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator.swift
@@ -1,30 +1,15 @@
 import Foundation
 
-/// Applies `KiwiEvent`s to the state managers.
-///
-/// This is the single write path for KiwiDesk's internal state:
-/// the event loop produces events, the coordinator folds them into
-/// `WindowManager` and `WorkspaceManager`. Pure and synchronous,
-/// so the full pipeline is unit-testable without AX access.
+/// Applies `KiwiEvent`s to the state managers (`WindowManager`,
+/// `WorkspaceManager`). Pure and synchronous write path.
 public struct StateCoordinator: Sendable {
-    // internal(set), like `workspaces`: the intent split
-    // (`+Intents.swift`) mutates it from its own file.
     public internal(set) var windows = WindowManager()
     public internal(set) var workspaces = WorkspaceManager()
 
-    /// `app_rules` from init.lua: new windows of these apps go
-    /// to a fixed space instead of the active one.
+    /// `app_rules` routing new windows of these apps to a fixed space.
     public var appRules: [String: SpaceID] = [:]
 
-    /// `new_window_placement` per layout mode. Mirrored from
-    /// the tiler settings before each event (KiwiCore) — which
-    /// also seeds `.monocle` from `MonocleParams` — so it
-    /// survives profile loads and live commands. This
-    /// compile-time literal omits monocle (seeded at runtime)
-    /// and floating (no tiled slot); both fall back to
-    /// `.afterFocused` before the first event. Defaults derive
-    /// from the params structs so unit tests see production
-    /// behavior.
+    /// `new_window_placement` per layout mode, mirrored from tiler settings.
     public var spawnPlacements: [LayoutMode: SpawnPlacement] = [
         .bsp: BspParams().newWindowPlacement,
         .stack: StackParams().newWindowPlacement,
@@ -32,105 +17,31 @@ public struct StateCoordinator: Sendable {
         .grid: GridParams().newWindowPlacement,
     ]
 
-    /// Per-space `new_window_placement_override`: beats the
-    /// layout's spawn placement, like the gap override.
+    /// Per-space `new_window_placement_override`.
     public var spawnOverride: [SpaceID: SpawnPlacement] = [:]
 
-    /// The track layout's params (#128), mirrored from the
-    /// tiler settings like `spawnPlacements`: a new **tiled**
-    /// window in a track space follows `new_window`/`count`
-    /// instead of a `SpawnPlacement` (the flat-index vocabulary
-    /// cannot say "own track"). A floating window still takes
-    /// the `SpawnPlacement` path (it has no track slot), so its
-    /// array position — and thus which track it would join if
-    /// it later tiles — honors the placement override as in
-    /// every other mode.
+    /// Track layout params (#128) governing new tiled track allocations.
     public var trackParams = TrackParams()
 
-    /// Per-space fill-then-spill capacity (#437), mirrored from the
-    /// tiler before each event like `trackParams`: how many windows
-    /// a track holds at `min_window_size` before a `focused_track`
-    /// spawn spills into a new track beside the focused one. The
-    /// number is geometry-derived (the space's display), computed
-    /// where the geometry lives (`TilingEngine.trackCapacities`) so
-    /// this state core stays pure. An absent entry (unknown display)
-    /// makes the spawn join-and-pile — the same safe fallback a
-    /// traveler takes.
+    /// Per-space fill-then-spill track capacity (#437), geometry-derived.
     public var trackCapacities: [SpaceID: Int] = [:]
 
-    /// The display an ARRIVING window's frame physically sits on
-    /// (#1010), written by KiwiCore before each `.windowCreated`
-    /// because resolving a frame to a screen needs `NSScreen`
-    /// and the AX/AppKit y-flip, neither of which may enter this
-    /// pure core (§2.6). Nil when no screen backs the frame —
-    /// the arrival then resolves exactly as it did before this
-    /// input existed.
-    ///
-    /// Unlike `trackCapacities` and the settings mirrors above,
-    /// this is a **single-event payload**, not a standing mirror:
-    /// it is meaningless outside the one arrival it was resolved
-    /// for, and a stale value would re-home an unrelated window
-    /// across monitors. So the create fold CONSUMES it — reads
-    /// it and clears it — and a producer that forgets to write
-    /// it makes the fold resolve as it always did rather than
-    /// inheriting the last arrival's screen.
+    /// Physical display of an arriving window (#1010), consumed on create.
     public var arrivalDisplay: DisplayID?
 
-    /// Last known space per window. Window ids are stable OS
-    /// ids, so a "created" window with a remembered space is
-    /// one coming back from another native macOS Space (or a
-    /// session restore) and returns there instead of landing
-    /// in the active space. Minimized windows are deliberately
-    /// forgotten: deminiaturize opens in the active space.
-    /// Internal, not private: the create fold lives in
-    /// `StateCoordinator+WindowCreated.swift` (file-ceiling
-    /// split).
+    /// Last known space per window for native-Space restores.
     var rememberedSpaces: [WindowID: SpaceMemory] = [:]
 
-    /// Windows currently minimized, newest last, each with the
-    /// app that owned it — so a deminiaturize classifies as
-    /// `restored` (#40) and Open or Focus can restore this app's
-    /// most recent one (#673). Lives here beside
-    /// `rememberedSpaces`: both are memory carried across
-    /// tracking gaps, and both go stale the same way, an entry
-    /// for a window closed while minimized lingering because no
-    /// event fires. Slightly weaker than `rememberedSpaces`'
-    /// staleness — these are DEAD ids, so a recycled WindowID
-    /// could inherit one — which is why the create fold prunes
-    /// unconditionally. The payload is advisory; accepted.
-    ///
-    /// `StateCoordinator+Minimize.swift` owns its lifetime and
-    /// argument (internal, not private, for that file-ceiling
-    /// split); `rekey` below reaches in directly, alongside the
-    /// other id-keyed containers it migrates.
+    /// Minimized windows in order (#40, #673; `MinimizeOrderTests`).
     var minimizeOrder: [MinimizedWindow] = []
 
-    /// Explicit `make_floating` / `make_tiled` verdicts per
-    /// tracked window — the only float state worth carrying
-    /// across close/reopen; detection re-derives the rest.
-    /// Internal, not private: the intent logic lives in
-    /// `StateCoordinator+Intents.swift` (file-ceiling split).
+    /// Explicit `make_floating` / `make_tiled` verdicts per window.
     var manualFloatOverrides: [WindowID: Bool] = [:]
 
-    /// Manual float intent of windows that closed (#160).
-    /// Keyed by app + title, not `WindowID`: a reopened window
-    /// gets a fresh id, and old ids can be recycled onto
-    /// unrelated windows (`rememberedSpaces` above can key on
-    /// ids because a native-Space return keeps the window
-    /// alive). Two live windows sharing an identity share one
-    /// slot: last close wins, first reopen consumes — at worst
-    /// one misapplied float, corrected with one command. A
-    /// drifted title on reopen misses the same gracefully.
-    /// Unconsumed entries linger for the session, mirroring
-    /// `rememberedSpaces`' lifetime (manual floats are rare).
+    /// Manual float intent remembered across window close/reopen (#160).
     var rememberedFloating: [WindowIdentity: Bool] = [:]
 
-    /// Sticky intent of windows that closed (#414/#445), mirroring
-    /// `rememberedFloating`'s identity keying and lifetime. A map
-    /// now that sticky carries a SCOPE (`.global` / `.display`):
-    /// an absent identity means "not sticky" (`.none` is never
-    /// stored), so the close of a non-sticky window drops its
-    /// entry (last close wins, like float).
+    /// Sticky intent remembered across window close/reopen (#414, #445).
     var rememberedSticky: [WindowIdentity: StickyScope] = [:]
 
     /// Stable close/reopen identity of a window (#160).
@@ -148,30 +59,14 @@ public struct StateCoordinator: Sendable {
         workspaces.ensureSpace(defaultSpace)
     }
 
-    /// Swaps a window's tracked id in place across every id-keyed
-    /// map this coordinator owns — window snapshot, space slot
-    /// (position + focus + weights), plus the three cross-tracking
-    /// maps below — for a native-tab active-tab change (#308). This
-    /// is the hand-mirrored id-keyed field list AGENTS.md §5 warns
-    /// about: forgetting a map is silent data loss, so
-    /// `WindowRekeyParityTests` discovers every WindowID-keyed
-    /// container by reflection and fails if one still holds `old`.
-    /// `rememberedFloating` is keyed by app+title, not WindowID, so
-    /// it is deliberately untouched. No-op if `old` is untracked.
+    /// Swaps a window ID across all ID-keyed maps for native tab switches
+    /// (#308, #673; `WindowRekeyParityTests`, `MinimizeOrderTests`).
     mutating func rekey(_ old: WindowID, to new: WindowID) {
         windows.rekey(old, to: new)
         workspaces.rekey(old, to: new)
         if let space = rememberedSpaces.removeValue(forKey: old) {
             rememberedSpaces[new] = space
         }
-        // The minimize record's id is a `var` for exactly this
-        // (#673). Know which half of the parity guard reaches it:
-        // its `windowContainers` reflection cannot — the element
-        // is a struct, not a `WindowID` — so the count pin misses
-        // it, while `rekeyMigratesMinimized`'s
-        // `String(describing:)` scan renders the struct and does
-        // catch a forgotten migration. `MinimizeOrderTests` is
-        // the second net.
         if let index = minimizeOrder.firstIndex(
             where: { $0.id == old }
         ) {
@@ -184,10 +79,7 @@ public struct StateCoordinator: Sendable {
         }
     }
 
-    /// Folds an event into state and returns the facts the write
-    /// erases, for `handle(_:)` to compose its side effects from
-    /// (#166). `@discardableResult` — command and test call sites
-    /// apply purely for the state change.
+    /// Folds an event into state and returns side-effect facts (#166).
     @discardableResult
     public mutating func apply(
         _ event: KiwiEvent
@@ -217,12 +109,7 @@ public struct StateCoordinator: Sendable {
                 effects: &effects
             )
 
-        // A hide folds as a non-minimized destroy exactly
-        // (#913): the window keeps its remembered space, so
-        // unhiding returns it there rather than landing it
-        // wherever the user now stands. What differs is
-        // downstream of the fold — the public reason, and the
-        // close-return raise KiwiCore stands down.
+        // Hides fold as non-minimized destroys to remember space (#913).
         case .windowHidden(let id):
             applyWindowDestroyed(
                 id,
@@ -246,16 +133,11 @@ public struct StateCoordinator: Sendable {
         case .windowTitleChanged(let id, let title):
             let floatBefore = windows[id]?.isFloating
             windows.updateTitle(id, title: title)
-            // Lazy-title apps (Electron/WebKit) are tracked
-            // before their titles arrive, so the create-time
-            // identity match misses; retry once the real
-            // title lands (#160).
+            // Retry lazy-title app overrides once real title lands (#160).
             if let window = windows[id] {
                 restoreFloatOverride(of: window)
                 restoreStickyIntent(of: window)
             }
-            // A late title can restore a remembered float
-            // override — the only title change that retiles.
             if let floatBefore,
                 windows[id]?.isFloating != floatBefore
             {
@@ -263,20 +145,12 @@ public struct StateCoordinator: Sendable {
             }
 
         case .windowFloatChanged(let id, let floating):
-            // A manual override always wins over detection:
-            // the title recheck (#160) makes verdicts flip
-            // routinely for `App:Title` rules, and a flip must
-            // not revert an explicit make_floating/make_tiled
-            // (docs promise re-checks never do).
+            // Manual overrides beat AX detection on title flips (#160).
             guard manualFloatOverrides[id] == nil else { break }
-            // `windows.setFloating` also clears any stale overlay
-            // flag when a window heals back to tiled (#300).
+            // Clears stale overlay flag on return to tiled (#300).
             windows.setFloating(id, floating)
 
         case .windowFullscreenChanged(let id, let fullscreen):
-            // No override layer here (unlike float): fullscreen
-            // is purely AX-detected, so the re-check verdict
-            // always applies.
             windows.setFullscreen(id, fullscreen)
 
         case .windowRekeyed(let old, let new):
@@ -286,15 +160,8 @@ public struct StateCoordinator: Sendable {
             reconcile(displays: displays)
 
         case .desktopChanged:
-            // Handled by KiwiCore (profile binding); the
-            // internal state keys off the AX reconcile that
-            // follows the switch.
             break
         }
         return effects
     }
 }
-
-// `effectiveMembers` / `effectiveTiledMembers` live in
-// `StateCoordinator+EffectiveMembers.swift` (file-ceiling
-// split, #414 v2).

--- a/Sources/KiwiDeskCore/State/WorkspaceManager.swift
+++ b/Sources/KiwiDeskCore/State/WorkspaceManager.swift
@@ -1,63 +1,27 @@
 import Foundation
 
-/// Manages Spaces and their display assignment.
-///
-/// Pure state container: window-to-space membership lives here as
-/// flat arrays inside each `Space`. A window belongs to at most one
-/// space at a time.
+/// Manages Spaces and their display assignment. Flat window arrays per space.
 public struct WorkspaceManager: Sendable {
     private var spaces: [SpaceID: Space] = [:]
-    /// Creation order, used for deterministic iteration.
-    /// Internal (not private) with the three display maps
-    /// below: the `+Displays` split reads them cross-file.
-    /// Writes stay inside the two `WorkspaceManager*` files —
-    /// `WorkspaceMapSealTests` pins the two scannable names
-    /// and states why these two are not.
+    /// Creation order; `WorkspaceMapSealTests` pins cross-file internal
+    /// access.
     var order: [SpaceID] = []
     var displays: [DisplayID: Display] = [:]
     var spaceDisplay: [SpaceID: DisplayID] = [:]
-    /// The space shown on the FOCUSED display — the one the user
-    /// is currently acting on. Every command that means "the
-    /// current space" reads this. On a single monitor it is the
-    /// whole story; with several, the other displays' shown
-    /// spaces live in `secondaryShown`.
+    /// Space shown on currently focused display.
     public private(set) var activeSpace: SpaceID?
 
-    /// The space shown on each display OTHER than the focused
-    /// one (multi-monitor, #multi-monitor). AeroSpace's
-    /// `screenPointToVisibleWorkspace` minus the focused entry:
-    /// we keep the focused display's space in `activeSpace`, so
-    /// the invariant is that `display(of: activeSpace)` is never
-    /// a key here. A display absent from the map falls back to
-    /// its first-assigned space, so a freshly attached monitor
-    /// needs no explicit seeding — only an explicit switch away
-    /// from that default records an entry. Every non-focused
-    /// display's shown space is thus `activeSpace(on:)`.
-    /// Internal like `order`: the `+Displays` split writes it.
+    /// Spaces shown on non-focused displays (#multi-monitor).
     var secondaryShown: [DisplayID: SpaceID] = [:]
 
-    /// The window holding the SYSTEM focus, across spaces —
-    /// every focus write lands here (`focus(_:in:)` is the one
-    /// write path). Distinct from a space's own `focused`,
-    /// which is just that space's last-focused member: a
-    /// sticky window focused from a foreign space (#414) makes
-    /// the two disagree, and surfaces that accent "the focused
-    /// window" (the Space Bar) must follow this one.
+    /// Window holding system-wide focus (#414).
     public private(set) var lastFocused: WindowID?
 
-    /// The window focused immediately BEFORE `lastFocused` — a
-    /// one-deep history, not a stack. Read by the destroy fold's
-    /// close-return pick (validated there against current state:
-    /// alive, same space, surfaceable); deliberately never a
-    /// deeper walk-back — invisible, self-reordering history is
-    /// what the repeat-press-cycling ruling rejected, and one
-    /// visible step back is the whole close-return promise
-    /// (`docs/design-decisions.md` ▸ Close-return focus).
+    /// Previous focused window for close-return focus
+    /// (`focusReturnCandidate`).
     public private(set) var focusReturnCandidate: WindowID?
 
     public init() {}
-
-    // MARK: - Spaces
 
     public var allSpaces: [Space] {
         order.compactMap { spaces[$0] }
@@ -67,7 +31,7 @@ public struct WorkspaceManager: Sendable {
         spaces[id]
     }
 
-    /// Returns the space, creating it on first use.
+    /// Returns space, creating it on first use.
     @discardableResult
     public mutating func ensureSpace(
         _ id: SpaceID,
@@ -85,16 +49,8 @@ public struct WorkspaceManager: Sendable {
         return space
     }
 
-    /// Sets a space's layout mode; an actual mode *change* also
-    /// clears the scrolling viewport offset (#66): a stale
-    /// offset from a previous scrolling stint (different window
-    /// count, different anchor) is not a meaningful "previous
-    /// position" for a fresh one — re-entering scrolling should
-    /// reseed from the anchor, not resume mid-scroll. A
-    /// same-mode set must NOT clear: profile / GUI applies call
-    /// this densely over all live spaces on every apply, and an
-    /// unconditional clear would snap every scrolling viewport
-    /// home whenever an unrelated setting is edited.
+    /// Sets layout mode; mode changes clear viewport offset and stint state
+    /// (#66, #458, #128, #437).
     public mutating func setMode(
         _ id: SpaceID,
         _ mode: LayoutMode,
@@ -103,12 +59,7 @@ public struct WorkspaceManager: Sendable {
         guard spaces[id]?.mode != mode else { return }
         spaces[id]?.mode = mode
         spaces[id]?.scrollRest = nil
-        // The session resize layer (#458) is a stint value like
-        // the offset: a fresh mode stint reseeds from config.
         spaces[id]?.sessionRatios = SessionRatios()
-        // Track boundaries follow the same rule (#128). Entering
-        // track uses the caller's `trackSeed` (fill-then-spill
-        // packing, #437) or seeds every window as its own track.
         spaces[id]?.trackWeights = [:]
         let seed: Set<WindowID> =
             mode == .track
@@ -117,18 +68,10 @@ public struct WorkspaceManager: Sendable {
         spaces[id]?.trackBreaks = seed
     }
 
-    /// Reorders the iteration order to follow `desired` for
-    /// spaces present in both; spaces not mentioned keep their
-    /// relative order, appended after. `ensureSpace` never
-    /// reorders an existing space, so profile application calls
-    /// this to reconcile creation order with the stored display
-    /// order (#75/#55) — both profile-save paths then capture
-    /// ONE order representation.
+    /// Reorders iteration order to match desired order (#75, #55).
     public mutating func reorder(matching desired: [SpaceID]) {
         let current = Set(order)
         var seen: Set<SpaceID> = []
-        // First occurrence wins — a duplicate id in `desired`
-        // must not duplicate a space in the iteration order.
         let front = desired.filter {
             current.contains($0) && seen.insert($0).inserted
         }
@@ -136,48 +79,25 @@ public struct WorkspaceManager: Sendable {
         order = front + rest
     }
 
-    /// Makes `id` the shown space on its display and moves focus
-    /// to that display. If `id` lives on a DIFFERENT display than
-    /// the currently focused one, the previously focused display
-    /// keeps showing its space (parked in `secondaryShown`) — it
-    /// is not stashed. On one monitor (or before displays are
-    /// assigned) this reduces to the old behavior: replace the
-    /// single `activeSpace`.
+    /// Activates space on its display and shifts display focus.
     public mutating func activate(_ id: SpaceID) {
         ensureSpace(id)
         let newDisplay = spaceDisplay[id]
         let oldDisplay = activeSpace.flatMap { spaceDisplay[$0] }
         if let newDisplay, newDisplay != oldDisplay {
-            // Focus is moving to another display. Preserve the
-            // display we're leaving so its space stays visible.
             if let oldDisplay, let old = activeSpace {
                 secondaryShown[oldDisplay] = old
             }
-            // The newly focused display's space is now the
-            // authoritative `activeSpace`, not a secondary entry.
             secondaryShown[newDisplay] = nil
         }
         activeSpace = id
     }
 
-    /// The space shown on `display`: the focused `activeSpace`
-    /// when that space is assigned to this display, else an
-    /// explicit `secondaryShown` pick, else the first space
-    /// assigned to it (creation order). Nil when nothing is
-    /// assigned. This is the single truth the tiler lays out per
-    /// display and the bars read (superseding `currentSpace`).
+    /// Active space shown on specified display.
     public func activeSpace(on display: DisplayID) -> SpaceID? {
         if let active = activeSpace, spaceDisplay[active] == display {
             return active
         }
-        // Self-healing: a `secondaryShown` pick counts only while
-        // that space still lives on THIS display. A reassignment
-        // (profile apply, topology change) can leave the entry
-        // stale — pointing at a space now on another display — and
-        // honoring it would lay the same space on two screens. A
-        // stale entry is ignored, falling back to the first
-        // assigned space, so the read path stays correct even if a
-        // writer forgot to prune.
         if let shown = secondaryShown[display],
             spaceDisplay[shown] == display
         {
@@ -186,13 +106,7 @@ public struct WorkspaceManager: Sendable {
         return spaces(on: display).first
     }
 
-    /// Every space currently visible on some display — the
-    /// focused `activeSpace` plus each other display's shown
-    /// space. Drives `stashInactive`: a space in this set is
-    /// laid out in place on its display; every space outside it
-    /// is parked in a corner. With no displays known yet, this
-    /// is just `{activeSpace}`, so the single-monitor path is
-    /// unchanged.
+    /// All spaces currently visible across displays.
     public var visibleSpaces: Set<SpaceID> {
         var result: Set<SpaceID> = []
         if let active = activeSpace { result.insert(active) }
@@ -204,10 +118,7 @@ public struct WorkspaceManager: Sendable {
         return result
     }
 
-    /// Removes a space and forgets its display assignment. Any
-    /// windows still in it are dropped, so callers that must keep
-    /// them move them out first (`add(_:to:)`). The active space
-    /// falls back to the first remaining space when removed.
+    /// Removes space and clears display assignments.
     public mutating func removeSpace(_ id: SpaceID) {
         spaces[id] = nil
         order.removeAll { $0 == id }
@@ -218,16 +129,12 @@ public struct WorkspaceManager: Sendable {
         }
     }
 
-    // MARK: - Window membership
-
-    /// The space currently containing the window, if any.
+    /// Space containing window, if any.
     public func space(of window: WindowID) -> SpaceID? {
         order.first { spaces[$0]?.windows.contains(window) == true }
     }
 
-    /// Adds a window to a space, removing it from its old
-    /// space. With an anchor, the window is inserted right
-    /// after it (new windows split the focused window).
+    /// Adds window after anchor or at end.
     public mutating func add(
         _ window: WindowID,
         to id: SpaceID,
@@ -238,9 +145,7 @@ public struct WorkspaceManager: Sendable {
         spaces[id]?.insert(window, after: anchor)
     }
 
-    /// Adds a window to a space per the layout's spawn
-    /// placement rule (`new_window_placement`), removing it
-    /// from its old space.
+    /// Adds window according to layout spawn placement policy.
     public mutating func add(
         _ window: WindowID,
         to id: SpaceID,
@@ -251,9 +156,7 @@ public struct WorkspaceManager: Sendable {
         spaces[id]?.insert(window, placement: placement)
     }
 
-    /// Adds a window to a track-mode space per `new_window` (#128,
-    /// #437), removing it from its old space; the track twin of
-    /// `add(_:to:placement:)`. `isTiled` supplies float knowledge.
+    /// Adds window to track layout (#128, #437).
     public mutating func add(
         _ window: WindowID,
         to id: SpaceID,
@@ -275,7 +178,7 @@ public struct WorkspaceManager: Sendable {
         )
     }
 
-    /// Removes a window from whatever space contains it.
+    /// Removes window from containing space and clears focus trackers.
     public mutating func remove(_ window: WindowID) {
         if lastFocused == window { lastFocused = nil }
         if focusReturnCandidate == window { focusReturnCandidate = nil }
@@ -283,13 +186,9 @@ public struct WorkspaceManager: Sendable {
         spaces[id]?.remove(window)
     }
 
-    /// Re-keys a window in its space, preserving slot and focus
-    /// (#308). No-op if `old` is in no space.
+    /// Re-keys window ID preserving slot and focus (#308).
     public mutating func rekey(_ old: WindowID, to new: WindowID) {
         if lastFocused == old { lastFocused = new }
-        // The close-return candidate must follow a native-tab
-        // rekey like `lastFocused` does, or every tab switch
-        // silently kills it.
         if focusReturnCandidate == old { focusReturnCandidate = new }
         guard let id = space(of: old) else { return }
         spaces[id]?.rekey(old, to: new)
@@ -302,8 +201,6 @@ public struct WorkspaceManager: Sendable {
         guard spaces[id]?.windows.contains(window) == true else {
             return
         }
-        // A re-focus of the already-focused window must not
-        // collapse the history to itself.
         if lastFocused != window {
             focusReturnCandidate = lastFocused
         }
@@ -311,7 +208,7 @@ public struct WorkspaceManager: Sendable {
         lastFocused = window
     }
 
-    /// Mutates one space in place (array reordering etc.).
+    /// Mutates space in place.
     public mutating func withSpace(
         _ id: SpaceID,
         _ body: (inout Space) -> Void
@@ -320,5 +217,4 @@ public struct WorkspaceManager: Sendable {
         body(&space)
         spaces[id] = space
     }
-
 }

--- a/Sources/KiwiDeskCore/State/WorkspaceManager.swift
+++ b/Sources/KiwiDeskCore/State/WorkspaceManager.swift
@@ -11,14 +11,21 @@ public struct WorkspaceManager: Sendable {
     /// Space shown on currently focused display.
     public private(set) var activeSpace: SpaceID?
 
-    /// Spaces shown on non-focused displays (#multi-monitor).
+    /// Spaces shown on non-focused displays (#multi-monitor). The
+    /// invariant: `display(of: activeSpace)` is never a key here;
+    /// a display absent from the map falls back to its
+    /// first-assigned space.
     var secondaryShown: [DisplayID: SpaceID] = [:]
 
     /// Window holding system-wide focus (#414).
     public private(set) var lastFocused: WindowID?
 
-    /// Previous focused window for close-return focus
-    /// (`focusReturnCandidate`).
+    /// The window focused immediately before `lastFocused` — a
+    /// one-deep history, deliberately never a deeper walk-back:
+    /// invisible self-reordering history is what the
+    /// repeat-press-cycling ruling rejected, and one visible step
+    /// back is the whole close-return promise
+    /// (design-decisions ▸ Close-return focus).
     public private(set) var focusReturnCandidate: WindowID?
 
     public init() {}
@@ -49,8 +56,11 @@ public struct WorkspaceManager: Sendable {
         return space
     }
 
-    /// Sets layout mode; mode changes clear viewport offset and stint state
-    /// (#66, #458, #128, #437).
+    /// Sets layout mode; an actual mode CHANGE clears the viewport
+    /// offset and stint state (#66, #458, #128, #437). A same-mode
+    /// set must NOT clear: profile/GUI applies call this densely
+    /// over all live spaces, and an unconditional clear would snap
+    /// every scrolling viewport home on any unrelated edit.
     public mutating func setMode(
         _ id: SpaceID,
         _ mode: LayoutMode,
@@ -98,6 +108,10 @@ public struct WorkspaceManager: Sendable {
         if let active = activeSpace, spaceDisplay[active] == display {
             return active
         }
+        // Self-healing: a pick counts only while that space still
+        // lives on THIS display — a stale entry would lay one
+        // space on two screens, so it is ignored rather than
+        // honored.
         if let shown = secondaryShown[display],
             spaceDisplay[shown] == display
         {
@@ -189,6 +203,8 @@ public struct WorkspaceManager: Sendable {
     /// Re-keys window ID preserving slot and focus (#308).
     public mutating func rekey(_ old: WindowID, to new: WindowID) {
         if lastFocused == old { lastFocused = new }
+        // The candidate follows a native-tab rekey like
+        // `lastFocused`, or every tab switch silently kills it.
         if focusReturnCandidate == old { focusReturnCandidate = new }
         guard let id = space(of: old) else { return }
         spaces[id]?.rekey(old, to: new)
@@ -201,6 +217,8 @@ public struct WorkspaceManager: Sendable {
         guard spaces[id]?.windows.contains(window) == true else {
             return
         }
+        // A re-focus of the already-focused window must not
+        // collapse the history to itself.
         if lastFocused != window {
             focusReturnCandidate = lastFocused
         }

--- a/Sources/KiwiDeskCore/Tiling/FrameApplier.swift
+++ b/Sources/KiwiDeskCore/Tiling/FrameApplier.swift
@@ -2,23 +2,8 @@ import ApplicationServices
 import CoreGraphics
 import Foundation
 
-/// Applies animation frames to real windows without ever
-/// blocking the animation clock.
-///
-/// AX frame-setting is synchronous IPC into the target app
-/// (1–20 ms per call), so frames run on one serial queue *per
-/// application*: a slow app only delays its own windows,
-/// never other apps' frames or the display link. Per window,
-/// only the newest frame is kept — while one is waiting to be
-/// applied, later frames overwrite it, so a slow app skips
-/// intermediate steps instead of falling behind (and the
-/// final frame is always the one that lands).
-///
-/// While an app's windows animate, its
-/// `AXEnhancedUserInterface` is switched off: with it on,
-/// AppKit performs extra work per frame-set that makes moves
-/// visibly stutter. It is restored when the app's last
-/// animation ends (see AGENTS.md guardrails).
+/// Applies animation frames to real windows via per-app queues without
+/// blocking the clock.
 @MainActor
 final class FrameApplier {
     var elementProvider: @MainActor (WindowID) -> AXUIElement? =
@@ -31,45 +16,26 @@ final class FrameApplier {
     private let recent = RecentApplies()
     private let instantTargets = InstantTargets()
 
-    /// How long after one of our own frame-sets a window's
-    /// move events are still considered self-inflicted. AX
-    /// echoes arrive asynchronously, usually well under this.
+    /// Grace period for ignoring self-inflicted AX frame echoes.
     private static let echoGrace: TimeInterval = 1.0
 
-    /// Whether we set this window's frame within the echo
-    /// grace period. Used to tell the AX echoes of our own
-    /// frame-sets apart from user drags — without this, the
-    /// echo of a settled animation reads as a drag end (and in
-    /// stack layouts, where all slots overlap, that fake drop
-    /// swaps windows and retriggers itself forever).
+    /// True if window's frame was set within echo grace period.
     func didRecentlySetFrame(_ id: WindowID) -> Bool {
         recent.isRecent(id, within: Self.echoGrace)
     }
 
-    /// The frame a recent `applyInstant` commanded for this
-    /// window, while its echo may still be in flight (#881):
-    /// the steady-state overlay syncs prefer it over the
-    /// echo-fed state frame, so a ring moves at monocle park's
-    /// instant focus switch instead of a whole echo behind it.
-    /// Cleared by the first self-echo (`clearInstantTarget` —
-    /// reality reported, and an app may have clamped the ask)
-    /// or by the echo grace expiring.
+    /// Commanded frame from recent `applyInstant` while echo is in flight
+    /// (#881).
     func instantTarget(_ id: WindowID) -> CGRect? {
         instantTargets.frame(id, within: Self.echoGrace)
     }
 
-    /// The window's first self-echo arrived: the echo-fed state
-    /// frame is now the better truth, so the stamp retires
-    /// early rather than shadowing a clamped answer for the
-    /// rest of the grace.
+    /// Retires instant target stamp upon arrival of first self-echo.
     func clearInstantTarget(_ id: WindowID) {
         instantTargets.clear(id)
     }
 
-    // MARK: - Animation lifecycle (EUI management)
-
-    /// Marks a window as animating; disables the app's
-    /// EnhancedUserInterface while any of its windows move.
+    /// Marks window animating and disables app EnhancedUserInterface.
     func beginAnimating(_ id: WindowID) {
         guard animatingPid[id] == nil,
             let element = elementProvider(id),
@@ -82,9 +48,7 @@ final class FrameApplier {
         }
     }
 
-    /// Ends a window's animation (settled or cancelled) and
-    /// restores EnhancedUserInterface when it was the app's
-    /// last moving window.
+    /// Ends window animation and restores EnhancedUserInterface if last.
     func endAnimating(_ id: WindowID) {
         guard let pid = animatingPid.removeValue(forKey: id)
         else { return }
@@ -95,13 +59,7 @@ final class FrameApplier {
         }
     }
 
-    // MARK: - Frame application
-
-    /// Hands one frame to the target app's queue. `setSize`
-    /// marks the rare frames that change size (a size step and
-    /// the final frame); all others apply position
-    /// only — a single AX call that never forces the app to
-    /// re-lay-out its content.
+    /// Dispatches frame to target app queue (position-only unless `setSize`).
     func apply(_ id: WindowID, _ frame: CGRect, setSize: Bool) {
         guard let element = elementProvider(id) else { return }
         guard
@@ -132,36 +90,12 @@ final class FrameApplier {
                     of: entry.element
                 )
             }
-            // Stamped after the AX call: echoes trail it.
             recent.record(id)
         }
     }
 
-    /// Applies a frame instantly (no spring), AeroSpace-style:
-    /// on the app's serial queue, drop `AXEnhancedUserInterface`
-    /// around the set so an EUI-on app does not animate the move
-    /// itself — which stutters and can clamp or swallow the
-    /// frame — then restore whatever it was. `WindowControl`'s
-    /// size→position→size order lands the window in one pass, so
-    /// no settle frame is needed. Reading the live EUI state
-    /// (rather than a cached flag) means that if a sibling
-    /// window of the same app is still spring-animating — and so
-    /// already holds EUI off — this leaves it off for that
-    /// animation to restore.
-    ///
-    /// This deliberately does NOT participate in the `pidCounts`
-    /// ref-counting that `begin/endAnimating` use: every EUI
-    /// toggle and frame-set for a pid is enqueued from the main
-    /// actor onto the one serial `queue(for: pid)`, so the live
-    /// read observes the correct interleaved state without a
-    /// lock. Callers must `animation.cancel(window:)` before an
-    /// instant set (as `retile` and `stashInactive` do) so a
-    /// window is never spring-animated and instant-set at once.
+    /// Applies frame instantly dropping EUI around the set (#881).
     func applyInstant(_ id: WindowID, _ frame: CGRect) {
-        // Recorded before the element guard, at enqueue time:
-        // the overlay sync wants the commanded frame this same
-        // turn (#881), and a stamp for a window whose element
-        // is gone expires unread.
         instantTargets.record(id, frame: frame)
         guard let element = elementProvider(id) else { return }
         guard
@@ -186,25 +120,13 @@ final class FrameApplier {
                     enabled: true
                 )
             }
-            // Stamped after the AX calls: echoes trail them.
             recent.record(id)
         }
     }
 
-    // MARK: - Internals
-
     private func queue(for pid: pid_t) -> DispatchQueue {
-        // Frame-sets for our own windows must run on the main
-        // queue: an in-process AX call never crosses to the AX
-        // server — HIServices runs the AppKit window move
-        // synchronously on the calling thread, and AppKit traps
-        // off the main thread. Since #678 Phase 5 this is no
-        // longer the exceptional path it was written for (a
-        // floating Settings window, nudged): the Settings window
-        // tiles, so an animated retile drives it every tick. It
-        // is still one in-process window whose move AppKit
-        // performs synchronously — the same work the main queue
-        // would do at the end of the tick anyway.
+        // Own process runs on main queue to prevent AppKit thread traps
+        // (#678 Phase 5).
         if pid == getpid() {
             return DispatchQueue.main
         }
@@ -219,10 +141,6 @@ final class FrameApplier {
         return queue
     }
 
-    /// EUI toggles ride the same per-app queue as the frames,
-    /// so off → frames → on ordering is guaranteed. Queues are
-    /// kept for the app's lifetime; one idle queue per app is
-    /// cheaper than risking two queues racing AX calls.
     private func setEUI(pid: pid_t, enabled: Bool) {
         queue(for: pid).async {
             AXHelper.setEnhancedUserInterface(
@@ -240,10 +158,7 @@ final class FrameApplier {
     }
 }
 
-/// Commanded instant-set targets whose echoes may still be in
-/// flight (#881) — `RecentApplies`' shape, carrying the frame.
-/// Written on the main actor at enqueue time (`applyInstant`),
-/// read from the main actor.
+/// Instant-set target frames awaiting AX echo (#881).
 private final class InstantTargets: @unchecked Sendable {
     private typealias Entry = (frame: CGRect, at: TimeInterval)
     private let lock = NSLock()
@@ -280,8 +195,7 @@ private final class InstantTargets: @unchecked Sendable {
     }
 }
 
-/// When each window's frame was last set by us. Written from
-/// the per-app queues, read from the main actor.
+/// Recent frame application timestamps for echo suppression.
 private final class RecentApplies: @unchecked Sendable {
     private let lock = NSLock()
     private var stamps: [WindowID: TimeInterval] = [:]
@@ -308,9 +222,7 @@ private final class RecentApplies: @unchecked Sendable {
     }
 }
 
-/// Latest pending frame per window, shared between the main
-/// actor (producer) and the per-app queues (consumers).
-/// AXUIElement is thread-safe; the lock guards the dictionary.
+/// Pending frames per window shared across threads.
 private final class PendingFrames: @unchecked Sendable {
     struct Entry {
         let element: AXUIElement
@@ -321,10 +233,7 @@ private final class PendingFrames: @unchecked Sendable {
     private let lock = NSLock()
     private var entries: [WindowID: Entry] = [:]
 
-    /// Stores the newest frame for a window. Returns true when
-    /// an apply is already scheduled (the caller must not
-    /// schedule another). A pending size change survives being
-    /// overwritten by a position-only frame.
+    /// Stores newest frame; returns true if an apply was already scheduled.
     func put(_ id: WindowID, _ entry: Entry) -> Bool {
         lock.lock()
         defer { lock.unlock() }

--- a/Sources/KiwiDeskCore/Tiling/FrameApplier.swift
+++ b/Sources/KiwiDeskCore/Tiling/FrameApplier.swift
@@ -19,7 +19,11 @@ final class FrameApplier {
     /// Grace period for ignoring self-inflicted AX frame echoes.
     private static let echoGrace: TimeInterval = 1.0
 
-    /// True if window's frame was set within echo grace period.
+    /// True if window's frame was set within the echo grace —
+    /// tells our own AX echoes apart from user drags. Without it
+    /// a settled animation's echo reads as a drag end, and in
+    /// stack layouts (all slots overlap) that fake drop swaps
+    /// windows and retriggers itself forever.
     func didRecentlySetFrame(_ id: WindowID) -> Bool {
         recent.isRecent(id, within: Self.echoGrace)
     }
@@ -94,8 +98,17 @@ final class FrameApplier {
         }
     }
 
-    /// Applies frame instantly dropping EUI around the set (#881).
+    /// Applies a frame instantly, dropping EUI around the set
+    /// (#881). Deliberately outside the `begin/endAnimating`
+    /// ref-count: every EUI toggle and frame-set for a pid rides
+    /// the one serial queue, so the live read observes the correct
+    /// interleaved state. Callers must `animation.cancel(window:)`
+    /// first (as `retile` and `stashInactive` do) so a window is
+    /// never spring-animated and instant-set at once.
     func applyInstant(_ id: WindowID, _ frame: CGRect) {
+        // Recorded before the element guard, at enqueue time: the
+        // overlay sync wants the commanded frame this same turn
+        // (#881); a stamp for a gone window expires unread.
         instantTargets.record(id, frame: frame)
         guard let element = elementProvider(id) else { return }
         guard
@@ -141,6 +154,8 @@ final class FrameApplier {
         return queue
     }
 
+    /// EUI toggles ride the same per-app queue as the frames, so
+    /// off → frames → on ordering is guaranteed.
     private func setEUI(pid: pid_t, enabled: Bool) {
         queue(for: pid).async {
             AXHelper.setEnhancedUserInterface(
@@ -233,7 +248,9 @@ private final class PendingFrames: @unchecked Sendable {
     private let lock = NSLock()
     private var entries: [WindowID: Entry] = [:]
 
-    /// Stores newest frame; returns true if an apply was already scheduled.
+    /// Stores the newest frame; returns true when an apply is
+    /// already scheduled. A pending size change survives being
+    /// overwritten by a position-only frame.
     func put(_ id: WindowID, _ entry: Entry) -> Bool {
         lock.lock()
         defer { lock.unlock() }

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Resolution.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Resolution.swift
@@ -88,7 +88,11 @@ extension TilingSettings {
         return params
     }
 
-    /// Writes splitRatioH into authored override if present (#458).
+    /// Writes splitRatioH into the authored override if present
+    /// (#458). Only the interactive-resize path routes into these
+    /// setters: on `false` the caller stores the value in the
+    /// space's SESSION layer instead — never the global, which
+    /// would visibly resize every other no-override space.
     @discardableResult
     public mutating func setSplitRatioH(
         _ value: Double,
@@ -150,7 +154,12 @@ extension TilingSettings {
         }
     }
 
-    /// Resolves bar hosting protocol for mode (#527).
+    /// The bar-hosting layout for a mode — the ONE place that
+    /// decides which layouts host an App Bar (#527): everything
+    /// asking "does this mode show a bar?" derives from here, so
+    /// a third hosting layout is one edit. `KiwiCore`'s per-space
+    /// twin keeps its own switch by necessity — two mirrors, which
+    /// §2.4 allows, never three.
     public func appBarHost(
         for mode: LayoutMode
     ) -> AppBarHosting? {
@@ -168,7 +177,12 @@ extension TilingSettings {
         }
     }
 
-    /// Insets visible bounds by Space Bar reservation (#293, #537).
+    /// Insets visible bounds by the Space Bar reservation (#293).
+    /// Deliberately NOT public: it takes a raw frame the caller
+    /// obtained some other way — the unsafe half. Callers with a
+    /// screen want `TilingEngine.layoutBounds(on:)` (#537), and
+    /// the routing guards scan only this module, so a cross-module
+    /// caller would be invisible to them.
     func layoutBounds(from visible: CGRect) -> CGRect {
         SpaceBarGeometry.remainingFrame(
             in: visible,
@@ -176,8 +190,14 @@ extension TilingSettings {
         )
     }
 
-    /// Builds LayoutContext with sticky (#414 v2),
-    /// overrides (#431, #881, #878), and sizeBounds (#677).
+    /// Builds a LayoutContext. `sticky` (#414 v2) is REQUIRED so every call
+    /// site chooses (the `forceRetile` pattern, §5): a
+    /// frame-producing build that silently omitted it would
+    /// diverge only when a sticky is piled — the hardest drift to
+    /// spot; strip-geometry builds pass `[]` explicitly.
+    /// `focusedOverride` (#431), `screenNeighbors` (#878, #881)
+    /// and `sizeBounds` (#677) follow the same choose-or-omit
+    /// shape.
     public func context(
         bounds: CGRect,
         space: Space,

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Resolution.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Resolution.swift
@@ -1,20 +1,14 @@
 import CoreGraphics
 import Foundation
 
-/// Per-space resolution and interactive-resize write helpers,
-/// split from `TilingSettings` for file size (AGENTS.md §2).
+/// Per-space resolution and interactive-resize write helpers
+/// (#17, #128, #458).
 extension TilingSettings {
-    // MARK: - Resolution
-
     public func gaps(for space: SpaceID) -> Gaps {
         gapsOverride[space] ?? gapsGlobal
     }
 
-    /// The scrolling params effective for `space` (#17): the
-    /// global params with that space's optional overrides merged
-    /// on top. An unoverridden space resolves an empty override,
-    /// so the result always drops the per-space map (never carried
-    /// into layout math) on both branches.
+    /// Resolved scrolling parameters for space (#17).
     public func resolvedScrolling(
         for space: SpaceID
     ) -> ScrollingParams {
@@ -22,28 +16,24 @@ extension TilingSettings {
             .resolved(onto: scrolling)
     }
 
-    /// The bsp params effective for `space` (#17); see
-    /// `resolvedScrolling`.
+    /// Resolved BSP parameters for space (#17).
     public func resolvedBsp(for space: SpaceID) -> BspParams {
         (bsp.override[space] ?? BspOverride()).resolved(onto: bsp)
     }
 
-    /// The stack params effective for `space` (#17); see
-    /// `resolvedScrolling`.
+    /// Resolved stack parameters for space (#17).
     public func resolvedStack(for space: SpaceID) -> StackParams {
         (stack.override[space] ?? StackOverride())
             .resolved(onto: stack)
     }
 
-    /// The grid params effective for `space` (#17); see
-    /// `resolvedScrolling`.
+    /// Resolved grid parameters for space (#17).
     public func resolvedGrid(for space: SpaceID) -> GridParams {
         (grid.override[space] ?? GridOverride())
             .resolved(onto: grid)
     }
 
-    /// The monocle params effective for `space` (#17); see
-    /// `resolvedScrolling`.
+    /// Resolved monocle parameters for space (#17).
     public func resolvedMonocle(
         for space: SpaceID
     ) -> MonocleParams {
@@ -51,21 +41,13 @@ extension TilingSettings {
             .resolved(onto: monocle)
     }
 
-    /// The track params effective for `space` (#128); see
-    /// `resolvedScrolling`.
+    /// Resolved track parameters for space (#128).
     public func resolvedTrack(for space: SpaceID) -> TrackParams {
         (track.override[space] ?? TrackOverride())
             .resolved(onto: track)
     }
 
-    // MARK: - Session-aware resolution (#458)
-
-    /// `resolvedBsp` with the space's session resize layer
-    /// overlaid — authored override field > session > global —
-    /// so an interactive resize on a no-override space shows on
-    /// that space alone. Layout reads (`context`) and resize
-    /// current-value reads use these; readers of non-ratio
-    /// params may keep the id form.
+    /// BSP parameters with space session resize ratio layer (#458).
     public func resolvedBsp(for space: Space) -> BspParams {
         var params = resolvedBsp(for: space.id)
         let override = bsp.override[space.id]
@@ -82,7 +64,7 @@ extension TilingSettings {
         return params
     }
 
-    /// See `resolvedBsp(for: Space)`.
+    /// Stack parameters with space session resize ratio layer (#458).
     public func resolvedStack(for space: Space) -> StackParams {
         var params = resolvedStack(for: space.id)
         if stack.override[space.id]?.masterRatio == nil,
@@ -93,7 +75,7 @@ extension TilingSettings {
         return params
     }
 
-    /// See `resolvedBsp(for: Space)`.
+    /// Scrolling parameters with space session resize ratio layer (#458).
     public func resolvedScrolling(
         for space: Space
     ) -> ScrollingParams {
@@ -106,19 +88,7 @@ extension TilingSettings {
         return params
     }
 
-    // MARK: - Per-space writes (interactive resize)
-    //
-    // Only the interactive-resize path routes here — Lua `set_*`
-    // and the GUI per-space bindings write the global params or
-    // the override map directly. Since #458 these write ONLY an
-    // authored override field; a no-override space returns
-    // false and the caller (`KiwiCore.writeSplitRatioH` family)
-    // stores the value in the space's session layer instead —
-    // never the global, which would visibly resize every other
-    // no-override space.
-
-    /// Writes into the space's override when it already
-    /// overrides the field; returns whether it did.
+    /// Writes splitRatioH into authored override if present (#458).
     @discardableResult
     public mutating func setSplitRatioH(
         _ value: Double,
@@ -131,6 +101,7 @@ extension TilingSettings {
         return true
     }
 
+    /// Writes splitRatioV into authored override if present (#458).
     @discardableResult
     public mutating func setSplitRatioV(
         _ value: Double,
@@ -143,6 +114,7 @@ extension TilingSettings {
         return true
     }
 
+    /// Writes masterRatio into authored override if present (#458).
     @discardableResult
     public mutating func setMasterRatio(
         _ value: Double,
@@ -155,6 +127,7 @@ extension TilingSettings {
         return true
     }
 
+    /// Writes slotSize into authored override if present (#458).
     @discardableResult
     public mutating func setSlotSize(
         _ value: ScrollSize,
@@ -167,11 +140,7 @@ extension TilingSettings {
         return true
     }
 
-    /// True while the Space Bar and at least one *enabled*
-    /// layout App Bar resolve to the same edge (#293) — the
-    /// predicate behind the Settings same-edge info row and the
-    /// preview's coexistence stand-in, kept here so the two
-    /// can't drift. Honors per-layout edge overrides.
+    /// True if Space Bar and an enabled layout App Bar share an edge (#293).
     public var spaceBarSharesEdgeWithAppBar: Bool {
         guard spaceBarStyle.enabled else { return false }
         return appBarHosts.contains {
@@ -181,19 +150,7 @@ extension TilingSettings {
         }
     }
 
-    /// The bar-hosting layout for a mode, or nil for modes that
-    /// show no bar. **The one place that decides which layouts
-    /// host an App Bar** — everything that asks "does this mode
-    /// show a bar?" or "any bar shown?" derives from here, so a
-    /// third hosting layout is one edit.
-    ///
-    /// The list had been hand-copied to three sites; a fourth
-    /// hosting layout added later would have left the Settings
-    /// copy claiming no bar is shown while one rendered, greying
-    /// a live editor (#527). `KiwiCore.barHost(for mode:)`
-    /// delegates here; its per-*space* twin necessarily keeps its
-    /// own switch, because it resolves per-space params — two
-    /// mirrors, which §2.4 allows, rather than three.
+    /// Resolves bar hosting protocol for mode (#527).
     public func appBarHost(
         for mode: LayoutMode
     ) -> AppBarHosting? {
@@ -204,27 +161,14 @@ extension TilingSettings {
         }
     }
 
-    /// Every bar-hosting layout's per-layout bar, derived from
-    /// `appBarHost(for:)` rather than re-listed.
+    /// Every bar-hosting layout's bar configuration.
     public var appBarHosts: [LayoutAppBar] {
         LayoutMode.allCases.compactMap {
             appBarHost(for: $0)?.appBar
         }
     }
 
-    /// The bounds layouts may use on a display whose visible
-    /// frame is `visible`: the frame minus the Space Bar's
-    /// reservation (#293). The one seam between a screen's raw
-    /// visible frame and `context(bounds:space:)` — every
-    /// caller routes through it so no flow can silently skip
-    /// the inset.
-    ///
-    /// Deliberately **not** `public`: it takes a raw frame the
-    /// caller had to obtain some other way, so it is the
-    /// unsafe half of the pair. Callers with a screen in hand
-    /// want `TilingEngine.layoutBounds(on:)` (#537), and both
-    /// routing guards scan only this module — a cross-module
-    /// caller would be invisible to them.
+    /// Insets visible bounds by Space Bar reservation (#293, #537).
     func layoutBounds(from visible: CGRect) -> CGRect {
         SpaceBarGeometry.remainingFrame(
             in: visible,
@@ -232,38 +176,8 @@ extension TilingSettings {
         )
     }
 
-    /// `sticky` = the sticky window ids (#414 v2), so overflow
-    /// piles can keep them fully tiled. REQUIRED so every new
-    /// call site chooses (the `forceRetile` pattern, §5): a
-    /// frame-producing build that silently omitted it would
-    /// diverge from the applied layout only when a sticky is
-    /// piled — the hardest drift to spot. Strip-geometry-only
-    /// builds pass `[]` explicitly.
-    ///
-    /// `focusedOverride` supplies the anchor the focus-driven
-    /// layouts read — Scrolling to pan, Monocle's `park` to
-    /// pick the shown member (#881) — for the one case a window
-    /// a space should center on can never be its `focused`
-    /// slot: a tiled-sticky traveler is injected into the
-    /// active space's row but is a member only of its home
-    /// space, so the membership guard keeps `space.focused` off
-    /// it (#431). Callers that carve only the bar strip omit it
-    /// and fall back to `space.focused`.
-    /// `screenNeighbors` carries the per-retile neighbor
-    /// verdicts (#878) for the screen `bounds` describes;
-    /// Scrolling reads them to wall its blocked edges, and
-    /// Monocle's `park` picks its stash corner from them
-    /// (#881). Callers that never materialize scrolled-out or
-    /// parked frames (capacity probes, bar-strip carving,
-    /// previews) omit it and get the single-screen verdict —
-    /// every edge open, park corner bottom-right.
-    /// `sizeBounds` carries the engine's confirmed app-enforced
-    /// bounds (#677); a frame-producing build threads
-    /// `TilingEngine.sizeBounds(for:)` so the residue a refusal
-    /// leaves is placed (scrolling re-packs, monocle centers).
-    /// Callers whose frames never reach a window (probes,
-    /// previews) omit it and every layout asks what it always
-    /// did.
+    /// Builds LayoutContext with sticky (#414 v2),
+    /// overrides (#431, #881, #878), and sizeBounds (#677).
     public func context(
         bounds: CGRect,
         space: Space,
@@ -294,14 +208,7 @@ extension TilingSettings {
         )
     }
 
-    /// The whole settings as `space` sees them under `mode`: the
-    /// active layout's params overlaid with that space's overrides,
-    /// every other layout left global (they are not drawn). The
-    /// per-space override editor's live preview feeds this to the
-    /// SAME schematic the Layout Defaults preview draws, so the
-    /// preview asks the engine rather than re-deriving a resolution
-    /// rule beside the drawing (gui.md). Floating has no schematic,
-    /// so it is returned untouched.
+    /// Returns copy of settings with active layout mode resolved for space.
     public func resolved(
         for space: SpaceID,
         activeMode mode: LayoutMode


### PR DESCRIPTION
## Summary

Batch 7 of the AGENTS.md §2.8 comment diet.
Trims 52 contract-dense source files across `KiwiDeskCore` and `KiwiDesk` to the §2.8 comment budget (1–3 lines plus issue refs, contract-only docstrings, preservation of all platform traps, issue numbers, test citations, numeric constants, and dated rulings).

- **Files touched:** 52
- **Net diff:** -5,338 lines (+736 / -6,074)
- **Excluded:** `EventLoop*`, `KiwiCore*`, `TilingEngine*`, `SizeBound*` (handled manually).

## Verification
- `swift build` passes
- `swift test` passes (4,293 tests across 814 suites)
- `./scripts/lint.sh` passes (0 line-length violations, 0 formatting errors)
