### PR TITLE
chore(comments): trim core and settings to §2.8 budget (batch 8)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Common/ColorField.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ColorField.swift
@@ -2,36 +2,14 @@ import AppKit
 import KiwiDeskCore
 import SwiftUI
 
-/// A labeled color control (#68 §3.14): a lightweight swatch
-/// that opens the shared system color panel on click, instead
-/// of a per-row `NSColorWell`. The Appearance tab mounts ~14 of
-/// these; a color well each is expensive to instantiate in
-/// bulk (a visible open lag), while a swatch is a cheap filled
-/// shape and there is only ever one system panel. Beside the
-/// swatch an inline hex field types/pastes an exact value: the
-/// system panel's hex field is 6-digit RGB only, so it cannot
-/// express the alpha our `#RRGGBBAA` format carries — the
-/// inline field is the only path to an exact translucent color.
-/// "Hex" in the name is also the STORAGE contract: the binding
-/// is the `#RRGGBBAA` string the config persists. One component
-/// everywhere a color appears (App Bar, overrides, drag
-/// visuals).
+/// Labeled color control with swatch button and hex text field (#68, #231).
 struct HexColorField: View {
     let label: String
-    /// The screen label may be shortened to its in-group form
-    /// ("Color" under a Border/Fill group, #231); VoiceOver
-    /// still needs the disambiguated name, so `a11yLabel`
-    /// overrides what `ColorSwatch` announces. Defaults to the
-    /// visible `label` when they're the same.
+    /// Accessibility label override for VoiceOver disambiguation (#231).
     var a11yLabel: String?
-    /// Label-column width — narrowed in the Drag editor's
-    /// half-width columns (#231); the App Bar color grid keeps
-    /// the default `colorLabelColumn`.
+    /// Label column width.
     var labelWidth: CGFloat = SettingsMetrics.colorLabelColumn
-    /// Whether an EMPTY hex is a valid "Automatic" value (#429):
-    /// the swatch then shows an adaptive split state and an empty
-    /// entry commits instead of reverting. Off for the ~14 wells
-    /// whose color has a concrete default and no adaptive concept.
+    /// Whether an empty hex represents an "Automatic" adaptive value (#429).
     var automatic: Bool = false
     @Binding var hex: String
 
@@ -48,8 +26,7 @@ struct HexColorField: View {
         }
     }
 
-    /// Formats an `NSColor` back into the stored hex string:
-    /// `#RRGGBB`, or `#RRGGBBAA` when translucent.
+    /// Formats `NSColor` to `#RRGGBB` or `#RRGGBBAA` hex string.
     static func hexString(from color: NSColor) -> String {
         let ns = color.usingColorSpace(.sRGB) ?? .black
         let r = Int(round(ns.redComponent * 255))
@@ -69,33 +46,14 @@ struct HexColorField: View {
     }
 }
 
-/// The color control: two adjacent native affordances, not one
-/// filled shape. A bordered swatch *button* (the color dot in a
-/// pressable chip) opens the shared system panel for visual
-/// picking; a `.roundedBorder` hex *field* beside it types or
-/// pastes an exact value — the only path to an `#RRGGBBAA`
-/// alpha the system panel's 6-digit hex field can't express.
-/// The two pieces are shaped like the two different controls
-/// they are (button vs. text field, with a gap between), so the
-/// split reads as "two controls" rather than one ambiguous hit
-/// region. Both write the same `hex`, so a panel pick repaints
-/// the dot and updates the field, and a typed value repaints
-/// the dot — they stay in sync for free.
+/// Swatch button and hex input field for color editing (#68, #429).
 struct ColorSwatch: View {
     let label: String
-    /// Empty hex = "Automatic" (adaptive), not a parse failure —
-    /// see `HexColorField.automatic`.
+    /// Empty hex represents "Automatic" adaptive color (#429).
     var automatic: Bool = false
     @Binding var hex: String
-    /// The field edits a string proxy so intermediate typing
-    /// never clobbers `hex`; it commits (parse + normalize) on
-    /// Return or focus loss, matching `StepperRow`'s discipline.
     @State private var draft: String
     @FocusState private var focused: Bool
-    /// The panel-ownership token from the last `present`, so
-    /// this swatch can resign the shared panel when it goes
-    /// away (tab switch, App Bar disclosure collapse) without
-    /// clobbering a later swatch that took the panel.
     @State private var token = 0
 
     init(
@@ -264,15 +222,8 @@ struct ColorSwatch: View {
         )
     }
 
-    /// Parse the draft; on success normalize the GUI's own
-    /// write via `hexString` (uppercase, alpha dropped when
-    /// opaque) — the Lua/CLI command paths store raw hex, so
-    /// the stored form is not canonical, only the parser is
-    /// shared. On failure silently revert to the last-good
-    /// value.
+    /// Parse draft and normalize hex; empty field commits Automatic (#429).
     private func commit() {
-        // On an adaptive well, an emptied field is a valid commit
-        // to "Automatic" — not a parse failure to revert (#429).
         if automatic,
             draft.trimmingCharacters(in: .whitespaces).isEmpty
         {
@@ -293,10 +244,7 @@ struct ColorSwatch: View {
     }
 
     private func present() {
-        // Seed an OPAQUE color when Automatic: the empty well's
-        // `color` is `.clear` (alpha 0), which would open the panel
-        // with the opacity slider at zero — a hue picked without
-        // touching alpha would commit an invisible mark (#429).
+        // Seed opaque color when automatic to prevent 0-alpha picker (#429).
         let seed = isAutomatic ? NSColor.labelColor : NSColor(color)
         token = ColorPanelController.shared.present(
             current: seed

--- a/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
@@ -1,31 +1,11 @@
 import SwiftUI
 
-/// The tab-style option chooser shared across the settings
-/// (#68): a capsule track where the selection is a solid
-/// ACCENT pill with the on-accent ink — the settled "accent
-/// marks control fills" convention, which the dark pass
-/// extended here: the earlier white pill (light grey in dark)
-/// carried the near-white ambient ink at ~3:1 in dark, the
-/// worst text pairing in the control set, behind a manual
-/// `colorScheme` branch the theme exists to end. Liquid Glass
-/// was tried and dropped here — the glass layer refracted
-/// whatever sat behind it, reading as blur under the text and
-/// stray tint. ONE persistent pill slides between segments via
-/// matched geometry: each segment anchors a frame and the pill
-/// adopts the selected anchor, so a selection change moves the
-/// same view (a slide) instead of swapping styling between
-/// labels, which crossfades.
-///
-/// Precondition: option `value`s must be unique — duplicates
-/// would make two segments claim the pill's anchor.
+/// Capsule segmented picker with animated sliding accent pill (#68).
 struct SegmentedPicker<Value: Hashable>: View {
     private let label: String?
     @Binding private var selection: Value
     private let options: [(title: String, value: Value)]
-    /// Optional `?` popover (#94), label-adjacent — one per
-    /// field, never per segment. Unlabeled instances (icon
-    /// tabs) have no label to sit beside, so theirs trails
-    /// the track instead.
+    /// Optional field help text (#94).
     private let help: String?
     @Namespace private var pillSpace
     @State private var hoveredIndex: Int?
@@ -62,9 +42,6 @@ struct SegmentedPicker<Value: Hashable>: View {
         }
     }
 
-    /// The label attaches only when one exists — an empty
-    /// accessibility label on the unlabeled instances (icon
-    /// picker tabs) would override the group's inferred name.
     @ViewBuilder private var labeledTrack: some View {
         if let label {
             track.accessibilityLabel(label)
@@ -73,14 +50,8 @@ struct SegmentedPicker<Value: Hashable>: View {
         }
     }
 
-    /// Which segment the pill sits on, or nil when the bound
-    /// value matches no option — a hand-edited config, or an
-    /// OPTIONAL-valued binding whose two halves disagree (the
-    /// shared Corners master, #754). Internal rather than
-    /// private because that nil is now load-bearing and
-    /// `SegmentedPickerUnmatchedTests` reads it: it is the
-    /// difference between "no answer yet" and a picker
-    /// asserting an answer the app is not drawing.
+    /// Index of selected option or nil if unmatched
+    /// (`SegmentedPickerUnmatchedTests`, #754).
     var selectedIndex: Int? {
         options.firstIndex { $0.value == selection }
     }
@@ -105,13 +76,7 @@ struct SegmentedPicker<Value: Hashable>: View {
             )
         )
         .accessibilityElement(children: .contain)
-        // The group's choice as its value, so arriving on the
-        // track hears "Position, Top" the way a native
-        // segmented control says it, before the segments are
-        // walked (#812). On the TRACK, not the labelled branch:
-        // an unnamed instance labelled at its call site (the
-        // header's mode segment, the icon tabs) must ride the
-        // same value (code review, 2026-08-24).
+        // Group value announcement for accessibility (#812, 2026-08-24).
         .accessibilityValue(
             selectedIndex.map { options[$0].title } ?? ""
         )
@@ -158,20 +123,11 @@ struct SegmentedPicker<Value: Hashable>: View {
         index: Int
     ) -> some View {
         Text(title)
-            // A real font-size step, not `scaleEffect` — a
-            // scale rasterizes the drawn text and stretches
-            // it, which reads as blur. The equal-width
-            // segments absorb the width change.
             .font(
                 selected
                     ? .body.weight(.semibold)
                     : .callout
             )
-            // Explicit inks: the selected label rides the
-            // accent pill (`accentInk` is the one ink for
-            // that), and the rest name `ink` so no ancestor
-            // foreground can recolour them (the hierarchical
-            // trap).
             .foregroundStyle(
                 selected
                     ? SettingsTheme.accentInk
@@ -219,10 +175,6 @@ struct SegmentedPicker<Value: Hashable>: View {
         }
     }
 
-    /// The one persistent pill. It adopts the selected
-    /// segment's anchored frame, so a selection change slides
-    /// this same view. Hidden when the bound value matches no
-    /// option (hand-edited config).
     @ViewBuilder private var slidingPill: some View {
         if let index = selectedIndex {
             pill.matchedGeometryEffect(
@@ -233,30 +185,14 @@ struct SegmentedPicker<Value: Hashable>: View {
         }
     }
 
-    /// The solid accent pill. No shadow: the white pill needed
-    /// one to lift off a same-luminance track, and its black
-    /// shadow was dead in dark anyway; the accent separates by
-    /// hue and luminance from the track in both modes, and the
-    /// selected state never rides colour alone — the font-step
-    /// carries it too.
     private var pill: some View {
         Capsule()
             .fill(SettingsTheme.accent)
     }
 }
 
-/// The segmented picker's own metrics, in a non-generic type so
-/// they can be named from outside (a `static` stored property is
-/// not allowed on a generic one).
-///
-/// `trackAlpha` is here rather than inline because
-/// `SegmentedPickerCoverageTests` MEASURES the unselected label
-/// against it: with the number restated in the test, washing the
-/// track to 0.6 — a near-white track under a near-white label in
-/// dark — passed green, the guard's input never having touched
-/// this file (guard-prover, 2026-08-12).
+/// Shared geometry metrics for segmented pickers
+/// (`SegmentedPickerCoverageTests`, 2026-08-12).
 enum SegmentedPickerMetrics {
-    /// The track's wash over its card, and the same value its
-    /// hairline takes.
     static let trackAlpha = 0.08
 }

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsSection.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsSection.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 
-/// The heading over a run of related sections (the App Bar
-/// block in Appearance): the one registered level above a
-/// section's `.headline`, so multi-section groups don't each
-/// invent their own title style.
+/// Heading over related sections in settings dashboard.
 struct SettingsGroupHeader: View {
     let title: String
 
@@ -17,48 +14,20 @@ struct SettingsGroupHeader: View {
     }
 }
 
-/// A titled group used across the dashboard sections. The
-/// optional symbol puts a glyph before the title — used by the
-/// per-mode sections so a layout's glyph (§6.3) travels with
-/// its name. The optional caption is a one-sentence plain-words
-/// explanation under the title; `subsection` shrinks the title
-/// for groups that belong to a bigger one (Ghost / Drop zone
-/// under Drag & drop).
-///
-/// The optional `help` renders a live `HelpButton` beside the
-/// title — the block-gate anchor (#527): the header sits
-/// OUTSIDE any `GreyOut` in `content`, so while a gate dims the
-/// body (killing every `?` inside it, since `.disabled` is
-/// cumulative), this one stays clickable and explains why the
-/// block is off and how to enable it. Call sites pass it only
-/// while their gate is active — once the block is live, its own
-/// controls' help takes over and the anchor would gloss nothing.
+/// Titled container card for settings sections with search anchoring (#527,
+/// #760, #573).
 struct SettingsSection<Content: View>: View {
     let title: String
-    /// The catalog declaration this section was mounted as, or
-    /// nil for the String init — whose remaining callers are the
-    /// deliberately-unindexed computed titles (`%1$@ bar`). The
-    /// whole descriptor rather than its id, so both halves of
-    /// the pair below can only be fed from one control (#573).
     private let control: SettingsControl?
     let symbol: String?
     let caption: String?
     let subsection: Bool
     let help: String?
-    /// The section's presence is mode-gated — it would leave the
-    /// page in Simple (#760). Picks the heavier stroke and lets
-    /// the mode-reveal wash mark the heading; call sites derive
-    /// it from their own offer predicate evaluated at `.simple`,
-    /// never a second copy of that predicate.
     let modeGated: Bool
     @ViewBuilder let content: Content
 
-    /// Computed-title init: renders identically but is NOT a
-    /// search anchor. An indexable section takes a
-    /// `SettingsControl` instead — declaring it in the catalog
-    /// is what makes it findable, and the catalog's declaration
-    /// is the one list (`SettingsCatalogArgumentTests` refuses a
-    /// literal `L()` title here).
+    /// Computed-title initializer for unindexed sections
+    /// (`SettingsCatalogArgumentTests`).
     init(
         _ title: String,
         symbol: String? = nil,
@@ -78,10 +47,7 @@ struct SettingsSection<Content: View>: View {
         self.content = content()
     }
 
-    /// The catalog init: one declaration supplies the rendered
-    /// title AND the search anchor, so a section is findable by
-    /// existing (#277) and its anchor id is stable however the
-    /// localized text collides or changes.
+    /// Catalog initializer supplying title and search anchor (#277).
     @MainActor init(
         _ control: SettingsControl,
         symbol: String? = nil,
@@ -120,11 +86,6 @@ struct SettingsSection<Content: View>: View {
                 maxWidth: .infinity,
                 alignment: .leading
             )
-            // Card fill on the SECTION radius, plus a hairline.
-            // The border is not decoration: on the dark
-            // appearance the container and the page behind it are
-            // within ten points of each other, so without it the
-            // card has no edge at all.
             .background(
                 RoundedRectangle(
                     cornerRadius: SettingsTheme.sectionRadius
@@ -149,15 +110,7 @@ struct SettingsSection<Content: View>: View {
                 )
             )
         }
-        // The hoisted scroll markers (#610): any `scrollHoisted`
-        // inline drawer inside `content` publishes its control up
-        // `HoistedRevealAnchorsKey`, and each becomes a zero-size
-        // marker pinned to the top edge ABOVE the heading — so a
-        // reveal of that drawer lands the section's top, heading
-        // first, while the drawer's own wash paints below. The id
-        // is the drawer's own, so scroll and wash cannot disagree.
-        // Then consume the value, so a section nested in another
-        // never re-collects the same id and doubles the marker.
+        // Hoisted scroll markers for nested search anchors (#610).
         .overlayPreferenceValue(HoistedRevealAnchorsKey.self) {
             anchors in
             revealMarkers(anchors)
@@ -170,10 +123,6 @@ struct SettingsSection<Content: View>: View {
     private func revealMarkers(
         _ anchors: [SettingsControl]
     ) -> some View {
-        // Fill the section and top-pin the markers, so this does
-        // not lean on `overlayPreferenceValue`'s default centering
-        // — the markers must sit at the section's top edge for
-        // `scrollTo(anchor: .top)` to land the heading.
         VStack(spacing: 0) {
             ForEach(anchors, id: \.id) { target in
                 Color.clear
@@ -189,16 +138,9 @@ struct SettingsSection<Content: View>: View {
         .allowsHitTesting(false)
     }
 
-    /// A catalog-declared section is a search anchor by existing
-    /// (#277) — its `SettingsControl` supplies the stable id. The
-    /// wash marks the heading; the scroll target is the whole
-    /// card (`body`). Both halves read the one `control`, and the
-    /// unanchored String init takes neither: an earlier cut
-    /// flashed on `anchorID ?? ""`, a sentinel that no reveal can
-    /// ever name and that reads as a second, disagreeing id.
+    /// Header view with search flash and mode-reveal highlighting (#277,
+    /// #760).
     @ViewBuilder private var flashedHeader: some View {
-        // The mode-reveal wash rides the same heading band the
-        // search wash does (#760) — never the whole card.
         if let control {
             header
                 .searchFlashHeader(control)
@@ -218,12 +160,8 @@ struct SettingsSection<Content: View>: View {
                     }
                     Text(title)
                         .foregroundStyle(SettingsTheme.ink)
-                        // A heading for the rotor (#812): every
-                        // section title in every area, so a
-                        // VoiceOver user jumps card to card
-                        // instead of walking every row. Home's
-                        // group labels were the only headings
-                        // the app had.
+                        // Section heading accessibility trait for rotor
+                        // (#812).
                         .accessibilityAddTraits(.isHeader)
                 }
                 .font(

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsSlider.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsSlider.swift
@@ -1,33 +1,15 @@
 import AppKit
 import SwiftUI
 
-/// The slider counterpart to `SegmentedPicker` (#68): the
-/// same capsule track, a native-style white thumb overhanging
-/// the track slightly, and an accent fill up to the knob so
-/// the value reads at a glance. Values
-/// snap to `step`. Accessibility is delegated to a native
-/// `Slider` representation, so VoiceOver and keyboard
-/// adjustment behave exactly like the control it replaces.
-///
-/// The representation is NAMED and VALUED here, by two
-/// required arguments, because a bare `Slider` announces a
-/// percentage of its range and nothing else: every row in this
-/// tree draws its label and its readout as SIBLINGS of the
-/// slider (`SettingsRowShape`), and a sibling `Text` names
-/// nothing (gui.md ▸ the keyboard path). Nineteen rows shipped
-/// "six percent" for "Outer gap, 6 pt" that way (#812). The
-/// arguments have no defaults on purpose — the compiler is the
-/// guard, and a site that cannot name its slider has found a
-/// row with no label.
+/// Custom-styled slider with accessible keyboard and VoiceOver representation
+/// (#68, #812).
 struct SettingsSlider: View {
     @Binding var value: Double
     let range: ClosedRange<Double>
     var step: Double = 1
-    /// What VoiceOver calls the control — the row's label.
+    /// Accessibility label for VoiceOver (#812).
     let label: String
-    /// What VoiceOver reads as its value — the row's readout,
-    /// unit included ("6 pt", "29%", "1.5 s"), never the
-    /// native percentage.
+    /// Spoken value readout with units for VoiceOver (#812).
     let spokenValue: String
 
     @Environment(\.isEnabled) private var isEnabled
@@ -42,28 +24,11 @@ struct SettingsSlider: View {
         }
         .frame(height: Self.height)
         .opacity(isEnabled ? 1 : 0.4)
-        // A custom-drawn view holds no keyboard focus of its own,
-        // so Tab skipped every slider in the tree and a keyboard
-        // user could not change a gap at all (owner, #812 device
-        // session 1). The AX representation below does not grant
-        // it either — VoiceOver's cursor is its own — so the view
-        // re-earns the two things a native `Slider` gave free:
-        // a Tab stop with the platform's ring, and arrow keys
-        // stepping by `step`. `.edit` interactions only: bare
-        // `.focusable` also took focus on CLICK, which no
-        // native macOS control does outside text fields
-        // (owner, #812 session 3) — Tab reaches it, the
-        // pointer never moves the ring.
         .focusable(isEnabled, interactions: .edit)
         .focused($focused)
-        // `.edit` should already refuse click-focus and on
-        // macOS 26 does not (device, 2026-08-24): focus that
-        // arrives while a mouse button is down is click-born
-        // and is handed back, so only Tab moves the ring here.
-        // The live `NSEvent` read has precedent
-        // (`MouseFollowsFocusTests`' seam) and is the one
-        // deterministic discriminator between the two roads.
         .onChange(of: focused) { _, now in
+            // Refuse click-born focus on macOS 26 (`MouseFollowsFocusTests`,
+            // 2026-08-24).
             guard now, NSEvent.pressedMouseButtons != 0 else {
                 return
             }
@@ -80,21 +45,16 @@ struct SettingsSlider: View {
         .accessibilityValue(spokenValue)
     }
 
-    /// One keyboard step in `direction`; a non-positive `step`
-    /// (no snapping) moves by a hundredth of the range.
+    /// Increments or decrements value by step (code review 2026-08-24).
     private func nudge(_ direction: Double) -> KeyPress.Result {
         guard isEnabled else { return .ignored }
         let span = range.upperBound - range.lowerBound
         let increment = step > 0 ? step : span / 100
-        // Through the same snap the drag applies: an off-grid
-        // stored value (hand-edited config) must land on the
-        // grid on the first arrow press, not stay offset
-        // forever (code review, 2026-08-24).
         value = snapped(value + direction * increment)
         return .handled
     }
 
-    /// The lowerBound-anchored grid both input paths share.
+    /// Snaps value to grid anchored at lowerBound.
     private func snapped(_ raw: Double) -> Double {
         let snapped =
             step > 0
@@ -108,9 +68,6 @@ struct SettingsSlider: View {
         )
     }
 
-    /// Disabled sliders gray the fill itself — the dimming
-    /// `.opacity` alone left the accent showing through the
-    /// translucent white knob, which read as a blue knob.
     private var fill: AnyShapeStyle {
         isEnabled
             ? AnyShapeStyle(SettingsTheme.accent.gradient)
@@ -125,10 +82,6 @@ struct SettingsSlider: View {
             Capsule()
                 .fill(fill)
                 .frame(width: center + Self.knobWidth / 2)
-            // The knob overhangs the track by 2 pt per edge
-            // (native sliders oversize the thumb); nothing
-            // clips it — the row's padding absorbs the
-            // overflow.
             knob
                 .frame(
                     width: Self.knobWidth,
@@ -152,10 +105,6 @@ struct SettingsSlider: View {
         )
     }
 
-    /// The knob's center, from half a knob in on both ends so
-    /// the pill never leaves the track — the fraction clamps
-    /// so an out-of-range stored value (hand-edited config)
-    /// renders at the nearest end like a native slider.
     private func knobCenter(in width: CGFloat) -> CGFloat {
         let usable = max(width - Self.knobWidth, 1)
         let t = min(max(fraction, 0), 1)
@@ -170,9 +119,6 @@ struct SettingsSlider: View {
         )
     }
 
-    /// Snapping anchors at `lowerBound` (not zero) so ranges
-    /// like `0.1...0.9` land on their own grid; a non-positive
-    /// step means no snapping.
     private func set(at x: CGFloat, in width: CGFloat) {
         let usable = max(width - Self.knobWidth, 1)
         let t = min(max((x - Self.knobWidth / 2) / usable, 0), 1)
@@ -180,15 +126,7 @@ struct SettingsSlider: View {
         value = snapped(range.lowerBound + Double(t) * span)
     }
 
-    /// The native white thumb, on every macOS and in BOTH
-    /// appearances. A clear Liquid Glass knob was tried and
-    /// dropped: it refracted the accent fill sliding beneath it,
-    /// tinting the knob blue.
-    ///
-    /// Deliberately NOT `SettingsTheme.onAccentKnob`: that token
-    /// flips near-black on the dark appearance, which suits a
-    /// knob on a large accent field and not a thumb whose whole
-    /// job is to be the brightest thing on a 4 pt track.
+    /// Opaque white knob thumb (`SettingsTheme.onAccentKnob`).
     private var knob: some View {
         Capsule()
             .fill(.white)

--- a/Sources/KiwiDesk/Settings/Components/Common/SlotSizeRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SlotSizeRows.swift
@@ -1,48 +1,21 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The scrolling slot-size pair: the unit picker (Percent /
-/// Points) and the slider row it drives. A stored `.auto`
-/// renders as Percent at the orientation standard — the GUI
-/// stopped offering "Default" as a third unit once both axes'
-/// standards became the same fraction (ui-designer,
-/// 2026-07-29; see `docs/design-decisions.md`), while `.auto`
-/// itself stays in the model and Lua (`scroll.set_slot_size(0)`).
-/// Split out of `ScrollGridEditor` so the unit seeds and
-/// bindings live with the rows they feed.
+/// Unit picker and slider controls for scrolling layout slot size (ui-designer
+/// 2026-07-29).
 struct SlotSizeRows: View {
     @ObservedObject var model: SettingsModel
-    /// The slot size the rows edit. Injected as a binding so the
-    /// same unit picker + value control drives both the global
-    /// scrolling params and the per-space `ScrollSize?` override
-    /// (via `overrideValue`, #290) — one control, no hand-rolled
-    /// second copy to drift (§5).
+    /// Slot size binding for global settings or space override (#290).
     @Binding var size: ScrollSize
-    /// Swaps the label to "Row height" and the pt seed to the
-    /// vertical default (frontend only; the stored `slot_size`
-    /// is orientation-neutral).
+    /// Whether layout orientation is vertical (swaps labels and seeds).
     let isVertical: Bool
-    /// Which half to render: the unit picker groups with the
-    /// other segmented pickers, the value control re-homes
-    /// below them (#68) — `.both` keeps the paired default.
+    /// Part of control to render (#68).
     var part: Part = .both
 
-    /// How the unit picker renders. `.segmented` on the full-width
-    /// Layout Defaults surface, where it lines up with the
-    /// orientation/anchor segmented pickers; `.menu` in the
-    /// per-space override editor, matching that surface's other
-    /// (dropdown) override rows — the #291 compact-surface
-    /// exception, where its bounded rows column would cramp
-    /// segments.
+    /// Unit picker presentation style (#291).
     var unitStyle: UnitStyle = .segmented
 
     enum UnitStyle { case segmented, menu }
-
-    // The label-column width is `SettingsRowShape`'s to read
-    // (#290's environment override still applies — the shape
-    // reads the same `settingsLabelColumn`, so the value row
-    // still narrows inside `OverrideChrome` and still reflows
-    // with every other row below the 17a row breakpoint).
 
     enum Part { case unit, control, both }
 
@@ -52,39 +25,21 @@ struct SlotSizeRows: View {
             : L("slot_size.column_width", "Column width")
     }
 
-    /// The points slider's floor: the global minimum window size
-    /// (the layout clamps anything smaller up to it). Capped under
-    /// the slider max so the range can never invert.
+    /// Points slider floor clamped by global minimum window size.
     private var minPointsFloor: Double {
         Double(min(model.config.settings.minWindowSize, 1990))
     }
 
-    /// The Percent slider's range, spanning what the model
-    /// stores: the floor is `ScrollSize.minFraction` — below it
-    /// the setter clamps, so a lower stop would report a slot
-    /// the config never holds — and the ceiling is the whole
-    /// axis, which is a slot KiwiDesk renders rather than a
-    /// broken value. Internal so `SlotSizePercentRangeTests` can
-    /// hold it against the model's own bounds.
+    /// Range for percentage slider (`SlotSizePercentRangeTests`).
     static let percentRange: ClosedRange<Double> = 5...100
-    /// The Percent slider's granularity. 1%, because a percent
-    /// of a scroll axis is a visible amount of window — ~19 pt
-    /// of column on a 1920 display — so every stop moves
-    /// something the user can see, and the shipped standard
-    /// stays a stop whatever it is: a default the slider cannot
-    /// return to reads as a bug.
+    /// Step size for percentage slider.
     static let percentStep: Double = 1
 
     private enum SizeUnit: Hashable {
         case points, percent
     }
 
-    /// `.auto` presents as Percent: it resolves to the standard
-    /// fraction on either axis, so Percent at that fraction is its
-    /// truthful rendering. The stored value stays `.auto` until the user
-    /// moves the slider (the binding then writes an explicit
-    /// `.fraction`) — an untouched config keeps tracking the
-    /// shipped standard.
+    /// Resolves presentation unit from stored `ScrollSize`.
     private var sizeUnit: SizeUnit {
         switch size {
         case .auto, .fraction: return .percent
@@ -92,10 +47,7 @@ struct SlotSizeRows: View {
         }
     }
 
-    /// Seed for the Points unit: keep an explicit pt, else a
-    /// sensible per-axis start. The editor has no screen to
-    /// resolve `.auto` (a fraction on both axes) against, so each
-    /// axis uses a fixed pt hint rather than the fraction standard.
+    /// Seed points value clamped to valid range.
     private var currentPoints: CGFloat {
         let stored: CGFloat
         if case .points(let points) =
@@ -105,14 +57,10 @@ struct SlotSizeRows: View {
         } else {
             stored = isVertical ? 700 : 1100
         }
-        // Keep the readout and slider thumb inside the slider's
-        // range; a smaller stored slot is floored at minWindowSize
-        // by the engine anyway.
         return max(stored, CGFloat(minPointsFloor))
     }
 
-    /// Seed for the Percent unit: keep an explicit fraction, else
-    /// the orientation's auto standard.
+    /// Seed fraction value using default orientation auto fraction.
     private var currentFraction: Double {
         if case .fraction(let fraction) =
             size

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGates.swift
@@ -1,43 +1,10 @@
 import KiwiDeskCore
 
-/// The Gaps & Borders area's greying, resolved from the census
-/// (#678 Phase 3). Keyed on a row's own `SettingKey` over
-/// `TilingSettings`, returning a REASON case rather than a Bool
-/// — the shape General and Layout Defaults already share, so
-/// this area adds no new resolver signature (owner ruling
-/// 2026-08-03: converge Bars/Shortcuts onto it in a later PR,
-/// not here).
-///
-/// Unlike Layout Defaults this area carries all three gate
-/// flavours, so the resolver answers two questions:
-///
-/// - `containerReason(for:)` — the Focus-border block gate. Every
-///   row in `.focusBorder` is inert while the ring is off, except
-///   the enable toggle that owns the gate (`exemptFromContainer\
-///   Gate`). The block draws one grey with one sentence, so the
-///   gate resolves once at the container, not per row.
-/// - `inertReason(for:)` — the row gates inside a live block:
-///   the glow-size row (glow off), each drag column's Border and
-///   Fill toggles (the visual itself off) and the two gap
-///   masters (their edges / axes differ, the
-///   `.runtime(.perEdgeValuesDiffer)` gate).
-///
-/// Returning the reason rather than a Bool keeps the grey and its
-/// inline sentence from being two decisions that can disagree
-/// (`GapsBordersGateHelp` renders it). The reason cases keep the
-/// whole resolver assertable off the main actor.
-///
-/// It answers one question that is not a gate at all —
-/// `strokesDiffer(for:)`, whether a shared master's strokes
-/// currently disagree. That lives here because the same
-/// predicates resolve the corner master's own displayed value,
-/// and a view re-deriving "differ" beside the control is the
-/// drift `inertReason` exists to prevent one row further down.
+/// Gaps & Borders row and container gate resolver (#678 Phase 3, 2026-08-03).
 struct GapsBordersGates {
     let settings: TilingSettings
 
-    /// Why a row (or the Focus-border block) is inert. One case
-    /// per predicate; the sentence lives in `GapsBordersGateHelp`.
+    /// Why a row or container is inert (`GapsBordersGateHelp`).
     enum InertReason: Hashable {
         case borderOff
         case glowOff
@@ -45,9 +12,7 @@ struct GapsBordersGates {
         case gapsDiffer
     }
 
-    /// The one container gate in this area: the Focus-border block
-    /// is inert while the ring is off. Other containers gate
-    /// nothing.
+    /// Container-level gate reason.
     func containerReason(
         for container: SettingsContainer
     ) -> InertReason? {
@@ -59,10 +24,7 @@ struct GapsBordersGates {
         }
     }
 
-    /// The row / runtime gate for a row inside a LIVE block. The
-    /// container gate is the block's job, so a Focus-border row's
-    /// reason here never repeats `.borderOff` — it guards on the
-    /// ring being enabled first.
+    /// Row-level gate reason inside a live block.
     func inertReason(for key: SettingKey) -> InertReason? {
         guard key.placement.gate != nil else { return nil }
         switch key {
@@ -81,11 +43,6 @@ struct GapsBordersGates {
             return settings.dragDropZone.enabled
                 ? nil : .visualOff
         default:
-            // A gated key with no arm here is a bug: the census
-            // declared a gate this resolver cannot answer. Fail
-            // loud in debug, fail-open in release so a shipped
-            // Settings window never locks a row it can't reason
-            // about (mirrors `LayoutDefaultsGates`).
             assertionFailure(
                 "unhandled Gaps & Borders gate: \(key.id)"
             )
@@ -93,10 +50,7 @@ struct GapsBordersGates {
         }
     }
 
-    /// The gated rows this resolver answers (data, so
-    /// `everyGatedRowIsResolved` reds when a new census gate lands
-    /// in neither set). The Focus-border CONTAINER gate is held
-    /// separately by `containerGateIsResolved`.
+    /// Gated rows answered by this resolver (`everyGatedRowIsResolved`).
     static let resolved: Set<SettingKey> = [
         .gaps(.outer),
         .gaps(.inner),
@@ -107,25 +61,10 @@ struct GapsBordersGates {
         .borders(.dragDropZoneFill),
     ]
 
-    /// Declared-but-answered-elsewhere. Empty and kept so a new
-    /// gate this resolver cannot answer must land here on purpose
-    /// rather than pass silently.
+    /// Declared-but-answered-elsewhere set.
     static let resolvedElsewhere: Set<SettingKey> = []
 
-    // MARK: - Shared masters
-
-    /// Whether the strokes a shared MASTER row writes disagree
-    /// with each other right now.
-    ///
-    /// Deliberately NOT an `InertReason`. The gap masters grey
-    /// on their own version of this because a per-edge drawer
-    /// sits under them to repair from; these two have none, so
-    /// greying them would state the disagreement and then
-    /// withhold the only control that ends it. They stay live
-    /// and acknowledge instead, through the row's `?`
-    /// (`GapsBordersGateHelp.strokesDiffer`) — and the corner
-    /// master additionally shows no segment selected, which is
-    /// `agreedCornerStyle` below.
+    /// True if strokes written by a shared master row currently disagree.
     func strokesDiffer(for key: SettingKey) -> Bool {
         switch key {
         case .borders(.borderWidthMaster):
@@ -137,13 +76,7 @@ struct GapsBordersGates {
         }
     }
 
-    /// The corner shape all three strokes agree on, or nil while
-    /// the ring's two-value style and the drag pair's radius
-    /// disagree. The ONE copy of that comparison: the master
-    /// binding's getter reads it as its displayed value and
-    /// `strokesDiffer` reads it as the `?` predicate, so the
-    /// blank picker and the sentence explaining it cannot
-    /// contradict each other.
+    /// Agreed corner shape across ring style and drag radius.
     var agreedCornerStyle: BorderStyle.CornerStyle? {
         let fromRadius: BorderStyle.CornerStyle =
             settings.dragCornerRadius > 0 ? .rounded : .square

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGates.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGates.swift
@@ -43,6 +43,10 @@ struct GapsBordersGates {
             return settings.dragDropZone.enabled
                 ? nil : .visualOff
         default:
+            // A gated key with no arm is a bug — fail loud in
+            // debug, fail-OPEN in release so a shipped Settings
+            // window never locks a row it cannot reason about
+            // (mirrors `LayoutDefaultsGates`).
             assertionFailure(
                 "unhandled Gaps & Borders gate: \(key.id)"
             )
@@ -64,7 +68,12 @@ struct GapsBordersGates {
     /// Declared-but-answered-elsewhere set.
     static let resolvedElsewhere: Set<SettingKey> = []
 
-    /// True if strokes written by a shared master row currently disagree.
+    /// True if the strokes a shared MASTER row writes currently
+    /// disagree. Deliberately NOT an `InertReason`: the gap
+    /// masters grey because a per-edge drawer sits under them to
+    /// repair from; these two have none, so greying them would
+    /// state the disagreement and withhold the only control that
+    /// ends it — they stay live and acknowledge through the `?`.
     func strokesDiffer(for key: SettingKey) -> Bool {
         switch key {
         case .borders(.borderWidthMaster):
@@ -76,7 +85,11 @@ struct GapsBordersGates {
         }
     }
 
-    /// Agreed corner shape across ring style and drag radius.
+    /// Agreed corner shape across ring style and drag radius —
+    /// the ONE copy of that comparison: the master binding reads
+    /// it as its displayed value and `strokesDiffer` as the `?`
+    /// predicate, so the blank picker and its explanation cannot
+    /// contradict.
     var agreedCornerStyle: BorderStyle.CornerStyle? {
         let fromRadius: BorderStyle.CornerStyle =
             settings.dragCornerRadius > 0 ? .rounded : .square

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog.swift
@@ -1,24 +1,15 @@
 import AppKit
 import KiwiDeskCore
 
-/// The catalog backing the keybindings tab: navigation presets
-/// and installed applications. Known macOS shortcuts used for
-/// conflict detection live in Core's `SystemShortcuts`.
+/// Catalog backing shortcuts settings tab: navigation presets and application
+/// launchers.
 enum KeybindingCatalog {
-    // dir is the Lua argument; phrase is the positional English
-    // wording used in the canonical `label` ("above"/"below"
-    // read better than "up"/"down").
     private static let directions = [
         ("left", "to the left"), ("down", "below"),
         ("up", "above"), ("right", "to the right"),
     ]
 
-    /// The translated phrase for a direction's Lua argument.
-    /// A literal `L(...)` per case (not a dynamic key lookup)
-    /// so `scripts/extract-keys` can enumerate it — the
-    /// extractor only recognizes string-literal key/English
-    /// arguments (`docs/translating.md` § Extraction
-    /// limitations).
+    /// Translates direction argument for display (`docs/translating.md`).
     @MainActor private static func directionPhrase(
         _ dir: String
     ) -> String {
@@ -36,7 +27,7 @@ enum KeybindingCatalog {
         }
     }
 
-    /// The four directional focus rows (#68 §3.6.1 Focus).
+    /// Four directional focus rows (#68 §3.6.1).
     static let focusDirections: [NavCommand] = directions.map {
         dir,
         phrase in
@@ -53,9 +44,7 @@ enum KeybindingCatalog {
         )
     }
 
-    /// One "Go to Space …" row per defined space. The space
-    /// name is user data (never translated), passed as a
-    /// positional arg into the translated sentence.
+    /// "Go to Space …" commands for configured spaces.
     static func goToSpace(
         _ spaces: [SpaceID],
         icons: [SpaceID: String] = [:]
@@ -77,7 +66,7 @@ enum KeybindingCatalog {
         }
     }
 
-    /// The four directional swap rows (Move windows).
+    /// Four directional swap rows.
     static let swapDirections: [NavCommand] = directions.map {
         dir,
         phrase in
@@ -94,22 +83,11 @@ enum KeybindingCatalog {
         )
     }
 
-    /// The track verbs speak prev/next, not compass directions
-    /// (#185 review): they act on the 1D track sequence, so
-    /// two rows replace four (no per-axis inert pair, and a
-    /// binding survives an axis flip). prev = the track toward
-    /// the sequence start — left for columns, top for rows;
-    /// next toward the end — right/bottom.
     private static let sequenceSteps = [
         ("prev", "previous"), ("next", "next"),
     ]
 
-    /// The translated phrase for a sequence step's Lua
-    /// argument (the `directionPhrase` twin). i18n seam: the
-    /// one phrase interpolates into BOTH sentence frames
-    /// (move + swap), which works for en/de but cannot carry
-    /// per-frame case/gender inflection — if a 1.0 language
-    /// (#95) needs it, split into per-frame keys then.
+    /// Translates sequence step argument for display (#95).
     @MainActor private static func sequencePhrase(
         _ step: String
     ) -> String {
@@ -123,8 +101,7 @@ enum KeybindingCatalog {
         }
     }
 
-    /// The two move-to-track rows (#128, prev/next). Labels
-    /// name the actor — the window moves, not the focus.
+    /// Move window to previous/next track rows (#185, #128).
     static let moveToTrackRows: [NavCommand] =
         sequenceSteps.map { step, phrase in
             NavCommand(
@@ -140,9 +117,7 @@ enum KeybindingCatalog {
             )
         }
 
-    /// The two whole-track swap rows (#182, prev/next).
-    /// Always rendered like `moveToTrackRows` (the gate was
-    /// dropped in #188); only relevant in the track layout.
+    /// Swap with previous/next track rows (#182, #188).
     static let trackSwapRows: [NavCommand] =
         sequenceSteps.map { step, phrase in
             NavCommand(
@@ -158,16 +133,8 @@ enum KeybindingCatalog {
             )
         }
 
-    /// The per-space "Move to …" / "… & follow" row pairs,
-    /// interleaved per space — the order the import classifier
-    /// and the old flat group both read.
-    ///
-    /// Composed from the two half-builders below rather than
-    /// repeating their commands: "Move to Space" and "Move to
-    /// Space & follow" are two census families (#678 Phase 3),
-    /// so the Shortcuts area renders each half on its own, and a
-    /// second copy of either Lua here would be the byte-for-byte
-    /// drift that silently demotes an import to Custom (#4).
+    /// Interleaved "Move to Space" and "Move to Space & follow" command pairs
+    /// (#678 Phase 3, #4).
     static func moveToSpace(
         _ spaces: [SpaceID],
         icons: [SpaceID: String] = [:]
@@ -179,8 +146,7 @@ enum KeybindingCatalog {
         .flatMap { [$0, $1] }
     }
 
-    /// One "Move to Space …" row per space. The space name is
-    /// user data, passed as a positional arg.
+    /// "Move to Space …" commands for configured spaces.
     static func moveToSpaceRows(
         _ spaces: [SpaceID],
         icons: [SpaceID: String] = [:]
@@ -202,7 +168,7 @@ enum KeybindingCatalog {
         }
     }
 
-    /// One "Move to Space … & follow" row per space.
+    /// "Move to Space … & follow" commands for configured spaces.
     static func moveToSpaceFollowRows(
         _ spaces: [SpaceID],
         icons: [SpaceID: String] = [:]
@@ -225,11 +191,7 @@ enum KeybindingCatalog {
         }
     }
 
-    /// Navigation grouped for the import classifier (#4): the
-    /// commands the sections render, so a recovered row matches
-    /// byte-for-byte. Grow/Shrink is deliberately absent — its
-    /// magnitude is configurable (#58), so import matches it by
-    /// *shape* via `resizeShape(from:)`, not from this map.
+    /// Grouped navigation commands for keybinding import classifier (#4, #58).
     static func navigationGroups(
         spaces: [SpaceID]
     ) -> [NavGroup] {
@@ -248,28 +210,17 @@ enum KeybindingCatalog {
         ]
     }
 
-    // Size & float presets (resizeAndFloat, makeFloating,
-    // resizeShape) live in `KeybindingCatalog+Resize.swift`.
-
-    /// A space id as a quoted, escaped Lua string argument.
+    /// Formats space ID as quoted Lua string argument (#13).
     static func spaceArg(_ space: SpaceID) -> String {
         quote(space.raw)
     }
 
-    /// A quoted, escaped Lua string literal. Delegates to the
-    /// canonical `SpaceLuaArg.quote` so the form a space rename
-    /// rewrites always matches what the catalog authored (#13).
+    /// Quotes raw string via `SpaceLuaArg.quote`.
     static func quote(_ raw: String) -> String {
         SpaceLuaArg.quote(raw)
     }
 
-    /// The bindable "open the shortcuts reference panel" row
-    /// (#330): a GUI action verb (`KiwiDesk.show_shortcuts()`).
-    /// Seeded to **⌃⌥K** by default (#602) — reachable from the
-    /// keyboard out of the box — but editable or clearable per
-    /// layer like any default. The Lua comes from
-    /// `ShortcutsOpenBinding` so the row, the classifier, and the
-    /// quick-menu combo all speak of one binding.
+    /// Command opening shortcuts cheat sheet overlay (#330, #602).
     static let showShortcuts = NavCommand(
         label: "Show shortcuts panel",
         lua: ShortcutsOpenBinding.lua,
@@ -278,12 +229,8 @@ enum KeybindingCatalog {
         }
     )
 
-    /// The bindable "Open Settings" row (#678 item 18): a GUI
-    /// action verb (`KiwiDesk.open_settings()`), deliberately
-    /// UNBOUND by default — Settings is not a prerequisite, so
-    /// no default chord is spent on it. The catalog row is the
-    /// one production copy of the Lua body;
-    /// `OpenSettingsClassifyTests` pins it to the Core verb.
+    /// Command opening settings window (`OpenSettingsClassifyTests`, #678 item
+    /// 18).
     static let openSettings = NavCommand(
         label: "Open Settings",
         lua: "KiwiDesk.open_settings()",

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingOverrideEnvironment.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingOverrideEnvironment.swift
@@ -33,9 +33,19 @@ extension KeyBinding {
 }
 
 extension View {
-    /// Applies dimmed styling and accessibility hint for inherited/unavailable
-    /// shortcut rows
-    /// (#678, #830, #818).
+    /// Applies dimmed styling and a spoken hint for
+    /// inherited/unavailable rows (#678 turn 20a rule 3). Both
+    /// states stay EDITABLE — dim, never disable. The hint names
+    /// no control, deliberately, against #830's table: the label
+    /// it quoted renders only while `combo.isEmpty`, so the
+    /// sentence named a word not on screen for the one row it
+    /// describes — when a control's label is not visible, the fix
+    /// is to stop naming it, not a better interpolation (#818's
+    /// boundary). Unverified whether a container hint reaches the
+    /// control inside; kept because the worse case here is an
+    /// inert hint — where `GreyOut`'s was DELETING shipped hints,
+    /// which is why that one was backed out. Confirm both in one
+    /// Accessibility Inspector pass.
     func keybindingRowStyle(
         inherited: Bool,
         unavailable: String? = nil

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingOverrideEnvironment.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingOverrideEnvironment.swift
@@ -1,14 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Environment plumbing for the Shortcuts tab's override layer
-/// (#55 phase 7): while editing a stored profile the tab shows
-/// the RESOLVED layers (base + the profile's sparse override).
-/// Rows equal to their base gui.json row are inherited and
-/// render dimmed; rows that diverge are this profile's
-/// overrides and render at full strength — the same
-/// inherited/overridden affordance as the per-space layout
-/// overrides (#17). nil = live editing, no affordance.
+/// Environment keys for Shortcuts tab profile override rendering (#55, #17).
 private struct KeybindingOverrideBaseKey: EnvironmentKey {
     static let defaultValue: [KeyBinding]? = nil
 }
@@ -18,16 +11,14 @@ private struct KeybindingLayerNameKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    /// The selected layer's base bindings while the Shortcuts
-    /// tab edits a stored profile; nil during live editing.
+    /// Base bindings for selected layer during profile override editing; nil
+    /// during live editing.
     var keybindingOverrideBase: [KeyBinding]? {
         get { self[KeybindingOverrideBaseKey.self] }
         set { self[KeybindingOverrideBaseKey.self] = newValue }
     }
 
-    /// Layer whose recorder rows are currently rendered. The
-    /// live-apply seam uses it without threading another value
-    /// through every intent-section wrapper.
+    /// Name of layer whose keybindings are currently rendered.
     var keybindingLayerName: String {
         get { self[KeybindingLayerNameKey.self] }
         set { self[KeybindingLayerNameKey.self] = newValue }
@@ -35,74 +26,16 @@ extension EnvironmentValues {
 }
 
 extension KeyBinding {
-    /// Whether this row is inherited unchanged from `base` —
-    /// SEMANTIC match (`sameAction`: combo + lua), so the GUI
-    /// import classifier's display-only kind/label upgrades
-    /// never render an untouched row as overridden. Always
-    /// false outside override layer (`base == nil`).
+    /// Whether this binding is semantically identical to a base binding (#55).
     func isInherited(from base: [KeyBinding]?) -> Bool {
         base?.contains { $0.sameAction(as: self) } == true
     }
 }
 
 extension View {
-    /// Dimmed when inherited, full strength when overridden
-    /// or while editing live.
-    ///
-    /// The dim carries the whole distinction, so it also goes out
-    /// as a spoken hint (#678 Phase 4 pass 10, turn 20a rule 3).
-    /// The only explanation on screen is a caption at the top of
-    /// the card — "Dimmed rows are inherited from the base" —
-    /// which a screen-reader user reaches once, long before the
-    /// row it explains, and cannot re-read from inside the list.
-    /// A per-row hint is the version that survives arriving at
-    /// row forty by keyboard.
-    ///
-    /// One site, three consumers (the nav rows, the app group and
-    /// the raw-Lua drawer), which is why the hint belongs on the
-    /// shared modifier rather than at each of them.
-    ///
-    /// **Unverified in one respect, and kept anyway because the
-    /// two outcomes are not symmetric**: this modifier is applied
-    /// to a whole ROW, and whether a hint on a container reaches
-    /// the control inside it could not be observed headlessly
-    /// (see `GreyOut`, where the same question sent the same
-    /// change back out). Here the worse case is that the hint is
-    /// inert — nothing in a keybinding row sets a hint of its
-    /// own, so there is none for an empty inherited value to
-    /// displace. `GreyOut` was backed out because there the worse
-    /// case was DELETING hints that ship today. Confirm both in
-    /// one Accessibility Inspector pass.
-    /// **This hint names no control, deliberately, against #830's
-    /// table.** That issue listed it as quoting `key_recorder
-    /// .record` ("Record") and the conversion interpolated it —
-    /// which was wrong twice. Grammatically, the label sat in the
-    /// sentence's VERB slot, which only works in English: `es`,
-    /// `it`, `pt-BR` and `ru` repaired it by supplying a verb of
-    /// their own, and `de` and `fr` shipped verbless clauses
-    /// (localization audit, 2026-08-17). Referentially — the
-    /// sharper half — `KeyRecorderField.label` renders "Record"
-    /// only while `combo.isEmpty`, and an INHERITED row shows the
-    /// combo it inherited. So the sentence named a word that is
-    /// not on screen for the one row it describes, and a
-    /// VoiceOver user, who has no visual context at all, would
-    /// have been sent to look for it.
-    ///
-    /// Interpolation is the right answer when prose names a
-    /// control the reader can see (#818). When the control's
-    /// label is not on screen, the fix is not a better
-    /// interpolation — it is to stop naming it.
-    /// A row dims for one of two reasons, and says which.
-    ///
-    /// Both leave the row EDITABLE — that is the whole point of
-    /// dimming rather than disabling: an inherited row is
-    /// waiting to be overridden, and a row whose Desktop is
-    /// away is waiting for the screen to come back. Neither is
-    /// a control the user may not touch.
-    ///
-    /// `unavailable` is the short spoken mark; the block
-    /// sentence under the family carries the explanation, so a
-    /// reader who cannot see the dimming gets both.
+    /// Applies dimmed styling and accessibility hint for inherited/unavailable
+    /// shortcut rows
+    /// (#678, #830, #818).
     func keybindingRowStyle(
         inherited: Bool,
         unavailable: String? = nil

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/ShortcutsRowOrder.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/ShortcutsRowOrder.swift
@@ -1,33 +1,7 @@
-/// The Shortcuts area's display order (turn 5 of the redesign,
-/// #678 Phase 3). Same split as `BarsRowOrder` and
-/// `ColorsRowOrder`: the census owns *placement* — which
-/// container and tier each row sits in — and records no display
-/// order, so the renderer declares it here as data.
-///
-/// `ShortcutsCensusRenderTests` pins each list against the
-/// census: every `.shortcuts`-area key must appear in exactly
-/// the list its placement names, so a census row added or
-/// retiered without a renderer update is a red test, not a
-/// silently missing control.
-///
-/// **These are FAMILIES, not rows.** A census case here is one
-/// keybinding family — `focusDir` is the setting, and the four
-/// directional rows on screen are its instances. The expansion
-/// lives in `ShortcutsFamilyRows`, which switches exhaustively
-/// over the same cases, so the two halves cannot drift: a family
-/// added to the census must be placed in a list here AND given
-/// an expansion there before it compiles and passes.
+/// Display order definitions for Shortcuts settings section (#678,
+/// `ShortcutsCensusRenderTests`).
 enum ShortcutsRowOrder {
-    /// Containers the section draws with BESPOKE views rather
-    /// than a `ForEach` over an order list: the app list, the
-    /// layer strip and the raw-Lua drawer.
-    ///
-    /// Data, not prose, because the promise above is weaker for
-    /// these three — their order lists guard MEMBERSHIP and
-    /// nothing checks that a family added to one reaches the
-    /// screen. A fourth container going bespoke has to edit this
-    /// set, which `ShortcutsCensusRenderTests` asserts over, so
-    /// the limitation cannot quietly widen.
+    /// Containers drawn with bespoke views rather than a standard list loop.
     static let bespokeContainers: Set<SettingsContainer> = [
         .openApplications,
         .layers,
@@ -35,20 +9,15 @@ enum ShortcutsRowOrder {
         .defaultShortcuts,
     ]
 
-    /// Focus: the four directions, one row per live space, then
-    /// one per macOS Desktop. KiwiDesk's own Spaces lead — they
-    /// are what the rest of the app is about, and a Desktop row
-    /// is the escape into macOS's own arrangement.
+    /// Focus group order: directions, live spaces, macOS Desktops.
     static let focusAtRest: [SettingKey] = [
         .shortcuts(.focusDir),
         .shortcuts(.goToSpace),
         .shortcuts(.focusDesktop),
     ]
 
-    /// Move windows: the directional swaps, the track verbs
-    /// (authoring rows, always rendered — only meaningful in the
-    /// track layout, which the caption says), then the per-space
-    /// move pair and the per-Desktop one.
+    /// Move windows group order: swaps, track verbs, space moves, Desktop
+    /// moves.
     static let moveWindowsAtRest: [SettingKey] = [
         .shortcuts(.swapDir),
         .shortcuts(.moveWindowToTrack),
@@ -59,27 +28,7 @@ enum ShortcutsRowOrder {
         .shortcuts(.moveToDesktopFollow),
     ]
 
-    /// Families whose INSTANCES interleave instead of stacking.
-    ///
-    /// An order list orders FAMILIES, which is almost always the
-    /// whole story — but "Move to Space 2" and "Move to Space 2
-    /// & follow" are one decision about one space, and drawing
-    /// every plain row and then every follow row makes the user
-    /// cross-reference two lists to make it. So the per-space
-    /// pair renders per space: plain, follow, plain, follow. The
-    /// per-Desktop pair is the same decision one noun over.
-    ///
-    /// Data rather than a special case inside the renderer,
-    /// because it is a design decision about instance order and
-    /// the render guard compares SETS — set equality cannot see
-    /// interleaving, which is exactly how splitting these two
-    /// families into two census cases un-paired them on screen
-    /// with every test green.
-    ///
-    /// Each run's members must share a container and tier;
-    /// `ShortcutsCensusRenderTests` pins that, and the runs stay
-    /// short by construction — a run is a row shape, not a
-    /// grouping mechanism.
+    /// Families whose instances interleave per target rather than stacking.
     static let interleavedRuns: [[SettingKey]] = [
         [.shortcuts(.moveToSpace), .shortcuts(.moveToSpaceFollow)],
         [
@@ -88,22 +37,21 @@ enum ShortcutsRowOrder {
         ],
     ]
 
-    /// The run `key` leads, if it leads one. A non-leading member
-    /// draws nothing: its rows were emitted with the leader's.
+    /// Interleaved run starting at `key`, if any.
     static func interleavedRun(
         startingAt key: SettingKey
     ) -> [SettingKey]? {
         interleavedRuns.first { $0.first == key }
     }
 
+    /// True if `key` is a non-leading member of an interleaved run.
     static func isInterleavedFollower(_ key: SettingKey) -> Bool {
         interleavedRuns.contains {
             $0.dropFirst().contains(key)
         }
     }
 
-    /// Size & float: the four resize rows in grow/shrink pairs
-    /// per axis, then the three state toggles.
+    /// Size & float order: resize pairs followed by state toggles.
     static let sizeAndFloatAtRest: [SettingKey] = [
         .shortcuts(.growWidth),
         .shortcuts(.shrinkWidth),
@@ -114,58 +62,40 @@ enum ShortcutsRowOrder {
         .shortcuts(.toggleDisplaySticky),
     ]
 
-    /// Behind Size & float's disclosure: the unsupported-resize
-    /// cue. Not a keybinding at all but a `TilingSettings`
-    /// toggle, which is why its census case lives in the
-    /// Behaviour sub-enum while its PLACEMENT names this
-    /// container — the census is grouped by model subsystem and
-    /// placed by area, and this row is the case that proves the
-    /// two are separate axes.
+    /// Unsupported resize sound cue setting.
     static let sizeAndFloatMore: [SettingKey] = [
         .behaviour(.resizeFeedback)
     ]
 
-    /// Open applications: one family, expanding to a row per
-    /// configured app plus the trailing "Add application".
+    /// Open applications group order.
     static let openApplicationsAtRest: [SettingKey] = [
         .shortcuts(.openApplications)
     ]
 
-    /// App chrome rather than a workspace action, so it sits
-    /// below the action groups and behind a disclosure.
+    /// General shortcuts behind disclosure.
     static let generalKeysMore: [SettingKey] = [
         .shortcuts(.showShortcuts),
         .shortcuts(.openSettings),
     ]
 
-    /// Layers: the strip itself, the selected layer's menu-bar
-    /// icon, and one switch row per other layer. All three are
-    /// one container — the rows that switch layers belong beside
-    /// the strip that defines them, not among the action groups.
+    /// Layers group order behind disclosure.
     static let layersMore: [SettingKey] = [
         .shortcuts(.layers),
         .shortcuts(.layersIcon),
         .shortcuts(.switchToLayer),
     ]
 
-    /// The power-user escape hatch, behind the Advanced drawer.
+    /// Advanced Lua bindings behind disclosure.
     static let luaBindingsMore: [SettingKey] = [
         .shortcuts(.advanced)
     ]
 
-    /// Import draws at rest, in the header — the same container
-    /// as the raw-Lua rows, a different tier. Its runtime gate,
-    /// not a disclosure, is what keeps it out of the way until
-    /// `init.lua` holds something to adopt.
+    /// Header import action.
     static let luaBindingsAtRest: [SettingKey] = [
         .shortcuts(.import)
     ]
 
-    /// Restore Defaults, beside Import in the header. Its
-    /// own container because the set it restores spans four
-    /// of them, and at rest for Import's reason: a runtime
-    /// gate, not a disclosure, keeps it away until there is
-    /// something to restore.
+    /// Header restore defaults action.
     static let defaultShortcutsAtRest: [SettingKey] = [
         .shortcuts(.restoreDefaults)
     ]

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutCard.swift
@@ -1,19 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// One layout's parameter card, rendered from the census (#678
-/// Phase 3, turn 10): `LayoutDefaultsRowOrder` gives the order,
-/// `SettingPlacement` the tier and gate, and
-/// `LayoutDefaultsGates` resolves every gate the rows declare.
-///
-/// Only the selected layout's card is ever mounted, which is the
-/// point of the strip above it: the area's thirty-six rows never
-/// appear at once, and the most anyone sees is eight.
-///
-/// No block gate and no disclosure — a layout's card is never
-/// off as a unit, because the card *is* the layout the reader
-/// picked, and a "show more" inside it would be a second door
-/// behind the one they just opened.
+/// Layout parameters settings card (#678 Phase 3).
 struct LayoutCard: View {
     @ObservedObject var model: SettingsModel
     let mode: LayoutMode
@@ -33,16 +21,8 @@ struct LayoutCard: View {
         }
     }
 
-    /// Monocle and Scrolling are the only layouts that host an
-    /// App Bar, and its enable toggle plus all its styling are
-    /// owned by the Bars page. The row is chrome, not a census
-    /// row — it sets nothing — but it carries the bar's live
-    /// On/Off state so it isn't a dead pointer, which is the
-    /// design consult's ruling from when this row was born.
-    ///
-    /// Layout Defaults is a Power-User-mode area and Bars is a Simple
-    /// one, so the destination always exists in the mode the
-    /// reader is already in (item 14).
+    /// Cross-reference link to Bars settings for hosting layouts
+    /// (`SidebarCrossReferenceTests`).
     @ViewBuilder private var appBarCrossReference: some View {
         if let host = model.config.settings.appBarHost(for: mode),
             let appBarProse = LayoutCardText.appBarState(
@@ -52,21 +32,6 @@ struct LayoutCard: View {
         {
             CrossReferenceRow(
                 prose: appBarProse,
-                // A BREADCRUMB, not the section name alone. The
-                // sentence says where the toggle lives, and
-                // "App Bar" names no row any sidebar shows —
-                // that row reads "Bars" / "Leisten" / "情報バー"
-                // — so the reader was sent looking for a pane
-                // that is not there, the way #678's spaces card
-                // was until c35407fa. Now that the link sits
-                // INSIDE the sentence the German said "wird
-                // unter App Bar konfiguriert", naming the thing
-                // twice. The head is the destination's own
-                // title, which also brings this link inside
-                // `SidebarCrossReferenceTests` — its subjects
-                // are derived from `▸`-shaped values, so a
-                // one-segment link never entered the set and
-                // nothing was watching this at all.
                 linkTitle: L(
                     "scroll_grid.app_bar_xref_link",
                     "Bars ▸ App Bar"
@@ -76,9 +41,6 @@ struct LayoutCard: View {
         }
     }
 
-    /// Each row carries the grey its census gate resolves to —
-    /// asked of the resolver, never re-derived here, so the
-    /// declared owner and the on-screen grey cannot drift.
     private func rows(_ keys: [SettingKey]) -> some View {
         ForEach(keys, id: \.id) { key in
             let reason = gates.inertReason(for: key)
@@ -103,10 +65,6 @@ struct LayoutCard: View {
         case .colours(.animationsScrollDurationMS):
             scrollDurationRow
         default:
-            // The render-parity guard forces every census row of
-            // these containers into the order lists, so a
-            // cross-family key placed in one reaches this arm —
-            // it must fail loud in debug rather than vanish.
             let _ = assertionFailure(
                 "unrendered Layout Defaults key: \(key.id)"
             )
@@ -115,11 +73,7 @@ struct LayoutCard: View {
     }
 }
 
-/// The per-layout header caption — one sentence saying what the
-/// layout does, so the card answers "what am I tuning" without
-/// the reader having to decode its rows. Split from the view so
-/// the strings sit together rather than inside a `switch` in a
-/// `body`.
+/// Header blurb and cross-reference text per layout mode.
 @MainActor
 enum LayoutCardText {
     static func blurb(_ mode: LayoutMode) -> String? {
@@ -163,35 +117,11 @@ enum LayoutCardText {
                     + "per-track resize."
             )
         case .floating:
-            // Floating has no card — nothing to tune, so it
-            // never reaches the strip.
             return nil
         }
     }
 
-    /// The App Bar cross-reference's prose, with the bar's live
-    /// state AND the destination link read into the sentence —
-    /// the link as `CrossReferenceRow.linkSlot`, so a
-    /// translation may put the pane's name wherever its word
-    /// order wants it rather than dangling off the end.
-    /// One key per layout, because
-    /// the layout's name is inside it and a language that
-    /// inflects around that name cannot be handed a bare noun.
-    /// Exhaustive rather than defaulted, so a third hosting
-    /// layout fails to COMPILE — which is the discipline this
-    /// area states everywhere else, and a `default:` here would
-    /// quietly give that layout Scrolling's sentence.
-    ///
-    /// Returns `nil` for a layout with no sentence rather than
-    /// asserting and handing back `""`. That axis is the one the
-    /// exhaustive switch does NOT defend — granting Grid a host
-    /// compiles, because Grid is already listed — and an
-    /// `assertionFailure` here reports it by KILLING the test
-    /// process (signal 5, no attribution), which is what
-    /// guard-prover hit driving this from
-    /// `CrossReferenceRowSlotTests`. A nil fails as a value: the
-    /// suite reds naming the mode, and the caller draws no row
-    /// rather than an empty sentence beside a live link.
+    /// App Bar cross-reference prose (`CrossReferenceRowSlotTests`).
     static func appBarState(
         _ mode: LayoutMode,
         on: Bool
@@ -216,11 +146,7 @@ enum LayoutCardText {
                 CrossReferenceRow.linkSlot
             )
         case .bsp, .stack, .grid, .track, .floating:
-            // Unreachable while Core's `appBarHost(for:)` — the
-            // one copy of who may show a bar — grants no host to
-            // these. `CrossReferenceRowSlotTests` reds naming
-            // the mode if one of them ever gains a host, which
-            // is why this returns nil instead of asserting.
+            // Non-hosting layouts return nil (`CrossReferenceRowSlotTests`).
             return nil
         }
     }

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicStandIns.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicStandIns.swift
@@ -1,15 +1,29 @@
 import CoreGraphics
 
-/// Display-capacity stand-ins for schematic previews on mini-canvases
-/// (#708, #712; `LayoutSchematicTrackFoldTests.foldIsScaleIndependent`).
+/// Display-capacity stand-ins for schematic previews (#708). **A
+/// schematic's ceiling is the engine's rule, never the canvas's**
+/// (#712): clamp the drawing if you must, never the rule — a
+/// clamped ceiling once made one config draw two capacities.
+/// Every constant here is the same at every `SchematicScale`;
+/// `LayoutSchematicTrackFoldTests.foldIsScaleIndependent` holds
+/// it for the two Track constants. Stated residue:
+/// `gridAutoSizeCap` has no scale-independence guard of its own —
+/// one is owed.
 extension LayoutSchematic {
     /// Grid preview stand-in for display-computed `auto_size` ceiling (#712).
     static let gridAutoSizeCap = (columns: 3, rows: 3)
 
     /// Track preview stand-in for `spillCapacity` (#437, #708).
+    /// Three — the smallest number that SHOWS fill-then-spill: at
+    /// two, every second window opens a track and the fill half
+    /// never reads as filling.
     static let trackSpillCapacity = 3
 
-    /// Track preview geometric track cap under `auto_tracks` (architect
-    /// review 2026-08-16).
+    /// Track preview geometric cap — under `auto_tracks` ONLY: a
+    /// stand-in fills in where the user gave no number, and
+    /// passed unconditionally it overruled a typed limit of 6
+    /// (architect review, 2026-08-16); `TrackSchematic+Fold`
+    /// passes `.max` for a fixed limit. Without it the auto arm
+    /// would never fold at all.
     static let trackGeoCap = 5
 }

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicStandIns.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicStandIns.swift
@@ -1,93 +1,15 @@
 import CoreGraphics
 
-/// The stand-ins a schematic uses for a quantity the ENGINE
-/// derives from a real display, which a mini-canvas is not.
-///
-/// One family, one file, because the alternative is what #708
-/// nearly shipped: Grid already had a reasoned answer to this
-/// class (`gridAutoSizeCap`, #712) and Track was about to get a
-/// second, differently-argued one two files away. A schematic
-/// meeting a display-derived ceiling takes a constant from here
-/// and states it, rather than inventing a local number.
-///
-/// **A schematic's ceiling is the engine's rule, never the
-/// canvas's** — the rule this family exists to keep. An earlier
-/// cut of #712 clamped a ceiling to what the canvas could legibly
-/// draw, which made the drawn *capacity* scale-dependent: rigid
-/// 8 × 1 with five windows drew a two-window pile on the strip
-/// thumbnail and none in the panel, inventing an overflow the
-/// engine does not have. So every constant here is a stand-in for
-/// a DISPLAY quantity and is the same at every
-/// `SchematicScale` — clamp the drawing if you must; never the
-/// rule.
-///
-/// `LayoutSchematicTrackFoldTests.foldIsScaleIndependent` holds
-/// that property for the two Track constants — the one thing no
-/// reviewer can see by reading a single schematic. Stated
-/// residue: `gridAutoSizeCap` has no scale-independence guard of
-/// its own, so a Grid schematic that came to fold differently at
-/// `.tile` would not red. A guard over it is owed
-/// (`rule-authoring.md` — name the suite that exists, and say
-/// which half is uncovered).
+/// Display-capacity stand-ins for schematic previews on mini-canvases
+/// (#708, #712; `LayoutSchematicTrackFoldTests.foldIsScaleIndependent`).
 extension LayoutSchematic {
-    /// The Grid preview's stand-in for the one ceiling it cannot
-    /// compute: `auto_size`, where `GridLayout.capDimensions`
-    /// fits as many minimum-size cells as the *display* allows.
-    /// The canvas is not a display and has no minimum window
-    /// size, so it draws a plausible grid and the caption states
-    /// these numbers rather than prose (#712).
-    ///
-    /// With auto-size **off** no stand-in is needed: the ceiling
-    /// is the user's own typed columns × rows.
+    /// Grid preview stand-in for display-computed `auto_size` ceiling (#712).
     static let gridAutoSizeCap = (columns: 3, rows: 3)
 
-    /// The Track preview's stand-in for `spillCapacity` — how
-    /// many windows fit in ONE track at `min_window_size`, which
-    /// `TilingEngine.trackCapacities` measures against the real
-    /// display (#437, #708).
-    ///
-    /// Three, because it is the smallest number that shows the
-    /// rule rather than merely satisfying it: at two, every
-    /// second window opens a track and the "fill" half of
-    /// fill-then-spill never reads as filling.
-    ///
-    /// This is the RULE's number, not the drawing's. The focused
-    /// track's drawn run is clamped separately, and the two must
-    /// not be conflated — that conflation is exactly what #712's
-    /// argument above forbids.
+    /// Track preview stand-in for `spillCapacity` (#437, #708).
     static let trackSpillCapacity = 3
 
-    /// The Track preview's stand-in for the geometric track cap —
-    /// `geoCap` in `TrackLayout.overflowCap`, which on a real
-    /// display is how many tracks fit across it.
-    ///
-    /// Five — four normal tracks beside one folded far-edge
-    /// track. For a preview the canvas IS the display, so this is
-    /// a genuine fit count rather than a clamp bolted onto a
-    /// rule: five is what the strip shows without the tracks
-    /// becoming slivers.
-    ///
-    /// **Applies only under `auto_tracks`**, which is the whole
-    /// of `gridAutoSizeCap`'s rule restated for this axis: a
-    /// stand-in fills in where the user gave NO number, and a
-    /// typed `limit` is a number. Passed unconditionally it
-    /// bound below the limit stepper's own range (1…10) and the
-    /// preview answered a typed 6 with four normal tracks —
-    /// the stand-in overruling the setting it illustrates
-    /// (architect review, 2026-08-16). `TrackSchematic+Fold`
-    /// passes `.max` for a fixed limit, so the typed value is
-    /// the ceiling and the drawing may go thin.
-    ///
-    /// Fixed across `SchematicScale`, which is the property that
-    /// keeps this on the right side of #712: the thumbnail and
-    /// the panel fold identically, so one configuration never
-    /// draws two different capacities.
-    ///
-    /// Without a stand-in the auto arm would have to pass
-    /// `.max`, and `normalCap` is `.max` there too — so it would
-    /// never fold at all: an unbounded row of ever-thinner
-    /// tracks and no overflow track, on the very setting whose
-    /// whole story is that tracks open until the display runs
-    /// out.
+    /// Track preview geometric track cap under `auto_tracks` (architect
+    /// review 2026-08-16).
     static let trackGeoCap = 5
 }

--- a/Sources/KiwiDesk/Settings/Components/Layouts/ScrollingSchematic+Caption.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/ScrollingSchematic+Caption.swift
@@ -1,25 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Scrolling preview's words (#753).
-///
-/// **The caption and the a11y label switch on the anchor.** The
-/// anchor is a picker the reader is operating, and one string
-/// covering all four says nothing when they move it. Worse, it
-/// would have to state `follow`'s pan — the one fact the frame
-/// cannot carry — under `center`, `start` and `end` too, so three
-/// anchors would carry a sentence about a fourth and VoiceOver
-/// would assert it over a tile that never drew it. The family
-/// already splits a caption wherever a control splits the picture
-/// (`layout.schematic.monocle.caption_h` / `_v`,
-/// `layout.schematic.stack.caption_all` / `_overflow`).
-///
-/// `center`, `start` and `end` share one frame of words on
-/// purpose: what they change is *where* the focused window rests,
-/// and the picture already shows that. `follow` rests where
-/// `center` does — the two frames are pixel-identical, which is
-/// the trade `docs/design-decisions.md` argues — so the caption is
-/// the only place the difference can be stated at all.
+/// Caption and accessibility text for Scrolling schematic preview (#753).
 extension ScrollingSchematic {
     var caption: String {
         switch anchor {
@@ -70,15 +52,7 @@ extension ScrollingSchematic {
         }
     }
 
-    /// The `+` sentence — and only where the `+` is actually on
-    /// the frame.
-    ///
-    /// The row is finite but several canvases wide at most counts,
-    /// so the incoming slot is often clipped away entirely: with
-    /// New window ▸ Last and the default five windows it already
-    /// is, and First loses it the same way from about eight. A
-    /// caption pointing at a mark that is not drawn is worse than
-    /// no caption at all.
+    /// Insertion point caption clause when insertion marker is drawn.
     var insertionClause: String {
         guard drawsInsertionMark else { return "" }
         return L(
@@ -87,61 +61,18 @@ extension ScrollingSchematic {
         )
     }
 
-    /// Whether the `+` is on the frame — a condition on the ROW
-    /// and the SCALE, deliberately, not on the pixels.
-    ///
-    /// The caption is drawn *beside* the frame and cannot read the
-    /// `GeometryReader`'s width, so a pixel test here would be a
-    /// model of the drawing rather than the drawing. A slot
-    /// **adjacent to the focus** needs no width to answer — but
-    /// only where the monitor leaves a margin beside itself
-    /// (`hasMargin`, the same answer the outline turns on): the
-    /// focused tile sits wholly inside the monitor, one step is
-    /// one slot plus 3 pt, and that margin is what the neighbour
-    /// reaches into, at every anchor, slot size and canvas length
-    /// a panel can take.
-    ///
-    /// Where the monitor IS the canvas the margin is zero, and
-    /// the neighbour's near edge lands 3 pt past the far border —
-    /// `end` with New window ▸ After focused would claim a `+`
-    /// nothing draws. So the scale is folded into the answer
-    /// rather than assumed by it. Today `.tile` is the only
-    /// marginless scale and it suppresses the caption anyway
-    /// (`SchematicScale.showsCaption`), which is exactly what
-    /// would keep a wrong answer invisible until some thumbnail
-    /// gained a caption.
-    ///
-    /// Only *sufficient*, on purpose: at a thin slot the `+` can
-    /// be three slots out and still show, and the caption then
-    /// says nothing about a mark that is drawn — which is what
-    /// Stack's, Grid's and Monocle's captions do with theirs in
-    /// every case. Silence under-labels; the alternative
-    /// mislabels.
-    ///
-    /// Internal because `LayoutSchematicCaptionTests` holds the
-    /// claim against the drawing's own `onCanvas`, over every
-    /// anchor, placement, count, slot size and scale at the widths
-    /// a pane can take.
+    /// Whether next-window insertion '+' marker is on canvas
+    /// (`LayoutSchematicCaptionTests`).
     var drawsInsertionMark: Bool {
         hasMargin && abs(row.incoming) <= 1
     }
 
-    /// Named with the picker's own term, so every locale reads its
-    /// own translation of the segment rather than the English
-    /// word sitting inside a translated sentence.
     private var followName: String {
         L("scroll_grid.anchor.follow", "Follow")
     }
 
-    /// The frame carries the space before its optional clause, so
-    /// a translator owns the spacing; with no clause to place, the
-    /// space it left behind goes.
-    ///
-    /// Trimming can only reach a space at the END, so both frames
-    /// are registered in `WITHHELD_ARGUMENTS`
-    /// (`scripts/localization_guards.py`) and no catalog — nor a
-    /// future edit to the English — may move the clause into the
-    /// middle of the sentence.
+    /// Trims trailing whitespace when optional insertion clause is omitted
+    /// (`WITHHELD_ARGUMENTS`).
     private func oneLine(_ sentence: String) -> String {
         sentence.trimmingCharacters(in: .whitespaces)
     }

--- a/Sources/KiwiDesk/Settings/Components/Layouts/StackSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/StackSchematic.swift
@@ -1,26 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Stack schematic (#125): a master zone sized by the staged
-/// master ratio, beside a six-window stack zone that shows the
-/// overflow style *directly* rather than with a stand-in glyph —
-/// `cascade_overflow` piles only the surplus windows, `cascade_all`
-/// piles the whole zone so just the top edges peek. The #222
-/// arrangement fields feed it too: the split follows the staged
-/// stack position (which also derives the stack zone's lineup)
-/// and the master zone follows its staged orientation (piles
-/// keep cascading downward, like the engine).
-/// Focus sits on the first stack window, so the new-window
-/// placement (first / last / before / after focused) reads off
-/// which slot the dense `+` tile takes.
-///
-/// The piled tiles are drawn **opaque** (each with its own solid
-/// base), so overlapping them never sums the accent alpha into
-/// muddy bands — the front (last) window carries the dominant
-/// colour and the buried ones read as lighter title-bar slivers
-/// behind it. Hand-drawn, unlike the BSP schematic which drives the
-/// real `BspLayout`: the engine's 40 pt cascade offset would throw
-/// tiles off this mini canvas, so the offset is scaled down here.
+/// Stack layout schematic preview showing master and stack zones (#125, #222).
 struct StackSchematic: View {
     let masterCount: Int
     let masterRatio: Double
@@ -28,40 +9,28 @@ struct StackSchematic: View {
     let masterOrientation: StackParams.Orientation
     let stackPosition: StackParams.StackPosition
     let placement: SpawnPlacement
-    /// Windows on screen, the incoming one included. This is the
-    /// input that makes the two overflow styles diverge (turn
-    /// 10): below the tiled run they draw the same picture, and
-    /// only a stack deep enough to overflow separates "pile the
-    /// surplus" from "pile the lot".
+    /// Total windows drawn including incoming tile.
     var windows = LayoutSchematic.defaultWindowCount
     var scale: SchematicScale = .tile
 
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// The restage damping, gated on Reduce Motion (#1069) —
-    /// the arrangement still redraws, it just stops travelling.
-    /// The ternary is spelled here rather than folded into
-    /// `LayoutSchematic.damping`; that file says why.
+    /// Restage animation damping gated on Reduce Motion (#1069).
     private var damping: Animation? {
         reduceMotion ? nil : LayoutSchematic.damping
     }
 
-    /// Derived, like the engine (`StackPosition.stackOrientation`).
-    /// Internal (not private) for `StackSchematic+Slots.swift`.
+    /// Derived stack orientation matching engine
+    /// (`StackSchematic+Slots.swift`).
     var stackOrientation: StackParams.Orientation {
         stackPosition.stackOrientation
     }
 
-    /// Tiled windows kept beside the cascade-overflow pile; the
-    /// rest (the surplus) pile. Internal (not private), with
-    /// the offset below and `stackWins`, for the slot math in
-    /// `StackSchematic+Slots.swift`.
+    /// Tiled windows count before cascade overflow kicks in.
     static let overflowTiled = 3
 
-    /// Masters cannot outnumber the established windows: at two
-    /// windows a master count of ten still leaves the stack zone
-    /// on screen, which is what the two-zone split is *for*.
+    /// Effective master count clamped to window count.
     var masters: Int {
         min(max(1, masterCount), max(1, windows - 1))
     }
@@ -69,32 +38,18 @@ struct StackSchematic: View {
         WindowID(UInt32(max(1, windows - 1) + 1))
     }
 
-    /// Established windows that land in the stack zone: the count
-    /// less the masters and less the incoming one.
+    /// Established windows assigned to stack zone.
     var stackWindows: Int {
         max(0, windows - 1 - masters)
     }
 
-    /// The first stack window is the focused one — or, where the
-    /// count leaves no stack zone at all, the last established
-    /// window, so the relative placements keep a reference. They
-    /// had none at two windows: the focus id was not in the
-    /// array, the old `if let` found no index and the incoming
-    /// window was dropped from the preview outright (#702).
+    /// Focused window ID for placement reference (#702).
     var focused: WindowID {
         WindowID(UInt32(min(masters + 1, max(1, windows - 1))))
     }
 
-    /// The windows in array order with the new one spliced in
-    /// where `placement` opens it (focus = first stack window),
-    /// asked of the engine through `SchematicPlacement` rather
-    /// than reproduced here (#702). Partitioning at `masters`
-    /// then sorts them into the two zones exactly as
-    /// `StackLayout` does.
-    ///
-    /// Internal so `LayoutSchematicPlacementTests` can read the
-    /// landing: a scan for the call cannot tell a live splice
-    /// from one whose result is thrown away.
+    /// Windows in array order with new window spliced in
+    /// (`LayoutSchematicPlacementTests`, #702).
     var order: [WindowID] {
         var w = (1...max(1, masters + stackWindows))
             .map { WindowID(UInt32($0)) }
@@ -107,21 +62,12 @@ struct StackSchematic: View {
         return w
     }
 
-    /// The master zone: the first `masters` windows of the array,
-    /// which is `StackLayout`'s own boundary rule. Internal with
-    /// `stackWins` and `masterDisplay` so
-    /// `LayoutSchematicZoneTests` can read the partition against
-    /// `StackLayout.partition` — the SIZES were guarded and the
-    /// membership was not, so both zone reads could be swapped
-    /// with the whole suite green (#707).
+    /// Master zone windows (`LayoutSchematicZoneTests`, #707).
     var masterWins: [WindowID] {
         Array(order.prefix(masters))
     }
 
-    /// Master tiles in render order — mirrored in lockstep with
-    /// the engine (#313, `StackLayout.mirrorsMasterZone`), so
-    /// the preview never lies about where the boundary master
-    /// sits when the stack leads.
+    /// Master tiles in display order (#313, `StackLayout.mirrorsMasterZone`).
     var masterDisplay: [WindowID] {
         var params = StackParams()
         params.masterOrientation = masterOrientation
@@ -217,11 +163,7 @@ struct StackSchematic: View {
         }
     }
 
-    // MARK: - Stack zone
-
-    /// One slot per stack window, in array order. Draw order is
-    /// array order, so a pile's later tiles land on top — the
-    /// front window covers the buried ones except their top edge.
+    /// Slot geometry and pile state per stack window.
     struct Slot {
         var rect: CGRect
         var piled: Bool

--- a/Sources/KiwiDesk/Settings/Components/Layouts/TrackSchematic+Fold.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/TrackSchematic+Fold.swift
@@ -1,26 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// How `TrackSchematic` turns a window count into tracks — the
-/// arithmetic half of #708, split from the drawing at the §2.1
-/// ceiling.
-///
-/// Every RULE here is the engine's: `TrackLayout.spillsToNewTrack`
-/// decides each fill-or-spill step and `TrackLayout.overflowCap`
-/// folds the far edge, exactly as a real spawn and a real render
-/// do. What this file owns is the loop around them, and the two
-/// stand-ins for quantities a mini-canvas cannot measure
-/// (`LayoutSchematicStandIns`). `LayoutSchematicTrackFoldTests`
-/// reads these directly, since no source scan can tell a live
-/// fold from one whose answer is discarded.
+/// Track partitioning and overflow folding arithmetic for `TrackSchematic`
+/// (#708).
 extension TrackSchematic {
-    /// Windows already open — the count less the incoming one.
+    /// Windows already open — count less incoming window.
     private var established: Int { max(1, windows - 1) }
 
-    /// The staged params, so the cap rules are read off the type
-    /// that owns them (`trackCap`, `normalCap`) rather than
-    /// re-spelled as `limit + 1` here — the drift `TrackParams`
-    /// says in its own docstring it exists to prevent.
+    /// Staged parameters for cap calculations (`TrackParams`).
     private var params: TrackParams {
         var p = TrackParams()
         p.autoTracks = autoTracks
@@ -28,29 +15,10 @@ extension TrackSchematic {
         return p
     }
 
-    /// How the established windows fall into tracks, **asked of
-    /// the engine's own rule at every step** (#708).
-    ///
-    /// This is the fill-then-spill the preview used to not model
-    /// (#437): a window joins the focused track until that track
-    /// holds `spillCapacity`, and then — while another track
-    /// fits under `trackCap` — the next one opens a NEW track
-    /// beside it and the focus follows. `own_track` needs no
-    /// fold: every window opens its own, always (#192).
-    ///
-    /// The decision itself is `TrackLayout.spillsToNewTrack`,
-    /// which `Space.insertIntoTrack` calls for a real spawn. A
-    /// copy of the condition here would be right today and wrong
-    /// the day the rule moved, which is #702's whole argument —
-    /// so the loop below owns the ARITHMETIC and the engine owns
-    /// the RULE.
-    ///
-    /// Internal so `LayoutSchematicTrackFoldTests` can read the
-    /// partition: a source scan cannot tell a live fold from one
-    /// whose result is discarded.
+    /// Evaluates track partition using engine's fill-or-spill rule
+    /// (`LayoutSchematicTrackFoldTests`, #708, #437, #192, #702).
     var markerTracks: (counts: [Int], focus: Int) {
         guard newWindow == .focusedTrack else {
-            // Every window its own track; the newest holds focus.
             return (
                 Array(repeating: 1, count: established),
                 established - 1
@@ -74,37 +42,21 @@ extension TrackSchematic {
         return (counts, focus)
     }
 
-    /// The render's normal/overflow fold, asked of the engine
-    /// (`TrackLayout.overflowCap`) against the two caps: the
-    /// user's own `normalCap`, and `trackGeoCap` standing in for
-    /// how many tracks a display fits.
+    /// Overflow cap resolution for schematic preview (architect review
+    /// 2026-08-16).
     private var fold: (effectiveCap: Int, overflows: Bool) {
         TrackLayout.overflowCap(
             markerCount: markerTracks.counts.count,
             normalCap: params.normalCap,
-            // The stand-in fills in ONLY where the user gave no
-            // number — the `gridAutoSizeCap` precedent, whose
-            // doc says it in as many words: "with auto-size off
-            // no stand-in is needed, the ceiling is the user's
-            // own typed columns × rows". With a fixed limit the
-            // typed value IS the ceiling, so passing the
-            // stand-in here answered a typed 6 with four tracks
-            // (architect review, 2026-08-16).
             geoCap: autoTracks
                 ? LayoutSchematic.trackGeoCap : .max
         )
     }
 
-    /// Whether the far-edge overflow track is on the frame. The
-    /// caption reads this too: it named the overflow track
-    /// unconditionally while the strip drew one only sometimes,
-    /// so at the shipped defaults the preview asserted a track
-    /// that was not there (#708).
+    /// Whether overflow track is rendered on frame (#708).
     var drawsOverflowTrack: Bool { overflowWindows > 0 }
 
-    /// Normal tracks — every marker track when nothing folds,
-    /// otherwise the effective cap less the one far-edge slot the
-    /// surplus folds into.
+    /// Number of normal visible tracks.
     var trackCount: Int {
         let f = fold
         return max(
@@ -113,8 +65,7 @@ extension TrackSchematic {
         )
     }
 
-    /// Windows piled in the far-edge overflow track: everything
-    /// in the marker tracks the fold left outside the normal run.
+    /// Number of windows pooled in far-edge overflow track.
     var overflowWindows: Int {
         let marker = markerTracks.counts
         guard fold.overflows, trackCount < marker.count else {
@@ -123,16 +74,7 @@ extension TrackSchematic {
         return marker[trackCount...].reduce(0, +)
     }
 
-    /// Windows in the focused track — the run of the track the
-    /// strip actually draws as focused (`focusIdx`), clamped to
-    /// what the canvas can legibly stack.
-    ///
-    /// Reading `counts[markerTracks.focus]` while the strip drew
-    /// some other slot is what made the two disagree; the run
-    /// and the slot now come from one index.
-    ///
-    /// The CLAMP is the drawing's; the run itself is the
-    /// engine's fold — the two are separate on purpose
+    /// Windows in focused track clamped for preview drawing
     /// (`LayoutSchematicStandIns`).
     var focusedRun: Int {
         let counts = markerTracks.counts

--- a/Sources/KiwiDesk/Settings/Components/Monitors/DisplayCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/DisplayCard.swift
@@ -1,50 +1,19 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// One display in the Monitors picture (#678 Phase 3, turn 13b):
-/// a rectangle the size and shape of the real monitor, holding
-/// the space chips that resolve to it.
-///
-/// **The rectangle is data, not decoration.** Its size and its
-/// place come from `MonitorArrangement`, which reads the live
-/// frames — so a portrait display draws portrait, a laptop under
-/// a desk display draws under it, and the picture answers "which
-/// one is that?" without reading a single name.
-///
-/// It draws as a lit PLATE on the picture's recessed well, not as
-/// a card on the section's card: a display and the desk around it
-/// filled with the same colour once, and the arrangement — the
-/// whole point of the area — was then invisible.
-///
-/// Three states, three channels, because an opacity step on one
-/// hue separates nothing: **main** is the badge (plus an accent
-/// glow, which is decoration — the badge is the answer, since a
-/// glow is hue alone and dies under colour-vision deficiency,
-/// #758), **selected** is the border, **targeted** is a fill
-/// wash.
+/// Display card in monitors arrangement preview (#678, #758).
 struct DisplayCard: View {
     @ObservedObject var model: SettingsModel
     let display: Display
-    /// The area's row expansion — the same instance the census
-    /// guards read, so the chips on screen are the rows the
-    /// census counts.
+    /// Row expansion from census.
     let rows: MonitorsFamilyRows
-    /// The card's drawn size, from the arrangement. Passed in
-    /// rather than measured: the chip capacity is arithmetic over
-    /// it, and a capacity that waited for a layout pass could
-    /// only ever clip.
+    /// Scaled dimensions from arrangement.
     let size: CGSize
     @Binding var selection: DisplayID?
     @State private var targeted = false
     @State private var showingOverflow = false
 
     var body: some View {
-        // TWO children and one gap, laid out with the constant
-        // the capacity arithmetic subtracts. The trailing
-        // `Spacer` this used to carry was a third child — so a
-        // second gap the arithmetic did not know about — and the
-        // frame below already pins the content to the top
-        // (code review, 2026-08-04).
         VStack(
             alignment: .leading,
             spacing: MonitorCardChips.stackSpacing
@@ -62,15 +31,7 @@ struct DisplayCard: View {
         .overlay(dropWash)
         .overlay(border)
         .clipShape(RoundedRectangle(cornerRadius: 6))
-        // The main display's glow — OUTSIDE the clip, so it can
-        // spill past the card's edge onto the well. Decoration
-        // only; the header's "main" badge stays the answer
-        // (#758). The compositing group is load-bearing:
-        // `.shadow` shadows every drawing primitive separately,
-        // so without flattening first the main card's text,
-        // chips and strokes each grow their own green halo
-        // while the silhouette gets none (ui-designer,
-        // 2026-08-09).
+        // Main display accent glow (#758, ui-designer 2026-08-09).
         .compositingGroup()
         .shadow(
             color: isMain
@@ -95,12 +56,8 @@ struct DisplayCard: View {
         .help(readout)
     }
 
-    /// By display ID, not by fingerprint: two identical monitors
-    /// share a fingerprint, so a fingerprint comparison drew the
-    /// "main" badge on BOTH cards while the tray hung off one —
-    /// the two answers to one question that
-    /// `SettingsModel.mainDisplay` exists to prevent (code
-    /// review, 2026-08-04).
+    /// Checked by ID rather than fingerprint for duplicate screens
+    /// (2026-08-04).
     private var isMain: Bool {
         model.mainDisplay?.id == display.id
     }
@@ -221,12 +178,6 @@ struct DisplayCard: View {
             .strokeBorder(
                 isSelected || targeted
                     ? AnyShapeStyle(.tint)
-                    // ink3, not the hairline: on the sunken
-                    // well the hairline sits within a few
-                    // points of the ground and the resting
-                    // cards read borderless — every display
-                    // owes a visible frame, the main one keeps
-                    // the tint on top (owner, 2026-08-09).
                     : AnyShapeStyle(
                         SettingsTheme.ink3.opacity(0.5)
                     ),
@@ -236,8 +187,7 @@ struct DisplayCard: View {
             )
     }
 
-    /// The one thing the picture cannot say by drawing: how many
-    /// spaces live here, and which of them is up.
+    /// Readout sentence describing assigned and showing spaces.
     private var readout: String {
         MonitorReadout.sentence(
             held: rows.held(on: display, isMain: isMain),
@@ -245,11 +195,6 @@ struct DisplayCard: View {
         )
     }
 
-    /// Named with its object, not deictically: these reach a
-    /// translator as bare worksheet lines with no element label
-    /// and no screen, and "what this holds" needs an explicit
-    /// noun in most target languages (localization audit,
-    /// 2026-08-04).
     private var selectActionName: String {
         isSelected
             ? L(
@@ -262,17 +207,11 @@ struct DisplayCard: View {
             )
     }
 
-    /// Selecting is a toggle: the readout under the picture is
-    /// the only thing selection drives, so a second click on the
-    /// same card puts it away rather than leaving the user
-    /// hunting for what dismisses it.
     private func toggleSelection() {
         selection = isSelected ? nil : display.id
     }
 
-    /// Pins each dropped space to this monitor's fingerprint
-    /// (clearing a follows-main assignment); the footer's profile
-    /// actions persist it into the profile JSON (#36).
+    /// Pins dropped spaces to monitor fingerprint (#36).
     private func pin(_ items: [DraggableSpace]) -> Bool {
         var assigned = false
         for item in items {

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsPicture.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorsPicture.swift
@@ -1,52 +1,15 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Monitors picture (#678 Phase 3, turn 13b): the display
-/// cards laid out where the displays actually are, with the
-/// follows-main tray hanging off the main one.
-///
-/// The geometry is `MonitorArrangement`'s and nothing is
-/// re-derived here — this view's whole job is to put each drawn
-/// rectangle on screen and hand it a card. Both axes scroll,
-/// because the arrangement is allowed to exceed the canvas: the
-/// scale has a FLOOR (every card stays big enough to drop a chip
-/// onto), and honouring that floor on a wide desk is what pushes
-/// the picture past the pane.
+/// Monitors spatial arrangement diagram with display cards and follows-main
+/// tray (#678 Phase 3).
 struct MonitorsPicture: View {
     @ObservedObject var model: SettingsModel
     let rows: MonitorsFamilyRows
     @Binding var selection: DisplayID?
 
-    /// The canvas the arrangement is fitted into. A fixed height
-    /// rather than one derived from the arrangement: the pane's
-    /// width is only known inside the reader, and a height that
-    /// followed the content would move every card on screen each
-    /// time a monitor was plugged in.
     private static let canvasHeight: CGFloat = 240
-
-    /// The breathing room around the picture inside its well.
-    ///
-    /// SUBTRACTED from the canvas the arrangement is fitted into,
-    /// not merely added around it: `layout` fills the canvas it
-    /// is handed almost exactly — it fits the displays into
-    /// `canvas − trayHeight − trayGap` and then puts the band
-    /// back — so padding applied afterwards pushed the content
-    /// past the frame by twice this, and the picture scrolled by
-    /// a few points on a desk that fits comfortably (owner,
-    /// 2026-08-04). A many-display desk still scrolls, which is
-    /// the minimum-card floor doing its job.
     private static let inset: CGFloat = 4
-
-    /// The band under the picture that the stands hang into.
-    ///
-    /// RESERVED, not merely drawn into: a stand hangs past its
-    /// card's frame, and the scroll content is sized to the
-    /// layout's `contentSize` — so without a band the feet were
-    /// clipped off at the content's edge, and the topmost card's
-    /// stand was cut where it met the card above it (owner,
-    /// 2026-08-04). Subtracted from the canvas that is fitted and
-    /// added back to the content frame, so the arrangement keeps
-    /// the same room it had and the stands get their own.
     private static let standBand: CGFloat = 16
 
     var body: some View {
@@ -74,29 +37,10 @@ struct MonitorsPicture: View {
             )
         }
         .frame(height: Self.canvasHeight)
-        // No well any more (owner + ui-designer, 2026-08-09):
-        // the section container's own surface is the ground —
-        // a shape whose fill equals its parent's is only its
-        // frame, and it read as an empty box inside a box. The
-        // soft-green cards on their ink3 rest borders carry
-        // the separation; the dashed tray's stroke is its own
-        // edge and never leaned on the well.
     }
 
-    /// A neck and a foot under each display, in `ink3` — the
-    /// hairline read as too shallow against the well on device
-    /// (owner, 2026-08-09); the quietest legible ink keeps the
-    /// picture reading as an arrangement, not furniture.
-    ///
-    /// SCALED from the card, within bounds. A fixed size was
-    /// tried first, on the reasoning that a stand is a real
-    /// object of roughly one size whatever the panel above it —
-    /// which is true of desks and false of this picture, where a
-    /// single display fills the whole canvas and a 34 pt foot
-    /// under a 520 pt screen reads as a speck of dirt (owner,
-    /// 2026-08-04). The share, its clamp and the card stroke all
-    /// come from `SettingsTheme` (#758), which is the one copy
-    /// of the numbers.
+    /// Scaled display stand footer (#758, owner ruling 2026-08-04,
+    /// 2026-08-09).
     private func stand(cardWidth: CGFloat) -> some View {
         let base = min(
             max(
@@ -130,9 +74,6 @@ struct MonitorsPicture: View {
             displays: rows.displays,
             mainID: model.mainDisplay?.id,
             canvas: canvas,
-            // The tray box grows with what it holds: its chips
-            // wrap, and a fixed box pushed its own heading out of
-            // the top at four spaces (owner, 2026-08-04).
             trayChips: rows.mainSpaces.count
         )
     }
@@ -153,25 +94,12 @@ struct MonitorsPicture: View {
                     width: drawn.rect.width,
                     height: drawn.rect.height
                 )
-                // Drawn BELOW the card and outside its frame, so
-                // it costs the card no drop area: the layout
-                // floors a card at the size that holds one space
-                // chip, and a stand carved out of that would eat
-                // into the floor it guarantees. Decoration only —
-                // it is what makes a rectangle read as a monitor
-                // rather than as a box.
                 .overlay(alignment: .bottom) {
                     stand(cardWidth: drawn.rect.width)
                         .alignmentGuide(.bottom) { $0[.top] }
                 }
                 .offset(x: drawn.rect.minX, y: drawn.rect.minY)
             }
-            // No gate on the tray: `.mainSpaces` and `.spacePins`
-            // are one row family drawn by one picture, and a
-            // `showsTray` flag derived from the same resolver arm
-            // as the picture itself could never be false — an
-            // inert branch, with a wiring needle pinning it
-            // (code review, 2026-08-04).
             if let tray = layout.tray {
                 FollowsMainTray(
                     model: model,

--- a/Sources/KiwiDesk/Settings/Components/Profiles/DesktopsGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/DesktopsGroup.swift
@@ -1,8 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Settings group for binding profiles to macOS Desktops (#7, #678, #768,
-/// #888).
+/// Settings group for binding profiles to macOS Desktops (#7,
+/// #678, #768, #888). The remaining grey is the resolver's and is
+/// scoped to the ROWS, not the whole card (#527: the drawer keeps
+/// its header and `?` anchor clickable). By the #815 derivation
+/// (`GateReasonPlacement`) these rows owe no inline sentence —
+/// the `bindingsAreGlobal` cause is on the surface, exactly like
+/// `presetsApply` under the same reason.
 struct DesktopsGroup: View {
     @ObservedObject var model: SettingsModel
     @State private var expanded = true
@@ -43,7 +48,11 @@ struct DesktopsGroup: View {
         }
     }
 
-    /// Help explanation for main screen Desktop binding behavior (#888).
+    /// Help explanation for the main-screen authority (#888,
+    /// ui-designer 2026-08-18). Descriptive, never prescriptive —
+    /// the retired shape was ambient advice with a one-click
+    /// flip; the checkbox is quoted verbatim so System Settings'
+    /// own search finds it (config-vocabulary.md's ask).
     private var helpText: String {
         L(
             "desktops.help",
@@ -158,6 +167,9 @@ struct DesktopsGroup: View {
         .labelsHidden()
         .controlSize(.large)
         .frame(width: 180)
+        // An empty title names nothing, so the picker is named
+        // here — and named, it owes its selection back as the
+        // value (#812).
         .accessibilityLabel(
             L(
                 "desktops.profile_ax",

--- a/Sources/KiwiDesk/Settings/Components/Profiles/DesktopsGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/DesktopsGroup.swift
@@ -1,37 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Whole App ▸ Profiles ▸ **Profiles per macOS Desktop** (#7,
-/// rebuilt in #678 turn 13a): bind a saved profile to each macOS
-/// Desktop, picked from the row's dropdown; the binding emits
-/// `bind_profile_to_desktop` — a wire name #768 deliberately
-/// froze — and loads that profile when the Desktop activates on
-/// the main display (#888, the definition that made the rows
-/// well-defined under "Displays have separate Spaces" and
-/// retired that state's grey, warning and escape hatch).
-/// Rows are named "Desktop n", the name Mission Control shows,
-/// never "Space n", which is how KiwiDesk's own Spaces read
-/// elsewhere in the app. Bindings mutate
-/// `model.config.profileBindings`; the footer's profile actions
-/// persist them.
-///
-/// A drawer now, because the census tiers `profileBindings`
-/// `.showMore` — most people never bind a Desktop, and the ones
-/// who do are looking for it. It opens by default all the same:
-/// the card is one interaction deep, not hidden, and a reader who
-/// scrolled to it has already asked the question its title
-/// answers.
-///
-/// The remaining grey is the resolver's (`ProfilesGates`) and is
-/// scoped to the ROWS: the explanation stays live under it. That
-/// is also why the gate is not wrapped around the whole card
-/// (#527): the drawer keeps its header and its `?` anchor
-/// clickable.
+/// Settings group for binding profiles to macOS Desktops (#7, #678, #768,
+/// #888).
 struct DesktopsGroup: View {
     @ObservedObject var model: SettingsModel
-    /// Drawn open (#678 turn 13a). View state, like every other
-    /// drawer in the tree — per-container disclosure memory
-    /// arrives with the mode mechanics.
     @State private var expanded = true
 
     private var gates: ProfilesGates {
@@ -70,23 +43,7 @@ struct DesktopsGroup: View {
         }
     }
 
-    /// Why only some Desktops are offered, and what the other
-    /// side of the macOS lever costs (#888, ui-designer
-    /// 2026-08-18).
-    ///
-    /// **Behind a click, and descriptive rather than
-    /// prescriptive.** #888 retired a standing recommendation to
-    /// turn "Displays have separate Spaces" off — advice shown to
-    /// every multi-screen user whether or not it applied, with a
-    /// button one click from flipping it. This answers a question
-    /// a reader has visibly already asked, names the ergonomic
-    /// costs the retirement was argued on rather than only the
-    /// gain, and carries no imperative and no deep link: the
-    /// checkbox is quoted verbatim so System Settings' own search
-    /// finds it, which is what `config-vocabulary.md` asks for
-    /// and all it asks for. Putting this in the card's caption
-    /// instead would make it ambient again, which is the retired
-    /// shape in miniature.
+    /// Help explanation for main screen Desktop binding behavior (#888).
     private var helpText: String {
         L(
             "desktops.help",
@@ -112,18 +69,6 @@ struct DesktopsGroup: View {
                 + "(the one with the menu bar)."
         )
     }
-
-    // #888 retired the inline warning note along with the
-    // separate-Spaces grey. The one reason left
-    // (`bindingsAreGlobal`) has its cause on the surface — the
-    // header chip names the profile being edited — so by the
-    // #815 derivation (`GateReasonPlacement`) these rows owe no
-    // inline sentence, exactly like `presetsApply` under the
-    // same reason; the `GreyOut`'s hover help still carries it.
-    // The "Clear all bindings" escape hatch retired with the
-    // grey too: with the rows live, each binding is cleared on
-    // its own row, so the hatch lost the trap it existed to
-    // open — `docs/design-decisions.md` re-argues the ruling.
 
     @ViewBuilder private func rows(
         inert reason: ProfilesGates.InertReason?
@@ -213,9 +158,6 @@ struct DesktopsGroup: View {
         .labelsHidden()
         .controlSize(.large)
         .frame(width: 180)
-        // An empty title names nothing, so the picker is named
-        // here — and named, it owes its selection back as the
-        // value (#812).
         .accessibilityLabel(
             L(
                 "desktops.profile_ax",
@@ -228,11 +170,7 @@ struct DesktopsGroup: View {
         )
     }
 
-    // MARK: - Data
-
-    /// Desktops to list — from the family seam that records
-    /// what this census key expands to, so the guard over that
-    /// expansion watches the rows the card actually draws.
+    /// Desktops to list from `ProfilesFamilyRows.desktops`.
     private var spaceNumbers: [Int] {
         ProfilesFamilyRows.desktops(
             onMain: model.mainDesktops,

--- a/Sources/KiwiDesk/Settings/Components/Profiles/PresetPreviewPlan.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/PresetPreviewPlan.swift
@@ -1,8 +1,15 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Derives preset preview structure and layout modes (#859,
-/// `PresetPreviewPlanTests`, `SparseModeFallbackTests`).
+/// Derives the preset preview from the LAYOUT's own accessors
+/// and nothing else (#859, `PresetPreviewPlanTests`).
+/// `liveSizes` threads through unchanged — a caller that CAN know
+/// the hardware and passes nil makes preview and apply disagree.
+/// From the "For other setups" drawer nil is correct, and the
+/// drawer's answer genuinely differs from what Apply would draw
+/// (`SparseModeFallbackTests`); what makes that unreachable is
+/// Apply being GATED on the screen-count match, not the drawer
+/// being right (architect review, 2026-08-17).
 struct PresetPreviewPlan: Equatable {
     /// One planned space and its layout mode.
     struct Slot: Equatable, Identifiable {
@@ -11,7 +18,11 @@ struct PresetPreviewPlan: Equatable {
         var id: SpaceID { space }
     }
 
-    /// One screen's planned spaces.
+    /// One screen's planned spaces — INCLUDING a screen the
+    /// preset plans nothing for (empty `slots`): empties are kept
+    /// in the value and dropped at the DRAWING site, which is what
+    /// lets `PresetScreenCard` consume this plan too (review,
+    /// 2026-08-17).
     struct Group: Equatable, Identifiable {
         let screen: Int
         let slots: [Slot]
@@ -53,7 +64,11 @@ struct PresetPreviewPlan: Equatable {
         }
     }
 
-    /// Resolves `ScreenClass` for screen index from live display sizes (#859).
+    /// Resolves `ScreenClass` for a screen index — THE ONE COPY
+    /// (#859): `PresetScreenCard` kept its own four lines of this,
+    /// held by an agreement test that could not see the card's
+    /// private half, so a drift passed green (code review,
+    /// 2026-08-17). Both consumers now read this.
     static func shape(
         of screen: Int,
         in liveSizes: [CGSize]?

--- a/Sources/KiwiDesk/Settings/Components/Profiles/PresetPreviewPlan.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/PresetPreviewPlan.swift
@@ -1,98 +1,40 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// What the preset preview sheet draws (#859), derived from the
-/// LAYOUT's own accessors and nothing else.
-///
-/// The sheet's whole claim is that it shows what applying the
-/// preset produces, so every mode here comes from
-/// `StandardLayout.mode(of:on:)` — the same accessor
-/// `ProfileComposition.compose` builds a real profile from and
-/// the same one `PresetScreenCard` reads for its glyphs. A second
-/// derivation beside the drawing is what gui.md's "a preview that
-/// claims engine behavior asks the engine" forbids, and the card
-/// carried exactly that copy until `StandardLayout+Screens`
-/// existed.
-///
-/// **`liveSizes` threads through unchanged**, for the reason
-/// `mode(of:on:)` states in its own docstring: a caller that CAN
-/// know the hardware and passes nil makes the preview and the
-/// apply disagree.
-///
-/// From the "For other setups" drawer there genuinely is no
-/// hardware to resolve against, so nil is correct and the historic
-/// `bsp` stands for an unlisted space. **That is NOT what Apply
-/// would draw** — `ProfileComposition.compose` clamps those spaces
-/// onto the live displays and resolves each mode from the live
-/// `ScreenClass`, so the two answers differ for every SPARSE preset
-/// — `SparseModeFallbackTests` holds both arms of that fallback,
-/// and a count here would rot the day a preset is added or fully
-/// declared. What makes the divergence unreachable is that
-/// Apply is GATED on the screen-count match
-/// (`ProfilesGates`/`.screenCountMismatch`), not that the drawer's
-/// answer is right. An earlier draft of this comment claimed the
-/// latter (architect review, 2026-08-17); `docs/user-guide.md` ▸
-/// Seeing what a preset contains carries the user-facing caveat.
-///
-/// A value type rather than a view property so the whole
-/// derivation is assertable off the main actor
-/// (`PresetPreviewPlanTests`).
+/// Derives preset preview structure and layout modes (#859,
+/// `PresetPreviewPlanTests`, `SparseModeFallbackTests`).
 struct PresetPreviewPlan: Equatable {
-    /// One drawn schematic: a planned space and the mode it opens
-    /// in.
+    /// One planned space and its layout mode.
     struct Slot: Equatable, Identifiable {
         let space: SpaceID
         let mode: LayoutMode
         var id: SpaceID { space }
     }
 
-    /// One screen's spaces, in plan order — **including a screen
-    /// the preset plans nothing for**, which carries an empty
-    /// `slots`.
-    ///
-    /// Empty groups are kept in the value type and dropped at the
-    /// DRAWING site (`drawnGroups`), which is what lets
-    /// `PresetScreenCard` consume this plan too: the card draws one
-    /// outline per screen whether or not that screen has spaces, so
-    /// a plan that filtered here could not serve it and the card
-    /// kept its own second copy of the same three accessors
-    /// (architect + code review, 2026-08-17). The copy is gone; a
-    /// filter belongs to whoever is drawing, not to the derivation.
+    /// One screen's planned spaces.
     struct Group: Equatable, Identifiable {
         let screen: Int
         let slots: [Slot]
         var id: Int { screen }
 
-        /// The mode this screen OPENS in — its first space's — or
-        /// nil where it plans nothing. What the card's glyph draws.
+        /// Opening layout mode for the first space on this screen.
         var openingMode: LayoutMode? { slots.first?.mode }
     }
 
     let groups: [Group]
 
-    /// The groups a sheet draws: the ones with something on them.
-    ///
-    /// A screen with no spaces opens no layouts, so it would be a
-    /// heading over an empty row. No shipped preset has one and
-    /// none may acquire one silently — `PresetPreviewPlanTests`
-    /// requires every preset in the catalog to fill every screen it
-    /// plans for, so a future preset leaving one empty reds and the
-    /// decision gets made then rather than rendering as a gap.
+    /// Non-empty screen groups rendered by preview sheet.
     var drawnGroups: [Group] { groups.filter { !$0.slots.isEmpty } }
 
-    /// Every schematic the sheet draws, flattened — the count the
-    /// sheet's own arithmetic is asserted against.
+    /// All planned slots across drawn groups.
     var slots: [Slot] { drawnGroups.flatMap(\.slots) }
 
-    /// One screen's group, or nil outside the plan's screens.
+    /// Returns group for specified screen index.
     func group(screen: Int) -> Group? {
         groups.first { $0.screen == screen }
     }
 
     init(layout: StandardLayout, liveSizes: [CGSize]?) {
-        // Clamped at zero for the same reason `PresetScreenCard`
-        // clamps: a hand-edited layout claiming a negative screen
-        // count must not trap on the range.
         let screens = max(layout.screenCount, 0)
         groups = (0..<screens).map { screen in
             let shape = Self.shape(of: screen, in: liveSizes)
@@ -111,18 +53,7 @@ struct PresetPreviewPlan: Equatable {
         }
     }
 
-    /// The shape of the display this positional screen resolves
-    /// to, or nil where the plan is not drawn against hardware.
-    ///
-    /// **The one copy.** `PresetScreenCard` had its own four lines
-    /// of this until #859's review round, held to the plan by an
-    /// agreement test that could not see the card's half at all —
-    /// the card's `shape(of:)` was `private` and the test recomputed
-    /// `ScreenClass.of(...)` itself, so a drift in the card's bound
-    /// or its index passed green. The docstring here claimed such a
-    /// drift would be "loud rather than structural"; it was neither
-    /// (code review, 2026-08-17). Both consumers now read this, and
-    /// the promise is structural instead of asserted.
+    /// Resolves `ScreenClass` for screen index from live display sizes (#859).
     static func shape(
         of screen: Int,
         in liveSizes: [CGSize]?

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows.swift
@@ -1,38 +1,21 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The per-space layout override rows (issue #17): the fields
-/// the space's current mode can override, each inheriting the
-/// global value (gray) until its checkbox is ticked. Rendered in
-/// the pushed per-space override editor (#678 8b,
-/// `SpacesSection+Overrides.swift`; an inline expander in #68
-/// §3.2, then a Customize popover in #205 before the pane) — the
-/// row set mirrors the app-bar override controls, keyed by space
-/// instead of layout.
+/// Per-space layout override rows editor (#17, #678, #68, #205).
 struct SpaceOverrideRows: View {
     @ObservedObject var model: SettingsModel
     let space: SpaceID
-    /// Set by the `Reset All Layout Overrides` button to arm the
-    /// confirmation dialog (#290). The dialog lives on
-    /// `SpacesSection`, not here, so it survives the popover
-    /// dismissing — this row set only requests it.
+    /// Armed confirmation dialog for resetting overrides (#290).
     @Binding var pendingResetAll: SpaceID?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
-                // Floating has no override rows, only the placeholder
-                // below, so it carries no caption or column header —
-                // an "inherit Floating defaults" caption over "has no
-                // overrides" contradicts itself.
                 if mode != .floating {
                     captionRow
                 }
                 modeRows
             }
-            // The active layout's name, read by every `OverrideChrome`
-            // below to render "follows <Layout> defaults · <value>"
-            // on an inheriting row (#678 8b).
             .environment(\.overrideLayoutName, mode.displayName)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(14)
@@ -44,9 +27,7 @@ struct SpaceOverrideRows: View {
         }
     }
 
-    /// The caption and the "OVERRIDE" column header aligned over
-    /// the rows' trailing checkboxes. Only drawn for a tiling
-    /// layout (the caller gates Floating out).
+    /// Caption and override column header row (2026-08-16).
     private var captionRow: some View {
         HStack(
             alignment: .firstTextBaseline,
@@ -56,22 +37,6 @@ struct SpaceOverrideRows: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Spacer(minLength: SettingsMetrics.overrideRowInset)
-            // ONE line, always. The column was sized for the
-            // English "OVERRIDE" and every longer noun stacked:
-            // German's "ÜBERSCHREIBUNG" hyphenated into three
-            // lines above the checkboxes (owner, on device,
-            // 2026-08-16). Italian's "PERSONALIZZAZIONE" is 17
-            // characters and sizing the column to it would give
-            // a checkbox a 110 pt column in every locale — so
-            // the width fits the middle of the range and the
-            // two longest shrink slightly rather than wrap.
-            //
-            // Stated residue: a column that MEASURED its header
-            // would need neither the constant nor the scale
-            // factor, but the header and the checkboxes live in
-            // different views, so sharing an intrinsic width
-            // needs a preference key. Worth it if a third
-            // surface ever grows this column.
             Text(L("space_override.override_column", "Override"))
                 .font(.caption2)
                 .fontWeight(.semibold)
@@ -87,9 +52,8 @@ struct SpaceOverrideRows: View {
         .padding(.horizontal, SettingsMetrics.overrideRowInset)
     }
 
-    /// Dynamic caption naming the active layout whose defaults an
-    /// unchecked row inherits (#290), replacing the old generic
-    /// "gray = inherit" gloss.
+    /// Dynamic caption naming the active layout whose defaults an unchecked
+    /// row inherits (#290).
     private var caption: String {
         L(
             "space_override.caption",
@@ -98,24 +62,14 @@ struct SpaceOverrideRows: View {
         )
     }
 
-    /// Internal so the footer extension
-    /// (`SpaceOverrideRows+Footer.swift`) can read the active
-    /// layout for its reset label and dormant filter.
     var mode: LayoutMode {
         model.config.spaceModes[space] ?? .bsp
     }
 
-    /// Internal (not private) so the Grid/Monocle/Track rows,
-    /// which live in `SpaceOverrideRows+ModeRows.swift` to keep
-    /// each file under the line ceiling, can read it.
     var g: TilingSettings { model.config.settings }
 
-    /// The census-resolved greying for this space's override rows
-    /// and reset action (#678 Phase 3). One per-instance resolver,
-    /// keyed on the space and its active layout, so a row never
-    /// re-derives "is this Space rigid / auto-sized" beside the
-    /// gate that declares it. Internal so the mode-row and footer
-    /// extensions consult the same instance.
+    /// Census-resolved greying for space override rows and reset action (#678
+    /// Phase 3).
     var gates: SpacesGates {
         SpacesGates(settings: g, space: space, mode: mode)
     }
@@ -125,8 +79,6 @@ struct SpaceOverrideRows: View {
             .font(.caption)
             .foregroundStyle(.secondary)
     }
-
-    // MARK: - Per-mode rows
 
     @ViewBuilder
     private var modeRows: some View {
@@ -195,11 +147,7 @@ struct SpaceOverrideRows: View {
         }
     }
 
-    /// The effective scroll orientation for this space (its
-    /// override, else the global), so the slot-size and anchor
-    /// labels read Row height / Top-Bottom on a vertical space and
-    /// Column width / Left-Right otherwise — the values stored
-    /// stay axis-neutral (`start`/`end`, `ScrollSize`) (#239).
+    /// Effective scroll orientation for space (#239).
     private var scrollingIsVertical: Bool {
         g.resolvedScrolling(for: space).orientation == .vertical
     }
@@ -248,16 +196,7 @@ struct SpaceOverrideRows: View {
         )
     }
 
-    // The Stack rows live in `SpaceOverrideRows+StackRows.swift`
-    // (#222 grew them past this file's line budget).
-
-    // MARK: - Binding helper
-
-    /// One generic bridge from an override map's optional field
-    /// to a `Binding<T?>`. Setting a field to nil that empties
-    /// the override drops the map entry, mirroring the Lua
-    /// command. Internal so the mode rows split into
-    /// `SpaceOverrideRows+ModeRows.swift` can reach it.
+    /// Generic binding bridge for optional override map fields.
     func binding<O: SpaceLayoutOverride, T>(
         _ map: WritableKeyPath<TilingSettings, [SpaceID: O]>,
         _ space: SpaceID,

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows.swift
@@ -37,6 +37,13 @@ struct SpaceOverrideRows: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Spacer(minLength: SettingsMetrics.overrideRowInset)
+            // ONE line, always: sized for the middle of the
+            // range, the two longest locales shrink slightly
+            // rather than wrap (German's ÜBERSCHREIBUNG
+            // hyphenated into three lines; owner, on device,
+            // 2026-08-16). Stated residue: a measured column
+            // needs a preference key across two views — worth it
+            // if a third surface grows this column.
             Text(L("space_override.override_column", "Override"))
                 .font(.caption2)
                 .fontWeight(.semibold)

--- a/Sources/KiwiDesk/Settings/HomeCardPlate.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardPlate.swift
@@ -1,19 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The dark desktop plate atop a profile-group Home card (#786):
-/// a full-bleed picture of the user's desktop, drawn from the
-/// draft in the user's palette (4g — brand describes the app,
-/// profile colours describe the desktop). The plate sits ABOVE
-/// the title and bleeds to the card's edges; the card's own
-/// border and corner clip are its visible edge. The whole-app
-/// cards never plate: their previews are data rows
-/// (`HomeCardPreview`), not desktops.
+/// Full-bleed desktop preview plate atop profile Home cards (#786, 4g).
 @MainActor
 enum HomeCardPlate {
-    /// The card's plate, or nil for the plateless cards — ONE
-    /// switch, like `HomeCardPreview.preview`, so "has a plate"
-    /// and "which plate" cannot drift apart.
+    /// Renders desktop plate view for supported profile destinations.
     static func plate(
         for destination: SettingsDestination,
         model: SettingsModel
@@ -25,10 +16,6 @@ enum HomeCardPlate {
                 HomeCardSpacesTile(model: model)
             }
         case .gapsAndBorders:
-            // Padding 4, not the family 11: the tile centres
-            // its own 16:10 screen and the outer-gap readouts
-            // inset from THAT outline, so the plate's frame
-            // stays thin around it.
             return tile(padding: 4, settings: settings) {
                 HomeCardGapsTile(settings: settings)
             }
@@ -44,18 +31,9 @@ enum HomeCardPlate {
                 HomeCardColorsTile(settings: settings)
             }
         case .layoutDefaults:
-            // The engine-backed schematic of the most-used mode
-            // (G stays), carrying the prototype's number
-            // readout — the mode's own headline value, so the
-            // tile says "settings with numbers live here"
-            // without a decorative sketch (owner, 2026-08-09).
             return tile(padding: 7, settings: settings) {
                 HomeCardSchematicBand(
                     model: model,
-                    // The interior minus 4 more: the schematic
-                    // earns extra air to the plate's edge
-                    // (owner, 2026-08-09) — derived, never a
-                    // hand-summed copy of the paddings.
                     height: interior(padding: 7) - 4,
                     readout: LayoutReadout.value(
                         for: LayoutUsage.mostUsed(
@@ -70,9 +48,6 @@ enum HomeCardPlate {
                 HomeCardMonitorsTile(model: model)
             }
         case .behavior:
-            // Owner ruled the prototype's pictogram IN
-            // (2026-08-09), made honest: the divider answers
-            // the real mouse-resize choice.
             return tile(padding: 11, settings: settings) {
                 HomeCardBehaviorTile(settings: settings)
             }
@@ -85,20 +60,10 @@ enum HomeCardPlate {
         }
     }
 
-    /// The shared plate: fixed height, desktop-dark ground,
-    /// the user's palette injected for every schematic inside,
-    /// silent to VoiceOver — the renderers carry AX elements
-    /// of their own (`SchematicCanvas`), a card is ONE button
-    /// whose value is its subtitle, and a plate that voiced
-    /// its parts would read the picture over the answer.
-    /// Extra air under the card's top edge — at the uniform
-    /// inset the tiles sat visibly close to it (owner,
-    /// 2026-08-09). Named so the interior height derives.
+    /// Top margin air inside plate card (2026-08-09).
     static let topAir: CGFloat = 4
 
-    /// The room a tile's content actually gets at a given
-    /// dispatch padding — the one derivation, so a band height
-    /// cannot drift from the paddings it is carved from.
+    /// Calculates available interior tile height for given padding.
     static func interior(padding: CGFloat) -> CGFloat {
         SettingsTheme.plateHeight - padding * 2 - topAir
     }
@@ -119,10 +84,6 @@ enum HomeCardPlate {
                 .frame(height: SettingsTheme.plateHeight)
                 .frame(maxWidth: .infinity)
                 .background(SettingsTheme.previewPlate)
-                // 16b dark construction: the plate is fixed
-                // dark and the card flips to within 1.07:1 of
-                // it, so in dark this inset line is the only
-                // seam. Transparent in light by the token.
                 .overlay(
                     Rectangle().strokeBorder(
                         SettingsTheme.planeRing,
@@ -138,18 +99,8 @@ enum HomeCardPlate {
         )
     }
 
-    /// The user's palette folded to the three colours the
-    /// pictures draw with: the Space Bar's active accent is the
-    /// palette's primary voice, the App Bar's item ink its
-    /// light ink, and the plate itself the opaque base under
-    /// piles. Read off the style structs directly — cheap field
-    /// reads, never `ColorPaletteKeys.extract` per card (the
-    /// `PaletteShelf.liveColors` lesson). Each colour passes
-    /// the legibility floor first: the plate is KiwiDesk's
-    /// fixed ground, so a user colour that sinks into it —
-    /// legible on the user's own bar, invisible here — swaps
-    /// for a theme fallback rather than drawing dark-on-dark
-    /// (ui-designer, 2026-08-09).
+    /// Resolves three-color palette from active profile settings (ui-designer
+    /// 2026-08-09).
     static func palette(
         _ settings: TilingSettings
     ) -> SchematicPalette {
@@ -167,11 +118,7 @@ enum HomeCardPlate {
     }
 }
 
-/// The most-used layout's schematic, scaled from its fixed
-/// `.tile` canvas into a plate band — scaled, never cropped
-/// (the 13b picture-drawn-invisible class) — with the mode's
-/// headline value as a mono readout in the plate's corner when
-/// the caller passes one (the Layout Defaults card).
+/// Scaled layout schematic preview band with headline parameter readout.
 struct HomeCardSchematicBand: View {
     @ObservedObject var model: SettingsModel
     let height: CGFloat
@@ -206,22 +153,14 @@ struct HomeCardSchematicBand: View {
     }
 }
 
-/// The most-used mode's headline number — the value its own
-/// editor leads with where that value is a number, and the
-/// area's min-window default for the modes whose editors lead
-/// with non-numeric controls (Scrolling's anchor picker,
-/// Monocle and Floating). A tile carrying a number it cannot
-/// explain still tells the truth: the number is the draft's,
-/// and the area it opens shows the control it belongs to.
+/// Headline number readout for layout mode parameter display (code review
+/// 2026-08-09).
 @MainActor
 enum LayoutReadout {
     static func value(
         for mode: LayoutMode,
         settings: TilingSettings
     ) -> String {
-        // Exhaustive on purpose: a `default` arm handed a new
-        // mode the min-window readout silently; a new case must
-        // decide its own number here (code review, 2026-08-09).
         switch mode {
         case .bsp:
             return String(
@@ -240,9 +179,6 @@ enum LayoutReadout {
         case .track:
             return "\(settings.track.limit)"
         case .scrolling, .monocle, .floating:
-            // A unit word is a translated frame, never a Swift
-            // literal — `border.fit_gaps.unit` is the binding
-            // precedent (localization-auditor, 2026-08-09).
             return L(
                 "home.plate.readout.points",
                 "%1$d pt",

--- a/Sources/KiwiDesk/Settings/HomeCardPreview.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardPreview.swift
@@ -1,21 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The data-row half of a Home card's picture (#678 turn 9,
-/// re-cut in #786): the whole-app cards' previews, drawn only
-/// from the real draft — a card is a mirror, not an
-/// illustration. The profile-group cards moved their pictures
-/// to the desktop plate (`HomeCardPlate`); what stays here are
-/// rows of data — key caps, profile chips, app icons, the
-/// version — that belong beside the title, not on a desktop.
+/// Data-row preview views for Whole App Home cards (#678, #786).
 @MainActor
 enum HomeCardPreview {
-    /// The card's data row, or nil for the cards with none —
-    /// ONE switch, so "has a preview" and "which preview"
-    /// cannot drift apart (review 2026-08-04: the earlier
-    /// `hasPreview` twin was a second hand-kept copy of this
-    /// partition). `AnyView` is the price of the optional; a
-    /// card body mounts it at most once.
+    /// Preview data view for given destination or nil (review 2026-08-04).
     static func preview(
         for destination: SettingsDestination,
         model: SettingsModel
@@ -32,49 +21,15 @@ enum HomeCardPreview {
         case .spaces, .bars, .layoutDefaults, .monitors,
             .gapsAndBorders, .colors, .advancedColors,
             .behavior:
-            // The profile group draws on the plate or not at
-            // all (`HomeCardPlate.plate` is that partition's
-            // one switch).
             return nil
         }
     }
 
-    // MARK: - Pieces
-
-    /// How many chips the row draws before the "+N" takes a slot.
+    /// Maximum profile chips drawn before "+N" overflow chip.
     static let chipCap = 4
 
-    /// Capsule chips of the real profile names, the default one
-    /// inverted — the answer "which one wins" read without the
-    /// subtitle — capped with a "+N" chip that is a label, not
-    /// an affordance.
-    ///
-    /// **In the LIST's order, and capped by the shared grammar.**
-    /// Two defects lived here until #859, and both were #789's own
-    /// arguments surviving on a second surface:
-    ///
-    /// - It sliced raw `profileSummaries`, which is
-    ///   `allProfiles()`'s **unordered** read
-    ///   (`ProfilesFamilyRows.profiles` says so itself), while
-    ///   every other consumer takes `orderedProfiles` — the
-    ///   match-first sort. So the card could hide the
-    ///   live-matching profile behind a "+N" and show three that
-    ///   match nothing, under a comment claiming it answered
-    ///   "which one wins".
-    /// - It computed `count - cap` by hand, so five profiles drew
-    ///   four chips and "+1" — the one thing the shared grammar
-    ///   forbids (`docs/ui-patterns.md` ▸ "+N"): the marker takes
-    ///   a slot of its own precisely so it never claims to hide
-    ///   exactly one. Routing it through `OverflowSplit` CHANGES
-    ///   what this draws rather than preserving it, which is why
-    ///   it waited for a branch that books an eye-confirm.
-    ///
-    /// The two sibling non-adopters in this tree — `ruleIcons`
-    /// below and `HomeCardSpacesTile` — are deliberately NOT swept
-    /// here: each is a different card owing its own eye-confirm,
-    /// and neither carries the ordering half. `OverflowSplit`'s own
-    /// doc comment states the obligation rather than a census of
-    /// who has not met it yet, and that is the form it stays in.
+    /// Capsule chips of ordered profiles with overflow indicator
+    /// (`OverflowSplit`, #859, #789).
     private static func profileChips(
         _ model: SettingsModel
     ) -> some View {
@@ -128,19 +83,10 @@ enum HomeCardPreview {
             )
     }
 
-    /// The ruled apps' real icons in small wells — through the
-    /// memoized cache the App Rules rows warm, never a raw
-    /// `NSWorkspace` read per card — with a "+N" well for the
-    /// rest. Union of both rule kinds, the same pair the
-    /// subtitle counts.
+    /// App icon wells for configured app rules (code review 2026-08-09).
     private static func ruleIcons(
         _ model: SettingsModel
     ) -> some View {
-        // Float rules are colon syntax ("app:Title") — the app
-        // segment comes from the ONE parse the area renders
-        // with (`FloatFacet.appSegment`), or a titled rule
-        // draws a generic well and a doubly-ruled app draws
-        // twice (code review, 2026-08-09).
         let ids = Set(model.config.appRules.keys)
             .union(
                 model.config.floatRules.map(
@@ -182,9 +128,7 @@ enum HomeCardPreview {
             .overlay(content())
     }
 
-    /// The version the About row states, through the one shared
-    /// derivation, so the card can never disagree with the area
-    /// it opens.
+    /// Version label matching About pane display.
     private static var versionLine: some View {
         Text(
             L(
@@ -198,11 +142,7 @@ enum HomeCardPreview {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// The first few default-layer combos as native key caps,
-    /// through the same glyph pipeline the recorder displays
-    /// with — the prototype's cut: small semibold mono on the
-    /// sunken chip fill, no stroke ring (owner, 2026-08-09:
-    /// "softer, smaller, sleeker").
+    /// Key cap chips for default layer keybindings (owner ruling 2026-08-09).
     @ViewBuilder
     private static func keyCaps(
         _ model: SettingsModel
@@ -234,9 +174,7 @@ enum HomeCardPreview {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// The recorder's own combo rendering (#23): glyphs mapped
-    /// through the active keyboard layout, raw string on a
-    /// parse failure.
+    /// Renders combo string using key glyph pipeline (#23).
     private static func capText(_ combo: String) -> String {
         guard let parsed = KeyCombo.parse(combo) else {
             return combo

--- a/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
@@ -128,6 +128,11 @@ struct AppRulesSection: View {
         HStack {
             AppSelector(name: $newApp, exclude: Set(apps))
             Button {
+                // Lower-cased so a hand-typed mixed-case bundle
+                // id (osascript reports `com.apple.Safari`) keys
+                // the same as the normalized `appBundleID` the
+                // engine and dropdown use — otherwise dedup and
+                // the open-title list silently miss (#262 review).
                 let app = newApp.trimmed.lowercased()
                 guard !app.isEmpty else { return }
                 if !apps.contains(app) {

--- a/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
@@ -1,26 +1,15 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Whole App ▸ App Rules (#68 §3.11): one list, one row per
-/// app, with the app's rules as two structured facets — Space
-/// (pin to a space) and Float (never tile). Replaces the two
-/// mismatched lists whose `App:Title` colon syntax leaked the
-/// serialization format into the UI; storage is untouched
-/// (`app_rules` dict + `float_rules` strings), the GUI now
-/// assembles the syntax.
+/// Whole App ▸ App Rules settings section (#68 §3.11).
 struct AppRulesSection: View {
     @ObservedObject var model: SettingsModel
-    /// Apps added this session that have no stored rule yet
-    /// (both facets still at their defaults) — they live only
-    /// in the GUI until a facet is set.
     @State private var draftApps: [String] = []
-    /// Where the keyboard lands after a rule row stops existing
-    /// (#816), keyed by the row's app id.
+    /// Restores keyboard focus after deleting a rule row (#816).
     @FocusState private var returningRow: String?
     @State private var newApp = ""
 
-    /// The base rules while editing a stored profile — the
-    /// override-mode switch (#109); nil during live editing.
+    /// Base rules when editing stored profile (#109); nil during live editing.
     private var overrideBase: [String: SpaceID]? {
         model.profileEditingBaseAppRules
     }
@@ -59,8 +48,7 @@ struct AppRulesSection: View {
         }
     }
 
-    /// Shown while editing a stored profile whose space rules
-    /// diverge from the base — the Shortcuts tab's twin (#109).
+    /// Banner shown when active profile overrides base app rules (#109).
     @ViewBuilder private var overrideIndicator: some View {
         if model.editedProfileOverridesAppRules {
             Label(
@@ -89,25 +77,14 @@ struct AppRulesSection: View {
                     + "loaded profile in the header's picker."
             )
         }
-        // States the card's SUBJECT, not its instructions
-        // (turn 14a). The rows are sentences now, so they teach
-        // what a rule can say better than a caption listing the
-        // options could; and "deleting a row removes all of the
-        // app's rules" moved to the delete button's own help,
-        // where it is read at the moment it matters.
         return L(
             "app_rules.section.caption",
             "What an app should do when it opens."
         )
     }
 
-    /// One row per distinct app, however its rules are stored:
-    /// assignment key, float-rule app segment, or a session
-    /// draft. Hand-written float rules for apps that aren't
-    /// installed still render (name as typed). In override
-    /// mode the BASE's pinned apps are included too, so a
-    /// tombstoned (un-pinned) app keeps its row — visible as
-    /// "Automatic" overriding the base pin (#109).
+    /// Sorted list of unique apps with configured rules or drafts (#333,
+    /// #109).
     private var apps: [String] {
         var set = Set(model.config.appRules.keys)
         for rule in model.config.floatRules {
@@ -122,11 +99,6 @@ struct AppRulesSection: View {
             }
         }
         set.formUnion(draftApps)
-        // Sort by the display name the row actually shows, not
-        // the raw bundle id (#333). Resolve each name once into a
-        // map so the O(n log n) compare doesn't re-hit NSWorkspace/
-        // Spotlight per comparison; tie-break on the id for a
-        // stable order when two apps share a display name.
         let names = Dictionary(
             uniqueKeysWithValues: set.map {
                 ($0, KeybindingCatalog.displayName(forBundleID: $0))
@@ -140,11 +112,6 @@ struct AppRulesSection: View {
         }
     }
 
-    /// What happens to an app with no rule — the answer to the
-    /// question an empty list otherwise leaves open. It states
-    /// the default behaviour rather than inviting an action,
-    /// because having no rules is a perfectly good state and the
-    /// "Add app…" control below is already the invitation.
     private var emptyNote: some View {
         Text(
             L(
@@ -159,17 +126,8 @@ struct AppRulesSection: View {
 
     private var addRow: some View {
         HStack {
-            // Each app has at most one rule row, so hide the ones
-            // already listed — re-adding would only re-select the
-            // existing row.
             AppSelector(name: $newApp, exclude: Set(apps))
             Button {
-                // Lower-case so a hand-typed Custom bundle id
-                // (e.g. the mixed-case `com.apple.Safari` that
-                // `osascript` reports) keys the same as the
-                // normalized `appBundleID` the engine and the
-                // dropdown path use — otherwise the row's open-
-                // title list and dedup silently miss (#262 review).
                 let app = newApp.trimmed.lowercased()
                 guard !app.isEmpty else { return }
                 if !apps.contains(app) {
@@ -188,19 +146,8 @@ struct AppRulesSection: View {
         }
     }
 
-    /// Deleting a rule row, and where the keyboard lands (#816).
-    ///
-    /// The focus move is conditional on the row actually LEAVING
-    /// the list, which in override mode it does not: `apps`
-    /// unions the base's pinned apps, so a tombstoned row stays
-    /// drawn as "Automatic" overriding the base pin (#109). Focus
-    /// belongs where the user left it there — moving it to the
-    /// next row would step off a row that is still on screen
-    /// (code review, 2026-08-12).
+    /// Removes app rules and updates focus target (#816, #109, 2026-08-12).
     private func delete(_ app: String) {
-        // Before the mutation (#816): afterwards the list cannot
-        // name the deleted row's neighbour, only whichever row
-        // slid into the gap.
         let neighbour = neighbourAfterDeleting(app)
         model.config.appRules[app] = nil
         model.config.floatRules.removeAll {
@@ -212,8 +159,6 @@ struct AppRulesSection: View {
         }
     }
 
-    /// `apps` is the DISPLAY order (sorted by the name the row
-    /// shows, #333), not the rules dictionary's.
     private func neighbourAfterDeleting(
         _ app: String
     ) -> String? {
@@ -221,19 +166,13 @@ struct AppRulesSection: View {
     }
 }
 
-/// The float-facet bridge over `float_rules` strings: `"App"`
-/// floats every window, `"App:Title"` floats windows whose
-/// title contains the fragment (first colon splits, matching
-/// `FloatRules`). The colon is assembled here and never shown.
+/// Float facet parsing and filtering helper matching `FloatRules`.
 enum FloatFacet: Equatable {
     case never
     case all
     case titled
 
-    /// Mirrors `FloatRules`' parse exactly: only a rule that
-    /// splits into two non-empty-side parts has a title; a
-    /// degenerate `"App:"` / `":Title"` is a literal app name
-    /// to the engine and must group the same way here.
+    /// Extracts app segment from float rule string (`FloatRules`).
     static func appSegment(of rule: String) -> String {
         let parts = rule.split(separator: ":", maxSplits: 1)
         return parts.count == 2 ? String(parts[0]) : rule

--- a/Sources/KiwiDesk/Settings/Sections/LayerStripEditor.swift
+++ b/Sources/KiwiDesk/Settings/Sections/LayerStripEditor.swift
@@ -1,24 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Layers card's body: the chip strip that defines the
-/// layers, the "+" popover that adds one, and the selected
-/// layer's menu-bar icon with Rename / Delete.
-///
-/// Its own `View` rather than a computed property on
-/// `ShortcutsHeader`: it owns four pieces of `@State`, and
-/// `@State` on a struct that is never mounted in the hierarchy
-/// silently does nothing. Splitting here also puts the header
-/// back under the file-size target without widening any
-/// `private` — the seam is real, not a line-count dodge.
-///
-/// At 268 lines this sits above the 100–250 target and below the
-/// 350 ceiling, and it stays that way deliberately: the only
-/// seam left (rename / add / delete) reads all four `@State`
-/// properties, so extracting it means widening them to
-/// `internal`. A soft size guideline does not buy a real seal,
-/// and review reached the same conclusion for `ShortcutsHeader`
-/// before this file existed.
+/// Shortcut layers chip strip, add popover, and layer management actions.
 struct LayerStripEditor: View {
     @ObservedObject var model: SettingsModel
     @Binding var selected: String
@@ -26,8 +9,7 @@ struct LayerStripEditor: View {
     @State private var newLayer = ""
     @State private var renameRequest: NameEditRequest?
     @State private var addLayerHovered = false
-    /// Where the keyboard lands after the selected layer's chip
-    /// stops existing (#816).
+    /// Keyboard focus target following layer deletion (#816).
     @FocusState private var focusedChip: String?
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
@@ -58,8 +40,6 @@ struct LayerStripEditor: View {
         )
     }
 
-    // MARK: - Layer strip
-
     private var layerStrip: some View {
         HStack(spacing: 6) {
             ForEach(model.config.layers) { layer in
@@ -76,13 +56,9 @@ struct LayerStripEditor: View {
         ) {
             selected = name
         }
-        // Every chip is a focus destination, so a deletion can
-        // name one (#816).
         .focused($focusedChip, equals: name)
     }
 
-    /// Defining a layer is rare — the "+" chip's popover
-    /// replaces the old always-visible text field (§3.6.1).
     private var addLayerChip: some View {
         Button {
             addingLayer = true
@@ -128,10 +104,7 @@ struct LayerStripEditor: View {
         reduceMotion ? nil : .easeOut(duration: 0.12)
     }
 
-    // MARK: - Selected-layer row
-
-    /// A selected non-default layer gets a compact header: its
-    /// menu-bar icon and Delete (base layers protected, #55).
+    /// Header controls for selected custom layer (base layers protected, #55).
     @ViewBuilder private var selectedLayerHeader: some View {
         if selected != KeyLayer.defaultName {
             HStack(spacing: 10) {
@@ -148,10 +121,6 @@ struct LayerStripEditor: View {
                     )
                     .buttonStyle(.bordered)
                 } else {
-                    // O4 soft: a base layer the profile
-                    // doesn't mention always survives —
-                    // removal is not expressible per profile
-                    // (#55 phase 7).
                     Text(
                         L(
                             "shortcuts.base_layer_protected",
@@ -184,15 +153,7 @@ struct LayerStripEditor: View {
         )
     }
 
-    /// Rename shares Delete's gate (base layers are protected
-    /// in profile-override editing, #55). Scope: the rewrite
-    /// covers THIS config's layers and switch-layer rows; a
-    /// stored profile whose sparse override (`Profile.layers`)
-    /// targets the old name keeps it and resurfaces it as a
-    /// standalone layer — the same accepted gap Delete has
-    /// (pre-release, single user; the edit here is a draft
-    /// until Save, so chasing stored files at click time
-    /// would desync them from an unsaved base).
+    /// Layer rename button (#55, #843).
     private var renameLayerButton: some View {
         Button(L("shortcuts.rename_ellipsis", "Rename…")) {
             renameRequest = NameEditRequest(
@@ -201,10 +162,6 @@ struct LayerStripEditor: View {
             )
         }
         .settingsActionButton()
-        // By ITEM, so the seed reaches the builder rather than
-        // being read back out of `@State` written one tick
-        // earlier (#843) — the shape that left the palette
-        // shelf's Save dead over a valid name.
         .popover(item: $renameRequest) { request in
             NameEditPopover(
                 seed: request.seed,
@@ -240,11 +197,6 @@ struct LayerStripEditor: View {
         renameRequest = nil
     }
 
-    // MARK: - Layer mutations
-
-    /// Live editing: any non-default layer. Override layer:
-    /// only layers the PROFILE added — base layers always pass
-    /// through (O4 soft), so deleting one is inexpressible.
     private var canDeleteSelected: Bool {
         guard selected != KeyLayer.defaultName else {
             return false
@@ -266,9 +218,7 @@ struct LayerStripEditor: View {
     private func addLayer() {
         let name = newLayer.trimmed
         guard canAddLayer else { return }
-        // Seed the ⌃⌥K "Show shortcuts panel" row so a fresh layer
-        // can open the cheat-sheet from the keyboard, not only via
-        // the menu bar (#602). Deletable per layer like any default.
+        // Seed default shortcuts panel keybinding for new layer (#602).
         model.config.layers.append(
             KeyLayer(
                 name: name,
@@ -280,24 +230,8 @@ struct LayerStripEditor: View {
         addingLayer = false
     }
 
-    /// Focus FOLLOWS the selection rather than stepping to the
-    /// neighbouring chip (#816). The strip is a selector, not a
-    /// list of independent rows: deleting the selected layer
-    /// already moves the selection to the default layer, and
-    /// every row below the strip is that layer's now, so landing
-    /// anywhere else would leave the keyboard on a chip that
-    /// does not match what is on screen.
-    ///
-    /// But only WHERE THE STRIP SURVIVES. `LayersCard` withholds
-    /// itself entirely on `layersExist || mode == .powerUser`,
-    /// and `layersExist` is "more than the default layer" — so in
-    /// Simple mode, deleting the last custom layer retires the
-    /// whole card in the same mutation, the default chip
-    /// included. Naming it then sends focus to a view that left
-    /// the tree, which lands at the top of the window: the exact
-    /// outcome this rule exists to prevent, reached by the road
-    /// gui.md warns about (code review, 2026-08-12). Nil is the
-    /// honest answer there — the card the user was in is gone.
+    /// Focus follows selection or clears if card disappears (#816, code review
+    /// 2026-08-12).
     private func deleteLayer() {
         guard selected != KeyLayer.defaultName else { return }
         model.config.layers.removeAll {
@@ -309,12 +243,6 @@ struct LayerStripEditor: View {
             ? KeyLayer.defaultName : nil
     }
 
-    /// Whether the card still draws after the deletion — asked
-    /// of the card's OWN offer, never re-derived here: a second
-    /// copy of an offer predicate is the drift
-    /// `HomeCardOrder.isOffered` exists to prevent one level up,
-    /// and an inverted copy is how a Simple-mode user ends up
-    /// with focus on a card that left the tree.
     private var stripSurvivesDeletion: Bool {
         LayersCard.isOffered(
             config: model.config,

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
@@ -1,41 +1,15 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Whole App ▸ Profiles (#36/#53/#68 §3.2, rebuilt in #678
-/// Phase 3 turn 13a): what a profile IS, which ones exist, which
-/// one loads, and where to start from nothing — in that order.
-///
-/// The list is flat now. It used to group by screen count with a
-/// header per count and a chip row of raw monitor names per row,
-/// which spent the whole row on the machine and left the user to
-/// infer what the profile contained. The subtitle counts what the
-/// profile OWNS instead — screens, spaces, shortcut overrides —
-/// and the screen count keeps the monitor names as its tooltip.
-///
-/// The lead-in text is the AREA's caption. The interim sidebar
-/// shell has no area header to hang it on (Home, the last Phase 3
-/// lane, is what grows one), so it renders as the pane's first
-/// line rather than being dropped until then — the sentence is
-/// the answer to "what is a profile", which is the question this
-/// page opens with.
+/// Profiles section: lists saved profiles, loading defaults, and presets
+/// (#36, #53, #68).
 struct ProfilesSection: View {
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
     @ObservedObject var model: SettingsModel
-    /// The profile whose rename popover is open, if any.
-    /// `internal`, not `private`: the rename affordance that
-    /// owns this state lives in `ProfilesSection+Rename.swift`
-    /// (file ceiling), and `@State` cannot move to an extension.
-    /// The rename popover's presentation, carrying the seed it
-    /// opens with (#843) — never a flag plus a separately
-    /// written draft, which the confirm button read as empty.
+    /// Profile whose rename popover is presented (#843).
     @State var renameRequest: NameEditRequest?
-    /// Where the keyboard lands after a row stops existing
-    /// (#816). Keyed by profile NAME across both lists — a
-    /// profile is either loaded or broken, never in both, so one
-    /// key cannot be claimed by two rows. `internal` for the
-    /// same reason the rename state is: the rows that bind it
-    /// live in extensions, and `@FocusState` cannot move there.
+    /// Keyboard focus return anchor after row deletion (#816).
     @FocusState var returningRow: String?
 
     var body: some View {
@@ -46,9 +20,7 @@ struct ProfilesSection: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                 if model.profileSummaries.isEmpty {
-                    // Bootstrap: with nothing saved, the presets
-                    // are the only thing on this page that can be
-                    // acted on, so they lead (#53).
+                    // Presets lead when no user profile is saved (#53).
                     PresetsSection(model: model)
                     profileSection
                     whichProfileLoads
@@ -75,8 +47,6 @@ struct ProfilesSection: View {
                 + "display arrangement."
         )
     }
-
-    // MARK: - Your profiles (#36)
 
     private var profileSection: some View {
         SettingsSection(
@@ -110,12 +80,6 @@ struct ProfilesSection: View {
         }
     }
 
-    /// "a built-in layout", not "the built-in Standard": no
-    /// layout is NAMED Standard — the ones that resolve silently
-    /// are Developer, Dual Developer and Command Center, and the
-    /// card below this one names whichever is live. Two
-    /// paragraphs of one page calling the same thing by two
-    /// nouns is what sends a translator two ways.
     private var noProfilesCaption: String {
         L(
             "profiles.saved.empty",
@@ -124,21 +88,11 @@ struct ProfilesSection: View {
         )
     }
 
-    /// Where the live edits land, and how to keep them apart —
-    /// the question a user asks the moment they realise editing
-    /// anything writes into the profile that is loaded.
+    /// Note describing current setup destination (#818).
     private var currentSetupNote: String? {
         guard !model.editingStoredProfile,
             let active = model.activeProfile
         else { return nil }
-        // The button's own label, INTERPOLATED rather than
-        // re-typed (#818) — a note that names a control by an
-        // approximation sends the reader looking for something
-        // that is not there, and this one had already drifted:
-        // it said "Save a Copy As…" while the button says
-        // "Save a copy…". A literal quotation is a mirror every
-        // locale then has to keep in step with nothing checking
-        // that it does.
         return L(
             "profiles.current_setup_note",
             "Your current setup is saved into %1$@. To keep it "
@@ -149,18 +103,14 @@ struct ProfilesSection: View {
         )
     }
 
-    /// The saved-profile rows, in display order — from the
-    /// family seam's own derivation, which is what the census
-    /// guards read too.
+    /// Saved profile summaries in display order.
     private var orderedSummaries: [ProfileSummary] {
         ProfilesFamilyRows.orderedProfiles(
             model.profileSummaries
         )
     }
 
-    /// This list's display order, handed to the shared rule
-    /// (`DeletionFocus`) — which order it is IS this call site's
-    /// contribution; the stepping is not.
+    /// Next focus target when deleting `name` (`DeletionFocus`).
     func neighbourAfterDeleting(_ name: String) -> String? {
         DeletionFocus.neighbour(
             after: name,
@@ -171,28 +121,8 @@ struct ProfilesSection: View {
     private func profileRow(
         _ summary: ProfileSummary
     ) -> some View {
-        // CENTRED, not first-text-baseline: the picture belongs
-        // to the whole row — the name AND the subtitle counting
-        // the screens it draws — so pinning it to the title's
-        // baseline sat it high against a two-line block and read
-        // as belonging to the first line only (owner eye-confirm,
-        // 2026-08-16). It is also what the design prototype's own
-        // row does (`align-items:center`), and it carries the
-        // buttons with it, which is the same arrangement there.
-        //
-        // Centring is what RETIRED an `.alignmentGuide` here: a
-        // picture with no text baseline resolves to its own bottom
-        // edge, so under baseline alignment a row whose picture
-        // carried a "+N" chip seated differently from one whose
-        // did not. With no baseline in the alignment there is
-        // nothing to correct.
         HStack(alignment: .center) {
-            // The screen count as a picture (#789), replacing a
-            // glyph that was identical on every row and so
-            // distinguished none of them. The tooltip stays on
-            // the subtitle below rather than moving here: `.help`
-            // on a decorative image is hover-only, and this one
-            // is `.accessibilityHidden`.
+            // Screen count icon (#789).
             screenPicture(summary)
             VStack(alignment: .leading, spacing: 3) {
                 rowTitle(summary)
@@ -210,9 +140,7 @@ struct ProfilesSection: View {
         }
     }
 
-    /// The row's leading picture — one outline per screen in the
-    /// same grammar the preset cards draw, so the two surfaces
-    /// answer "what shape is this profile" one way (#789).
+    /// Leading screen count diagram (#789).
     private func screenPicture(
         _ summary: ProfileSummary
     ) -> some View {
@@ -223,9 +151,7 @@ struct ProfilesSection: View {
         )
     }
 
-    /// The width every row's picture reserves — the widest
-    /// profile in THIS list, so the names align without a
-    /// one-screen list paying for four screens' worth of gap.
+    /// Slot count reserved for monitor icons across rows.
     private var reservedScreenSlots: Int {
         ProfileScreenPips.reservedSlots(
             forScreenCounts: orderedSummaries.map(\.count)
@@ -237,9 +163,6 @@ struct ProfilesSection: View {
     ) -> some View {
         HStack(spacing: 6) {
             Text(summary.name)
-                // Bonus discovery path (low-risk): a double-click
-                // on the name opens the same rename popover as
-                // the pencil, which stays the primary visible cue.
                 .onTapGesture(count: 2) {
                     beginRename(summary.name)
                 }
@@ -258,10 +181,7 @@ struct ProfilesSection: View {
         }
     }
 
-    /// Several profiles of one screen count marked default is a
-    /// hand-edited-file state, so the warning rides the rows it
-    /// is about rather than a count header the flat list no
-    /// longer has.
+    /// Warning shown when multiple profiles share a default flag for count.
     @ViewBuilder private func duplicateDefaultWarning(
         _ summary: ProfileSummary
     ) -> some View {

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection.swift
@@ -1,8 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Profiles section: lists saved profiles, loading defaults, and presets
-/// (#36, #53, #68).
+/// Profiles section: lists saved profiles, loading defaults, and
+/// presets (#36, #53, #68; rebuilt in #678 Phase 3 turn 13a).
 struct ProfilesSection: View {
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
@@ -80,6 +80,9 @@ struct ProfilesSection: View {
         }
     }
 
+    /// "a built-in layout", not "the built-in Standard": no
+    /// layout is NAMED Standard, and two nouns for one thing on
+    /// one page sends a translator two ways.
     private var noProfilesCaption: String {
         L(
             "profiles.saved.empty",
@@ -121,6 +124,12 @@ struct ProfilesSection: View {
     private func profileRow(
         _ summary: ProfileSummary
     ) -> some View {
+        // CENTRED, not first-text-baseline (owner eye-confirm,
+        // 2026-08-16): the picture belongs to the whole two-line
+        // block. Centring is also what RETIRED an .alignmentGuide
+        // here — a picture with no text baseline resolves to its
+        // own bottom edge, so rows with and without a "+N" chip
+        // seated differently under baseline alignment.
         HStack(alignment: .center) {
             // Screen count icon (#789).
             screenPicture(summary)

--- a/Sources/KiwiDesk/Settings/Sections/ShortcutsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ShortcutsSection.swift
@@ -1,9 +1,15 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Shortcuts settings section for keybinding configuration (#68, #678).
-/// Single active recorder (#33), duplicate blocking (#34), live conflict
-/// detection (#35).
+/// Shortcuts settings section, rendered FROM the census (#68,
+/// #678): the census owns placement, `ShortcutsRowOrder` display
+/// order, `ShortcutsFamilyRows` the family→rows expansion —
+/// `ShortcutsCensusRenderTests` pins all three. The Inactive
+/// shortcuts card is deliberately NOT censused: its rows are
+/// instances of families already placed, so the card is
+/// hand-mounted and the guard states why it holds no keys.
+/// Single active recorder (#33), duplicate blocking (#34), live
+/// conflict detection (#35).
 struct ShortcutsSection: View {
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
@@ -178,6 +184,12 @@ struct ShortcutsSection: View {
         )
     }
 
+    /// Withheld in Simple (owner ruling 2026-08-04): importing
+    /// bindings out of init.lua is not a first-week concept.
+    /// `hasCustomLua` is the FIRST term for `layersExist`'s
+    /// reason: someone whose init.lua already carries bindings
+    /// must not have the one surface that explains them hidden by
+    /// a mode they did not know they were in.
     private func offersAdvancedDrawer(
         in mode: SettingsMode
     ) -> Bool {
@@ -199,6 +211,8 @@ struct ShortcutsSection: View {
             SettingsCatalog.shortcuts.luaBindings,
             chrome: .card,
             isExpanded: $advancedExpanded,
+            // One predicate at `.simple` (#760): with custom Lua
+            // present the drawer is Simple content, unmarked.
             modeGated: !offersAdvancedDrawer(in: .simple)
         ) {
             VStack(alignment: .leading, spacing: 8) {
@@ -224,7 +238,11 @@ struct ShortcutsSection: View {
         )
     }
 
-    /// Family-to-rows expansion built from live state.
+    /// Family-to-rows expansion built from live state. The
+    /// Desktop list reads EVERY layer's bindings, not the
+    /// selected one's: a row existing only while its layer is
+    /// selected would vanish from under the duplicate block's
+    /// "Go to", which may point into another layer.
     private var expander: ShortcutsFamilyRows {
         return ShortcutsFamilyRows(
             spaces: model.config.spaces,

--- a/Sources/KiwiDesk/Settings/Sections/ShortcutsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ShortcutsSection.swift
@@ -1,26 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Whole App ▸ Shortcuts (#68 §3.6), rendered FROM the settings
-/// census (#678 Phase 3): flat intent groups (Focus / Move
-/// windows / Size & float / Open applications), then the
-/// advanced half — the Layers card and the raw-Lua drawer — with
-/// Import in the header where a new user can see it. One
-/// recorder can be active at a
-/// time (#33), duplicates hard-block with Steal / Go to (#34),
-/// and conflict state derives live from the bindings on every
-/// render (#35).
-///
-/// The census owns placement, `ShortcutsRowOrder` owns display
-/// order and `ShortcutsFamilyRows` owns the family→rows
-/// expansion; `ShortcutsCensusRenderTests` pins all three
-/// together. What the census does NOT place is the Inactive
-/// shortcuts card: its rows are instances of the `goToSpace` and
-/// `moveToSpace` families already censused under Focus and Move
-/// windows, surfaced a second time because their space left the
-/// list. A census row for it would be a second placement of a
-/// setting that already has one, so the card is hand-mounted and
-/// the guard states why it holds no census keys.
+/// Shortcuts settings section for keybinding configuration (#68, #678).
+/// Single active recorder (#33), duplicate blocking (#34), live conflict
+/// detection (#35).
 struct ShortcutsSection: View {
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
@@ -53,9 +36,6 @@ struct ShortcutsSection: View {
                 _,
                 target in
                 guard let target else { return }
-                // Gated like the detail pane's reveal scroll
-                // (`SettingsView+Detail`): Reduce Motion jumps
-                // to the target rather than travelling to it.
                 withAnimation(reduceMotion ? nil : .default) {
                     proxy.scrollTo(target, anchor: .center)
                 }
@@ -64,17 +44,12 @@ struct ShortcutsSection: View {
         }
         .onAppear {
             ensureSelection()
-            // Arm the recorder ⇒ suspend live hotkeys so testing
-            // an existing shortcut mid-capture can't fire it
-            // (#213). Idempotent across re-appears.
+            // Suspend hotkeys while capturing to avoid trigger during edit
+            // (#213).
             coordinator.onArmedChange = { [model] armed in
                 model.setRecorderArmed(armed)
             }
         }
-        // The section stays mounted across reloads and edit-
-        // target switches; a vanished layer must never leave
-        // `selected` pointing at layers[0] under a phantom
-        // header (#68 review M1).
         .onChange(of: model.config.layers.map(\.name)) {
             _,
             _ in
@@ -89,23 +64,11 @@ struct ShortcutsSection: View {
         }
     }
 
-    // MARK: - Body pieces
-    //
-    // Split out of `body` rather than nested in it: a single
-    // expression holding every group blew the type-checker's
-    // budget, which fails on the slower CI runner while
-    // compiling fine locally (gui.md's shallow-body rule).
-
     @ViewBuilder private var header: some View {
         KeybindingConflictBanner(model: model)
         overrideBanner
         ShortcutsHeader(model: model, selected: $selected)
-        // The layers that define alternate key sets. It LEADS the
-        // area rather than tailing it (owner ruling 2026-08-04):
-        // the layer selected here decides what every card below
-        // is showing, and a control that reframes the whole page
-        // cannot sit under the page it reframes. It withholds
-        // itself entirely until earned — see `LayersCard`.
+        // LayersCard leads section (owner ruling 2026-08-04).
         layersCard
     }
 
@@ -143,36 +106,21 @@ struct ShortcutsSection: View {
     }
 
     @ViewBuilder private var tail: some View {
-        // Orphaned space-targeting rows (#92): rendered so "Go
-        // to" from a rejected recording can reach the holder —
-        // the per-space groups above only render live spaces.
+        // Orphaned space-targeting rows (#92).
         OrphanedShortcutsGroup(
             model: model,
             bindings: bindingsBinding,
             spaces: model.config.spaces
         )
-        // Then the raw-Lua escape hatch, which is `.showMore`
-        // outright. `LayersCard` used to sit here and now LEADS
-        // the area — see `layersCard` above.
         advancedDrawer
     }
 
-    // MARK: - Override layer (#55 phase 7)
-
-    /// Shown while editing a stored profile: the section
-    /// renders the RESOLVED layers; only rows diverging from
-    /// the base are saved into the profile's sparse override.
+    // Profile keybinding overrides (#55, #123, #209).
     @ViewBuilder private var overrideBanner: some View {
         if model.editingStoredProfile {
             SettingsSection(
                 SettingsCatalog.shortcuts.profileShortcuts
             ) {
-                // #123: the live target applies recordings
-                // instantly; a stored profile stays staged —
-                // say so where the recording happens. But the
-                // loaded profile's own overrides re-apply on save
-                // (#209), so its banner can't claim "next time
-                // it's active" — it IS active.
                 if let name = model.editingProfile {
                     Text(overrideBannerText(name))
                         .font(.callout)
@@ -196,9 +144,7 @@ struct ShortcutsSection: View {
         }
     }
 
-    /// The loaded profile's overrides re-apply the moment you
-    /// save (it is the layout on screen); every other stored
-    /// profile stays staged until it next loads (#209).
+    /// Re-application notice when editing active vs stored profile (#209).
     private func overrideBannerText(_ name: String) -> String {
         if name == model.activeProfile {
             return L(
@@ -232,18 +178,6 @@ struct ShortcutsSection: View {
         )
     }
 
-    // MARK: - Advanced drawer (§3.6.1)
-
-    /// Withheld in Simple (owner ruling 2026-08-04): importing
-    /// bindings out of `init.lua` is not a first-week concept,
-    /// and a collapsed drawer for it still costs a Simple user a
-    /// row of chrome to read past.
-    ///
-    /// `hasCustomLua` is the FIRST term for the same reason
-    /// `layersExist` is on the Layers card: someone whose
-    /// `init.lua` already carries bindings must not have the one
-    /// surface that explains them hidden by a mode they did not
-    /// know they were in.
     private func offersAdvancedDrawer(
         in mode: SettingsMode
     ) -> Bool {
@@ -265,8 +199,6 @@ struct ShortcutsSection: View {
             SettingsCatalog.shortcuts.luaBindings,
             chrome: .card,
             isExpanded: $advancedExpanded,
-            // One predicate at `.simple` (#760): with custom Lua
-            // in init.lua the drawer is Simple content, unmarked.
             modeGated: !offersAdvancedDrawer(in: .simple)
         ) {
             VStack(alignment: .leading, spacing: 8) {
@@ -292,16 +224,7 @@ struct ShortcutsSection: View {
         )
     }
 
-    /// The family→rows expansion every group reads. Built once
-    /// per render from live state, so the per-space,
-    /// per-Desktop and per-layer families expand against what is
-    /// actually configured right now.
-    ///
-    /// The Desktop list is read across EVERY layer's bindings,
-    /// not the selected one's: a row that exists only while its
-    /// layer is selected would vanish from under the
-    /// duplicate-combo block's "Go to", which is free to point
-    /// at a row in another layer.
+    /// Family-to-rows expansion built from live state.
     private var expander: ShortcutsFamilyRows {
         return ShortcutsFamilyRows(
             spaces: model.config.spaces,
@@ -315,8 +238,6 @@ struct ShortcutsSection: View {
             currentLayer: selected
         )
     }
-
-    // MARK: - Bindings into the selected layer
 
     private var layerIndex: Int {
         model.config.layers.firstIndex {

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+Customize.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+Customize.swift
@@ -27,8 +27,15 @@ extension SpacesSection {
         )
     }
 
-    /// Per-row override cell button opening full-pane editor (#678 8b, owner
-    /// ruling 2026-08-04).
+    /// Per-row override cell opening the full-pane editor (#678
+    /// 8b). Wording turns on the mode (owner ruling 2026-08-04):
+    /// tiled counts read "N custom"; Floating reads a muted "N
+    /// saved" that still opens the editor (grey, don't hide).
+    /// Withheld entirely while the offer is locked (#678 8c) —
+    /// `SpaceOverrideOffer` owns that predicate, gated HERE at the
+    /// one render site so the row never holds a second copy (the
+    /// hand-negated-copy drift `HomeCardOrder.isOffered` prevents
+    /// one level up).
     @ViewBuilder func customizeButton(
         _ space: SpaceID
     ) -> some View {

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+Customize.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+Customize.swift
@@ -1,17 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The per-row override cell, the row context menu, the
-/// destructive-delete confirmation, and their mutations — split
-/// from `SpacesSection.swift` to stay under the line ceiling
-/// (#205). The cell summarises the space's saved overrides and
-/// pushes the full-pane editor (`SpacesSection+Overrides.swift`);
-/// its four-state wording is resolved purely by
-/// `OverrideCellState`.
-/// The widest override-cell label currently on screen, so every
-/// row's button locks to one shared column width instead of each
-/// hugging its own (variable-count / variable-locale) label —
-/// mirrors `SpaceRowFrames` in `SpacesSection+Drag.swift`.
+/// Per-row override cell, context menu, and delete confirmation dialogs (#205,
+/// #678).
 struct OverridesButtonWidth: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(
@@ -23,9 +14,7 @@ struct OverridesButtonWidth: PreferenceKey {
 }
 
 extension SpacesSection {
-    /// Destructive row action, kept behind the divider in the
-    /// trailing danger slot. The shared icon affordance supplies
-    /// its persistent chip, hover confirmation, and VoiceOver name.
+    /// Destructive row action in trailing danger slot.
     func deleteButton(_ space: SpaceID) -> some View {
         Button {
             requestRemove(space)
@@ -38,27 +27,8 @@ extension SpacesSection {
         )
     }
 
-    /// The per-row override cell: a bordered button whose label
-    /// summarises the space's saved overrides and whose tap pushes
-    /// the full-pane editor (#678 8b, replacing the #205 popover).
-    ///
-    /// The label is the SUM across every layout
-    /// (`overrideFieldCount(for:)`), the scannable "how much custom
-    /// config does this Space carry" signal; the editor breaks it
-    /// into active-layout rows and a dormant drawer. Wording turns
-    /// on the space's mode (owner ruling 2026-08-04):
-    /// - tiled, N>0 → "N custom"; N==0 → "Customize…";
-    /// - Floating, N>0 → a muted "N saved" (the values apply to
-    ///   OTHER layouts, not this one) that still opens the editor
-    ///   so they stay reachable — "grey, don't hide", §2.7;
-    /// - Floating, N==0 → "—", disabled: genuinely no destination.
-    /// Withheld entirely while the offer is locked (#678 8c) —
-    /// see `SpaceOverrideOffer`, which owns that predicate and
-    /// the argument for hiding rather than dimming. Gated HERE,
-    /// at the one render site, rather than at the row: the row
-    /// would then hold a second copy of the rule, which is the
-    /// hand-negated-copy drift `HomeCardOrder.isOffered` exists
-    /// to prevent one level up.
+    /// Per-row override cell button opening full-pane editor (#678 8b, owner
+    /// ruling 2026-08-04).
     @ViewBuilder func customizeButton(
         _ space: SpaceID
     ) -> some View {
@@ -90,15 +60,7 @@ extension SpacesSection {
         }
         .settingsActionButton()
         .controlSize(.large)
-        // Hug the label so the GeometryReader below measures its
-        // true (untruncated) width, not a compressed one.
         .fixedSize()
-        // Report this row's intrinsic width upward; the list-wide
-        // max (measured, never a hardcoded guess, so it survives
-        // longer locales) is fed back as every row's column width
-        // below. A bigger count or longer label only widens the
-        // shared column — it can never truncate one, and every
-        // button lines up in a stable column across rows.
         .background(
             GeometryReader { proxy in
                 Color.clear.preference(
@@ -124,8 +86,6 @@ extension SpacesSection {
         )
     }
 
-    /// The cell's text, muted on the Floating-dormant case so it
-    /// reads as "saved, not live" rather than an active count.
     @ViewBuilder
     private func overrideCellLabel(
         _ state: OverrideCellState
@@ -164,14 +124,7 @@ extension SpacesSection {
         }
     }
 
-    // MARK: - Destructive delete
-
-    /// Deleting a space that only holds a name and a mode is
-    /// cheap and reversible (re-add it), so it goes straight
-    /// through. One that carries overrides — a pin, the Main
-    /// role, the fallback flag, or per-space settings the user
-    /// may have just tuned in the popover — asks first, since
-    /// the delete cascades through all of them.
+    /// Prompts confirmation if space carries overrides before removing.
     func requestRemove(_ space: SpaceID) {
         if model.config.carriesOverrides(space) {
             pendingDelete = space
@@ -191,12 +144,7 @@ extension SpacesSection {
         L("spaces.delete_confirm.title", "Delete this Space?")
     }
 
-    /// The two roles are INTERPOLATED from the keys that label
-    /// them on screen rather than re-typed (#818). "Main" was
-    /// never a label at all — the tray header reads "Follows main
-    /// display" — so no locale had an anchor for it, and three
-    /// invented one each. Quoting the label keys means a
-    /// translation of either one moves this sentence with it.
+    /// Confirmation message with interpolated role names (#818).
     var deleteConfirmMessage: String {
         L(
             "spaces.delete_confirm.message",
@@ -225,15 +173,8 @@ extension SpacesSection {
         ) {}
     }
 
-    // MARK: - Reset all layout overrides
-
-    /// The only destructive reset that confirms (#290): clearing a
-    /// single layout's overrides is one click away from re-adding
-    /// them, but wiping every layout's saved values — including the
-    /// dormant ones the popover doesn't show — can't be eyeballed
-    /// before it happens, so it asks. State lives here (not on the
-    /// popover) so the dialog outlives the popover's dismissal,
-    /// mirroring `pendingDelete`.
+    /// Confirmation binding for resetting all layout overrides on space
+    /// (#290).
     var resetAllConfirmPresented: Binding<Bool> {
         Binding(
             get: { pendingResetAll != nil },
@@ -273,13 +214,7 @@ extension SpacesSection {
         ) {}
     }
 
-    // MARK: - Row context menu
-
-    /// Keyboard-reachable equivalents of the drag/badge
-    /// affordances (the §3.13 accessibility pattern). Here beside
-    /// the delete confirmation it invokes, and the reorder helpers
-    /// it is the only caller of, to keep `SpacesSection.swift`
-    /// under the line ceiling.
+    /// Context menu actions for space row reordering and role assignments.
     @ViewBuilder
     func contextActions(_ space: SpaceID) -> some View {
         if model.config.fallbackSpace == space {

--- a/Sources/KiwiDesk/Settings/SettingsCatalog+ThisProfile.swift
+++ b/Sources/KiwiDesk/Settings/SettingsCatalog+ThisProfile.swift
@@ -1,24 +1,10 @@
 import KiwiDeskCore
 
-// The declaration structs behind the sidebar's **This Profile**
-// group (`SettingsDestination.thisProfile`): Spaces, Layout
-// Defaults, Monitors, Colors & Animations, Advanced Colors, Gaps &
-// Borders, Bars, Behavior. Split from
-// `SettingsCatalog.swift` on the seam the sidebar already
-// draws, so a destination's declarations sit where its
-// neighbours do. The aggregation and the enumeration stay in
-// `SettingsCatalog.swift`; the authoring rules are in its
-// header, and the catalog guards treat every
-// `SettingsCatalog+*` slice as catalog, not as a render site —
-// the `+` is load-bearing, see `SettingsCatalogFiles`.
+// Settings catalog declarations for the "This Profile" sidebar group.
 
 struct SpacesControls: Sendable {
     let spacesCard = SettingsControl("spaces.title", "Spaces")
-    /// The detail panel's per-Space preview (#794). Its own
-    /// title rather than Layout Defaults' "Live preview": that
-    /// one draws a LAYOUT's defaults and this one draws a
-    /// SPACE's resolved reality, which is the whole distinction
-    /// the panel exists to make.
+    /// Detail panel per-Space preview (#794).
     let spacePreview = SettingsControl(
         "spaces.preview.title",
         "This Space's layout"
@@ -26,19 +12,10 @@ struct SpacesControls: Sendable {
 }
 
 struct LayoutDefaultsControls: Sendable {
-    /// The min-size card sits above the strip and feeds every
-    /// layout, so it is surface-free; the layout tiles are
-    /// appended from `LayoutMode.placementTabs` in
-    /// `entries(of:)`.
     let minWindowSize = SettingsControl(
         "layout_defaults.min_window_size",
         "Minimum window size"
     )
-    /// The live preview and the spaces list are cards a reveal
-    /// can land on, so they are declared rather than rendered
-    /// with a computed title — a reader searching "preview"
-    /// should reach the one that answers "what will this look
-    /// like".
     let livePreview = SettingsControl(
         "layout_defaults.live_preview",
         "Live preview"
@@ -79,10 +56,7 @@ struct GapAxisControls: Sendable {
     let axisVertical = SettingsControl("gaps.vertical", "Vertical")
 }
 
-/// Colours & Animations (#678 Phase 3): the palette shelf, the
-/// live-colours scene, and the Animations card that moved here
-/// whole
-/// from Behavior.
+/// Colors & Animations catalog controls (#678 Phase 3).
 struct ColorsControls: Sendable {
     let paletteShelf = SettingsControl(
         "palettes.title",
@@ -96,31 +70,14 @@ struct ColorsControls: Sendable {
         "behavior.animations.title",
         "Animations"
     )
-    /// Named for what it holds, not "more" or "advanced": this
-    /// area's Power-User twin is a whole separate card, and one word
-    /// must never mean both a row tier and mode depth.
     let motionMore = SettingsDrawer(
         "motion.more",
         "Per-event and duration"
     )
 }
 
-/// Advanced Colours (#678 Phase 3): four groups matching the four
-/// things on screen. The two drawers co-render on one page, so
-/// each carries its own instance id — the twice-mounted shape
-/// (#277) a shared declaration would make `scrollTo`-undefined.
+/// Advanced Colors catalog controls (#678 Phase 3, #277, #793).
 struct AdvancedColorsControls: Sendable {
-    /// Each group's title names the SUBSYSTEM plus "colors".
-    /// Bare "Space Bar" / "Drag & drop" would collide in search
-    /// with the cards that own those things' structure: sidebar
-    /// search returns one row per destination, so the query
-    /// would come back as two rows reading identically, with
-    /// nothing to tell the swatch grid from the bar's own card.
-    /// (The ORDER decides which comes first and is settled
-    /// separately, in `SettingsDestination.thisProfile`; it is
-    /// not what makes the titles distinct.) The two bar titles
-    /// are the retired interim cards' keys, so their eleven
-    /// translations carry straight over.
     let bordersGroup = SettingsControl(
         "colors.borders.title",
         "Border colors"
@@ -147,19 +104,14 @@ struct AdvancedColorsControls: Sendable {
         "More colors",
         instance: "app_bar"
     )
-    /// The detail panel's scene (#793). Its own key rather than
-    /// `colors.scene.title`: that one names Colours & Animations's
-    /// "Current colors", a sample of a palette, while this names
-    /// the whole set drawn at once — one concept, one word, and
-    /// two different concepts here.
+    /// Detail panel full-palette preview (#793).
     let everyColorScene = SettingsControl(
         "colors.advanced.scene.title",
         "Every color at once"
     )
 }
 
-/// Gaps & Borders — the structure half of the old Appearance
-/// destination, renamed with its page in #678 Phase 3.
+/// Gaps & Borders catalog controls (#678 Phase 3, #754).
 struct GapsAndBordersControls: Sendable {
     let gapsCard = SettingsControl("gaps.title", "Gaps")
     let gapsPerEdge = SettingsDrawer(
@@ -172,11 +124,6 @@ struct GapsAndBordersControls: Sendable {
         "Per-axis…",
         children: GapAxisControls()
     )
-    /// The shared-decisions card (#754). Titled for what it
-    /// DECIDES, not for the thing it decides about: a bare
-    /// "Borders" reads as a fourth section competing with the
-    /// two that draw the strokes, and sits one letter from the
-    /// `border.*` family whose own title is "Focus border".
     let bordersCard = SettingsControl(
         "border.shared.title",
         "Shared by all borders"
@@ -197,25 +144,12 @@ struct GapsAndBordersControls: Sendable {
     )
 }
 
+/// Bars catalog controls (#293, #277).
 struct BarsControls: Sendable {
-    /// The two bar cards, one page (turn 7a of the redesign —
-    /// the #293 App Bar / Space Bar switch is gone). The card
-    /// titles keep the old switch chips' `bars.switch.*` keys:
-    /// the English is unchanged ("Space Bar" / "App Bar"), so
-    /// re-keying would only throw away eleven translations.
-    ///
-    /// Space Bar leads, matching everywhere else it does — the
-    /// omnipresent bar, and the first card on the page — so a
-    /// bare "bar" query lists the leading bar's row above App
-    /// Bar's.
     let spaceBarCard = SettingsControl(
         "bars.switch.space_bar",
         "Space Bar"
     )
-    /// One "Style" drawer per card, co-rendered on the one page,
-    /// so each carries its own instance id — the twice-mounted
-    /// shape (#277) that a shared declaration would make
-    /// `scrollTo`-undefined.
     let spaceBarStyle = SettingsDrawer(
         "bars.style",
         "Style",
@@ -230,9 +164,6 @@ struct BarsControls: Sendable {
         "Style",
         instance: "app_bar"
     )
-    /// The two "Show it in" rows, titled by their layout's name
-    /// (the keys `LayoutMode.displayName` authors). Distinct
-    /// keys, so no instance tag is needed.
     let monocleShowIn = SettingsControl(
         "layout.monocle.name",
         "Monocle"

--- a/Sources/KiwiDesk/Settings/SettingsControl.swift
+++ b/Sources/KiwiDesk/Settings/SettingsControl.swift
@@ -1,7 +1,12 @@
 import KiwiDeskCore
 
-/// Descriptor for searchable, revealable settings control with stable anchor
-/// ID (#277).
+/// Descriptor for a searchable, revealable settings control
+/// (#277). Identity is `id`, never the text: label-text `.id()`
+/// churn would tear down rows holding uncommitted `@State`
+/// drafts and keyboard focus mid-edit (Appearance renders
+/// "Color" six times at once). Declared once in `SettingsCatalog`
+/// and read by BOTH the render site and the search index — one
+/// list, and it is the render path (parity-tests.md).
 struct SettingsControl: Hashable, Sendable {
     private enum Label: Hashable, Sendable {
         case tuple(key: String, english: String)
@@ -131,7 +136,10 @@ extension AnySettingsDrawer {
         )
     }
 
-    /// Whether drawer must expand to reveal target control ID.
+    /// Whether the drawer must expand to reveal `target`. True
+    /// only for an INTERIOR control — a direct hit on the drawer's
+    /// own label deliberately does not expand it (part-1 design
+    /// call, do not relitigate).
     func shouldExpand(revealing target: String?) -> Bool {
         guard let target else { return false }
         return childIDs.contains(target)
@@ -181,7 +189,12 @@ enum SettingsControlIndex {
         return out
     }
 
-    /// Identifies stored members that failed catalog enumeration.
+    /// Stored members `entries(in:)` did NOT enumerate. Always
+    /// empty for a well-formed catalog; the guard fails loudly
+    /// otherwise, so a member shape the enumerator drops becomes
+    /// a test failure instead of a rendered-but-unsearchable hole.
+    /// (A computed `var` is invisible to `Mirror`; a source scan
+    /// guards that separately.)
     static func unenumerated(in container: Any) -> [String] {
         var out: [String] = []
         for child in Mirror(reflecting: container).children {

--- a/Sources/KiwiDesk/Settings/SettingsControl.swift
+++ b/Sources/KiwiDesk/Settings/SettingsControl.swift
@@ -1,27 +1,7 @@
 import KiwiDeskCore
 
-/// One searchable, revealable thing in the Settings GUI (#277):
-/// its localized label, the local surface that must be selected
-/// for it to be on screen, and a **stable anchor id** that is
-/// independent of the label text.
-///
-/// Declared once, in `SettingsCatalog`, and read by BOTH the
-/// render site (which takes the descriptor and shows
-/// `control.text`) and the search index (which enumerates the
-/// catalog by reflection) — one list, and it is the render path,
-/// so there is no hand-mirrored index to drift from the views
-/// (`.claude/rules/parity-tests.md`).
-///
-/// Identity is `id`, never the text. Part 1 anchored by resolved
-/// label text, which is measured-dead one level down: Appearance
-/// renders "Color" six times simultaneously, and
-/// `SlotSizeRows.sizeLabel` swaps with a sibling picker — text
-/// `.id()` churn would tear down rows holding uncommitted
-/// `@State` drafts and keyboard focus mid-edit. The id is the
-/// `L()` key, prefixed by an `instance` tag when one declaration
-/// per co-mounted view is needed (the Bars page's two "Style"
-/// and two "Advanced colors" drawers co-render, so each mount
-/// takes its own descriptor and `scrollTo` stays well-defined).
+/// Descriptor for searchable, revealable settings control with stable anchor
+/// ID (#277).
 struct SettingsControl: Hashable, Sendable {
     private enum Label: Hashable, Sendable {
         case tuple(key: String, english: String)
@@ -29,14 +9,12 @@ struct SettingsControl: Hashable, Sendable {
     }
 
     private let label: Label
-    /// The local branch that must be showing before this
-    /// control exists in the view tree at all.
+    /// Surface that must be active for this control to appear in view
+    /// hierarchy.
     var surface: SettingsSurface = .main
     private let instanceTag: String?
 
-    /// The one tuple-literal shape `scripts/extract-keys` scans
-    /// (beside `L(...)` and `SettingsDrawer(...)`): key and
-    /// English must be adjacent string literals.
+    /// Tuple literal shape scanned by `scripts/extract-keys`.
     init(
         _ key: String,
         _ english: String,
@@ -48,9 +26,7 @@ struct SettingsControl: Hashable, Sendable {
         self.instanceTag = instance
     }
 
-    /// A Layout Defaults mode tab. Text routes through
-    /// `LayoutMode.displayName`, so the mode-name tuples keep
-    /// their one home in `LayoutModeGlyph.swift`.
+    /// Layout Defaults mode tab descriptor.
     static func layoutMode(_ mode: LayoutMode) -> SettingsControl {
         SettingsControl(mode: mode)
     }
@@ -61,8 +37,7 @@ struct SettingsControl: Hashable, Sendable {
         self.instanceTag = nil
     }
 
-    /// The scroll-anchor id — what the reveal
-    /// modifiers tag and what `SettingsAnchor.anchor` carries.
+    /// Scroll-anchor identifier for search reveal navigation.
     var id: String {
         switch label {
         case .tuple(let key, _):
@@ -73,7 +48,7 @@ struct SettingsControl: Hashable, Sendable {
         }
     }
 
-    /// The `L()` key, or nil for a mode tab. For the guards.
+    /// Localization key or nil for layout mode tabs.
     var key: String? {
         switch label {
         case .tuple(let key, _): return key
@@ -81,7 +56,7 @@ struct SettingsControl: Hashable, Sendable {
         }
     }
 
-    /// The resolved, localized label the user sees.
+    /// Resolved localized label string.
     @MainActor var text: String {
         switch label {
         case .tuple(let key, let english):
@@ -92,13 +67,8 @@ struct SettingsControl: Hashable, Sendable {
     }
 }
 
-/// A disclosure drawer's label control plus its interior
-/// controls, declared as one nested value so the
-/// control→parent-drawer relation has exactly one home: the
-/// render site mounts this value (`SettingsDisclosure`), and the
-/// index recurses into it — never a hand-maintained parent
-/// column, whose drift mode is "add a row, forget the parent,
-/// reveal scrolls into a subtree that was never built".
+/// Nested settings disclosure drawer descriptor linking label control to
+/// children (#277).
 struct SettingsDrawer<Children> {
     let control: SettingsControl
     let children: Children
@@ -122,8 +92,7 @@ struct SettingsDrawer<Children> {
 
 extension SettingsDrawer: Sendable where Children: Sendable {}
 
-/// A drawer whose interior is not cataloged yet (#277 fills
-/// iteratively).
+/// Placeholder for drawers without cataloged children (#277).
 struct SettingsNoChildren: Sendable {}
 
 extension SettingsDrawer where Children == SettingsNoChildren {
@@ -143,8 +112,7 @@ extension SettingsDrawer where Children == SettingsNoChildren {
     }
 }
 
-/// Type-erased view of a drawer for the reflection enumerator
-/// and the `SettingsDisclosure` auto-expand decision.
+/// Type-erased drawer interface for reflection and auto-expansion.
 protocol AnySettingsDrawer {
     var control: SettingsControl { get }
     var childContainer: Any { get }
@@ -155,7 +123,7 @@ extension SettingsDrawer: AnySettingsDrawer {
 }
 
 extension AnySettingsDrawer {
-    /// Ids of every control inside the drawer, at any depth.
+    /// Control IDs of all descendants within this drawer.
     var childIDs: Set<String> {
         Set(
             SettingsControlIndex.entries(in: childContainer)
@@ -163,33 +131,21 @@ extension AnySettingsDrawer {
         )
     }
 
-    /// Whether revealing `target` requires this drawer open.
-    ///
-    /// True only for an *interior* control. A direct hit on the
-    /// drawer's own label deliberately does not expand it — the
-    /// header is visible and highlighted, and opening it is one
-    /// honest click (part-1 design call, do not relitigate).
+    /// Whether drawer must expand to reveal target control ID.
     func shouldExpand(revealing target: String?) -> Bool {
         guard let target else { return false }
         return childIDs.contains(target)
     }
 }
 
-/// One enumerated control: the descriptor, the drawer label
-/// above it (nil at top level), and the catalog property path
-/// that declared it — the token the source-scanning guards look
-/// for at render sites.
+/// Catalog entry metadata emitted by reflection walker (`parity-tests.md`).
 struct SettingsIndexEntry {
     let control: SettingsControl
     let parent: SettingsControl?
     let propertyPath: [String]
 }
 
-/// Reflection over the catalog's declarations: every stored
-/// `SettingsControl` and every `SettingsDrawer` (label first,
-/// then its children, depth-first, in declaration order). Adding
-/// a declaration is indexing it — there is no second list to
-/// forget.
+/// Reflection walker over `SettingsCatalog` declarations.
 enum SettingsControlIndex {
     static func entries(in container: Any) -> [SettingsIndexEntry] {
         var out: [SettingsIndexEntry] = []
@@ -225,16 +181,7 @@ enum SettingsControlIndex {
         return out
     }
 
-    /// Property paths of stored members `entries(in:)` did NOT
-    /// enumerate — anything that is neither a `SettingsControl`
-    /// nor a `SettingsDrawer`, at any depth. Always empty for a
-    /// well-formed catalog; the catalog guard fails loudly when it
-    /// is not, so a member shape the enumerator silently drops (a
-    /// `[SettingsControl]` collection, a stray helper) becomes a
-    /// test failure instead of a rendered-but-unsearchable hole —
-    /// the exact silent-gap class the one-list design exists to
-    /// close. (A *computed* `var` is invisible to `Mirror` and so
-    /// to this walk too; a source scan guards that separately.)
+    /// Identifies stored members that failed catalog enumeration.
     static func unenumerated(in container: Any) -> [String] {
         var out: [String] = []
         for child in Mirror(reflecting: container).children {

--- a/Sources/KiwiDesk/Settings/SettingsDraftDiff.swift
+++ b/Sources/KiwiDesk/Settings/SettingsDraftDiff.swift
@@ -81,6 +81,11 @@ struct SettingsDraftDiff {
                 }
             }
         }
+        // A master's followers have no row of their own, so the
+        // master owns their leaves outright — an OVERRIDE, not
+        // first-wins: the follower's surfaceless census row claims
+        // its own path above and would book a second change for a
+        // value the user set once.
         for (key, paths) in SettingKey.masterWrites {
             for path in paths { bases[path] = key }
         }
@@ -109,8 +114,12 @@ struct SettingsDraftDiff {
         }
     }
 
-    /// Normalizes path keys by replacing instance identifiers with `[]`
-    /// (`guard-prover 2026-08-04`).
+    /// Normalizes path keys by replacing instance identifiers
+    /// with `[]`. Redundant with `censusBases()`' container-prefix
+    /// registration BY DESIGN — each is the other's only backup
+    /// (guard-prover 2026-08-04: deleting either alone leaves the
+    /// suite green through the other). Do not "simplify" one away
+    /// on the strength of a green run.
     private static func normalized(_ path: String) -> String {
         var result = ""
         var rest = Substring(path)

--- a/Sources/KiwiDesk/Settings/SettingsDraftDiff.swift
+++ b/Sources/KiwiDesk/Settings/SettingsDraftDiff.swift
@@ -1,41 +1,16 @@
 import KiwiDeskCore
 
-/// The per-setting view of the draft (#678 turn 9): which
-/// settings differ between the edited `GuiConfig` and the clean
-/// baseline, counted for the Home header's "N unsaved changes"
-/// button and grouped by area for its popover. One draft, one
-/// diff — the footer's dirty flag and this must never disagree,
-/// which `SettingsDraftDiffTests` holds by construction
-/// (`total == 0` exactly when the configs are equal).
-///
-/// The walk mirrors the census's path convention — struct
-/// fields as `.name` segments, dictionaries as `[]`, scalars
-/// and enums as leaves — which is the convention
-/// `SettingKeyModelParityTests` already proves the census's
-/// `settings.*` ids share. A changed leaf therefore resolves to
-/// its `SettingKey` by longest matching census base; several
-/// leaves under one setting (a per-space override dictionary, a
-/// master/value pair) count as ONE changed setting. Where a
-/// master's leaves are NOT under it — the two border masters
-/// write across the model — the prefix cannot see them, so the
-/// fan-out is declared in `SettingKey.masterWrites` and folded
-/// in below.
+/// Per-setting diff between draft `GuiConfig` and baseline (#678,
+/// `SettingsDraftDiffTests`).
 struct SettingsDraftDiff {
-    /// The distinct settings that differ, resolved to census
-    /// keys where the path has an owner.
+    /// Distinct settings that differ, resolved to census keys.
     var changedSettings: [SettingKey] = []
-    /// Changed leaf paths no census base claims. Empty in any
-    /// healthy diff — the guard keeps the attribution total, so
-    /// a `GuiConfig` field landing outside the map reds a test
-    /// instead of silently vanishing from the count.
+    /// Changed leaf paths not claimed by any census base.
     var unattributed: [String] = []
-    /// Whether the raw `init.lua` text differs from its baseline.
+    /// True if raw `init.lua` text differs from baseline.
     var luaChanged = false
 
-    /// The button's N: distinct changed settings, plus one for
-    /// an edited init.lua (the raw editor is one surface, not a
-    /// per-key edit), plus any unattributed stragglers so the
-    /// count can never read lower than the dirty flag implies.
+    /// Total count of changed settings, Lua edit, and unattributed paths.
     var total: Int {
         changedSettings.count + unattributed.count
             + (luaChanged ? 1 : 0)
@@ -66,8 +41,6 @@ struct SettingsDraftDiff {
                 orphans.insert(path)
             }
         }
-        // Census declaration order, so the popover lists changes
-        // the way the areas list their rows.
         diff.changedSettings = SettingKey.allCases.filter {
             keys.contains($0)
         }
@@ -75,25 +48,12 @@ struct SettingsDraftDiff {
         return diff
     }
 
-    // MARK: - Path → SettingKey attribution
-
-    /// Whether a census id names a model path the walk can
-    /// book — `settings.*` for `TilingSettings` fields and
-    /// `config.*` for `GuiConfig`'s top-level ones. The ONE
-    /// copy of that key-space: `censusBases()` builds the
-    /// attribution from it and the readout totality net
-    /// (`SettingsValueReadoutTests`) consults it, so the two
-    /// cannot drift apart.
+    /// True if census id names a model path (`SettingsValueReadoutTests`).
     static func namesModelPath(_ id: String) -> Bool {
         id.hasPrefix("settings.") || id.hasPrefix("config.")
     }
 
-    /// The census's model-path ids (`namesModelPath`),
-    /// normalized exactly as `SettingKeyModelParityTests`
-    /// normalizes the settings half (synthetic row suffixes
-    /// stripped, instance brackets `[space]`/`[app]`/`[n]` →
-    /// `[]`). Action/readonly/state ids name no model path and
-    /// stay out.
+    /// Normalized census model-path bases (`SettingKeyModelParityTests`).
     static func censusBases() -> [String: SettingKey] {
         var bases: [String: SettingKey] = [:]
         for key in SettingKey.allCases {
@@ -111,13 +71,7 @@ struct SettingsDraftDiff {
                     with: "[]"
                 )
             }
-            // First declaration wins: variants of one setting
-            // (auto/value pairs) share a base and must resolve
-            // to ONE key, or the count double-books a change.
             if bases[base] == nil { bases[base] = key }
-            // A dictionary setting also owns its container's
-            // own leaves — the walk's `.count` sentinel and any
-            // sibling the bracket form cannot prefix-match.
             if let bracket = base.range(of: "[]") {
                 let container = String(
                     base[..<bracket.lowerBound]
@@ -127,14 +81,6 @@ struct SettingsDraftDiff {
                 }
             }
         }
-        // A master's followers have no row of their own, so the
-        // master owns their leaves outright — an OVERRIDE, not
-        // a first-wins registration, because the follower's own
-        // surfaceless census row claims its own path in the
-        // loop above and would book a second change for a
-        // value the user set once. Prefix matching cannot do
-        // this: these leaves sit outside the master's subtree
-        // (`SettingKey.masterWrites`).
         for (key, paths) in SettingKey.masterWrites {
             for path in paths { bases[path] = key }
         }
@@ -163,22 +109,14 @@ struct SettingsDraftDiff {
         }
     }
 
-    /// `settings.gapsOverride[]1.outer.top` →
-    /// `settings.gapsOverride[].outer.top`.
-    ///
-    /// Redundant with `censusBases()`' container-prefix
-    /// registration by design, and each is the other's ONLY
-    /// backup (guard-prover 2026-08-04: deleting either alone
-    /// leaves the suite green through the other) — do not
-    /// "simplify" one away on the strength of a green run.
+    /// Normalizes path keys by replacing instance identifiers with `[]`
+    /// (`guard-prover 2026-08-04`).
     private static func normalized(_ path: String) -> String {
         var result = ""
         var rest = Substring(path)
         while let open = rest.range(of: "[]") {
             result += rest[..<open.upperBound]
             rest = rest[open.upperBound...]
-            // Drop the entry key: everything up to the next
-            // path separator.
             if let next = rest.firstIndex(where: {
                 $0 == "." || $0 == "["
             }) {
@@ -190,11 +128,7 @@ struct SettingsDraftDiff {
         return result + rest
     }
 
-    // MARK: - The walk
-
-    /// Leaf paths → display-agnostic value descriptions. Only
-    /// EQUALITY of two walks is consumed; the strings never
-    /// reach the screen.
+    /// Leaf paths mapped to value descriptions for comparison.
     static func leaves(of config: GuiConfig) -> [String: String] {
         var result: [String: String] = [:]
         walk(config.settings, at: "settings", into: &result)
@@ -226,9 +160,6 @@ struct SettingsDraftDiff {
                 result[path] = "nil"
             }
         case .dictionary:
-            // Dictionary order is unstable, so entries key by
-            // THEIR OWN key's description under `[]` — two walks
-            // of equal dictionaries then produce equal maps.
             for entry in mirror.children {
                 let pair = Mirror(reflecting: entry.value)
                     .children.map(\.value)
@@ -251,9 +182,6 @@ struct SettingsDraftDiff {
                 )
             }
         case .collection, .set:
-            // Order matters for arrays (the space list IS its
-            // order); sets stringify order-independently via a
-            // sorted dump.
             if mirror.displayStyle == .set {
                 let parts = mirror.children
                     .map { String(describing: $0.value) }

--- a/Sources/KiwiDesk/Settings/SettingsModel+AutoStart.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+AutoStart.swift
@@ -1,43 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The auto-start status, lifted out of `LoginItemCard`'s own
-/// `@State` (#678 item 16).
-///
-/// It lived in the card while ONE control read it. Turn 14b draws
-/// two rows in two different containers — the login toggle under
-/// "Applies immediately", the crash-restart toggle among
-/// Advanced's five — and a second section cannot see another
-/// view's `@State`, so the status has to belong to something both
-/// can reach.
-///
-/// Two things follow that are worth stating, because they are the
-/// reason this is a lift rather than a copy:
-///
-/// - **The pair is still folded.** Both rows write through
-///   `AutoStartLevel.level(openAtLogin:restartOnCrash:)`, so the
-///   contradiction *login off + restart on* cannot be expressed
-///   even though two independent-looking toggles now exist.
-/// - **The gate becomes answerable.** While the status sat in a
-///   view, `.runtime(.loginItemServiceStatus)` could only be
-///   resolved inline beside the control, which is what forced it
-///   to be declared "resolved elsewhere". Reading it from the
-///   model is what lets the area's gate resolver answer it like
-///   any other row.
-///
-/// Read-through is preserved exactly: no cached bool, every
-/// mutation re-reads, and `AutoStartManager` keeps doing the
-/// blocking launchctl work off the main actor.
+/// Auto-start status and mutations for Settings (#678, #1071).
 extension SettingsModel {
-    /// Re-reads the live level. Safe to call repeatedly — the
-    /// card calls it on appear and whenever the app reactivates,
-    /// because the user may have changed the login item in System
-    /// Settings while away.
-    /// Skipped while a write is in flight: a `didBecomeActive`
-    /// landing mid-write could publish a PRE-write read after the
-    /// write's own re-read, transiently showing a stale level.
-    /// The write re-reads from OS truth anyway, so nothing is
-    /// lost by deferring to the next event.
+    /// Re-reads the live auto-start status from LaunchServices / launchctl.
     func refreshAutoStart() {
         guard !autoStartBusy else { return }
         Task {
@@ -47,25 +13,8 @@ extension SettingsModel {
         }
     }
 
-    /// The Settings switch's setter: the LOGIN ITEM only
-    /// (#1071). Crash supervision is the CLI's, and this path
-    /// reaches no `ServiceManager` call, so a click taken on a
-    /// stale status cannot unload a service the user started
-    /// from a terminal.
-    ///
-    /// The registerability refusal is the same one
-    /// `setAutoStart` carries, and for the same #342 reason: a
-    /// translocated or bare copy would register a login item
-    /// pointing at an ephemeral path, which read-through cannot
-    /// undo. It lives here rather than in the view because the
-    /// harm is a filesystem side effect.
+    /// Sets login item enabled state (#1071, #342).
     func setLoginItem(_ enabled: Bool, reduceMotion: Bool) {
-        // The service owns the answer while it is loaded, so
-        // the model refuses here and not only in the view — a
-        // grey is never the sole gate on a side effect, and
-        // this one writes an OS registration (gui.md). Found by
-        // `greyAndRefusalAgree` once it read the real setter
-        // instead of a copy of the resolver's predicate.
         guard autoStart.level != .atLoginWithAutoRestart else {
             return
         }
@@ -88,22 +37,7 @@ extension SettingsModel {
         }
     }
 
-    /// Shows the confirmation for `level` and schedules its fade.
-    ///
-    /// 2.5 s, longer than the key recorder's 1.5 s
-    /// (`KeyRecorderField`) on purpose: that caption is a short
-    /// phrase read mid-interaction while the user watches for the
-    /// next chord, whereas these are full sentences read once
-    /// after a single click, so the reading load is ~double.
-    /// Don't "align" it back to 1.5 s.
-    ///
-    /// `reduceMotion` comes from the caller's environment, the
-    /// same way `flipSettingsMode` takes it — a model has no
-    /// environment of its own to read. With it on the caption
-    /// appears and leaves without the cross-fade: the house
-    /// split keeps the affordance and drops only the motion,
-    /// and the confirmation IS the affordance here (nothing
-    /// else says the level applied).
+    /// Displays confirmation for `level` and schedules fade (2.5s duration).
     private func flashAutoStart(
         _ level: AutoStartLevel,
         reduceMotion: Bool
@@ -119,19 +53,12 @@ extension SettingsModel {
         }
     }
 
-    /// A transient block that is NOT a gate reason: the first read
-    /// has not landed, or a write is in flight. The rows grey while
-    /// it holds, but there is no sentence — nothing is wrong, the
-    /// live value is simply not known yet.
+    /// True while initial status read or a write is in flight.
     var autoStartLoading: Bool {
         !autoStartLoaded || autoStartBusy
     }
 
-    /// The area's gate resolver over the live status. The rows
-    /// consult THIS for their durable greying and its sentence,
-    /// rather than re-deriving each predicate inline — the same
-    /// shape `LayoutCard` takes with `LayoutDefaultsGates`, so the
-    /// census-declared owner and the on-screen grey cannot drift.
+    /// Gate resolver for General section auto-start rows.
     var generalGates: GeneralGates {
         GeneralGates(autoStart: autoStart)
     }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Globals.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Globals.swift
@@ -3,7 +3,11 @@ import KiwiDeskCore
 
 /// Global settings persistence for `gui.json` (#516).
 extension SettingsModel {
-    /// Copies all `gui.json`-owned global fields from `source` into `target`.
+    /// Copies the `gui.json`-owned global fields — the ONE field
+    /// list, and both consumers ("did a global change?" and
+    /// "adopt as clean") go through it: two hand-kept copies drift
+    /// silently into a save that never clears the footer, or a
+    /// footer that never offers the save.
     static func copyGlobals(
         from source: GuiConfig,
         into target: inout GuiConfig
@@ -24,9 +28,23 @@ extension SettingsModel {
         return probe != saved
     }
 
-    /// Persists `gui.json` globals when AX is off (#516, #335).
+    /// Writes `gui.json` and nothing else (#516) — no global
+    /// field has a monitor dependency, so the #335 gate that
+    /// rightly blocks profile saves while AX is off must not
+    /// reach them. Its own narrow method on purpose: routing
+    /// through `persist(named:)` drags in warnings naming a
+    /// profile this save never touched.
     func saveGlobalsWhilePaused() {
+        // Self-guarding on the CANONICAL predicate: a write that
+        // can seize config ownership must not depend on its only
+        // caller remembering to check (§5 — refine the one
+        // `isGuiManaged` predicate, never mirror it).
         guard core.isGuiManaged else { return }
+        // The spaces freshness net runs here too — but only when
+        // live is trustworthy: on an AX-off cold boot it would
+        // append StateCoordinator's boot default and the saved
+        // list silently grows a spurious "1" on every save
+        // (caught by a probe: the save wrote ["work","mail","1"]).
         if core.state.workspaces.allSpaces.map(\.id)
             != [SpaceID(1)]
         {
@@ -38,6 +56,12 @@ extension SettingsModel {
         }
         do {
             if core.lua == nil {
+                // Cold paused boot: core.start() never ran, so a
+                // reload here would be the session's FIRST — it
+                // would execute init.lua, register hotkeys and
+                // retile while the dashboard says "paused". Write
+                // the store directly; start() picks the file up
+                // when permission arrives.
                 try core.guiConfigStore.save(config)
             } else {
                 try core.saveGuiConfig(config)
@@ -62,6 +86,10 @@ extension SettingsModel {
         savedSidecar = sidecar
         recomputeDirty()
         refreshProfiles()
+        // The recorder's rollback point was minted against the
+        // pre-save modes; every other save path retires it, and a
+        // stale one silently reverts a staged action edit on the
+        // next recorder change.
         liveKeySession = nil
     }
 }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Globals.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Globals.swift
@@ -1,18 +1,9 @@
 import Foundation
 import KiwiDeskCore
 
-/// Saving `gui.json` globals, split from
-/// `SettingsModel+Profiles.swift` for the file ceiling (#516).
-///
-/// The one field list lives here, and both consumers go through
-/// it: "did a global change?" and "adopt the globals as clean".
+/// Global settings persistence for `gui.json` (#516).
 extension SettingsModel {
-    /// The fields `gui.json` owns, in ONE place. Both consumers
-    /// — "did a global change?" and "adopt the globals as
-    /// clean" — go through this, so a seventh global cannot be
-    /// added to one and forgotten in the other. Two hand-kept
-    /// copies would drift silently: a save that never clears
-    /// the footer, or a footer that never offers the save.
+    /// Copies all `gui.json`-owned global fields from `source` into `target`.
     static func copyGlobals(
         from source: GuiConfig,
         into target: inout GuiConfig
@@ -33,42 +24,9 @@ extension SettingsModel {
         return probe != saved
     }
 
-    // MARK: - Saving globals while paused (#516)
-
-    /// Writes `gui.json` and nothing else.
-    ///
-    /// None of the six global fields has a monitor dependency,
-    /// so the #335 gate that blocks profile saves while
-    /// Accessibility is off — a profile persisted then would
-    /// record a degenerate 0-screen set and never resolve —
-    /// should never have reached them. It did, because
-    /// `saveGuiConfig` had exactly one caller and that caller
-    /// was behind the gate.
-    ///
-    /// Its own narrow method on purpose: routing through
-    /// `persist(named:)` would drag along the overlapping-
-    /// monitor-set warning and a "Saving failed" message that
-    /// names a profile this save never touched.
+    /// Persists `gui.json` globals when AX is off (#516, #335).
     func saveGlobalsWhilePaused() {
-        // Self-guarding, and on the CANONICAL predicate. The
-        // footer's classifier also checks this, but a write that
-        // can seize config ownership must not depend on its only
-        // caller remembering to (AGENTS §5: refine the one
-        // `isGuiManaged` predicate, never mirror it).
         guard core.isGuiManaged else { return }
-        // `spaces` is one of the six, so its freshness net runs
-        // here too — without it a space created live while the
-        // dashboard sat open is pruned on save.
-        //
-        // But ONLY when live is trustworthy. The net appends
-        // every live space the staged list lacks, so on an
-        // Accessibility-off cold boot it appends
-        // `StateCoordinator`'s boot default and the user's saved
-        // list silently grows a spurious "1" on every save. That
-        // state cannot have live-created spaces to rescue —
-        // the engine never started — so the net has nothing to
-        // do and is skipped. (Caught by a probe after the seed
-        // fix: the save wrote ["work", "mail", "1"].)
         if core.state.workspaces.allSpaces.map(\.id)
             != [SpaceID(1)]
         {
@@ -76,31 +34,12 @@ extension SettingsModel {
                 into: &config,
                 seededWith: seedSpaces
             )
-            // `reload()` normally re-seeds this; this path skips
-            // reload by design, so without the hand re-seed a
-            // merged-in space can never be deleted again this
-            // session — the next merge's `known` set would miss
-            // it while live still holds it, and re-append it.
             seedSpaces = config.spaces
         }
         do {
             if core.lua == nil {
-                // Cold paused boot: `core.start()` never ran, so
-                // `saveGuiConfig`'s reload would be the session's
-                // FIRST — it would execute init.lua, register
-                // Carbon hotkeys (which need no Accessibility and
-                // so would genuinely fire), apply a profile
-                // against an empty display set and retile, all
-                // while the dashboard says "paused". Write the
-                // store directly instead; `core.start()` picks the
-                // file up when permission arrives. Two precedents
-                // do exactly this for the same reason —
-                // `syncGuiSpacesToLive` and `topUpDigitShortcuts`.
                 try core.guiConfigStore.save(config)
             } else {
-                // Revoked mid-session: the engine is running and
-                // keybindings still fire, so the new modes and
-                // rules must reach it now.
                 try core.saveGuiConfig(config)
             }
         } catch {
@@ -115,32 +54,14 @@ extension SettingsModel {
         adoptGlobalsBaseline()
     }
 
-    /// Marks ONLY the global fields clean.
-    ///
-    /// Deliberately not `reload()`: nothing was written for the
-    /// profile/tiling side, so re-seeding from disk would throw
-    /// away staged tiling edits this save never persisted. If
-    /// tiling is also dirty the footer must keep saying so.
+    /// Marks global fields clean without wiping unpersisted tiling edits.
     private func adoptGlobalsBaseline() {
         Self.copyGlobals(from: config, into: &cleanConfig)
         var sidecar = savedSidecar ?? config
         Self.copyGlobals(from: config, into: &sidecar)
         savedSidecar = sidecar
         recomputeDirty()
-        // The write may have reloaded the config, and that can
-        // load a DIFFERENT profile via the native-Space binding
-        // (SkyLight works without Accessibility), so the footer's
-        // profile state and drift caption would be stale. Safe
-        // here where `reload()` is not: `refreshProfiles` never
-        // touches `config`, so the staged tiling edits this
-        // partial-clean contract protects are untouched.
         refreshProfiles()
-        // The recorder's rollback point was minted against the
-        // pre-save modes. Every other save path retires it —
-        // `saveLuaSource` nils it outright, `persist` reaches
-        // `restoreLiveKeySessionIfNeeded` via reload — and a
-        // stale one silently reverts a staged action edit on the
-        // next recorder change.
         liveKeySession = nil
     }
 }

--- a/Sources/KiwiDesk/Settings/SettingsSearchField.swift
+++ b/Sources/KiwiDesk/Settings/SettingsSearchField.swift
@@ -5,11 +5,19 @@ import SwiftUI
 /// `SettingsView.chrome`).
 struct SettingsSearchField: View {
     @Binding var text: String
-    /// Shared FocusState binding for programmatic focus (⌘K).
+    /// Focus, owned by the caller: the field lives as long as the
+    /// window, so it must NOT grab focus on appear — but ⌘K must
+    /// put focus here from anywhere, and that shortcut belongs to
+    /// the header. A `FocusState` binding is how the two share
+    /// one focus.
     let focus: FocusState<Bool>.Binding
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
-    /// Moves result highlight while maintaining field focus.
+    /// Moves the highlighted result while focus stays in the
+    /// field. No default value, deliberately: a default on a
+    /// required collaboration is fail-open — a call site that
+    /// forgot it would get a silently mouse-only field, the bug
+    /// this parameter exists to fix.
     let onMove: (MoveCommandDirection) -> Void
     /// Commits selection and performs search reveal.
     let onCommit: () -> Void
@@ -49,7 +57,16 @@ struct SettingsSearchField: View {
         .font(.body)
         .focused(focus)
         .onExitCommand { text = "" }
+        // `onKeyPress`, not `onMoveCommand`: the latter has no
+        // pass-through and would swallow ←/→, and the
+        // `KeyEquivalent` overload matches whatever the modifiers
+        // are — claiming ↑/↓ there also ate ⇧↑ and ⌘↑.
         .onKeyPress { press in
+            // Subtracting, not `isEmpty`: AppKit reports an arrow
+            // key with `.function` and `.numericPad` set, so an
+            // isEmpty test refuses EVERY bare arrow and silently
+            // kills the navigation this exists to restore — a
+            // green build says nothing about it.
             guard
                 press.modifiers.intersection(
                     [.shift, .command, .option]
@@ -91,6 +108,10 @@ struct SettingsSearchField: View {
     private var fieldShape: some View {
         ChipMetrics.shape
             .fill(SettingsTheme.sunken)
+            // Full-strength accent: `.plain` removes the system
+            // focus ring, so this stroke IS the focus indicator —
+            // blended at 0.55 it measured 1.52:1, below what the
+            // platform ring it replaces delivers.
             .overlay {
                 ChipMetrics.shape
                     .strokeBorder(

--- a/Sources/KiwiDesk/Settings/SettingsSearchField.swift
+++ b/Sources/KiwiDesk/Settings/SettingsSearchField.swift
@@ -1,41 +1,19 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The System Settings-style search field (#90), since #678
-/// turn 9 mounted inside the header's search popover rather
-/// than a sidebar. Hand-built chrome, not `.searchable`: the
-/// window's toolbar is deliberately empty (see
-/// `SettingsView.chrome`), so SwiftUI's toolbar-managed
-/// placement would reopen exactly that brittle interaction.
-/// Matches the `AppPickerButton` / `IconPicker` field
-/// precedent instead.
+/// Search input field with keyboard navigation and shortcut hint (#90, #678,
+/// `SettingsView.chrome`).
 struct SettingsSearchField: View {
     @Binding var text: String
-    /// Focus, owned by the caller. The field mounts in the header
-    /// and lives as long as the window does, so it must NOT grab
-    /// focus on appear — but ⌘K has to be able to put focus here
-    /// from anywhere, and that shortcut belongs to the header. A
-    /// `FocusState` binding is how the two share one focus.
+    /// Shared FocusState binding for programmatic focus (⌘K).
     let focus: FocusState<Bool>.Binding
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
-    /// Moves the highlighted result while focus stays in the
-    /// field, System Settings-style. Without this the results
-    /// were mouse-only: the `List` never takes focus while the
-    /// user is typing, so ↑/↓ went nowhere.
-    ///
-    /// No default value, deliberately: a default on a required
-    /// collaboration is fail-open — a second call site that forgot
-    /// it would get a silently mouse-only field, which is the bug
-    /// this parameter exists to fix.
+    /// Moves result highlight while maintaining field focus.
     let onMove: (MoveCommandDirection) -> Void
-    /// Return reveals the highlighted result. Separate from
-    /// `onMove` on purpose — arrowing navigates (cheap), Return
-    /// commits to the scroll and flash.
+    /// Commits selection and performs search reveal.
     let onCommit: () -> Void
-    /// The ⌘K hint, shown only while the field is empty and
-    /// unfocused — once someone is typing it is noise, and it
-    /// would sit where the clear button belongs.
+    /// Whether to display ⌘K shortcut hint when empty and unfocused.
     let shortcutHint: Bool
 
     var body: some View {
@@ -62,10 +40,6 @@ struct SettingsSearchField: View {
         TextField(
             "",
             text: $text,
-            // `ink3`, not `.secondary.opacity(0.42)` (~1.64:1):
-            // the field carries no visible label, so the prompt
-            // is the only thing naming the control and cannot be
-            // a whisper.
             prompt: Text(
                 L("search.placeholder", "Search")
             )
@@ -74,24 +48,8 @@ struct SettingsSearchField: View {
         .textFieldStyle(.plain)
         .font(.body)
         .focused(focus)
-        // Escape clears, matching `NSSearchField`.
         .onExitCommand { text = "" }
-        // `onKeyPress`, not `onMoveCommand`: the latter has no
-        // pass-through, so it would swallow ←/→ and break caret
-        // movement inside the field. Returning `.ignored` for
-        // anything else is the whole point — including for a
-        // MODIFIED arrow. The `KeyEquivalent` overload matches
-        // whatever the modifiers are, so claiming ↑/↓ there also
-        // ate ⇧↑ (extend selection to start) and ⌘↑ (caret to
-        // start), two standard text-editing shortcuts.
         .onKeyPress { press in
-            // Subtracting, not `isEmpty`: AppKit reports an arrow
-            // key with `.function` and `.numericPad` set, so an
-            // `isEmpty` test can refuse EVERY bare arrow and
-            // silently kill the navigation this exists to restore
-            // — a green build says nothing about it either way.
-            // Only the three intent-carrying modifiers may claim
-            // the key back for text editing.
             guard
                 press.modifiers.intersection(
                     [.shift, .command, .option]
@@ -109,17 +67,12 @@ struct SettingsSearchField: View {
             }
         }
         .onSubmit(onCommit)
-        // Explicit name, so accessibility does not depend on
-        // the placeholder staying non-decorative.
         .accessibilityLabel(
             L("search.placeholder", "Search")
         )
     }
 
-    /// Clearing is a control, not a choice (the icon picker's
-    /// rule): an explicit affordance instead of
-    /// select-all-delete, shown only while there is something
-    /// to clear.
+    /// Clear text button affordance.
     private var clearButton: some View {
         Button {
             text = ""
@@ -134,22 +87,10 @@ struct SettingsSearchField: View {
         )
     }
 
-    /// The chip shape the header row's other tokens use, not the
-    /// `Capsule` this shipped as: the field sits between the back
-    /// chip and the profile chip, and a pill among rounded rects
-    /// reads as a different KIND of thing. Keyboard focus gets the
-    /// restrained accent outline of System Settings, not SwiftUI's
-    /// oversized default halo.
+    /// Header chip-shaped background and custom focus ring (#1069).
     private var fieldShape: some View {
         ChipMetrics.shape
             .fill(SettingsTheme.sunken)
-            // Full-strength accent, not 0.55: `.textFieldStyle`
-            // `.plain` removes the system focus ring, so this
-            // stroke IS the focus indicator and there is nothing
-            // underneath it. Blended at 0.55 over `sunken` it
-            // measured 1.52:1 against the field — a focus state
-            // that replaces the platform's must be at least as
-            // legible as the one it replaced.
             .overlay {
                 ChipMetrics.shape
                     .strokeBorder(
@@ -165,9 +106,6 @@ struct SettingsSearchField: View {
                 ),
                 radius: 2
             )
-            // The focus outline is the indicator and must not
-            // wait on motion to appear; Reduce Motion drops the
-            // fade and it simply lands (#1069).
             .animation(
                 reduceMotion ? nil : .easeOut(duration: 0.12),
                 value: focus.wrappedValue

--- a/Sources/KiwiDesk/Settings/SettingsView+Chrome.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Chrome.swift
@@ -1,35 +1,19 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The shell's chrome — the one header bar, the two banners,
-/// the content, and the save surface in whichever form the
-/// measured band gives it (#678 turn 9, responsive since 17a).
-/// Split from `SettingsView` at the §2.1 ceiling; what stays
-/// there is the shell's routing and its state.
+/// Settings window shell chrome: header, banners, content, and save surface
+/// (#678, 17a).
 extension SettingsView {
 
-    /// Banner + footer wrapper shared by both modes, so the
-    /// profile banner and three-verb footer stay put whether the
-    /// raw Lua editor or the structured detail is showing.
+    /// Shared chrome wrapper for detail and raw config editor.
     @ViewBuilder func chrome(
         _ width: SettingsWidthClass,
         @ViewBuilder _ content: () -> some View
     ) -> some View {
         VStack(spacing: 0) {
             SettingsHeaderBar(model: model)
-                // The header's search results hang BELOW the bar
-                // as an overlay (see `HeaderSearch`), and a
-                // `VStack` paints its children in order, so
-                // without this lift the content below draws over
-                // the list. Not cosmetic — it is what makes the
-                // results visible at all.
+                // Lift header z-index so search dropdown paints over content.
                 .zIndex(1)
-            // Paused-permission banner outranks the per-section
-            // Lua banner: it renders in the shared chrome (every
-            // section *and* the raw Lua editor), because missing
-            // Accessibility makes the whole dashboard inert, not
-            // just one tab. Gated here (not self-gating) so the
-            // padding never reserves empty space when trusted.
             if model.permissionPaused {
                 PermissionPausedBanner(
                     onResolve: model.onResolvePermission
@@ -37,61 +21,28 @@ extension SettingsView {
                 .padding(.horizontal, 12)
                 .padding(.top, 10)
             }
-            // The one-line mode-switch confirmation (#678 4c):
-            // a search pick into a Power-User-only area flips
-            // the mode silently (`ensureModeAdmits`), and this
-            // line is the only place that says so. Transient —
-            // the model clears it itself.
             if let notice = model.searchModeNotice {
                 SettingsSearchNotice(text: notice)
                     .padding(.horizontal, 12)
                     .padding(.top, 10)
             }
-            // `ClickAwayResignsFocus` installs a window-scoped
-            // mouse-down monitor (#93) that commits an edited
-            // field when the click lands outside it. It's a
-            // zero-size, hit-test-transparent probe, so the ZStack
-            // order is incidental — it never intercepts clicks.
             ZStack {
                 ClickAwayResignsFocus()
                 content()
             }
-            // Above BOTH panes on purpose: the segment is always
-            // in the header, so a flip can wash Home's inserted
-            // cards or an in-area surface alike (#760). One
-            // mount; the model owns the timeline.
             .environment(
                 \.settingsModeReveal,
                 model.modeRevealActive
             )
-            // The offer to summon the detached preview. Below
-            // the card's own overlay because it exists only
-            // when the card does not — they are never both on
-            // screen, so their order is free.
             .overlay(alignment: .bottomTrailing) {
                 showPreviewOffer(width)
             }
-            // The save pill floats OVER the content instead of
-            // docking below it (#678 turn 9; owner 2026-08-09
-            // overturned the docked-footer ruling). An overlay
-            // never reserves layout space, so the content keeps
-            // the full height while the pill exists only when
-            // the draft does. Bottom-centred on the CONTENT
-            // column; `detailPane` offsets it past the preview
-            // panel when one is docked.
-            //
-            // Below the row breakpoint it stops floating and
-            // becomes the sibling bar below — see the branch
-            // after this stack. The overlay is EMPTY there
-            // rather than conditionally applied, so the content
-            // subtree's identity survives the crossing.
+            // Save pill floats over content when undocked (#678, owner ruling
+            // 2026-08-09).
             .overlay(alignment: .bottom) {
                 if !width.docksSavePill {
                     SettingsFooter(model: model)
                         .padding(.bottom, 22)
-                        // Centred on the CONTENT column: half
-                        // the panel's width, the prototype's
-                        // own `calc(50% - 196px)`.
                         .offset(
                             x: panelDocked(width)
                                 ? -SettingsTheme.panelWidth / 2
@@ -99,35 +50,17 @@ extension SettingsView {
                         )
                 }
             }
-            // The detached card goes on LAST, and the order is
-            // the whole point: `.overlay` composes outward, so
-            // whatever is applied last paints and hit-tests
-            // above everything before it. Mounted before the
-            // pill — as it was first written — a card dragged
-            // low is covered by the pill, and its grab bar
-            // loses clicks to a control it is sitting on top
-            // of (code review, 2026-08-11).
+            // Detached preview overlays above save pill (code review
+            // 2026-08-11).
             .overlay(alignment: .topTrailing) {
                 detachedPreview(width)
             }
-            // "Same content, same three verbs, different
-            // physics" (17a): at this width a floating pill
-            // sits on top of the rows it is about, so it docks
-            // into a real footer bar — a SIBLING, which reserves
-            // its own height, rather than an overlay. The one
-            // component in the shell that changes kind.
+            // Docks save pill as sibling footer on narrow width classes (17a).
             if width.docksSavePill {
                 SettingsFooter(model: model, docked: true)
             }
         }
-        // The page, behind everything. Opaque and flat — the
-        // prototype carries no vibrancy, and the header's `.bar`
-        // material was what read as a third grey.
         .background(SettingsTheme.page)
-        // Pull the detail up under the (empty) unified toolbar
-        // so the header bar sits flush at the top — no empty
-        // toolbar strip above it — while the sidebar keeps the
-        // traffic lights over its full height.
         .ignoresSafeArea(.container, edges: .top)
     }
 }

--- a/Sources/KiwiDesk/Settings/SettingsView+Chrome.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Chrome.swift
@@ -14,6 +14,10 @@ extension SettingsView {
             SettingsHeaderBar(model: model)
                 // Lift header z-index so search dropdown paints over content.
                 .zIndex(1)
+            // The paused banner outranks the per-section Lua one:
+            // missing Accessibility makes the whole dashboard
+            // inert. Gated here (not self-gating) so the padding
+            // never reserves empty space when trusted.
             if model.permissionPaused {
                 PermissionPausedBanner(
                     onResolve: model.onResolvePermission
@@ -26,10 +30,18 @@ extension SettingsView {
                     .padding(.horizontal, 12)
                     .padding(.top, 10)
             }
+            // `ClickAwayResignsFocus` installs a window-scoped
+            // mouse-down monitor (#93) committing an edited field
+            // when a click lands outside it — a zero-size,
+            // hit-test-transparent probe.
             ZStack {
                 ClickAwayResignsFocus()
                 content()
             }
+            // Above BOTH panes on purpose (#760): the segment is
+            // always in the header, so a flip can wash Home's
+            // inserted cards or an in-area surface alike — one
+            // mount, the model owns the timeline.
             .environment(
                 \.settingsModeReveal,
                 model.modeRevealActive
@@ -39,6 +51,9 @@ extension SettingsView {
             }
             // Save pill floats over content when undocked (#678, owner ruling
             // 2026-08-09).
+            // The overlay is EMPTY below the row breakpoint
+            // rather than conditionally applied, so the content
+            // subtree's identity survives the crossing.
             .overlay(alignment: .bottom) {
                 if !width.docksSavePill {
                     SettingsFooter(model: model)

--- a/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
@@ -2,21 +2,11 @@ import KiwiDeskCore
 import SwiftUI
 
 extension SettingsView {
-    /// The pushed area's pane. Split out of `SettingsView` when
-    /// the shell's theme wiring took that file past the §2.1
-    /// ceiling — pure routing, and the one place the twelve areas
-    /// are named, so it is the part that reads best alone.
-    ///
-    /// Takes the destination rather than reading `selection`: that
-    /// property is `private`, and an extension in a second file
-    /// cannot see it. Passing it also makes the pane a function of
-    /// its argument, which is what it always was.
+    /// Renders the section pane for `selection`.
     @ViewBuilder func detail(
         _ selection: SettingsDestination?
     ) -> some View {
         switch selection {
-        // nil is Home, which mounts instead of this pane —
-        // unreachable here, but the switch must be total.
         case nil:
             EmptyView()
         case .spaces:
@@ -46,25 +36,12 @@ extension SettingsView {
         }
     }
 
-    /// The two-column detail (digest §1.1): the flexing content
-    /// column, then — where the area offers one AND the window
-    /// is wide enough to seat it (17a) — the fixed preview panel
-    /// behind a hairline. The offer is consulted through
-    /// `SettingsDetailPanelOffer` only; an area outside the set
-    /// takes the full width, which is the prototype's stated
-    /// rule for areas with nothing to show, and an offering area
-    /// below 1200 pt keeps its preview as the detached card
-    /// instead (`SettingsView+Preview`).
+    /// Two-column detail hosting content and docked preview panel (17a).
     @ViewBuilder func detailPane(
         _ width: SettingsWidthClass
     ) -> some View {
         HStack(spacing: 0) {
             contentColumn
-            // `panelDocked` FIRST, the same predicate the
-            // pill's centring offset reads — one conjunct
-            // added there must move the pill and the mount
-            // together (review 2026-08-10; the two had
-            // already drifted on the `editingLua` half).
             if panelDocked(width),
                 let destination = model.destination
             {
@@ -86,24 +63,10 @@ extension SettingsView {
                 Divider()
                     .padding(.top, 10)
             }
-            // ONE reader for all ten sections (#277), above the
-            // `switch` rather than wrapped around each section's
-            // own `ScrollView`: the proxy scrolls any scroll view
-            // in its subtree that holds the id, so ten per-section
-            // wrappers would buy nothing and drift.
+            // Single reader across all sections (#277).
             ScrollViewReader { proxy in
                 detail(model.destination)
-                    // Every section's root is its own scroll
-                    // view, which VoiceOver lands on as a bare
-                    // "scroll area" (owner, #812 session 2);
-                    // the area's title names it, as the panel's
-                    // header names the panel's.
                     .accessibilityLabel(model.destination?.title ?? "")
-                    // The wide-window cap (owner 2026-08-10):
-                    // rows never stretch past the widest column
-                    // the prototype drew; the surplus becomes
-                    // symmetric margin. Inside the reader so the
-                    // reveal proxy still spans the pane.
                     .frame(
                         maxWidth: SettingsTheme.contentMaxWidth
                     )
@@ -111,16 +74,7 @@ extension SettingsView {
                         maxWidth: .infinity,
                         alignment: .center
                     )
-                    // The in-area half of the flip's reflow
-                    // (#760): Home's grid animates its own, and
-                    // an area the user is standing in animates
-                    // the surfaces the flip inserts (the
-                    // drawer, the Layers card, the per-row
-                    // offers) the same 0.3 s instead of popping
-                    // them in — one mount for all ten panes,
-                    // keyed on the mode so nothing else rides
-                    // it. Reduce Motion stands down; the wash
-                    // and frame still answer.
+                    // Animated surface reflow on mode switch (#760).
                     .animation(
                         reduceMotion
                             ? nil
@@ -129,20 +83,6 @@ extension SettingsView {
                             ),
                         value: model.settingsMode
                     )
-                    // The panes' top gutter, spent here rather
-                    // than as padding inside each one: a content
-                    // margin moves what "top of the viewport"
-                    // means, so `scrollTo(anchor: .top)` lands a
-                    // revealed card with the same gutter above it
-                    // that a pane's first card has at rest —
-                    // where padding would only have pushed the
-                    // resting content down and left the scrolled
-                    // card just as flush.
-                    //
-                    // One call site, not ten: the margin
-                    // propagates to every scroll view below,
-                    // which is the same reach the one
-                    // `ScrollViewReader` above already relies on.
                     .contentMargins(
                         .top,
                         SettingsMetrics.paneInset,
@@ -168,10 +108,7 @@ extension SettingsView {
         }
     }
 
-    /// Phase 2: scrolls the pane to `anchor` and flashes it, then
-    /// clears the request. Runs after `apply` has selected the
-    /// destination and surface, so the target exists or is about
-    /// to.
+    /// Scrolls pane to `anchor` and triggers highlight flash.
     func reveal(
         _ anchor: String?,
         proxy: ScrollViewProxy
@@ -179,17 +116,8 @@ extension SettingsView {
         guard let anchor else { return }
         model.nav.pendingScroll = nil
         revealTask?.cancel()
-        // Captured, so a task that outlives its pane bails instead
-        // of relying on the id being absent from the new one.
-        // Cross-destination duplicate labels are legitimate (only
-        // one destination mounts), and nothing guards them — this
-        // stale window is the single place where that would bite.
         let destination = model.destination
         revealTask = Task { @MainActor in
-            // Yield one pass first: `apply` may have just flipped
-            // the surface that *creates* the target view, and
-            // asking the proxy for an id in the same synchronous
-            // pass as the state change that mints it misses.
             await Task.yield()
             withAnimation(
                 reduceMotion
@@ -205,28 +133,15 @@ extension SettingsView {
                 !Task.isCancelled,
                 model.destination == destination
             else { return }
-            // Re-issue, un-animated. One cooperative yield drains
-            // queued main-actor work but does not promise SwiftUI
-            // has LAID OUT the new subtree, so the first
-            // `scrollTo` can be a silent no-op — and then the wash
-            // would paint off-screen and the user would see
-            // nothing at all. Layout has certainly run by now; if
-            // the first attempt landed, this is a no-op.
             proxy.scrollTo(anchor, anchor: .top)
             let token = model.nav.startFlash(anchor)
-            // Under Reduce Motion the wash has no fade to live
-            // through — clearing removes it instantly — so the
-            // hold absorbs the fade's duration instead. Without
-            // this the accessibility branch gets a 0.3 s cue
-            // against everyone else's 1.2 s, which is backwards.
+            // Under Reduce Motion, hold absorbs fade duration.
             try? await Task.sleep(
                 nanoseconds: SettingsReveal.nanoseconds(
                     SettingsReveal.hold
                         + (reduceMotion ? SettingsReveal.fade : 0)
                 )
             )
-            // Clearing is what triggers the fade — the modifier
-            // keeps no timer of its own.
             model.nav.endFlash(token: token)
         }
     }

--- a/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
@@ -42,6 +42,10 @@ extension SettingsView {
     ) -> some View {
         HStack(spacing: 0) {
             contentColumn
+            // `panelDocked` FIRST — the same predicate the pill's
+            // centring offset reads: a conjunct added there must
+            // move the pill and the mount together (review
+            // 2026-08-10; the two had already drifted once).
             if panelDocked(width),
                 let destination = model.destination
             {
@@ -66,6 +70,10 @@ extension SettingsView {
             // Single reader across all sections (#277).
             ScrollViewReader { proxy in
                 detail(model.destination)
+                    // Every section's root is a scroll view,
+                    // which VoiceOver lands on as a bare "scroll
+                    // area" (owner, #812 session 2) — the area's
+                    // title names it.
                     .accessibilityLabel(model.destination?.title ?? "")
                     .frame(
                         maxWidth: SettingsTheme.contentMaxWidth
@@ -116,6 +124,10 @@ extension SettingsView {
         guard let anchor else { return }
         model.nav.pendingScroll = nil
         revealTask?.cancel()
+        // Captured, so a task that outlives its pane bails —
+        // cross-destination duplicate labels are legitimate and
+        // unguarded; this stale window is the one place they
+        // would bite.
         let destination = model.destination
         revealTask = Task { @MainActor in
             await Task.yield()
@@ -133,6 +145,10 @@ extension SettingsView {
                 !Task.isCancelled,
                 model.destination == destination
             else { return }
+            // Re-issue, un-animated: one yield drains main-actor
+            // work but does not promise SwiftUI has LAID OUT the
+            // new subtree, so the first scrollTo can be a silent
+            // no-op — and the wash would paint off-screen.
             proxy.scrollTo(anchor, anchor: .top)
             let token = model.nav.startFlash(anchor)
             // Under Reduce Motion, hold absorbs fade duration.

--- a/Sources/KiwiDesk/StatusItemController+Menu.swift
+++ b/Sources/KiwiDesk/StatusItemController+Menu.swift
@@ -1,37 +1,16 @@
 import AppKit
 import KiwiDeskCore
 
-/// The quick menu (#68 §3.10): rebuilt on every open so the
-/// profile list and the conditional warning rows are always
-/// current. The icon state machine lives in the main
-/// `StatusItemController` file.
+/// Status bar quick menu builder (#68 §3.10, #802).
 extension StatusItemController {
     func menuNeedsUpdate(_ menu: NSMenu) {
         menu.removeAllItems()
-        // Every row below states its own `isEnabled` (#802): with
-        // AppKit's auto-enabling on, a row is enabled iff its
-        // action validates, so a row that WORKS cannot be greyed
-        // for a reason of ours — which is exactly what boot needs
-        // for Layout and Switch Profile. The cost is that a
-        // nil-action row is no longer disabled for free, so each
-        // one says so.
         menu.autoenablesItems = false
         let profiles = profilesProvider()
         let phase = bootPhase
 
-        // Problem zone (top): warning rows appear only when they
-        // apply, so a healthy menu opens straight on Layout with
-        // no permanent chrome above it. A missing permission
-        // blocks everything, so it outranks a broken-config
-        // issue. The fence separator is derived from presence —
-        // "fence iff a warning exists" stays structural, so a
-        // future third warning source can't forget it.
         var warnings: [NSMenuItem] = []
         if warning {
-            // A loud row naming the *consequence* (not the jargon
-            // "Accessibility"); click routes to the onboarding
-            // grant step — the app's one "why + how" explainer —
-            // not a bare System Settings link.
             let paused = NSMenuItem(
                 title: L(
                     "menu.accessibility_paused",
@@ -50,12 +29,6 @@ extension StatusItemController {
             warnings.append(paused)
         }
         if case .scanning = phase {
-            // A determinate count, deliberately in words: menus
-            // carry no progress bars, and the honest number is
-            // apps LOOKED AT of apps the boot queue admits —
-            // `BootPhase` argues both halves of that count.
-            // Disabled, monochrome, and gone the moment boot ends;
-            // the rows it explains are greyed below.
             let status = NSMenuItem(
                 title: Self.startingTitle(for: phase),
                 action: nil,
@@ -63,10 +36,6 @@ extension StatusItemController {
             )
             status.isEnabled = false
             warnings.append(status)
-            // Retitled in place while the menu stays open
-            // (`setBootPhase`) — a menu opened at second 2 of a
-            // ten-second boot would otherwise report second 2 for
-            // as long as the user holds it.
             startingRow = status
         } else {
             startingRow = nil
@@ -81,9 +50,6 @@ extension StatusItemController {
                 keyEquivalent: ""
             )
             issues.target = self
-            // A warning triangle makes the entry unmissable in
-            // the quick menu; safe from the §3.7 status-glyph
-            // distinction here because the row is text-labeled.
             issues.image = symbol("exclamationmark.triangle.fill")
             warnings.append(issues)
         }
@@ -92,24 +58,12 @@ extension StatusItemController {
             menu.addItem(.separator())
         }
 
-        // Daily actions — Layout first (the most-used control),
-        // Switch Profile under it: same topic, no separator
-        // between them. Switch Profile appears only when there is
-        // something to switch *to* — a saved profile that isn't the
-        // active one and isn't broken; with none, switching is a
-        // no-op or impossible, so the row is pure noise.
         let hasSwitchTarget = profiles.all.contains {
             $0 != profiles.active
                 && !profiles.broken.contains($0)
         }
-        // A disabled context line naming the active profile — shown
-        // only when a profile is loaded *and* a real alternative
-        // exists to switch to (the same gate as the Switch Profile
-        // row). With one profile or none there is no choice to
-        // orient, so the name would be permanent chrome the
-        // declutter (#324) removed. Any profile is loadable
-        // regardless of screen count (#36), so this does not filter
-        // by display setup.
+        // Active profile header shown only when alternative targets exist
+        // (#324, #36).
         if let active = profiles.active, hasSwitchTarget {
             let current = NSMenuItem.sectionHeader(
                 title: L(
@@ -120,10 +74,7 @@ extension StatusItemController {
             )
             menu.addItem(current)
         }
-        // Grey, don't hide (#171): both act on state the scan has
-        // not finished collecting, and both will work in a
-        // moment — which is the case dimming is for. The starting
-        // row above is the sentence that says why.
+        // Dim rather than hide during boot scanning (#171).
         let layout = layoutItem()
         layout.isEnabled = !phase.isStarting
         menu.addItem(layout)
@@ -133,10 +84,7 @@ extension StatusItemController {
             menu.addItem(switcher)
         }
 
-        // App chrome: Settings sits low, next to Quit, as in
-        // every native menu-bar extra — not mid-list among the
-        // workspace actions. "View Shortcuts…" shares Settings'
-        // separator group and reads glance → editor (#326).
+        // App chrome (#326).
         menu.addItem(.separator())
         let shortcutsTitle = L(
             "menu.view_shortcuts",
@@ -291,17 +239,13 @@ extension StatusItemController {
             ?? LayoutKeyGlyph.char(for: code)?.lowercased()
     }
 
-    // MARK: - Actions
-
     @objc private func openDashboard() {
         onOpenDashboard()
     }
 
     @objc private func showShortcuts(_ sender: NSMenuItem) {
-        // AppKit needs a real key equivalent to render its native
-        // trailing column, but Carbon already owns this shortcut
-        // globally. Ignore AppKit's duplicate keyboard action;
-        // mouse selection and programmatic dispatch still toggle.
+        // Carbon owns shortcut globally; ignore AppKit's duplicate keyDown
+        // event.
         if NSApp.currentEvent?.type == .keyDown { return }
         onShowShortcuts()
     }

--- a/Sources/KiwiDeskCore/App/FollowFocusIntent.swift
+++ b/Sources/KiwiDeskCore/App/FollowFocusIntent.swift
@@ -1,87 +1,20 @@
 import Foundation
 
-/// The focus a `move_to_desktop_and_follow` still owes the window
-/// it sent away (#1007).
-///
-/// **Why an intent rather than a focus call.** macOS attaches
-/// keyboard focus to a WINDOW, never to a screen, so switching
-/// another screen's Desktop is the whole of what the switch can
-/// do. At the moment of the move the window is not addressable —
-/// it sits on a Desktop nobody is showing, so Accessibility does
-/// not list it — and focusing it has to wait until the reveal
-/// makes it real. This records that debt.
-///
-/// **Bounded rather than open-ended, deliberately.** A follow
-/// macOS declined — or one whose Desktop the user never returns
-/// to — must not fire minutes later and yank focus to a window
-/// they have forgotten about.
-///
-/// The record needs no say in the close-return raise: the
-/// departure it describes is the #1023 eager fold, which is
-/// synchronous and already stands that raise down through the
-/// stand-down predicate's own arm
-/// (`EventLoop.eagerDepartureInFlight`) — no other removal of
-/// the followed window can reach the fold, because the fold
-/// also releases the event loop's registration.
-///
-/// Not an actor and not `Sendable`: it is `@MainActor` state on
-/// `KiwiCore`, declared beside `moveLatch` — the two halves of
-/// one verb's bookkeeping answering opposite questions. That one
-/// suppresses a focus-follow the user did not ask for
-/// (#482/#483, the no-follow move); this one owes a focus they
-/// did.
-///
-/// **A third per-window, time-bounded, re-key-following ledger
-/// is already planned** — #890's pending assignment for the
-/// no-follow Desktop move. If that lands, weigh extending this
-/// rather than minting a third beside it — but know what
-/// transfers and what does not: the per-window record, the time
-/// bound and the rekey-following transfer; the drain key does
-/// NOT (this drains at the owed window's own arrival, #890's at
-/// a DESKTOP's reveal) and neither does the cardinality (focus
-/// is singular; assignments are not).
+/// Tracks deferred focus debt across Desktop switches (#1007,
+/// `FollowFocusIntentTests`).
 @MainActor
 final class FollowFocusIntent {
-    /// How long the focus debt stays claimable: long enough for
-    /// the switch and for the window's app to re-list it on the
-    /// revealed Desktop, with room for a slow app. Past it the
-    /// reveal did not happen and the intent is abandoned, so a
-    /// follow macOS declined cannot fire minutes later.
-    ///
-    /// A slack bound rather than a derived one — nothing in the
-    /// tree measures how long an app takes to answer AX after a
-    /// reveal. Read `FollowFocusIntentTests`' green as holding
-    /// the behavior around the bound, never its magnitude.
+    /// Maximum duration focus debt remains claimable (5.0s, #1007).
     static let drainWindow: TimeInterval = 5.0
 
     private var pending: (window: WindowID, at: Date)?
 
-    /// Record that `id` was deliberately sent to a Desktop the
-    /// user asked to follow it onto.
+    /// Records that `id` was sent to a Desktop the user asked to follow onto.
     func record(_ id: WindowID, at now: Date = Date()) {
         pending = (id, now)
     }
 
-    /// Take the owed focus, if one is still owed and
-    /// `isPayable` says it can be paid now.
-    ///
-    /// **Three outcomes, and the middle one is the reason this
-    /// takes a predicate at all.** A debt that pays is cleared,
-    /// because a debt is paid once. An EXPIRED debt is cleared
-    /// unpaid. A live debt the caller cannot pay yet — the
-    /// window is back on screen but its app has not relisted it
-    /// — is left standing, so a later drain can still pay it
-    /// rather than the first drain swallowing it.
-    ///
-    /// **The unpayable case is rare by construction**, because
-    /// the drain runs at the ARRIVAL — the moment the window
-    /// re-materializes on the revealed Desktop, which is the
-    /// definition of it being addressable again. An earlier draft
-    /// drained at the reveal SETTLE instead and had to reason
-    /// about being too early; worse, a settle is not scoped to
-    /// the window that owes, so an unrelated switch inside
-    /// `drainWindow` would have paid the debt and yanked focus
-    /// mid-swipe (review, #1007).
+    /// Claims owed focus if window is currently payable (#1007).
     func claim(
         at now: Date = Date(),
         if isPayable: (WindowID) -> Bool
@@ -98,17 +31,9 @@ final class FollowFocusIntent {
         return pending.window
     }
 
-    /// Follow a native-tab re-key (#308), so a window that
-    /// changed id mid-flight is still the one we owe focus to.
+    /// Updates tracked window ID across native tab switches (#308).
     func rekey(old: WindowID, new: WindowID) {
         guard let pending, pending.window == old else { return }
         self.pending = (new, pending.at)
     }
-
-    /// Diagnosis is narrated at the two ends rather than read
-    /// out of here: the recorder logs the debt and the payer
-    /// logs the payment, so a trace carrying the first without
-    /// the second is a window that never came back — a symptom
-    /// otherwise indistinguishable from the bug being fixed, on
-    /// a subsystem whose only channel is `log stream`.
 }

--- a/Sources/KiwiDeskCore/App/FollowFocusIntent.swift
+++ b/Sources/KiwiDeskCore/App/FollowFocusIntent.swift
@@ -1,7 +1,19 @@
 import Foundation
 
-/// Tracks deferred focus debt across Desktop switches (#1007,
-/// `FollowFocusIntentTests`).
+/// The focus a `move_to_desktop_and_follow` still owes the window
+/// it sent away (#1007, `FollowFocusIntentTests`). An intent, not
+/// a focus call: macOS attaches focus to a WINDOW, and at the
+/// moment of the move the window sits on an unshown Desktop where
+/// AX does not list it. Bounded deliberately — an unpaid debt
+/// must not fire minutes later. It needs no say in the
+/// close-return raise: the #1023 eager fold already stands that
+/// down via `EventLoop.eagerDepartureInFlight`. Declared beside
+/// `moveLatch` — one verb's bookkeeping answering opposite
+/// questions (that one SUPPRESSES an unasked follow, #482/#483;
+/// this one OWES an asked one). Before minting a third such
+/// ledger (#890's pending no-follow assignment), weigh extending
+/// this — the per-window record, time bound and rekey transfer
+/// carry over; the drain key and cardinality do NOT.
 @MainActor
 final class FollowFocusIntent {
     /// Maximum duration focus debt remains claimable (5.0s, #1007).
@@ -14,7 +26,13 @@ final class FollowFocusIntent {
         pending = (id, now)
     }
 
-    /// Claims owed focus if window is currently payable (#1007).
+    /// Claims the owed focus if `isPayable` says it can be paid
+    /// now (#1007). Three outcomes: paid clears, EXPIRED clears
+    /// unpaid, and a live-but-unpayable debt is left standing for
+    /// a later drain. The drain runs at the ARRIVAL, deliberately:
+    /// a settle is not scoped to the owing window, so an unrelated
+    /// switch inside the window would have paid the debt and
+    /// yanked focus mid-swipe (review, #1007).
     func claim(
         at now: Date = Date(),
         if isPayable: (WindowID) -> Bool
@@ -32,6 +50,10 @@ final class FollowFocusIntent {
     }
 
     /// Updates tracked window ID across native tab switches (#308).
+    /// Follows a native-tab re-key (#308). Diagnosis is narrated
+    /// at the two ends (recorder logs the debt, payer logs the
+    /// payment) — a trace carrying the first without the second is
+    /// a window that never came back.
     func rekey(old: WindowID, new: WindowID) {
         guard let pending, pending.window == old else { return }
         self.pending = (new, pending.at)

--- a/Sources/KiwiDeskCore/App/TeardownRestack.swift
+++ b/Sources/KiwiDeskCore/App/TeardownRestack.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-/// Controls verified quit-grid raise sequencing across display groups (#688).
+/// Controls verified quit-grid raise sequencing across display
+/// groups (#688). Main-actor bound, deliberately unlike
+/// `ZOrderDrain`: this runs entirely inside the quit path, and
+/// marking it `Sendable` would force its seams to give up their
+/// access to `KiwiCore`.
 @MainActor
 struct TeardownRestack {
     /// Whether process holds Accessibility trust.
@@ -21,8 +25,13 @@ struct TeardownRestack {
     /// Raises each display group's circle until groups or budget are
     /// exhausted.
     func run(_ circles: [(display: UInt32, order: [WindowID])]) {
-        // Skip raises if Accessibility permission is missing (#688, code
-        // review 2026-08-03).
+        // `stop()` also runs mid-session on an AX REVOKE, and
+        // that path must not reach the drain: every raise lands
+        // nothing while the WindowServer read keeps answering
+        // (CGWindowList needs no AX grant) — the drain is not
+        // blind, merely never satisfied, and would spend the
+        // whole budget sleeping for landings that cannot come
+        // (#688, code review 2026-08-03).
         guard isTrusted() else {
             log(
                 "gatherWindows: no Accessibility permission — "
@@ -46,6 +55,13 @@ struct TeardownRestack {
                 let drain = drain(order, policy.limited(to: remaining))
             else { continue }
             let raised = drain.run(order)
+            // NOT `raised.count < order.count`: the drain raises
+            // only what is out of place, so fewer than the circle
+            // names is ordinary success. The clock is the signal
+            // (this policy drops its tail, so `run` returns only
+            // on a finished plan or a spent budget), and
+            // `!raised.isEmpty` removes the already-correct
+            // group's false positive (code review, 2026-08-03).
             guard !raised.isEmpty, now() >= deadline else { continue }
             log(
                 "gatherWindows: raise budget spent on display "

--- a/Sources/KiwiDeskCore/App/TeardownRestack.swift
+++ b/Sources/KiwiDeskCore/App/TeardownRestack.swift
@@ -1,67 +1,28 @@
 import Foundation
 
-/// The quit-grid raise circle's control flow, with every machine
-/// effect an injected seam — the same shape `ZOrderDrain` uses, and
-/// for the same reason (#688).
-///
-/// It exists because the decisions here are the ones a quit gets
-/// exactly one shot at, and they were guarded only by a source-text
-/// scan: seven `#expect(source.contains(…))` needles re-typing the
-/// body, which red on renaming a local and pass on `budget * 2`
-/// (architect review, 2026-08-03). Behind these seams they are
-/// ordinary unit tests instead. The wiring scan stays, narrowed to
-/// what it is actually good at — proving the real seams are the
-/// ones bound in production.
-///
-/// What it owns, in order: refuse to run at all without the
-/// Accessibility grant; drop the one window no quiet raise can beat;
-/// give each display group only what is LEFT of the whole-quit wall
-/// clock; and stop dead once that clock is spent rather than
-/// spending more of it issuing raises it can no longer verify.
-/// Main-actor bound, deliberately unlike `ZOrderDrain`: that one
-/// crosses to `zOrderQueue` and so is `Sendable` with `@Sendable`
-/// seams, while this runs entirely inside the quit path on the
-/// actor that calls it. Marking it `Sendable` would only force its
-/// seams to give up their access to `KiwiCore`.
+/// Controls verified quit-grid raise sequencing across display groups (#688).
 @MainActor
 struct TeardownRestack {
-    /// Whether the process still holds the Accessibility grant.
+    /// Whether process holds Accessibility trust.
     let isTrusted: () -> Bool
-    /// The frontmost app's key window, if any — the one member a
-    /// quiet raise cannot lift anything above, so the one the
-    /// circle drops rather than orders around.
+    /// Frontmost app key window that quiet raises cannot beat.
     let unbeatable: () -> WindowID?
-    /// Monotonic seconds.
+    /// Monotonic clock provider (seconds).
     let now: () -> TimeInterval
-    /// Builds the drain for one display group's circle. Returns nil
-    /// when none of the group's windows can be reached (no AX
-    /// element), which is not the same as an empty circle.
+    /// Builds `ZOrderDrain` for a display group's raise circle.
     let drain:
         ([WindowID], ZOrderDrain.Policy) ->
             ZOrderDrain?
-    /// Diagnostics.
+    /// Diagnostic logger.
     let log: (String) -> Void
-    /// The whole-quit policy. One value, so the deadline below and
-    /// every group's drain cannot be sized from different things.
+    /// Teardown raise policy and overall time budget.
     let policy: ZOrderDrain.Policy
 
-    /// Raises each group's circle in turn, verified, until the
-    /// groups run out or the wall clock does.
-    ///
-    /// `circles` is one raise order per display group, already in
-    /// `QuitGridLayout.raiseOrder` order and already filtered to
-    /// windows the gather actually placed.
+    /// Raises each display group's circle until groups or budget are
+    /// exhausted.
     func run(_ circles: [(display: UInt32, order: [WindowID])]) {
-        // `stop()` also runs mid-session when the AX permission is
-        // REVOKED (`KiwiCore+Lifecycle`), and that path must not
-        // reach the drain. Every raise there lands nothing, while
-        // the WindowServer read keeps answering — it reads
-        // `CGWindowList`, which needs no AX grant — so the drain is
-        // not blind, it is merely never satisfied: it would plan
-        // the whole circle and spend the entire budget sleeping for
-        // landings that cannot come. The loop this replaced cost
-        // nothing there, so the gate is not an optimization, it is
-        // that regression's fix (code review, 2026-08-03).
+        // Skip raises if Accessibility permission is missing (#688, code
+        // review 2026-08-03).
         guard isTrusted() else {
             log(
                 "gatherWindows: no Accessibility permission — "
@@ -74,17 +35,6 @@ struct TeardownRestack {
         for circle in circles {
             let remaining = deadline - now()
             guard remaining > 0 else {
-                // These groups are not raised at all, so their
-                // piles keep whatever stacking the moves left them.
-                //
-                // The same answer the drain gives its own tail
-                // (`policy.spendsBudgetOnUnverifiedTail` is false
-                // for teardown), and for the same reason rather
-                // than by accident: once the wall clock is spent,
-                // issuing anything costs a blocking AX call per
-                // window that the budget has no room left to pay
-                // for. Dropping is what the bare loop this replaced
-                // did at exactly this boundary.
                 log(
                     "gatherWindows: raise budget exceeded — "
                         + "stacking left partial"
@@ -96,25 +46,6 @@ struct TeardownRestack {
                 let drain = drain(order, policy.limited(to: remaining))
             else { continue }
             let raised = drain.run(order)
-            // A different fact from the one above, so it gets a
-            // different line: this display's circle was started and
-            // stopped part way, so the windows it never reached
-            // keep whatever stacking the moves left them.
-            //
-            // NOT `raised.count < order.count`: the drain raises
-            // only what is out of place, so raising fewer than the
-            // circle names is its ordinary success. The signal is
-            // the clock, which is exact here precisely because this
-            // policy drops its tail — the only way `run` returns is
-            // a finished plan or a spent budget. `!raised.isEmpty`
-            // removes the one false positive that leaves: an
-            // already-correct group returns after a single ~0.4 ms
-            // read having raised nothing (code review,
-            // 2026-08-03). It still over-reports a drain that
-            // finished its whole plan right at the deadline, and
-            // that window is `landingLimit` wide rather than one
-            // poll interval, because `awaitLanding` caps its own
-            // wait at the deadline.
             guard !raised.isEmpty, now() >= deadline else { continue }
             log(
                 "gatherWindows: raise budget spent on display "

--- a/Sources/KiwiDeskCore/Bar/AppBarManager.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarManager.swift
@@ -43,6 +43,8 @@ public final class AppBarManager {
 
     private var overlays: [DisplayID: AppBarOverlay] = [:]
     private var spaceOfDisplay: [DisplayID: SpaceID] = [:]
+    /// The bars actually painted after `sync`'s filter — the one
+    /// source for anything that must sit clear of a bar (#242).
     private var shownBars: [Bar] = []
 
     public init() {}
@@ -64,9 +66,13 @@ public final class AppBarManager {
         }
     }
 
-    /// True when a painted bar is currently rendering or announcing `id`'s
-    /// title
-    /// (#670, #937, 2026-08-20).
+    /// True when a painted bar is currently rendering or
+    /// announcing `id`'s title (#670, 2026-08-20). Deliberately
+    /// NOT gated on `showsText` or the edge (#937): icon-only and
+    /// vertical bars still build their accessibility label from
+    /// the title, and an announced-stale title is as wrong as a
+    /// drawn-stale one. A `count > 1` group draws its APP NAME,
+    /// never a member's title, so a group is not a consumer.
     public func showsTitle(of id: WindowID) -> Bool {
         shownBars.contains { bar in
             bar.items.contains {

--- a/Sources/KiwiDeskCore/Bar/AppBarManager.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarManager.swift
@@ -1,25 +1,17 @@
 import AppKit
 
-/// One app bar per display (#16). Owns an `AppBarOverlay` keyed by
-/// `DisplayID`, so several monitors can each show the bar of the
-/// space currently visible on them at the same time. The driver
-/// (`KiwiCore.updateAppBar`) computes the bars; this manager just
-/// creates, shows, and retires overlays and routes their callbacks.
+/// Manages per-display `AppBarOverlay` instances and event routing (#16,
+/// #293).
 @MainActor
 public final class AppBarManager {
-    /// One display's resolved bar. `space` rides along so a drag
-    /// on that bar reorders the right space (not the global
-    /// active one) — displays other than the focused one host
-    /// their own space's bar.
+    /// Resolved bar configuration and geometry for a single display.
     public struct Bar {
         public let display: DisplayID
         public let space: SpaceID
         public let items: [AppBarOverlay.Item]
         public let activeIndex: Int?
         public let strip: CGRect
-        /// The resolved style; its `edge` is the stored absolute
-        /// edge the bar sits on (#293) — no separate channel, so
-        /// strip and edge can't disagree.
+        /// The resolved style with absolute bar edge (#293).
         public let style: AppBarStyle
 
         public init(
@@ -42,8 +34,7 @@ public final class AppBarManager {
     /// Click-to-focus hook; wired to `KiwiCore.focusWindow`.
     public var onSelect: @MainActor (WindowID) -> Void = { _ in }
     /// Drag reorder hook (space, from slot, to slot); wired to
-    /// `KiwiCore.moveBarItem`. The space is the one whose bar the
-    /// dragged overlay is currently showing.
+    /// `KiwiCore.moveBarItem`.
     public var onMove: @MainActor (SpaceID, Int, Int) -> Void = {
         _,
         _,
@@ -52,27 +43,16 @@ public final class AppBarManager {
 
     private var overlays: [DisplayID: AppBarOverlay] = [:]
     private var spaceOfDisplay: [DisplayID: SpaceID] = [:]
-    /// The bars actually painted after `sync`'s render filter —
-    /// the single source of truth for anything that must sit clear
-    /// of a bar (the #242 float clamp), so it can never disagree
-    /// with what is on screen.
     private var shownBars: [Bar] = []
 
     public init() {}
 
-    /// Displays currently showing a bar; the manager's contract
-    /// surface for tests and diagnostics.
+    /// Displays currently showing an app bar.
     public var shownDisplays: Set<DisplayID> {
         Set(spaceOfDisplay.keys)
     }
 
-    /// Every painted bar as `(space, strip, edge)`. A window
-    /// that must clear a bar (a floating window — #242, all
-    /// four edges since QA 2026-07-19) reads these rendered
-    /// strips rather than re-deriving bar geometry, which
-    /// drifts (outer gaps, empty-bar suppression, per-display
-    /// screen). Covers all displays, so a bar on a non-active
-    /// monitor is included.
+    /// Painted app bar strips across all displays (#242, QA 2026-07-19).
     public var shownStrips: [(space: SpaceID, strip: CGRect, edge: AppBarEdge)]
     {
         shownBars.map {
@@ -84,31 +64,9 @@ public final class AppBarManager {
         }
     }
 
-    /// True when a painted bar is showing `id`'s own window
-    /// title right now — drawing it, or announcing it.
-    ///
-    /// Read from `shownBars` — what `sync` accepted and the
-    /// overlays drew — for the same reason `shownStrips` is:
-    /// a second derivation drifts from what is on screen. The
-    /// title-refresh gate asked its own copy of this question
-    /// until a review found it disagreeing with a driver
-    /// (2026-08-20); everything it had to re-derive (the #670
-    /// stand-down, the screen pick, the empty-bar filter, the
-    /// cold-start fallback) is already folded into this array.
-    ///
-    /// Deliberately NOT gated on `showsText` or the edge (#937).
-    /// Icon-only and vertical bars draw no title text, but
-    /// `AppBarItemView` builds its accessibility label from
-    /// the same title unconditionally, so there the title is
-    /// announced rather than drawn — and a title that is
-    /// announced stale is as wrong as one drawn stale (the
-    /// same rule `SpaceBarManager.showsTitle` follows).
-    ///
-    /// A `count > 1` item draws and announces its APP NAME and
-    /// count, never a member's title (`KiwiCore.barItemText`,
-    /// `AppBarItemView.updateAccessibilityLabel`), so a group
-    /// is not a consumer — exact here, where the groups are the
-    /// painted ones, and only approximable from state.
+    /// True when a painted bar is currently rendering or announcing `id`'s
+    /// title
+    /// (#670, #937, 2026-08-20).
     public func showsTitle(of id: WindowID) -> Bool {
         shownBars.contains { bar in
             bar.items.contains {
@@ -117,9 +75,7 @@ public final class AppBarManager {
         }
     }
 
-    /// The painted strips covering `space` (empty when it shows
-    /// no bar: off, or suppressed because it has no non-floating
-    /// windows).
+    /// Painted app bar strips covering `space`.
     public func strips(
         forSpace space: SpaceID
     ) -> [(strip: CGRect, edge: AppBarEdge)] {
@@ -128,17 +84,9 @@ public final class AppBarManager {
             .map { (strip: $0.strip, edge: $0.edge) }
     }
 
-    /// Shows exactly `bars` — one per display — and retires the
-    /// overlays of any display no longer in the set (passing an
-    /// empty array retires them all). Retiring releases the
-    /// panel, so a display that never returns leaves nothing
-    /// behind.
+    /// Synchronizes painted overlays with `bars`, retiring overlays for
+    /// removed displays.
     public func sync(_ bars: [Bar]) {
-        // A bar whose strip/items can't render is treated as
-        // absent — AppBarOverlay.show would hide it anyway — so
-        // its display retires instead of keeping a stale panel,
-        // and the "shown" bookkeeping (and thus onMove routing)
-        // never claims a display whose panel is hidden.
         let valid = bars.filter {
             !$0.items.isEmpty
                 && $0.strip.width >= 1 && $0.strip.height >= 1
@@ -163,19 +111,13 @@ public final class AppBarManager {
     }
 
     #if DEBUG
-        /// Test seam: the overlay currently backing a display.
         func overlayForTesting(
             _ display: DisplayID
         ) -> AppBarOverlay? {
             overlays[display]
         }
 
-        /// Test seam: the bars `sync` last accepted, items and
-        /// all. `shownStrips` exposes only geometry, which
-        /// cannot answer "what does the item SAY" — the question
-        /// the title refresh exists to change, and the one a
-        /// suite asserting on task identity alone cannot reach
-        /// (`BarTitleRefreshTests.refreshRedrawsTheItem`).
+        /// Test seam: bars accepted by last `sync` (`BarTitleRefreshTests`).
         var shownBarsForTesting: [Bar] { shownBars }
     #endif
 

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
@@ -1,15 +1,6 @@
 import AppKit
 
-/// The app bar: a non-activating panel listing the windows of a
-/// container, one item per window, the active one highlighted
-/// (or left out as a gap). Items that don't fit the strip scroll
-/// instead of shrinking: the bar follows the focused item, and
-/// clickable arrows appear over the ends that hide more items.
-///
-/// Deliberately generic — it renders items into a strip handed
-/// to it in AX coordinates and knows nothing about layouts.
-/// Monocle and scrolling both drive it; Lua-registered custom
-/// layouts can adopt it later without a rewrite.
+/// Non-activating overlay panel displaying window items in AX coordinates.
 @MainActor
 public final class AppBarOverlay {
     /// Click-to-focus hook; wired to `KiwiCore.focusWindow`.
@@ -24,23 +15,14 @@ public final class AppBarOverlay {
         _ in
     }
 
-    /// Depth of the clickable scroll-arrow zones at the
-    /// strip's ends; doubles as the visibility margin the
-    /// active item keeps clear of them. The shared constant
-    /// lives on `BarArrowView` (the Space Bar reuses it, #385).
+    /// Depth of scroll-arrow zones at strip ends (`BarArrowView.zone`, #385).
     nonisolated static let arrowZone = BarArrowView.zone
 
-    /// The inputs of the last `show()`, kept so manual arrow
-    /// scrolling can re-render without a new layout pass from
-    /// the core.
+    /// Cached inputs from last `show()` for manual arrow scrolling.
     private struct RenderState {
         let items: [Item]
         let activeIndex: Int?
         let strip: CGRect
-        /// The already-resolved style (global overlaid by the
-        /// active layout's overrides) — the overlay is
-        /// layout-agnostic. Its `edge` is the stored absolute
-        /// edge the bar sits on (#293).
         let style: AppBarStyle
     }
 
@@ -49,47 +31,25 @@ public final class AppBarOverlay {
     let itemContainer = FlippedView()
     let backArrow = BarArrowView()
     let forwardArrow = BarArrowView()
-    /// The Liquid Glass plate under the items when `backgroundStyle`
-    /// resolves to `material` (#390); nil otherwise / below macOS
-    /// 26. Stored as a plain view — the concrete type is 26-only.
+    /// Liquid Glass plate under items for material background (#390).
     var glassPlate: NSView?
-    /// Per-box Liquid Glass: one `NSGlassEffectView` per item under
-    /// `boxed + liquid_glass`, each hosting its item as `contentView`
-    /// (piece 2). Empty otherwise / below macOS 26. Plain views —
-    /// the concrete type is 26-only (see AppBarOverlay+BoxGlass).
+    /// Per-box Liquid Glass views for `boxed + liquid_glass`.
     var boxGlasses: [NSView] = []
-    /// Solid colored backdrops behind each per-box glass, filled
-    /// with the box Fill so the near-colorless glass refracts a hue
-    /// (#408). Kept parallel to `boxGlasses`. Empty / below macOS 26.
+    /// Solid backdrops behind per-box glass for tint refraction (#408).
     var boxTints: [NSView] = []
-    /// The scroll arrows' own frosted backdrop boxes under per-box
-    /// glass, so they read as glass, not solid islands. The arrow
-    /// stays interactive on top (its own box goes transparent).
+    /// Scroll arrows frosted backdrop boxes.
     var backArrowGlass: NSView?
     var forwardArrowGlass: NSView?
-    /// Colored backdrops behind the arrow glasses (#408), so the
-    /// arrows tint with the boxes instead of staying grey.
+    /// Tinted backdrops behind arrow glasses (#408).
     var backArrowTint: NSView?
     var forwardArrowTint: NSView?
-    /// Colored backdrop behind the single glass plate (plain +
-    /// glass, hug and span), filled with the bar Fill (#408).
+    /// Colored backdrop behind single glass plate (#408).
     var glassTint: NSView?
-    /// `plain`'s shared fill plate — its own view (not the
-    /// container layer) so it can hug the run
-    /// (`background_fit`, QA 2026-07-19).
+    /// Shared fill plate for plain style (`background_fit`, QA 2026-07-19).
     var plainPlate: NSView?
-    /// Under plain + glass when the run fits (no overflow), the
-    /// glass hosts this flipped run wrapper at the hugged plate
-    /// frame with the items positioned run-local inside it — so the
-    /// frosted plate hugs the run instead of spanning the viewport.
-    /// On overflow the glass falls back to hosting `itemContainer`
-    /// at the viewport (piece 1). Empty otherwise / below macOS 26.
+    /// Flipped run wrapper for plain + glass without overflow.
     var glassRun: AppBarOverlay.FlippedView?
-    /// The hugging plate's span geometry from the last render,
-    /// so a reorder drag that begins mid-hug can hand the items
-    /// back to `itemContainer` and span the plate for the drag
-    /// (`spanPlainGlassForDrag`) — the mover and its reflowing
-    /// siblings then share one coordinate space.
+    /// Hugging plate span geometry for reorder drag transitions.
     struct GlassDragSpan {
         let viewport: CGRect
         let radius: CGFloat
@@ -97,8 +57,6 @@ public final class AppBarOverlay {
     }
     var glassDragSpan: GlassDragSpan?
     var scrollOffset: CGFloat = 0
-    /// The last render's geometry, kept for the drag
-    /// handlers (AppBarOverlay+Drag).
     var lastMetrics: Metrics?
     private var lastShown: RenderState?
 
@@ -200,11 +158,6 @@ public final class AppBarOverlay {
             alignment: m.alignment,
             scrolledBy: scrollOffset
         )
-        // The shared plate (plain fill / glass) hugs or spans
-        // per `background_fit`. With no arrow inset the
-        // viewport is the strip, so viewport-local frames are
-        // already strip-local; while inset > 0 the plate is
-        // full anyway.
         let runStart: CGFloat
         if let first = frames.first {
             runStart = m.horizontal ? first.minX : first.minY
@@ -220,15 +173,8 @@ public final class AppBarOverlay {
             horizontal: m.horizontal,
             fit: style.backgroundFit
         )
-        // The one hosting mode for this render (#407): prepared
-        // (non-target teardown) in the animation group below, then
-        // installed post-loop once the item frames are laid out.
         let depth = edge.isHorizontal ? strip.height : strip.width
         let hosting = glassHosting(style, overflow: m.inset > 0)
-        // Frame changes ease into place so group expansion
-        // (and scroll-follow) widens out instead of popping;
-        // fresh views snap. The plates ride the same group —
-        // a hug plate must slide with the items it wraps.
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.15
             context.timingFunction = CAMediaTimingFunction(
@@ -245,10 +191,6 @@ public final class AppBarOverlay {
             )
             for (index, view) in itemViews.enumerated()
             where view.superview === itemContainer {
-                // Items hosted in a glass wrapper (per-box, or the
-                // plain-glass run) are placed by the glass path;
-                // animating them here in container coords would
-                // fight that and flicker.
                 if view.frame == .zero {
                     view.frame = frames[index]
                 } else {
@@ -259,8 +201,7 @@ public final class AppBarOverlay {
         for (index, item) in items.enumerated() {
             let view = itemViews[index]
             let active = index == activeIndex
-            // "gap" indicator: the focused window's slot stays
-            // empty instead of being marked.
+            // "gap" indicator: focused window slot stays empty.
             view.isHidden =
                 active && style.activeIndicator == .gap
             view.configure(
@@ -274,8 +215,6 @@ public final class AppBarOverlay {
                 horizontal: m.horizontal,
                 style: style
             )
-            // Only the run's outer items meet a rounded plate end,
-            // so only they clip their outer corner (Plain).
             view.isFirstInRun = index == 0
             view.isLastInRun = index == items.count - 1
             view.onSelect = { [weak self] id in
@@ -288,11 +227,7 @@ public final class AppBarOverlay {
                 self?.dragEnded(view)
             }
         }
-        // Install the target hosting from the now-laid-out frames
-        // (per-box glass and the plain-glass run both position items
-        // from them, so this runs after the item loop with the
-        // gap-hidden state set). #407: one dispatch, no per-mode
-        // branching at the call site.
+        // Single dispatch for glass hosting mode (#407).
         installGlassHosting(
             hosting,
             panel: panel,

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay.swift
@@ -1,6 +1,8 @@
 import AppKit
 
-/// Non-activating overlay panel displaying window items in AX coordinates.
+/// Non-activating overlay panel displaying window items in AX
+/// coordinates; the style's `edge` is the stored absolute edge
+/// the bar sits on (#293).
 @MainActor
 public final class AppBarOverlay {
     /// Click-to-focus hook; wired to `KiwiCore.focusWindow`.
@@ -189,6 +191,9 @@ public final class AppBarOverlay {
                 viewport: viewport,
                 animated: true
             )
+            // Items hosted in a glass wrapper are placed by the
+            // glass path; animating them here in container coords
+            // would fight that and flicker.
             for (index, view) in itemViews.enumerated()
             where view.superview === itemContainer {
                 if view.frame == .zero {

--- a/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
@@ -39,7 +39,10 @@ final class SpaceBarDropCoordinator {
 
     /// Clear hover tint and pending sweep.
     var clearFeedback: @MainActor () -> Void = {}
-    /// Springs visible space to `target` mid-drag (#445).
+    /// Springs the visible space to `target` mid-drag. Returns
+    /// whether the spring actually happened — a refused sticky
+    /// move (#445) or an already-active target springs nothing,
+    /// so `fire` must not record it as `sprungSpace`.
     var spring:
         @MainActor (_ target: SpaceID, _ window: WindowID)
             -> Bool = { _, _ in false }
@@ -53,7 +56,11 @@ final class SpaceBarDropCoordinator {
     private var pendingDwell: Task<Void, Never>?
 
     #if DEBUG
-        /// Pending dwell task for async test synchronization (#994; tests.md).
+        /// Pending dwell task for async test synchronization
+        /// (#994; tests.md ▸ Async tests). Cleared the instant the
+        /// dwell fires or disarms, and it also completes for a
+        /// CANCELLED dwell — it says the dwell ended, never that
+        /// it sprang; `sprungSpace` is that fact.
         var dwellTask: Task<Void, Never>? { pendingDwell }
     #endif
 

--- a/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarDropCoordinator.swift
@@ -1,40 +1,22 @@
 import CoreGraphics
 import Foundation
 
-/// The Space Bar drag-drop state machine (#372).
-///
-/// A two-speed gesture, driven off the same AX drag signal the
-/// rest of tiling uses (`DragCoordinator` → `onDragMove`/
-/// `onDragEnd`):
-///
-/// - **Fast drop** — release on a Space item before the dwell
-///   fires → relocate the window there, stay put (`move_to_space`).
-/// - **Dwell** — hold over a Space item for `dwell` seconds → the
-///   visible space springs to it; the drop is then an ordinary
-///   in-space placement into the now-live layout.
-///
-/// The switch and the relocate are performed by injected closures
-/// (KiwiCore), so this type stays AppKit-free and unit-testable.
+/// Space Bar drag-drop state machine for fast relocate and spring hover
+/// (#372).
 @MainActor
 final class SpaceBarDropCoordinator {
     /// What `ended` asks the driver to do.
     enum Outcome: Equatable {
-        /// No bar target — hand back to the ordinary drag-end
-        /// logic (same-space swap / snap-back).
+        /// No bar target — hand back to ordinary drag-end logic.
         case none
         /// Fast drop onto a different space's item — relocate.
         case relocate(SpaceID)
-        /// The space had already sprung; the window is on the
-        /// now-visible target, so place it there with the
-        /// ordinary in-space drop after re-homing its membership.
+        /// Drop into a space that already sprang visible during dwell.
         case placeInSprung(SpaceID)
     }
 
-    /// The dwell before a hover springs the space, read fresh at
-    /// arm time so a live `space_bar.set_spring_delay` change takes
-    /// effect on the next gesture with no cached-value staleness
-    /// (#372). Injected so this type stays settings-free; the
-    /// default is only a pre-wiring placeholder.
+    /// Dwell duration provider before spring fires
+    /// (`space_bar.set_spring_delay`, #372).
     var dwellProvider: @MainActor () -> TimeInterval = { 1.5 }
 
     /// Space whose item contains a Cocoa screen point, else nil.
@@ -43,61 +25,35 @@ final class SpaceBarDropCoordinator {
     var currentSpace: @MainActor (WindowID) -> SpaceID? = {
         _ in nil
     }
-    /// Tint a space's item with the synthetic drag-hover (nil
-    /// clears all).
+    /// Tint a space's item with synthetic drag-hover (nil clears all).
     var setHover: @MainActor (SpaceID?) -> Void = { _ in }
-    /// Start the pending-spring ring sweep on a space's item: it
-    /// stays empty for `delay`, then fills over `fill`.
+    /// Start pending-spring sweep on a space's item: (space, fill, delay).
     var beginSweep:
         @MainActor (
             _ space: SpaceID, _ fill: TimeInterval,
             _ delay: TimeInterval
         ) -> Void = { _, _, _ in }
 
-    /// Quiet time after entering an item before the sweep starts
-    /// (#372 QA): a quick flick-to-relocate shows no loading ring.
-    /// The spring still fires at the full dwell, so the sweep fills
-    /// over `dwell - springPreDelay`; the dwell range floors above
-    /// this so the sweep is always visible.
+    /// Quiet time after entering item before sweep starts (#372 QA).
     static let springPreDelay: TimeInterval = 0.5
 
-    /// Clear every hover tint and pending sweep.
+    /// Clear hover tint and pending sweep.
     var clearFeedback: @MainActor () -> Void = {}
-    /// Spring the visible space to `target` while `window` stays
-    /// pinned mid-drag. Returns whether the spring actually
-    /// happened — a refused sticky move (#445) or an already-active
-    /// target springs nothing, so `fire` must not record it as
-    /// `sprungSpace`.
+    /// Springs visible space to `target` mid-drag (#445).
     var spring:
         @MainActor (_ target: SpaceID, _ window: WindowID)
             -> Bool = { _, _ in false }
 
-    /// The item currently armed (hover tint + running sweep), or
-    /// nil. Lets `handleDragMove` suppress the in-space ghost
-    /// while a bar target is armed.
+    /// Armed space target (hover tint + active sweep).
     private(set) var armedSpace: SpaceID?
-    /// The space this drag has already sprung into, if any.
+    /// Space already sprung during this drag.
     private(set) var sprungSpace: SpaceID?
-    /// The window this gesture is dragging, or nil between
-    /// gestures. Lets an abnormal drag end (window closed / tab
-    /// rekeyed mid-drag) scope its teardown to the right window.
+    /// Dragged window in flight.
     private(set) var draggingWindow: WindowID?
     private var pendingDwell: Task<Void, Never>?
 
     #if DEBUG
-        /// The pending spring's timeline, so a test can await the
-        /// dwell instead of polling a clock for its effect (#994;
-        /// `.claude/rules/tests.md` ▸ Async tests). Debug-only so
-        /// a production read fails the release build rather than
-        /// a review — `isArmed` is the in-flight predicate.
-        ///
-        /// What awaiting it does **not** mean. It is cleared the
-        /// instant the dwell fires or is disarmed, so it is only
-        /// readable while a spring is pending: read it afterwards
-        /// and it is nil, whose `await` returns at once and
-        /// asserts nothing. It also completes for a *cancelled*
-        /// dwell, so it says the dwell ended, never that it
-        /// sprang — that fact is `sprungSpace`.
+        /// Pending dwell task for async test synchronization (#994; tests.md).
         var dwellTask: Task<Void, Never>? { pendingDwell }
     #endif
 

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
@@ -81,6 +81,10 @@ extension SpaceBarOverlay {
                 ? style.fontSize : depth * 0.42
             extent +=
                 ceil(
+                    // What is DRAWN, not the app name: measuring
+                    // a different string than `layoutFrontName`
+                    // lays out slides the whole Space run off its
+                    // alignment.
                     ((app.title ?? app.name) as NSString).size(
                         withAttributes: [
                             .font: NSFont.systemFont(
@@ -94,6 +98,10 @@ extension SpaceBarOverlay {
     }
 
     private func attachFrontViewsIfNeeded() {
+        // Re-added every render so the segment stays ABOVE item
+        // views created later (`syncItemViewCount` appends on
+        // top); moving hosts also detaches from the previous
+        // parent (a plain `addSubview` reparents).
         let content = frontHost ?? itemContainer
         for view in [
             frontBox, frontDivider, frontIcon, frontGlyph, frontName,
@@ -160,6 +168,12 @@ extension SpaceBarOverlay {
                 width: cell,
                 height: cell
             )
+        // The one AX element the segment exposes. Names the APP
+        // even when a title is drawn, and first — a title alone
+        // says nothing about where it lives. Two frames rather
+        // than one with a withheld argument: an app with no title
+        // yet (#160) should announce a short sentence, not a
+        // dangling separator.
         let axLabel =
             app.title.map {
                 L(

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontApp.swift
@@ -1,13 +1,9 @@
 import AppKit
 
-/// The trailing front-app segment (#293 verdict 6):
-/// `| <glyph + window title>` after the last Space item. On
-/// vertical bars the segment is icon-only — never rotated
-/// text, never hidden — and the divider flips to a horizontal
-/// rule. Informational; no click target.
+/// Trailing front-app segment rendering for `SpaceBarOverlay` (#293 verdict
+/// 6).
 extension SpaceBarOverlay {
-    /// Lays out (or hides) the segment starting at `cursor`
-    /// along the bar axis.
+    /// Lays out or hides front-app segment along bar axis.
     func renderFrontSegment(
         _ app: SpaceBarItemView.App?,
         after cursor: CGFloat,
@@ -25,8 +21,6 @@ extension SpaceBarOverlay {
         attachFrontViewsIfNeeded()
         let depth = horizontal ? strip.height : strip.width
         let cell = max(depth - SpaceBarItemView.pad * 2, 8)
-        // The focused window's accent paints the front-app glyph
-        // and name — the segment IS the focused window.
         let accent = NSColor(kiwiHex: style.focusedItemColor)
         var offset = cursor
         offset += layoutDivider(
@@ -65,17 +59,7 @@ extension SpaceBarOverlay {
         )
     }
 
-    /// Axis length the segment will consume, for the render
-    /// pass's alignment total — the leading item gap, the
-    /// divider and glyph (`layoutDivider`/`layoutFrontGlyph`
-    /// mirrors), and on horizontal bars the glyph→name pad
-    /// plus the measured name. Vertical bars end at the glyph
-    /// (no name), so no trailing pad is counted there. The
-    /// horizontal name is an estimate on both ends —
-    /// `sizeToFit` at layout time pads a little wider than
-    /// `NSString.size`, the trailing pad here absorbs that —
-    /// and the name still clamps to the remaining strip, so
-    /// no alignment can push content past the rim.
+    /// Total axis length consumed by front segment (#409).
     func frontExtent(
         _ app: SpaceBarItemView.App?,
         depth: CGFloat,
@@ -85,9 +69,6 @@ extension SpaceBarOverlay {
         guard let app else { return 0 }
         let pad = SpaceBarItemView.pad
         let cell = max(depth - pad * 2, 8)
-        // Mirror the placement (#409): leading gap, rule, symmetric
-        // `itemGap` right gap, glyph cell, plus the chip's `pad`
-        // inset each side — which also reserves the pinned band.
         let chip = style.hasBox || wantsBoxGlass(style)
         let inset = chip ? pad : 0
         var extent =
@@ -100,11 +81,6 @@ extension SpaceBarOverlay {
                 ? style.fontSize : depth * 0.42
             extent +=
                 ceil(
-                    // What is DRAWN, not the app name: the
-                    // estimate feeds the render pass's alignment
-                    // total, so measuring a different string
-                    // than `layoutFrontName` lays out slides the
-                    // whole Space run off its alignment.
                     ((app.title ?? app.name) as NSString).size(
                         withAttributes: [
                             .font: NSFont.systemFont(
@@ -118,16 +94,7 @@ extension SpaceBarOverlay {
     }
 
     private func attachFrontViewsIfNeeded() {
-        // The segment hosts in the clipping viewport (run tail) or,
-        // while pinned, in the panel content outside it (#409) — see
-        // `frontHost`. Re-added every render so it stays ABOVE item
-        // views created later (`syncItemViewCount` appends on top,
-        // and pinned it must sit over the plate) — otherwise a long
-        // item row paints over it. Moving hosts also detaches it
-        // from the previous parent (a plain `addSubview` reparents).
         let content = frontHost ?? itemContainer
-        // frontBox first so it lands beneath the divider/glyph/
-        // name added above it — the box is the chip behind them.
         for view in [
             frontBox, frontDivider, frontIcon, frontGlyph, frontName,
         ] {
@@ -142,9 +109,7 @@ extension SpaceBarOverlay {
         frontName.setAccessibilityElement(false)
     }
 
-    /// The separator rule; returns the axis length consumed.
-    /// Derives its own treatment from the style so no caller
-    /// can hand it an untreated color.
+    /// Separator rule between Space items and front app segment (#409).
     private func layoutDivider(
         at offset: CGFloat,
         depth: CGFloat,
@@ -164,18 +129,13 @@ extension SpaceBarOverlay {
             thickness: BarDivider.sectionThickness,
             fullDepth: true
         )
-        // Symmetric gap (#409): `itemGap` on the rule's right to
-        // match the `itemGap` the run cursor already left on its
-        // left. Under a chip (Boxed / per-box glass) the content is
-        // `pad`-inset, so the chip EDGE lands `itemGap` out; Plain
-        // has no chip, so the bare glyph sits `itemGap` out.
         let chip = style.hasBox || wantsBoxGlass(style)
         return BarDivider.sectionThickness + style.itemGap
             + (chip ? SpaceBarItemView.pad : 0)
     }
 
-    /// The focused app's glyph (App Font ligature or image);
-    /// returns the axis length consumed.
+    /// Focused app glyph or icon layout with accessibility (#160, QA
+    /// 2026-07-19, `SpaceBarItemView.place`).
     private func layoutFrontGlyph(
         _ app: SpaceBarItemView.App,
         at offset: CGFloat,
@@ -200,17 +160,6 @@ extension SpaceBarOverlay {
                 width: cell,
                 height: cell
             )
-        // The one AX element the segment exposes; everything
-        // else stays silent (glyphs are informational).
-        //
-        // Names the APP even when a title is drawn, and names it
-        // first: the icon beside it is the app's, a title alone
-        // ("Downloads") says nothing about where it lives, and
-        // an app name is stable under a reader while a title
-        // changes as the user types. Two frames rather than one
-        // with a withheld argument — an app with no title yet
-        // (#160) should announce a short sentence, not a
-        // dangling separator.
         let axLabel =
             app.title.map {
                 L(
@@ -229,17 +178,11 @@ extension SpaceBarOverlay {
             frontIcon.isHidden = true
             frontGlyph.isHidden = false
             frontGlyph.stringValue = glyph
-            // The item glyphs' shared ladder — a second formula
-            // here rendered the same app at a visibly different
-            // size in auto mode (QA 2026-07-19).
             let size = style.glyphFontSize(forDepth: depth)
             frontGlyph.font =
                 AppFont.font(size: size)
                 ?? .systemFont(ofSize: size)
             frontGlyph.textColor = accent
-            // Text draws from the frame's top: shrink to the
-            // measured height, centered in the cell — the
-            // `SpaceBarItemView.place` twin.
             var glyphFrame = frame
             let height = ceil(
                 frontGlyph.cell?.cellSize.height ?? 0
@@ -266,9 +209,7 @@ extension SpaceBarOverlay {
         return cell + SpaceBarItemView.pad
     }
 
-    /// The window's title (app name where it has none) —
-    /// horizontal bars only (vertical stays
-    /// icon-only, never rotated).
+    /// Front app window title layout for horizontal bars.
     private func layoutFrontName(
         _ app: SpaceBarItemView.App,
         at offset: CGFloat,

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
@@ -1,15 +1,6 @@
 import AppKit
 
-/// The Space Bar panel for one display (#293): renders Space
-/// items into a strip handed to it in AX coordinates. A dumb
-/// renderer like `AppBarOverlay` — the driver resolves state,
-/// identifiers, and glyphs. Items size to their content
-/// (identifier + app glyphs), so lengths vary per item. When the
-/// run overflows the strip the bar scrolls rather than clipping
-/// (#385): items render inside a clipping viewport inset by an
-/// arrow zone at each end, with clickable chevrons toward the
-/// hidden Spaces and a scroll that follows the active Space — the
-/// App Bar's overflow model (see `SpaceBarOverlay+Scroll`).
+/// Space Bar overlay panel for one display in AX coordinates (#293, #385).
 @MainActor
 public final class SpaceBarOverlay {
     /// One Space's resolved content.
@@ -20,81 +11,44 @@ public final class SpaceBarOverlay {
         let active: Bool
         /// Windows hidden past the glyph cap ("+n" badge).
         let overflow: Int
-        /// The focused window is one hidden past the cap — the "+n"
-        /// tints to signal focus is behind it (#376).
+        /// Focused window is hidden past the cap (#376).
         let focusInOverflow: Bool
     }
 
     /// Click-to-focus hook; wired to `KiwiCore.focusSpace`.
     public var onSelect: @MainActor (SpaceID) -> Void = { _ in }
 
-    // Internal (not private): `render()` in the +Render extension
-    // reads and lazily creates the panel.
     var panel: NSPanel?
     var itemViews: [SpaceBarItemView] = []
-    /// The clipping item viewport (#385): items and the trailing
-    /// front segment render inside it, inset by an arrow zone at
-    /// each end while the run overflows, so a half-scrolled item
-    /// is cut a gap short of the arrows instead of sliding under
-    /// them. Spans the full strip while everything fits.
+    /// Clipping item viewport (#385).
     let itemContainer = AppBarOverlay.FlippedView()
     let backArrow = BarArrowView()
     let forwardArrow = BarArrowView()
-    /// Where the front-app segment's views (and its glass backdrop)
-    /// are hosted this render (#409): `itemContainer` while the run
-    /// fits, so the segment is the run's tail as before; the panel
-    /// content (outside the clipping viewport) while the run
-    /// overflows, so the segment stays pinned to the trailing rim
-    /// while only the Spaces scroll behind the arrows. Set by
-    /// `render()` before the front pass; read by
-    /// `attachFrontViewsIfNeeded` and `updateFrontGlass`.
+    /// Host view for front-app segment (#409).
     weak var frontHost: NSView?
-    /// The Liquid Glass plate under the items when `backgroundStyle`
-    /// resolves to `material` (#390); nil otherwise / below macOS
-    /// 26. Stored as a plain view — the concrete type is 26-only.
+    /// Liquid Glass plate for material background (#390).
     var glassPlate: NSView?
-    /// Per-box Liquid Glass: one `NSGlassEffectView` per Space item
-    /// under `boxed + liquid_glass`, each hosting its item as
-    /// `contentView` (piece 2, App Bar twin). Empty otherwise /
-    /// below macOS 26. See SpaceBarOverlay+BoxGlass.
+    /// Per-box Liquid Glass views for `boxed + liquid_glass`.
     var boxGlasses: [NSView] = []
-    /// Colored backdrops behind each per-box glass (`GlassTint`,
-    /// #408); parallel to `boxGlasses`, empty / below macOS 26.
+    /// Colored backdrops behind per-box glass (#408).
     var boxTints: [NSView] = []
-    /// The front-app segment's own frosted box under per-box glass.
-    /// The segment is non-interactive, so this sits as a backdrop
-    /// behind its loose views rather than hosting them.
+    /// Front-app segment frosted backdrop box.
     var frontGlass: NSView?
-    /// Colored backdrop behind the front segment's glass (#408).
+    /// Colored backdrop behind front segment glass (#408).
     var frontTint: NSView?
-    /// Colored backdrop behind the single glass plate (#408).
+    /// Colored backdrop behind single glass plate (#408).
     var glassTint: NSView?
-    /// Throwaway content view that turns the shared plate into a
-    /// bare frosted backdrop when the front app is pinned over an
-    /// overflowing run (#409) — an empty content view frosts as
-    /// true glass (the `frontGlass` precedent), letting the plate
-    /// span the strip under both the items and the pinned segment.
+    /// Backdrop filler view for glass hosting (#409).
     let glassBackdropFiller = NSView()
-    /// Under plain + glass when the run fits, the glass hosts this
-    /// flipped run wrapper at the hugged plate frame with the run
-    /// (items + front segment) placed run-local — so the frosted
-    /// plate hugs instead of spanning the viewport (piece 1). On
-    /// overflow the glass falls back to hosting `itemContainer`.
+    /// Flipped run wrapper for plain + glass without overflow.
     var glassRun: AppBarOverlay.FlippedView?
-    /// `plain`'s shared fill plate — its own view (not the
-    /// container layer) so it can hug the run
-    /// (`background_fit`, QA 2026-07-19).
+    /// Shared fill plate for plain style (`background_fit`, QA 2026-07-19).
     var plainPlate: NSView?
-    /// Whole-bar scroll offset (#385); 0 while the run fits.
+    /// Whole-bar scroll offset (#385).
     var scrollOffset: CGFloat = 0
-    /// Cached scroll geometry, kept for the arrow-zone hit test
-    /// and the drag autoscroll stepping between renders (#385).
+    /// Cached scroll geometry for hit-testing and autoscroll (#385).
     var scrollGeom: ScrollGeom?
-    /// The running drag-autoscroll task and its direction while a
-    /// window drag dwells over an arrow zone (#385); nil when idle.
-    /// A `Task` loop (not a `Timer`) mirrors the drop coordinator's
-    /// dwell — a `Timer`'s `@Sendable` block can't weak-capture
-    /// this non-`Sendable` `@MainActor` type in a release build.
+    /// Running drag-autoscroll task when dwelling on arrow zone (#385).
     var autoScrollTask: Task<Void, Never>?
     var autoScrollDirection: ScrollArrow?
     /// Last-rendered strip in AX coordinates and the per-item
@@ -104,10 +58,7 @@ public final class SpaceBarOverlay {
     /// arrow zone or a scrolled-off item is never a drop target.
     var hitStrip: CGRect = .zero
     var hitFrames: [(space: SpaceID, frame: CGRect)] = []
-    // The optional trailing front-app segment (#293 verdict 6):
-    // a Boxed-only fill box behind the content, a divider rule,
-    // the focused app's glyph, and — on horizontal bars only —
-    // its name.
+    // Optional trailing front-app segment (#293).
     let frontBox = NSView()
     let frontDivider = NSView()
     let frontIcon = NSImageView()
@@ -118,8 +69,6 @@ public final class SpaceBarOverlay {
         return tf
     }()
     let frontName = NSTextField(labelWithString: "")
-    // Internal (not private): read by `render()` in the +Render
-    // extension.
     var lastShown:
         (
             items: [Item],
@@ -133,9 +82,7 @@ public final class SpaceBarOverlay {
 
     public var isVisible: Bool { panel?.isVisible ?? false }
 
-    /// Renders `items` into `strip` (AX coordinates).
-    /// `frontApp` is the trailing segment's app; nil while the
-    /// toggle is off or no window is focused.
+    /// Renders `items` into `strip` in AX coordinates.
     func show(
         items: [Item],
         frontApp: SpaceBarItemView.App? = nil,
@@ -163,21 +110,10 @@ public final class SpaceBarOverlay {
         panel?.orderOut(nil)
     }
 
-    /// Whether the panel is on screen — the hit test is only
-    /// meaningful for a visible bar.
+    /// True if overlay panel is visible on screen.
     var isPanelVisible: Bool { panel?.isVisible == true }
 
-    // MARK: - Rendering
-
-    // `render(followingActive:)` and `activeIndex` live in
-    // `SpaceBarOverlay+Render.swift` (file size, §2).
-
-    /// Axis start of the content run per `alignment` (#293
-    /// QA). `pad` keeps the run off the strip's rim and floors
-    /// every case. Overflowing runs never reach this — they start
-    /// at the scroll offset (#385, see `runMetrics`). `pad` is a
-    /// parameter (callers pass `SpaceBarItemView.pad`) so this
-    /// stays nonisolated and unit-testable.
+    /// Content run start for given alignment (#293 QA, #385).
     nonisolated static func contentStart(
         total: CGFloat,
         axis: CGFloat,

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay.swift
@@ -48,7 +48,10 @@ public final class SpaceBarOverlay {
     var scrollOffset: CGFloat = 0
     /// Cached scroll geometry for hit-testing and autoscroll (#385).
     var scrollGeom: ScrollGeom?
-    /// Running drag-autoscroll task when dwelling on arrow zone (#385).
+    /// Running drag-autoscroll task when dwelling on an arrow
+    /// zone (#385). A `Task` loop, not a `Timer`: a `Timer`'s
+    /// `@Sendable` block cannot weak-capture this non-`Sendable`
+    /// `@MainActor` type in a release build.
     var autoScrollTask: Task<Void, Never>?
     var autoScrollDirection: ScrollArrow?
     /// Last-rendered strip in AX coordinates and the per-item

--- a/Sources/KiwiDeskCore/Borders/AppKitBorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/AppKitBorderOverlay.swift
@@ -1,54 +1,21 @@
 import AppKit
 
-/// One window's focus-border ring (#278): a borderless,
-/// non-activating, shadowless panel that ignores mouse events and
-/// draws a single stroked rounded rect. The manager
-/// (`BorderManager`) creates one per bordered window and feeds it
-/// geometry; the overlay knows nothing about layouts or focus.
-///
-/// Non-interactive by design (`ignoresMouseEvents`) — unlike the
-/// app bar, a border is never clicked. Sits at the normal window
-/// level and is stacked directly behind its target window with
-/// `order(.below, relativeTo:)` (see `order(relativeTo:)`). The stroke's
-/// inner overlap sits under the target while its outward reach stays
-/// visible; child panels and other windows above the target therefore
-/// cover the ring naturally. The mandatory AppKit fallback for the
-/// SkyLight fast path — `BorderOverlay` swaps to one on any private
-/// surface failure — so it is module-internal, not file-private.
+/// AppKit NSPanel fallback backend for window focus border rings (#278, #320).
 @MainActor
 final class AppKitBorderOverlay: BorderOverlayBackend {
     private var panel: NSPanel?
     private let shape = CAShapeLayer()
-    /// A second, tighter shadow stacked under the ring (#533): a
-    /// single Gaussian shadow starts at only ~half the glow
-    /// colour's intensity at the ring edge and reads washy. This
-    /// layer casts the same silhouette at half the radius, so
-    /// the two sum toward the full colour at the edge and fade
-    /// out along the wider tail — the "100% at the ring → 0 at
-    /// the reach" ramp the owner asked for. Content-free: only
-    /// its `shadowPath` renders.
+    /// Secondary shadow layer stacked under ring for edge bloom density
+    /// (#533).
     private let glowBoost = CAShapeLayer()
 
-    /// The AppKit panel stacks below its target (it cannot express a
-    /// SkyLight sub-level, so `above` here would paint over child
-    /// popovers — the #320 regression). Below keeps that occlusion
-    /// correct at the cost of the rounded corner seam, which only
-    /// the SkyLight `above` path fixes.
+    /// Stacks below target window to preserve popover occlusion (#320).
     let orderMode: BorderGeometry.Order = .below
 
-    /// Explicit, not just the protocol default: this backend IS
-    /// the glow renderer (#533), and the capability should be
-    /// legible beside `applyGlow` rather than inherited by
-    /// omission.
+    /// AppKit backend supports glow rendering (#533).
     let rendersGlow = true
 
-    /// Positions the ring around `geometry.overlayFrame` (AX
-    /// coords) and strokes it in `colorHex`. Used both for a
-    /// steady-state sync and per animation tick — implicit Core
-    /// Animation is disabled so the ring snaps to each commanded
-    /// frame instead of easing a step behind the window. Stacking
-    /// is left to `order(relativeTo:)`, called only on sync (not per
-    /// tick) so the ring isn't re-ordered every frame.
+    /// Updates ring geometry, stroke color, and glow bloom (#358).
     func update(
         geometry: BorderGeometry,
         colorHex: String,
@@ -70,11 +37,6 @@ final class AppKitBorderOverlay: BorderOverlayBackend {
             size: geometry.overlayFrame.size
         )
         shape.frame = bounds
-        // Stroke is centered on its path, so inset the path by half
-        // the line width to keep the whole stroke inside the overlay
-        // bounds — plus `glowMargin` (0 without glow) so the ring
-        // stays put in the grown frame and the margin is bloom room
-        // (#358).
         let inset = geometry.glowMargin + geometry.lineWidth / 2
         let rect = bounds.insetBy(dx: inset, dy: inset)
         shape.path = CGPath(
@@ -95,15 +57,7 @@ final class AppKitBorderOverlay: BorderOverlayBackend {
         return true
     }
 
-    /// The glow bloom (#358/#533) — this backend is the SOLE
-    /// glow renderer: the facade swaps every glow ring here
-    /// (`BorderOverlay.ensureBackend`). The shadow is cast from
-    /// a **filled** outer rounded-rect `shadowPath`, not the
-    /// thin stroke, so the bloom is a solid halo instead of a
-    /// banded contour smear. Below-order occludes the inward
-    /// half of the bloom behind the window, so only the outward
-    /// bloom shows. `masksToBounds` stays false so the halo can
-    /// spill past the shape into the grown frame.
+    /// Renders outer glow halo from filled silhouette (#358, #533).
     private func applyGlow(
         geometry: BorderGeometry,
         rect: CGRect,
@@ -141,12 +95,7 @@ final class AppKitBorderOverlay: BorderOverlayBackend {
         glowBoost.shadowPath = silhouette
     }
 
-    /// Stacks the ring directly behind its target window in the
-    /// global window order (`windowNumber` is the target's
-    /// `CGWindowID`). Anything layered over the target — an
-    /// ignored panel, a higher-level utility window — therefore
-    /// stays in front of the ring. Called on sync, not per tick.
-    /// A no-op until the panel exists (first `update` creates it).
+    /// Stacks ring directly behind target window in WindowServer hierarchy.
     func order(relativeTo windowNumber: CGWindowID) -> Bool {
         panel?.order(.below, relativeTo: Int(windowNumber))
         return true
@@ -158,8 +107,7 @@ final class AppKitBorderOverlay: BorderOverlayBackend {
     }
 
     private func makePanel() -> NSPanel {
-        // A frame-constraining panel would clamp a top-row ring's
-        // upward dead-end bump to zero (#436) — see BorderOverlayPanel.
+        // BorderOverlayPanel avoids frame clamping on top edge (#436).
         let panel = BorderOverlayPanel(
             contentRect: .zero,
             styleMask: [.borderless, .nonactivatingPanel],
@@ -170,19 +118,9 @@ final class AppKitBorderOverlay: BorderOverlayBackend {
         panel.backgroundColor = .clear
         panel.hasShadow = false
         panel.ignoresMouseEvents = true
-        // Normal window level (not floating): the ring is stacked
-        // relative to its target by `order(relativeTo:)`, so it must
-        // share the target's band to sit *below* windows layered
-        // over it — a floating level would force it above them.
         panel.level = .normal
         panel.isReleasedWhenClosed = false
         panel.animationBehavior = .none
-        // A fullscreen window gets no border (auxiliary only); not
-        // cycled by the app switcher. `.transient` hides this AppKit
-        // fallback ring in Exposé/Mission Control at the compositor
-        // level so it vanishes with the swipe — the SkyLight fast
-        // path self-vanishes via its space pin, and this hint gives
-        // the fallback ring the same instant behavior.
         panel.collectionBehavior = [
             .transient,
             .fullScreenAuxiliary,

--- a/Sources/KiwiDeskCore/Borders/AppKitBorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/AppKitBorderOverlay.swift
@@ -15,7 +15,11 @@ final class AppKitBorderOverlay: BorderOverlayBackend {
     /// AppKit backend supports glow rendering (#533).
     let rendersGlow = true
 
-    /// Updates ring geometry, stroke color, and glow bloom (#358).
+    /// Updates ring geometry, stroke color, and glow bloom
+    /// (#358). Implicit Core Animation is disabled so the ring
+    /// snaps to each commanded frame instead of easing a step
+    /// behind the window; stacking is `order(relativeTo:)`'s job,
+    /// called on sync only, never per tick.
     func update(
         geometry: BorderGeometry,
         colorHex: String,
@@ -118,6 +122,9 @@ final class AppKitBorderOverlay: BorderOverlayBackend {
         panel.backgroundColor = .clear
         panel.hasShadow = false
         panel.ignoresMouseEvents = true
+        // Normal level, not floating: the ring is stacked
+        // relative to its target and must share the target's band
+        // to sit below windows layered over it.
         panel.level = .normal
         panel.isReleasedWhenClosed = false
         panel.animationBehavior = .none

--- a/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
@@ -14,10 +14,19 @@ struct BorderGeometry: Equatable {
     let lineWidth: CGFloat
     /// Corner radius of stroke centerline path.
     let cornerRadius: CGFloat
-    /// Outward margin for glow bloom expansion (#358).
+    /// Outward margin for glow bloom expansion (#358); 0 when
+    /// glow is off. Deliberately kept OUT of `outwardReach`: the
+    /// soft bloom may bleed into the layout gap, so
+    /// `border.fit_gaps` stays sized to the crisp stroke (#358
+    /// ui-designer decision).
     let glowMargin: CGFloat
 
-    /// Below-order cushion to close squircle corner seam (#361).
+    /// Below-order cushion to close the squircle corner seam
+    /// (#361). Kept to a sliver because a below-order ring lingers
+    /// through a minimize genie (macOS reports the minimize only
+    /// once the window lands at the Dock) and the shrinking window
+    /// un-masks the overlap as a band this thick. Nudge up if a
+    /// faint corner seam ever shows.
     static let hiddenOverlapCushion: CGFloat = 0.1
 
     /// Corner reveal depth for square ring behind rounded window (#361).
@@ -28,11 +37,17 @@ struct BorderGeometry: Equatable {
         return systemRadius * tuck + hiddenOverlapCushion
     }
 
-    /// Above-order visible overlap cap to avoid content smearing (#311).
+    /// Above-order visible overlap cap (#311 hybrid): capped to
+    /// `min(visible / 2, this)` so the ring stays predominantly
+    /// outside the window; the outer edge stays at
+    /// `systemRadius + visible` regardless — only the inner edge
+    /// moves, so fit-gaps' reach is unchanged.
     static let aboveVisibleLapCap: CGFloat = 1
 
-    /// Computes ring geometry for `windowFrame` in AX coordinates (#358,
-    /// #533).
+    /// Computes ring geometry for `windowFrame` in AX coordinates.
+    /// `glowBlur` arrives RESOLVED (`BorderStyle.resolvedGlowBlur`
+    /// — width-scaled auto or the explicit size, #533/#551), so
+    /// the geometry math stays free of style resolution.
     static func compute(
         windowFrame: CGRect,
         width: CGFloat,

--- a/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderGeometry.swift
@@ -1,108 +1,38 @@
 import CoreGraphics
 
-/// Pure geometry of one focus-border ring (#278). Turns a window
-/// frame + width + corner style into the overlay window's frame
-/// and the stroke's line width / corner radius, with no AppKit —
-/// so the hidden-overlap rule is unit-testable in isolation.
-///
-/// `width` is always the visible stroke width outside the target.
-/// The renderer adds a fixed overlap behind the target; that hidden
-/// part is not counted in the width. Ordering the overlay behind
-/// the target masks the overlap and lets square rings fill the reveal
-/// beneath rounded window corners.
+/// Pure geometry of one focus-border ring (#278).
 struct BorderGeometry: Equatable {
-    /// Where the ring sits in the window stack, which flips what the
-    /// overlap *is* (#357). `below` masks the overlap behind the
-    /// target (the AppKit fallback); `above` draws it on top of the
-    /// target (the SkyLight fast path), so the overlap is visible and
-    /// must stay a hairline.
+    /// Layering order in window stack determining overlap visibility (#357).
     enum Order: Sendable, Equatable {
         case above
         case below
     }
 
-    /// The overlay window's frame in AX (top-left) coordinates:
-    /// the window grown by the ring's outward reach on every
-    /// side, big enough to hold the whole stroke.
+    /// Overlay window frame in AX coordinates.
     let overlayFrame: CGRect
-    /// The renderer's total stroke width: configured visible width
-    /// plus the overlap hidden behind the target.
+    /// Total stroke width including overlap.
     let lineWidth: CGFloat
-    /// Corner radius (pt) of the stroke's centerline path, drawn
-    /// in the overlay's own bounds inset by `lineWidth / 2` plus
-    /// `glowMargin`.
+    /// Corner radius of stroke centerline path.
     let cornerRadius: CGFloat
-    /// Extra outward room (pt) the overlay frame carries **beyond**
-    /// the visible reach so a glow bloom isn't clipped by the
-    /// window bounds (#358). `0` when glow is off — then the frame
-    /// and draw math are identical to a plain ring. When on, the
-    /// frame grows by this on every side and the stroke path is
-    /// inset back by it, so the ring stays put and the margin is
-    /// pure bloom space. Deliberately kept OUT of `outwardReach`:
-    /// the soft bloom is allowed to bleed into the layout gap, so
-    /// `border.fit_gaps` stays sized to the crisp stroke (#358
-    /// ui-designer decision).
+    /// Outward margin for glow bloom expansion (#358).
     let glowMargin: CGFloat
 
-    /// **`below`-order only.** The one cushion beyond what corner
-    /// geometry strictly requires, shared by both styles: rounded's arc
-    /// already hugs the window's real radius, so its whole overlap is
-    /// this cushion; square adds it on top of the mandatory
-    /// `0.29 · radius` reveal (see `squareHiddenOverlap`). Kept to a
-    /// sliver because a below-order ring lingers through a minimize
-    /// genie — macOS reports the minimize only once the window lands at
-    /// the Dock, so there is no earlier signal to hide on — and the
-    /// shrinking window un-masks the overlap as a band whose thickness
-    /// this sets. It only has to hide the hairline where our circular
-    /// corner arc meets the window's continuous squircle, which the
-    /// real per-window radius already all but closes (#361). Nudge up
-    /// if a faint corner seam ever shows. Never used by `above`-order,
-    /// where the overlap is on-screen and stays a hairline (see
-    /// `aboveVisibleLapCap`).
+    /// Below-order cushion to close squircle corner seam (#361).
     static let hiddenOverlapCushion: CGFloat = 0.1
 
-    /// **`below`-order only.** The corner reveal a *square* ring must
-    /// fill sits at `systemRadius · (1 − √2/2)` — the deepest point of
-    /// a rounded window's corner, on the diagonal. Derived per window
-    /// from its real radius (`BorderManager` reads it via SkyLight)
-    /// plus `hiddenOverlapCushion`, rather than a fixed constant that
-    /// could not scale and left a corner gap on large-radius windows
-    /// (the old fixed 8 pt; #361). Under-provisioning re-opens the
-    /// reveal in steady state. Never used by `above`-order, where the
-    /// overlap is on-screen and stays a hairline (see
-    /// `aboveVisibleLapCap`).
+    /// Corner reveal depth for square ring behind rounded window (#361).
     static func squareHiddenOverlap(
         systemRadius: CGFloat
     ) -> CGFloat {
         let tuck = 1 - CGFloat(2).squareRoot() / 2
         return systemRadius * tuck + hiddenOverlapCushion
     }
-    /// **`above`-order cap.** With the ring stacked above the target
-    /// the overlap laps *on top of* the window and is therefore
-    /// visible, so over-provisioning is no longer free — a 5/8 pt
-    /// band would smear across window content. Its only job here is
-    /// to close the hairline seam where our circular corner arc meets
-    /// the window's continuous-squircle corner, so it is capped to
-    /// `min(visible / 2, aboveVisibleLapCap)` (the #311 hybrid): at
-    /// most 1 pt, and never more than half the visible width so the
-    /// ring stays predominantly outside the window. The outer edge
-    /// stays at `systemRadius + visible` regardless (fit-gaps reach
-    /// unchanged); only the inner edge moves.
+
+    /// Above-order visible overlap cap to avoid content smearing (#311).
     static let aboveVisibleLapCap: CGFloat = 1
 
-    // The glow blur formula lives on `BorderStyle.glowBlur(for:)`
-    // beside `glowColor` — both style-derived; the resolved
-    // number reaches `compute` via `Spec.glowBlur`.
-
-    /// Builds the ring geometry for `windowFrame` (AX coords).
-    /// `width` is clamped defensively; `systemRadius` is the
-    /// shared window corner radius (rounded style) or ignored
-    /// (square style → 0). `glowBlur` (`0` = no glow) grows the
-    /// overlay frame by itself on every side so the bloom has
-    /// room (#358). It arrives RESOLVED
-    /// (`BorderStyle.resolvedGlowBlur` — width-scaled auto or
-    /// the explicit `glow_size`, #533/#551): geometry takes the
-    /// finished number and stays free of style resolution.
+    /// Computes ring geometry for `windowFrame` in AX coordinates (#358,
+    /// #533).
     static func compute(
         windowFrame: CGRect,
         width: CGFloat,

--- a/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
@@ -1,10 +1,17 @@
 import AppKit
 
-/// WindowServer event integration and geometry tracking for `BorderManager`
-/// (#285, #414).
+/// WindowServer event integration and geometry tracking for
+/// `BorderManager` (#285). The manager is the WS-events broker
+/// for two consumers — the ring and the sticky mark's tees —
+/// because `SkyLightWindowEvents` has a single weak sink. Two is
+/// a deliberate deferral; a THIRD is the trigger to extract a
+/// standalone `WindowServerWatch` service (#414).
 extension BorderManager {
-    /// Configures WindowServer tracking state from environment
-    /// (`KIWIDESK_NO_WS_TRACKING`, #596).
+    /// Configures WindowServer tracking from the environment
+    /// (`KIWIDESK_NO_WS_TRACKING`, #596). Named after
+    /// `StrandDetector.configureFromEnvironment` but NOT its twin:
+    /// where `KIWIDESK_STRAND_LOG` only turns on logging, this
+    /// kills a production fast path for the whole run.
     func configureFromEnvironment(
         _ environment: [String: String] = ProcessInfo.processInfo
             .environment
@@ -32,7 +39,10 @@ extension BorderManager {
         updateSkyLightSubscription(Set(overlays.keys))
     }
 
-    /// Handles WindowServer notification from `SkyLightWindowEvents`.
+    /// Handles a WindowServer notification. The guard is scoped
+    /// to windows we watch EITHER way (ring or sticky-tracked); a
+    /// window watched neither way is a stale additive delivery
+    /// (`watch(_:)`'s undocumented semantics) and is dropped.
     func handleSkyLightEvent(
         _ kind: SkyLightWindowEvents.Kind,
         window id: WindowID
@@ -46,6 +56,10 @@ extension BorderManager {
             onWindowReordered(id)
             overlays[id]?.order(relativeTo: id.raw)
         case .followAndReorder:
+            // Unhide must re-assert order even when the bounds
+            // read fails; restoration stays with that one explicit
+            // order so a successful reconcile cannot issue it
+            // twice.
             _ = reconcile(id, restoreVisibility: false)
             onWindowReordered(id)
             overlays[id]?.order(relativeTo: id.raw)
@@ -104,8 +118,10 @@ extension BorderManager {
         }
     }
 
-    /// Status message reporting active WindowServer vs AX fallback tracking
-    /// mode.
+    /// The one line telling a QA run which path it is on — names
+    /// the lever explicitly when it forced the fallback, or an
+    /// unexplained "unavailable" on a healthy Mac reads as a real
+    /// WindowServer failure.
     private var trackingStatusMessage: String {
         if skyLightActive {
             return "WindowServer border tracking active"

--- a/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager+SkyLight.swift
@@ -1,33 +1,10 @@
 import AppKit
 
-/// The WindowServer integration for `BorderManager` (#285 Tier 2):
-/// the notification sink, the per-window watch subscription, and the
-/// tracking predicates. Split out of `BorderManager.swift` to keep
-/// each file under the size ceiling; the stored state it touches
-/// (`overlays`, `eventSource`, `skyLightActive`, `stickyTracked`, …)
-/// is internal on the main type for exactly this reason.
-///
-/// `BorderManager` is now the WindowServer-events broker for two
-/// consumers — the ring (its overlays) and the sticky mark (via the
-/// `onFrameReconciled` / `onWindowReordered` tees) — because
-/// `SkyLightWindowEvents` has a single weak sink. Two consumers is a
-/// deliberate deferral; a THIRD would be the trigger to extract a
-/// standalone `WindowServerWatch` service with peer subscribers (#414).
+/// WindowServer event integration and geometry tracking for `BorderManager`
+/// (#285, #414).
 extension BorderManager {
-    /// Reads the `KIWIDESK_NO_WS_TRACKING` QA lever (#596). Any
-    /// non-empty value keeps `skyLightActive` false for the whole
-    /// run, so the ring and mark exercise the AX-fallback path
-    /// the settle-tail symptoms live on — the same fallback
-    /// `os-private-apis.md` requires every private path to have,
-    /// and otherwise unreachable on a healthy Mac.
-    ///
-    /// Named after `StrandDetector.configureFromEnvironment` but
-    /// NOT its twin, in two ways worth keeping straight: this one
-    /// takes the environment as a parameter (that one reads
-    /// `ProcessInfo` directly), and where `KIWIDESK_STRAND_LOG`
-    /// only turns on logging and is otherwise inert, this kills a
-    /// production fast path for the whole run. Call once at
-    /// wiring.
+    /// Configures WindowServer tracking state from environment
+    /// (`KIWIDESK_NO_WS_TRACKING`, #596).
     func configureFromEnvironment(
         _ environment: [String: String] = ProcessInfo.processInfo
             .environment
@@ -36,45 +13,26 @@ extension BorderManager {
         windowServerTrackingDisabled = !(value?.isEmpty ?? true)
     }
 
-    /// Geometry tracking is independent of rendering. If a raw SLS
-    /// window falls back to AppKit, that panel can still follow real
-    /// bounds from a healthy WindowServer event stream.
+    /// Whether geometry tracking uses WindowServer stream for `id`.
     func usesWindowServerTracking(_ id: WindowID) -> Bool {
         overlays[id] != nil && skyLightActive
     }
 
-    /// Whether the sticky mark should trust the WindowServer stream
-    /// for this window (and suppress the laggy AX echo), mirroring
-    /// `usesWindowServerTracking` for the ring. True for any window
-    /// we actually watch — bordered OR sticky-tracked — once the
-    /// stream is live.
+    /// Whether sticky mark should consume WindowServer stream for `id` (#414).
     func markUsesWindowServerTracking(_ id: WindowID) -> Bool {
         skyLightActive
             && (overlays[id] != nil || stickyTracked.contains(id))
     }
 
-    /// The sticky mark's WS tracking set (#414 QA): sticky windows
-    /// need the reorder tee and frame stream even with no ring, so
-    /// they are folded into the watch subscription here. Driven by
-    /// `updateStickyMarks`; a no-op when unchanged.
+    /// Updates sticky mark window watch set in WindowServer subscription
+    /// (#414).
     func setStickyTracked(_ ids: Set<WindowID>) {
         guard ids != stickyTracked else { return }
         stickyTracked = ids
         updateSkyLightSubscription(Set(overlays.keys))
     }
 
-    /// Receives the WindowServer notifications registered by
-    /// `SkyLightWindowEvents`. Bounds are read from SkyLight's cache,
-    /// never AX, then fed through the same geometry path as animation
-    /// and cursor following.
-    ///
-    /// Scoped guard, not the ring's old overlay-only one: a
-    /// sticky-tracked window may wear a mark but no ring, so it must
-    /// pass too — it needs the same WS frame stream (`reconcile` →
-    /// `onFrameReconciled`) and z-order tee (`onWindowReordered`).
-    /// A window we watch neither way is a stale additive delivery
-    /// (`watch(_:)`'s undocumented semantics) and is dropped, so no
-    /// stray bounds read or tee fan-out fires for it.
+    /// Handles WindowServer notification from `SkyLightWindowEvents`.
     func handleSkyLightEvent(
         _ kind: SkyLightWindowEvents.Kind,
         window id: WindowID
@@ -88,9 +46,6 @@ extension BorderManager {
             onWindowReordered(id)
             overlays[id]?.order(relativeTo: id.raw)
         case .followAndReorder:
-            // Unhide must re-assert order even when the bounds read
-            // fails. Leave restoration to that one explicit order so
-            // a successful reconcile cannot issue it twice.
             _ = reconcile(id, restoreVisibility: false)
             onWindowReordered(id)
             overlays[id]?.order(relativeTo: id.raw)
@@ -99,14 +54,8 @@ extension BorderManager {
         }
     }
 
-    /// Re-reads the authoritative WindowServer bounds (the drag
-    /// stream, unhide). Floating windows do not retile, so their
-    /// final ring must be reconciled on button-up. Stands down
-    /// while OUR OWN animation drives the window (#594): the WS
-    /// bounds trail the commanded per-tick frame on slow-AX
-    /// apps, so mid-animation every event would rewind the ring
-    /// behind the motion. The first WS event after settle
-    /// reconciles any residual drift.
+    /// Reconciles authoritative WindowServer bounds unless window is animating
+    /// (#594).
     @discardableResult
     func reconcile(
         _ id: WindowID,
@@ -132,15 +81,9 @@ extension BorderManager {
             skyLightActive = false
             return
         }
-        // Sticky marks ride the same stream as rings (#414 QA), so
-        // their windows join the watch set even without a ring.
         let wanted = borderWanted.union(stickyTracked)
         let wasActive = skyLightActive
         if windowServerTrackingDisabled {
-            // Never attach or watch under the lever: a live
-            // subscription would keep feeding `reconcile`, which
-            // heals exactly the drift the fallback path is meant
-            // to expose.
             skyLightActive = false
         } else {
             if !triedEventSource, !wanted.isEmpty {
@@ -161,10 +104,8 @@ extension BorderManager {
         }
     }
 
-    /// The one line that tells a QA run which path it is on.
-    /// Names the lever explicitly when it is what forced the
-    /// fallback: an unexplained "unavailable" on a healthy Mac
-    /// would read as a real WindowServer failure.
+    /// Status message reporting active WindowServer vs AX fallback tracking
+    /// mode.
     private var trackingStatusMessage: String {
         if skyLightActive {
             return "WindowServer border tracking active"

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecord.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecord.swift
@@ -5,7 +5,14 @@ import Foundation
 public struct APIRecord: Sendable, Equatable {
     /// Single sentence summary (capitalized, ending in period).
     public let summary: String
-    /// Positional arguments in decoding order.
+    /// Positional arguments in decoding order; optionals come
+    /// last. Stated residue: this list is a hand-kept mirror of
+    /// the decoder — only the enum VALUES are derived — so a wrong
+    /// list is worse than a pending one. Two shapes it cannot
+    /// state take the closed-kind escape (`subscribe` is variadic,
+    /// `set_mode` takes a LEADING optional); weigh a third such
+    /// command as evidence the shape, not the summary, must
+    /// change.
     public let arguments: [APIArgument]
 
     public init(_ summary: String, _ arguments: APIArgument...) {
@@ -17,7 +24,9 @@ public struct APIRecord: Sendable, Equatable {
         self.arguments = arguments
     }
 
-    /// Placeholder summary for unwritten command documentation.
+    /// Placeholder summary for unwritten prose — deliberately not
+    /// sentence-shaped, so `APIRecordShapeTests` exempts it by
+    /// identity rather than by pattern.
     public static let pendingSummary = "(summary pending)"
 
     /// True if summary has not been authored yet.

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecord.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecord.swift
@@ -1,57 +1,11 @@
 import Foundation
 
-/// One command's machine-readable signature: what it takes, and
-/// what it does in one line (#1033).
-///
-/// **A record carries neither its own name nor its group.** Both
-/// are the keys it is filed under in `APIReference` — the
-/// `commands`, `namespaces` and `luaOnly` tables stay the single
-/// source of truth for names, exactly as that file already
-/// claimed to be, and a record that cannot name itself cannot
-/// disagree with them. What a record adds is the metadata those
-/// tables never carried. `APIRecordCensusTests` holds the key
-/// sets against the name tables in both directions.
+/// Machine-readable command signature and summary (#1033,
+/// `APIRecordCensusTests`, `APIRecordShapeTests`).
 public struct APIRecord: Sendable, Equatable {
-    /// One line, sentence-shaped: a capital, a full stop, no
-    /// newline. `APIRecordShapeTests` pins that shape, so 262
-    /// summaries written by different hands read as one voice.
+    /// Single sentence summary (capitalized, ending in period).
     public let summary: String
-
-    /// Positional arguments, in the order the command reads
-    /// them. Optional arguments come last — a positional list
-    /// cannot skip one (`APIRecordShapeTests`).
-    ///
-    /// **Stated residue: this list is a hand-kept mirror of the
-    /// decoder, and only its enum VALUES are derived.** A
-    /// decoder reads `args[0]` / `args[1]` positionally with no
-    /// declared signature to reflect over, so nothing can check
-    /// that a record's argument names, count or optionality
-    /// match what the command actually parses — `APIChoice`
-    /// covers the values an argument may carry, and the census
-    /// covers command names, but neither sees the argument that
-    /// carries them. `APIRecordShapeTests` holds the shape a
-    /// list must have, never that it is the right list.
-    ///
-    /// So an argument list is review's, and a wrong one is
-    /// worse than a pending one — it describes a call that will
-    /// be rejected. Closing this properly means the decoders
-    /// declaring their signature and parsing FROM the record,
-    /// which is a much larger change than #1033 and is where
-    /// this data wants to go next.
-    ///
-    /// **Two shapes this fixed positional list cannot state, and
-    /// both take the closed-kind escape — the closest kind, and
-    /// a summary that says the rest.** `subscribe` is VARIADIC
-    /// (`SocketServer.subscribe` loops over every argument), so
-    /// its one optional `event` stands for a list. `set_mode`
-    /// takes a LEADING optional (one argument means the active
-    /// Space), which cannot be encoded at all while optionals
-    /// must trail. Adding a `repeats` flag or a leading-optional
-    /// case for one command each would buy a truer list for two
-    /// records and a second way to describe an argument for all
-    /// 262; the summary already carries it. Weigh a third such
-    /// command as evidence the shape, not the summary, is what
-    /// needs to change.
+    /// Positional arguments in decoding order.
     public let arguments: [APIArgument]
 
     public init(_ summary: String, _ arguments: APIArgument...) {
@@ -63,23 +17,19 @@ public struct APIRecord: Sendable, Equatable {
         self.arguments = arguments
     }
 
-    /// The summary of a record whose prose is not written yet.
-    ///
-    /// Deliberately not sentence-shaped, so it can never be
-    /// mistaken for a written one and `APIRecordShapeTests`
-    /// exempts it by identity rather than by pattern.
+    /// Placeholder summary for unwritten command documentation.
     public static let pendingSummary = "(summary pending)"
 
-    /// Whether this record still owes its prose.
+    /// True if summary has not been authored yet.
     public var isPending: Bool { summary == Self.pendingSummary }
 }
 
-/// One positional argument of a command.
+/// One positional argument of a command (#1033).
 public struct APIArgument: Sendable, Equatable {
-    /// `lower_snake_case`, the name the docs use for it.
+    /// Argument name in snake_case.
     public let name: String
     public let kind: APIArgumentKind
-    /// Whether the command reads a default when it is absent.
+    /// True if argument has a default value when omitted.
     public let isOptional: Bool
 
     public init(
@@ -127,8 +77,7 @@ public struct APIArgument: Sendable, Equatable {
         APIArgument(name, .color, optional: optional)
     }
 
-    /// A Space identifier — a string, and a numeric string is
-    /// equivalent to the integer (AGENTS.md §5).
+    /// Space identifier argument (string or numeric string, AGENTS.md §5).
     public static func space(
         _ name: String,
         optional: Bool = false
@@ -136,8 +85,7 @@ public struct APIArgument: Sendable, Equatable {
         APIArgument(name, .space, optional: optional)
     }
 
-    /// A macOS Desktop's Mission Control number, counted
-    /// globally across every screen (#884/#888).
+    /// macOS Desktop index across all screens (#884, #888).
     public static func desktop(
         _ name: String,
         optional: Bool = false
@@ -145,8 +93,7 @@ public struct APIArgument: Sendable, Equatable {
         APIArgument(name, .desktop, optional: optional)
     }
 
-    /// A Lua function. Only a Lua-only entry point takes one —
-    /// nothing crossing the socket can carry a callback.
+    /// Lua function callback argument (Lua-only).
     public static func callback(
         _ name: String,
         optional: Bool = false
@@ -154,8 +101,7 @@ public struct APIArgument: Sendable, Equatable {
         APIArgument(name, .callback, optional: optional)
     }
 
-    /// A Lua table. Same reason as `callback`: it never crosses
-    /// the socket.
+    /// Lua table argument (Lua-only).
     public static func table(
         _ name: String,
         optional: Bool = false
@@ -163,13 +109,8 @@ public struct APIArgument: Sendable, Equatable {
         APIArgument(name, .table, optional: optional)
     }
 
-    /// An argument whose legal values are a Swift enum's cases.
-    ///
-    /// **The only way to build one, and it takes the type, not
-    /// the values** — so the listing can never disagree with the
-    /// decoder that accepts or rejects what a caller sends.
-    /// `APIChoiceDerivationTests` holds that there is no second
-    /// initializer to type them into.
+    /// Enum choice argument derived directly from type
+    /// (`APIChoiceDerivationTests`).
     public static func choice<T: APIChoiceType>(
         _ name: String,
         _ type: T.Type,
@@ -183,13 +124,7 @@ public struct APIArgument: Sendable, Equatable {
     }
 }
 
-/// The closed vocabulary of argument shapes.
-///
-/// Closed on purpose: a value shape that is none of these — the
-/// points-or-`"NN%"`-or-`0` of `scroll.set_slot_size`, say —
-/// takes the closest kind and explains itself in the summary.
-/// The alternative, a free-text type field, is where a second
-/// hand-typed spelling of an enum would eventually land.
+/// Closed vocabulary of supported argument kinds.
 public enum APIArgumentKind: Sendable, Equatable {
     case number
     case integer
@@ -202,8 +137,7 @@ public enum APIArgumentKind: Sendable, Equatable {
     case table
     case choice(APIChoice)
 
-    /// The word `list_commands` prints for this kind. English,
-    /// like every other CLI/IPC string (core-boundaries.md).
+    /// Name printed by `list_commands` (English, core-boundaries.md).
     public var wireName: String {
         switch self {
         case .number: return "number"

--- a/Sources/KiwiDeskCore/Config/ConfigMigration+ScrollDuration.swift
+++ b/Sources/KiwiDeskCore/Config/ConfigMigration+ScrollDuration.swift
@@ -1,9 +1,20 @@
 import Foundation
 
-/// Migrates `animations.scroll_speed` to `scroll_duration` (#1020,
-/// `ConfigMigrationRoutingTests`, `ScrollDurationMigrationTests`).
+/// Migrates `animations.scroll_speed` to `scroll_duration`
+/// (#1020, `ConfigMigrationRoutingTests`,
+/// `ScrollDurationMigrationTests`). The failure this prevents is
+/// SILENT: `AnimationSettings` decodes with
+/// `decodeIfPresent ?? 150`, so a file still carrying the old key
+/// decodes "successfully" with the user's tuned value replaced by
+/// the default, then saves back without the old key.
 extension ConfigMigration {
-    /// Retired key name and replacement target (#1020).
+    /// Retired key name and replacement target (#1020). The
+    /// TARGET is spelled here rather than derived from
+    /// `AnimationSettings.CodingKeys`, deliberately: a historical
+    /// step must keep emitting the name it was written to emit so
+    /// a LATER rename composes on top — derived, it would skip
+    /// every intermediate crossing. The routing guard's set
+    /// equality reds if the live key stops being declared.
     static let retiredScrollSpeedKey = "scroll_speed"
     static let scrollDurationKey = "scroll_duration"
 
@@ -22,8 +33,16 @@ extension ConfigMigration {
         )
     }
 
-    /// Surgically renames key in raw JSON text (stands down if target present,
-    /// code-reviewer 2026-08-27).
+    /// Surgically renames the key in raw JSON text — standing
+    /// down when the target key is already present, which is the
+    /// one case it cannot do correctly (code-reviewer 2026-08-27):
+    /// a textual rename cannot see a sibling, and a node carrying
+    /// both spellings would become one key twice. The envelope's
+    /// re-parse net cannot catch that — `JSONSerialization` keeps
+    /// the FIRST occurrence and `.sortedKeys` puts the new key
+    /// first, so the duplicate decodes right and compares equal
+    /// while Foundation and `jq` read different values out of one
+    /// file (measured, both ways). The tree walk handles it.
     static func surgicallyRenamed(
         _ text: String
     ) -> Data? {

--- a/Sources/KiwiDeskCore/Config/ConfigMigration+ScrollDuration.swift
+++ b/Sources/KiwiDeskCore/Config/ConfigMigration+ScrollDuration.swift
@@ -1,66 +1,14 @@
 import Foundation
 
-/// The `animations.scroll_speed` → `animations.scroll_duration`
-/// crossing (#1020) — the first step that renames a **key**
-/// where the other two rewrite a value or a shape.
-///
-/// Why it needs a crossing at all: the setting is the
-/// focus-shift animation's DURATION, so "speed" ran backwards —
-/// raising it made scrolling slower. The Lua verb and the label
-/// moved with it, and neither owes anything (nothing external
-/// depends on a command name, AGENTS.md §5). The stored key
-/// does.
-///
-/// **The failure this prevents is silent, not loud.**
-/// `AnimationSettings` decodes each knob with
-/// `decodeIfPresent ?? 150`, which is the missing-keys contract
-/// a sparse profile relies on — so a file still carrying
-/// `scroll_speed` does not fail to decode. It decodes with the
-/// user's tuned value replaced by the default, reports success,
-/// and is then saved back without the old key. A refusal would
-/// at least be visible; this would not be.
-///
-/// Reaching every reader is therefore the whole point.
-/// `animations` hangs off `TilingSettings`, and the file shapes
-/// that actually STORE one are `Profile.settings` and
-/// `SetupBundle`, which carries `[Profile]` inline.
-/// `GuiConfig` looks like a third and is not: its `settings`
-/// property is absent from `CodingKeys`, so it never reaches
-/// `gui.json` — checked rather than assumed, and recorded at
-/// `GuiConfig.currentFormat` so the next rename does not
-/// re-derive it. `ConfigMigrationRoutingTests` is the census of
-/// the readers; `ScrollDurationMigrationTests` exercises both
-/// shapes rather than trusting this sentence.
+/// Migrates `animations.scroll_speed` to `scroll_duration` (#1020,
+/// `ConfigMigrationRoutingTests`, `ScrollDurationMigrationTests`).
 extension ConfigMigration {
-    /// The retired key, and what this build reads instead.
-    ///
-    /// Scoped by NAME, and the name is what bounds it: the walk
-    /// below rewrites at any depth, so a second `scroll_speed`
-    /// CodingKey anywhere in the config would put a value this
-    /// was never scoped to inside its reach.
-    /// `ConfigMigrationRoutingTests.scrollDurationKeyStaysUnique`
-    /// is what says so on arrival — the same shape as the
-    /// `content` guard beside it.
-    ///
-    /// The TARGET is spelled here rather than read off
-    /// `AnimationSettings.CodingKeys`, and that is deliberate:
-    /// a historical step must keep emitting the name it was
-    /// written to emit, so that a LATER step can rename that
-    /// name again and the two compose. Derive it and this step
-    /// silently starts writing whatever the live key is today,
-    /// skipping every intermediate crossing. It cannot rot
-    /// unnoticed — the routing guard's set EQUALITY reds if
-    /// `AnimationSettings` stops declaring it.
+    /// Retired key name and replacement target (#1020).
     static let retiredScrollSpeedKey = "scroll_speed"
     static let scrollDurationKey = "scroll_duration"
 
-    /// `data` with the retired key renamed wherever it appears,
-    /// or nil when there was nothing to rename.
-    ///
-    /// The envelope — gate, parse, surgical edit, verify, fall
-    /// back — is `surgicallyApplying`, which owns the argument
-    /// for all three steps. What is local here is the walk and
-    /// its both-spellings rule.
+    /// Migrates data containing retired `scroll_speed` key to
+    /// `scroll_duration`.
     @Sendable
     static func migratingRetiredScrollSpeed(
         _ data: Data
@@ -74,29 +22,8 @@ extension ConfigMigration {
         )
     }
 
-    /// `text` with the retired KEY renamed, leaving every other
-    /// byte exactly as it was — or nil to hand the job to the
-    /// tree.
-    ///
-    /// The trailing `:` is required, so a string VALUE that
-    /// happens to read `"scroll_speed"` — a space named that, a
-    /// palette named that — is never touched. Only a key is.
-    ///
-    /// **It stands down when the target key is already present,
-    /// and that is not caution — it is the one case this cannot
-    /// do correctly** (`code-reviewer`, 2026-08-27). A textual
-    /// rename cannot see a sibling, so a node carrying both
-    /// spellings becomes a node carrying the SAME key twice.
-    /// The envelope's re-parse/compare net structurally cannot
-    /// catch it: `JSONSerialization` silently keeps the FIRST
-    /// occurrence, and `.sortedKeys` — which `ProfileManager`
-    /// writes with — puts `scroll_duration` first, so the
-    /// duplicate decodes to the RIGHT value and compares equal.
-    /// The bytes would then be written to disk and stamped
-    /// current, with Foundation reading 420 and `jq`/Python
-    /// reading the stale 50 out of one file (measured, both
-    /// ways). The walk handles this case exactly; the edit hands
-    /// it over.
+    /// Surgically renames key in raw JSON text (stands down if target present,
+    /// code-reviewer 2026-08-27).
     static func surgicallyRenamed(
         _ text: String
     ) -> Data? {
@@ -114,12 +41,7 @@ extension ConfigMigration {
         return out == text ? nil : out.data(using: .utf8)
     }
 
-    /// The tree with the retired key renamed, plus whether
-    /// anything changed.
-    ///
-    /// A node carrying BOTH spellings keeps the new one: the
-    /// file was written by a build that already had the rename,
-    /// so the retired sibling is stale rather than authoritative.
+    /// Tree walker renaming retired key; prefers new spelling when both exist.
     static func renamed(_ node: Any) -> (Any, Bool) {
         if let dict = node as? [String: Any] {
             var out: [String: Any] = [:]

--- a/Sources/KiwiDeskCore/Config/ManagedConfig+Adopt.swift
+++ b/Sources/KiwiDeskCore/Config/ManagedConfig+Adopt.swift
@@ -1,7 +1,14 @@
 import Foundation
 
-/// Generates adopted `init.lua` commenting out GUI-managed statements (#55,
-/// #355).
+/// Generates the adopted `init.lua`, commenting out GUI-managed
+/// statements while custom Lua stays LIVE (#55, #355). The
+/// correctness invariant is stated for FOREIGN code only: a
+/// `set_*` verb left live is benign (`loadConfig` applies the
+/// owned settings wholesale AFTER init.lua runs), so the net must
+/// NOT widen to `declaresManagedSettings` — that would re-comment
+/// a live hook whose body legitimately calls `set_`. Two accepted
+/// blind spots (a token split across lines, an aliased receiver)
+/// are `docs/design-decisions.md`'s.
 extension ManagedConfig {
     public static func adopt(
         original: String,
@@ -72,7 +79,11 @@ extension ManagedConfig {
         return false
     }
 
-    /// Bracket and keyword depth delta for a line of code.
+    /// Bracket and keyword depth delta for one line of code.
+    /// `do`/`then` are deliberately uncounted — they pair with an
+    /// already-counted opener, so counting them double-counts; a
+    /// bare `do … end` block reads as unbalanced and trips the
+    /// full-comment fallback, which is safe.
     static func depthDelta(_ code: String) -> Int {
         var depth = 0
         for ch in code {

--- a/Sources/KiwiDeskCore/Config/ManagedConfig+Adopt.swift
+++ b/Sources/KiwiDeskCore/Config/ManagedConfig+Adopt.swift
@@ -1,45 +1,7 @@
 import Foundation
 
-/// Builds the "adopted" `init.lua` when a hand-written config is
-/// migrated into GUI management (#55/#355).
-///
-/// The managed statements — the settings, rules, and keybindings
-/// `gui.json` now owns — are commented out as an inert, dated
-/// backup. Harmless custom Lua (event hooks like `KiwiDesk.on`,
-/// `print`, helper functions) is kept **live**, so integrations
-/// such as the sketchybar bridge keep firing after adoption
-/// instead of going silent (#355).
-///
-/// Correctness invariant: the result must contain **no** foreign
-/// code (`managedTokens` — rules/binds/modes), or `isGuiManaged`
-/// flips false and the adopt silently fails to switch ownership.
-/// Two nets guarantee it — statement segmentation bails to
-/// commenting everything on any structural anomaly
-/// (unbalanced/never-closing spans), and the finished file is
-/// re-checked with `hasForeignCode`; a positive there also falls
-/// back to the full comment. Data-safe either way: the original is
-/// always recoverable from the commented backup.
-///
-/// The invariant is stated for **foreign** code only, on purpose.
-/// A `set_*` setting verb left live is benign — it neither trips
-/// `hasForeignCode` (so ownership holds) nor survives: `loadConfig`
-/// applies the `gui.json`/profile settings **wholesale after**
-/// init.lua runs, overwriting it with the value `gui.json` already
-/// owns. So `set_*` needs no backstop, and the net must NOT widen
-/// to `declaresManagedSettings` — that would re-comment a live
-/// hook whose body legitimately calls `set_` (the whole point of
+/// Generates adopted `init.lua` commenting out GUI-managed statements (#55,
 /// #355).
-///
-/// Two blind spots are inherited from the token scanner and
-/// accepted (see `docs/design-decisions.md`): a foreign token
-/// split across physical lines (`app_rules\n= {…}`) or reached via
-/// an aliased receiver (`local K = KiwiDesk; K.bind(…)`) is kept
-/// live and also escapes the foreign net — rare in hand-written
-/// Lua, and the backup preserves the original. Conversely, a
-/// managed token mentioned only inside a **string** in otherwise
-/// custom code trips the foreign net and forces the whole file to
-/// the full-comment fallback (safe direction — no live foreign —
-/// but it silences that file's hooks).
 extension ManagedConfig {
     public static func adopt(
         original: String,
@@ -50,8 +12,7 @@ extension ManagedConfig {
             selectivelyCommented(original)
             ?? commentedEverything(original)
         let result = header + "\n" + body + "\n"
-        // Correctness net: if selective commenting somehow left a
-        // foreign token live, fall back to commenting everything.
+        // Fall back to commenting everything if foreign tokens remain.
         if hasForeignCode(result) {
             return header + "\n"
                 + commentedEverything(original) + "\n"
@@ -59,20 +20,14 @@ extension ManagedConfig {
         return result
     }
 
-    // MARK: - Selective commenting
-
-    /// Comments out only the managed statements, keeping custom
-    /// Lua live. Returns nil on any structural anomaly (a span
-    /// that never balances), so the caller falls back to
-    /// commenting the whole file.
+    /// Selectively comments out managed statements while keeping custom Lua
+    /// live (#355).
     static func selectivelyCommented(_ source: String) -> String? {
         let lines = source.components(separatedBy: "\n")
         var out: [String] = []
         var i = 0
         while i < lines.count {
             let trimmed = lines[i].trimmedLua
-            // Blank lines and full-line comments carry through
-            // verbatim — they belong to no statement.
             if trimmed.isEmpty || trimmed.hasPrefix("--") {
                 out.append(lines[i])
                 i += 1
@@ -92,10 +47,7 @@ extension ManagedConfig {
         return out.joined(separator: "\n")
     }
 
-    /// The index one past the last line of the statement starting
-    /// at `from`, found by tracking bracket + block depth until it
-    /// returns to zero. Nil if the depth goes negative or the file
-    /// ends mid-statement — the signal to fall back.
+    /// End index of statement starting at `from` tracked via block depth.
     static func statementSpan(
         _ lines: [String],
         from start: Int
@@ -110,11 +62,7 @@ extension ManagedConfig {
         return depth == 0 ? j : nil
     }
 
-    /// A statement block is managed when its **head** — the first
-    /// non-blank, non-comment line — opens a managed construct.
-    /// Keying on the head (not "any line") keeps a `KiwiDesk.on`
-    /// hook whose body happens to call `set_*` classified as
-    /// custom, so the hook stays live (#355).
+    /// True if block begins with a managed declaration (#355).
     static func blockIsManaged(_ block: [String]) -> Bool {
         for line in block {
             let t = line.trimmedLua
@@ -124,16 +72,7 @@ extension ManagedConfig {
         return false
     }
 
-    // MARK: - Depth scanning
-
-    /// The bracket + block-keyword depth change on one line of
-    /// code (comments and string contents already stripped).
-    /// `(`/`{` and the block openers `function`/`if`/`for`/
-    /// `while`/`repeat` open; `)`/`}` and `end`/`until` close.
-    /// `do`/`then` are deliberately uncounted — they pair with an
-    /// already-counted `for`/`while`/`if`, so counting them would
-    /// double-count. A bare `do … end` block therefore reads as
-    /// unbalanced and trips the fallback, which is safe.
+    /// Bracket and keyword depth delta for a line of code.
     static func depthDelta(_ code: String) -> Int {
         var depth = 0
         for ch in code {
@@ -211,10 +150,7 @@ extension ManagedConfig {
         return out
     }
 
-    // MARK: - Full-comment fallback
-
-    /// The whole original commented out, line by line — the
-    /// original `adopt` behavior, kept as the fallback.
+    /// Fallback that comments out the full source line-by-line.
     static func commentedEverything(_ source: String) -> String {
         source
             .components(separatedBy: "\n")

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager+HoldGlide.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager+HoldGlide.swift
@@ -1,36 +1,17 @@
 import Foundation
 
-/// The manager's half of hold-to-glide (#1056, retimed #1082),
-/// split out at the file ceiling: the release-channel wiring, the
-/// fire bracket that hands the ladder one press's tally, and the
-/// passthroughs `KiwiCore` feeds. The ladder itself —
-/// eligibility, the initial delay, the per-frame glide — lives on
-/// `HoldGlide`.
+/// Keybinding hold-to-glide integration and event routing (#1056, #1082).
 extension KeybindingManager {
-    /// Whether a held glide is applying right now. Read by the
-    /// refusal gate below and by `KiwiCore.resizeWritesAnimated`,
-    /// both of which need the state at a moment when `isFiring`
-    /// is false — the glide re-issues its command outside any
-    /// binding fire.
+    /// Whether a held glide is applying right now.
     public var isGliding: Bool { holdGlide.isGliding }
 
-    /// Whether a glide frame's own write is executing right now
-    /// — the per-WRITE question, which `isGliding` (the hold's
-    /// lifetime) answers wrongly. The distinction is argued on
-    /// `HoldGlide.isApplyingGlideStep`.
+    /// Whether a glide frame's own write is executing right now.
     public var isApplyingGlideStep: Bool {
         holdGlide.isApplyingGlideStep
     }
 
-    /// Called once from `init`. The glide arms only when the
-    /// registrar can report releases — without that channel a
-    /// hold would never stop. The press-only registrar fakes
-    /// across the test trees stay valid by not conforming to
-    /// `HotkeyReleaseReporting`; that the PRODUCTION default
-    /// registrar does conform — and so keeps the feature alive —
-    /// is pinned by `HoldGlideEligibilitySeamTests`, since every suite here
-    /// hands in a conforming fake and would stay green with the
-    /// live channel lost.
+    /// Connects release event channel to `HoldGlide`
+    /// (`HoldGlideEligibilitySeamTests`).
     func wireHoldGlideChannels(registrar: HotkeyRegistrar) {
         if let reporting =
             registrar as? HotkeyReleaseReporting
@@ -48,11 +29,7 @@ extension KeybindingManager {
         }
     }
 
-    /// `KiwiCore.execute` reports every command run inside a
-    /// hotkey fire, so the glide can decide eligibility from what
-    /// the press actually did — a binding's body is opaque Lua,
-    /// so this is the one honest signal — and can capture the
-    /// arguments it will re-issue.
+    /// Records command executed during hotkey press for glide eligibility.
     public func noteCommand(
         _ name: String,
         args: [JSONValue],
@@ -66,59 +43,20 @@ extension KeybindingManager {
         )
     }
 
-    /// A size-limit refusal cue fired (#933): a held run stops,
-    /// so the pill flashes once per hold. Heard during the press
-    /// fire AND during the glide, which runs outside any fire —
-    /// the gate is those two states rather than none.
-    ///
-    /// The residue that widening buys, stated rather than left
-    /// implied (code review, 2026-08-29): the same
-    /// `cueResizeRefusal` funnel serves the MOUSE resize end, so
-    /// for the glide's duration a mouse refusal now passes this
-    /// gate and ends the keyboard hold. Accepted — it needs a
-    /// drag and a held chord at once, and the failure is a hold
-    /// that stops early rather than one that cannot stop — but it
-    /// is a real widening, and the pre-#1082 comment here claimed
-    /// the gate excluded exactly this.
+    /// Notifies glide manager of resize limit refusal cue (#933, 2026-08-29).
     public func noteResizeRefusal() {
         guard isFiring || holdGlide.isGliding else { return }
         holdGlide.noteRefusal()
     }
 
-    /// A physical key-down fire: runs the binding, then lets the
-    /// ladder decide from the fire's own tally whether holding
-    /// the chord glides it. `id` is the registration the press
-    /// arrived on, CARRIED from the registration itself
-    /// (`RegistrationBox`) rather than re-derived after the fire,
-    /// where the Lua body may have rebuilt the bindings.
-    ///
-    /// It is looked up here for EXISTENCE only, which is the
-    /// opposite question and the one thing the table can still
-    /// answer honestly after a rebuild: does the id that will
-    /// deliver the release still exist?
-    /// A body that REBOUND mid-fire arms nothing, and the test
-    /// is that its own registration survived: `bind` inside a
-    /// body runs `deactivate`, which mints fresh ids for the
-    /// same ref and combo, so the physical release for the id
-    /// this press arrived on will never be delivered — and a
-    /// glide whose stop channel is gone would run to
-    /// `maxRunSeconds` (#1056, re-homed by #1082). Under the
-    /// repeat ladder this was caught one layer down, because a
-    /// tick looked its registration up in order to re-fire the
-    /// binding; the glide re-issues the captured command instead
-    /// and never looks anything up, so the question has to be
-    /// asked HERE. Existence only — never re-deriving WHICH
-    /// binding to act on from a rebuilt table.
+    /// Executes key-down binding and arms glide if chord is held (#1056,
+    /// #1082).
     func pressFire(ref: Int32, combo: KeyCombo, id: UInt32?) {
         let outer = holdGlide.beginFire()
         fire(ref: ref, combo: combo)
         if let id, activeBindings[id] != nil {
             holdGlide.endFire(id: id)
         } else {
-            // A press with no id — or one whose registration the
-            // body replaced — cannot arm, but it is still a new
-            // press: the previous run ends, latest wins,
-            // unconditionally.
             holdGlide.cancelRun()
         }
         holdGlide.restoreTally(outer)

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager+HoldGlide.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager+HoldGlide.swift
@@ -43,14 +43,28 @@ extension KeybindingManager {
         )
     }
 
-    /// Notifies glide manager of resize limit refusal cue (#933, 2026-08-29).
+    /// Notifies the glide of a size-limit refusal cue (#933) —
+    /// heard during the press fire AND during the glide, which
+    /// runs outside any fire. Stated residue (code review,
+    /// 2026-08-29): the same `cueResizeRefusal` funnel serves the
+    /// MOUSE end, so a mouse refusal during a glide ends the
+    /// keyboard hold. Accepted — it needs a drag and a held chord
+    /// at once, and the failure is a hold that stops early.
     public func noteResizeRefusal() {
         guard isFiring || holdGlide.isGliding else { return }
         holdGlide.noteRefusal()
     }
 
-    /// Executes key-down binding and arms glide if chord is held (#1056,
-    /// #1082).
+    /// Executes the key-down binding, then lets the ladder judge
+    /// the fire's tally (#1056/#1082). `id` is CARRIED from the
+    /// registration itself, and looked up for EXISTENCE only — the
+    /// one question the table still answers honestly after a Lua
+    /// body rebuilds the bindings: `bind` inside a body runs
+    /// `deactivate`, minting fresh ids, so the release for THIS
+    /// press's id will never arrive and a glide armed on it would
+    /// run to `maxRunSeconds`. The glide re-issues the captured
+    /// command and never looks anything up, so the question must
+    /// be asked here — never re-deriving WHICH binding to act on.
     func pressFire(ref: Int32, combo: KeyCombo, id: UInt32?) {
         let outer = holdGlide.beginFire()
         fire(ref: ref, combo: combo)

--- a/Sources/KiwiDeskCore/Layouts/AppBarGeometry.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarGeometry.swift
@@ -45,8 +45,12 @@ public enum AppBarGeometry {
     /// Tolerance for bar frame clamping (2 pt, #148).
     public static let clampTolerance: CGFloat = 2
 
-    /// Nudges `frame` clear of painted bar `strip` on `edge` (#242, #1091,
-    /// QA 2026-07-19).
+    /// Nudges `frame` clear of a painted bar strip (#242, QA
+    /// 2026-07-19); position only, size unchanged. `inset` widens
+    /// the strip by the focus ring's width so the RING clears the
+    /// bar too (#1091) — applied whether or not the window is
+    /// FOCUSED, which is the point: a focus-dependent inset would
+    /// move the window on every ring change.
     public static func clampClear(
         _ frame: CGRect,
         of strip: CGRect,
@@ -79,8 +83,12 @@ public enum AppBarGeometry {
         return result
     }
 
-    /// Carves `strip` from `region` for float bounding (#1091, architect
-    /// review 2026-08-29).
+    /// Carves `strip` from `region` for float bounding (#1091).
+    /// Its sibling is `windowFrame(in:minus:edge:inner:)`, NOT
+    /// `clampClear` (architect review 2026-08-29): a new caller
+    /// takes `windowFrame` if the layout is placing the window and
+    /// this if it is not. Monotonic, and never a negative extent —
+    /// an inside-out rect reads as enormous free space.
     public static func regionClear(
         _ region: CGRect,
         of strip: CGRect,

--- a/Sources/KiwiDeskCore/Layouts/AppBarGeometry.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarGeometry.swift
@@ -1,10 +1,6 @@
 import CoreGraphics
 
-/// The concrete screen edge a bar occupies. Stored directly in
-/// bar styles (`app_bar.edge`) — absolute, never derived from a
-/// layout's axis, so both bars can sit on any of the four edges
-/// regardless of layout (#293). `CaseIterable` feeds the GUI
-/// picker and the CodingKeys parity net.
+/// Screen edge a bar occupies (`app_bar.edge`, #293).
 public enum AppBarEdge: String, Sendable, Codable, CaseIterable,
     Equatable
 {
@@ -16,12 +12,9 @@ public enum AppBarEdge: String, Sendable, Codable, CaseIterable,
     }
 }
 
-/// Carves the indicator-bar strip out of a layout's usable area
-/// so bar and windows never overlap. Shared by every layout that
-/// hosts a bar (monocle, scrolling) via `AppBarHosting`.
+/// Computes bar strips and window bounds for layouts hosting a bar.
 public enum AppBarGeometry {
-    /// The strip the bar occupies, carved from the resolved
-    /// `edge` of `usable` (AX coordinates, y grows downward).
+    /// The strip the bar occupies in AX coordinates.
     public static func barFrame(
         in usable: CGRect,
         edge: AppBarEdge,
@@ -49,36 +42,11 @@ public enum AppBarGeometry {
         }
     }
 
-    /// How far a float may sit inside a bar before the clamp
-    /// acts. Mirrors the engine's frame tolerance (#148): an
-    /// app that lands a hair off the exact target (character grids,
-    /// min sizes) must not be re-clamped every retile, which would
-    /// wobble the window.
+    /// Tolerance for bar frame clamping (2 pt, #148).
     public static let clampTolerance: CGFloat = 2
 
-    /// Nudges `frame` clear of a painted bar `strip` on its
-    /// `edge` (AX coordinates, y grows downward). Keeps a
-    /// floating window — which layout never clamps — from
-    /// sliding under a bar: the original motivator was a TOP
-    /// bar covering the title bar (#242), but a bar reserves
-    /// its edge for every window kind, the way the Dock
-    /// reserves `visibleFrame` (QA 2026-07-19). A no-op once
-    /// the frame is within `clampTolerance` of clear; position
-    /// only, size unchanged.
-    /// `inset` widens the strip by that much before clearing —
-    /// the focus ring's own width, so the RING clears the bar
-    /// rather than only the window (#1091). The ring is the
-    /// window frame outset by `border.width` and paints at
-    /// `.normal` while the bars paint at `BarPanel.level`
-    /// (`.floating`), so a window pushed flush against a strip
-    /// has that outset sliver hidden under it and the ring reads
-    /// as cut off.
-    ///
-    /// Applied whether or not the window is FOCUSED, which is
-    /// the point rather than a simplification: an inset that
-    /// depended on focus would move the window a few points
-    /// every time it gained or lost the ring. Callers pass 0
-    /// when rings are off.
+    /// Nudges `frame` clear of painted bar `strip` on `edge` (#242, #1091,
+    /// QA 2026-07-19).
     public static func clampClear(
         _ frame: CGRect,
         of strip: CGRect,
@@ -111,36 +79,8 @@ public enum AppBarGeometry {
         return result
     }
 
-    /// `region` with the bar `strip` carved off its own `edge`.
-    ///
-    /// **Its sibling is `windowFrame(in:minus:edge:inner:)`
-    /// below, not `clampClear` above** (architect review,
-    /// 2026-08-29). Both carve a region; they differ in who is
-    /// asking. `windowFrame` serves the LAYOUT, so it also
-    /// spends an inner gap and trusts the strip to sit on the
-    /// edge. This serves a FLOAT, which the layout never places:
-    /// no gap, the strip clamped rather than trusted, and the
-    /// extent floored at zero — a float can sit anywhere, so the
-    /// carve cannot assume the strip is where a bar style says
-    /// it should be. A new caller takes `windowFrame` if the
-    /// layout is placing the window and this if it is not.
-    ///
-    /// It is NOT `clampClear`'s sibling, which answers "where
-    /// may this frame sit" by MOVING it and never resizing it —
-    /// which is why a window larger than the space between two
-    /// bars was pushed aside and still overflowed (#1091).
-    ///
-    /// Monotonic, like `clampClear`, so a fold over several
-    /// strips composes in any order and two strips on one edge
-    /// leave the deeper one's carve standing. Never returns a
-    /// negative extent: bars deeper than the screen would
-    /// otherwise produce an inside-out rect that reads as
-    /// enormous free space.
-    /// `inset` carves that much further, for the same reason
-    /// `clampClear`'s does: a float GROWN flush to the region's
-    /// edge would otherwise have its ring hidden under the bar,
-    /// so the two must inset alike or the fix covers only the
-    /// windows that were pushed and not the ones that grew.
+    /// Carves `strip` from `region` for float bounding (#1091, architect
+    /// review 2026-08-29).
     public static func regionClear(
         _ region: CGRect,
         of strip: CGRect,
@@ -172,8 +112,7 @@ public enum AppBarGeometry {
         return result
     }
 
-    /// `usable` minus the bar `strip` and one inner gap between
-    /// strip and window.
+    /// `usable` minus bar `strip` and inner gap.
     public static func windowFrame(
         in usable: CGRect,
         minus strip: CGRect,
@@ -201,26 +140,20 @@ public enum AppBarGeometry {
     }
 }
 
-/// A layout that can show the indicator bar: it owns a
-/// per-layout `LayoutAppBar` (whose `edge` override, like every
-/// look field, falls back to the global style).
+/// Protocol for layouts supporting an indicator bar.
 public protocol AppBarHosting {
     var appBar: LayoutAppBar { get }
 }
 
 extension AppBarHosting {
-    /// The concrete style this layout's bar renders with: the
-    /// global `style` overlaid by this layout's overrides. Its
-    /// `edge` is the stored absolute one — the single source
-    /// everything downstream reads. Resolve once, here, at the
-    /// layer boundary.
+    /// Resolves layout bar overrides against global style.
     public func resolvedBar(
         global: AppBarStyle
     ) -> AppBarStyle {
         appBar.resolved(with: global)
     }
 
-    /// The strip the bar occupies, or nil while it is off.
+    /// Bar strip bounds or nil when disabled.
     public func barFrame(
         in usable: CGRect,
         global: AppBarStyle
@@ -234,8 +167,7 @@ extension AppBarHosting {
         )
     }
 
-    /// The window area: `usable` minus the bar strip and one
-    /// inner gap. Falls back to all of `usable` when off.
+    /// Window area minus bar strip and inner gap.
     public func windowFrame(
         in usable: CGRect,
         inner: Gaps.Inner,

--- a/Sources/KiwiDeskCore/Layouts/LayoutParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/LayoutParams.swift
@@ -1,20 +1,16 @@
 import CoreGraphics
 import Foundation
 
-// MARK: - Per-mode parameters
-
-/// `new_window_placement`: where a new window lands in a
-/// space's flat window array. Every layout shares the same
-/// vocabulary; only the default differs per layout.
+/// Where a new window lands in a space's flat window array
+/// (`new_window_placement`).
 public enum SpawnPlacement: String, Sendable, Codable, CaseIterable {
-    /// Index 0 (stack mode: the new window becomes master).
+    /// Index 0 (master window).
     case first
     /// End of the array.
     case last
     /// Directly before the focused window.
     case beforeFocused = "before_focused"
-    /// Directly after the focused window (BSP: the new
-    /// window splits the focused window's region).
+    /// Directly after the focused window.
     case afterFocused = "after_focused"
 }
 
@@ -27,20 +23,16 @@ public struct BspParams: Sendable, Equatable, Codable {
     }
 
     public var strategy: Strategy = .longestSide
-    /// Ratio of every side-by-side split (#56). `resize("x")`
-    /// nudges this one; the stacked splits keep their own.
+    /// Ratio of side-by-side splits (#56).
     public var splitRatioH: Double = 0.5
-    /// Ratio of every stacked (top/bottom) split (#56), moved
-    /// by `resize("y")` — independent of the side-by-side one.
+    /// Ratio of stacked top/bottom splits (#56).
     public var splitRatioV: Double = 0.5
     public var newWindowPlacement: SpawnPlacement = .afterFocused
-    /// Per-space overrides (`layout.bsp.override[space_id]`),
-    /// resolved via `TilingSettings.resolvedBsp(for:)`.
+    /// Per-space overrides resolved via `TilingSettings.resolvedBsp(for:)`.
     public var override: [SpaceID: BspOverride] = [:]
 
     public init() {}
 
-    /// JSON keys follow the Lua setters (`bsp.set_ratio_h`).
     private enum CodingKeys: String, CodingKey {
         case strategy
         case splitRatioH = "ratio_h"
@@ -49,8 +41,6 @@ public struct BspParams: Sendable, Equatable, Codable {
         case override
     }
 
-    /// Manual decoding: profiles saved before a field existed
-    /// must keep loading (missing keys fall back to defaults).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self
@@ -82,8 +72,6 @@ public struct BspParams: Sendable, Equatable, Codable {
             ) ?? [:]
     }
 
-    /// Manual encode so the per-space override map stays sparse
-    /// (absent when empty), unlike the synthesized encode.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(strategy, forKey: .strategy)
@@ -99,82 +87,50 @@ public struct BspParams: Sendable, Equatable, Codable {
     }
 }
 
-// `StackParams` lives in `StackParams.swift` (#222 split).
-
 public struct ScrollingParams: Sendable, Equatable, Codable,
     AppBarHosting
 {
-    /// Where the focused slot rests in the viewport, applied on
-    /// every focus change (#239).
-    ///
-    /// `CaseIterable` so the sweeps stop hand-listing the cases: a
-    /// fifth anchor has to be *drawn* by the Scrolling preview and
-    /// *placed* by it, and a hand-listed sweep would go on passing
-    /// over four of five (#753).
+    /// Viewport resting anchor for focused slot (#239, #753).
     public enum Anchor: String, Sendable, Codable, CaseIterable {
         /// Focused slot centred in the viewport.
         case center
-        /// Flush against the leading edge of the scroll axis —
-        /// left when horizontal, top when vertical. Axis-relative
-        /// so it lands where the GUI label says on either
-        /// orientation.
+        /// Flush against leading edge (left when horizontal, top when
+        /// vertical).
         case start
-        /// Flush against the trailing edge (right / bottom).
+        /// Flush against trailing edge (right when horizontal, bottom when
+        /// vertical).
         case end
-        /// Keep the prior viewport offset and pan the minimum
-        /// needed to reveal the focused slot (#66 Niri/PaperWM
-        /// scroll-into-view). The only anchor that reads the
-        /// previous offset; the side you came from stays open.
+        /// Keep prior viewport offset and pan minimum needed to reveal focus
+        /// (#66).
         case follow
     }
 
-    /// Which axis the columns scroll along — the scrolling
-    /// analogue of monocle's orientation, and what decides
-    /// which edges the indicator bar may sit on.
+    /// Axis along which columns/rows scroll.
     public enum Orientation: String, Sendable, Codable, CaseIterable {
-        /// Columns side by side, scrolling left/right; bar on
-        /// top/bottom.
         case horizontal
-        /// Rows stacked, scrolling up/down; bar on left/right.
         case vertical
     }
 
-    /// Fixed slot size along the scroll axis (column width when
-    /// horizontal, row height when vertical). `auto` by default,
-    /// resolving to an orientation-aware standard at layout time.
+    /// Fixed slot size along scroll axis.
     public var slotSize: ScrollSize = .auto
     /// Where the focused column rests in the viewport (#239).
-    /// `follow` by default: keeps today's minimal-pan feel — the
-    /// viewport holds still and pans only to reveal the focus.
     public var anchor: Anchor = .follow
     public var orientation: Orientation = .horizontal
-    /// PaperWM-style default: new columns open next to the
-    /// one you are working in.
     public var newWindowPlacement: SpawnPlacement = .afterFocused
-    /// Whether stepping `focus` past a row end wraps to the far
-    /// end (#168). OFF by default: the stop-at-ends default
-    /// matches the physical-strip feel of the layout — the row
-    /// has real ends, so focus stopping there reads as reaching
-    /// the edge, not a dead input. Monocle wraps unconditionally
-    /// (all windows share one frame, so there is no strip to
-    /// end); scrolling makes it opt-in. `swap` never wraps (see
-    /// `scrollingStep`).
+    /// Whether focus wraps past row ends (#168).
     public var wrapFocus = false
     public var appBar = LayoutAppBar()
-    /// Per-space overrides (`layout.scroll.override[space_id]`),
-    /// resolved via `TilingSettings.resolvedScrolling(for:)`.
+    /// Per-space overrides resolved via
+    /// `TilingSettings.resolvedScrolling(for:)`.
     public var override: [SpaceID: ScrollingOverride] = [:]
 
     public init() {}
 
-    /// True while the scroll axis runs horizontally (the app
-    /// bar's edge is absolute since #293 and no longer follows
-    /// this).
+    /// True while scroll axis runs horizontally (#293).
     public var axisIsHorizontal: Bool {
         orientation == .horizontal
     }
 
-    /// JSON keys follow the Lua setters (`scroll.set_slot_size`).
     private enum CodingKeys: String, CodingKey {
         case slotSize = "slot_size"
         case anchor
@@ -185,8 +141,6 @@ public struct ScrollingParams: Sendable, Equatable, Codable,
         case override
     }
 
-    /// Manual decoding: profiles saved before a field existed
-    /// must keep loading (missing keys fall back to defaults).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self
@@ -228,8 +182,6 @@ public struct ScrollingParams: Sendable, Equatable, Codable,
             ) ?? [:]
     }
 
-    /// Manual encode so the per-space override map stays sparse
-    /// (absent when empty), unlike the synthesized encode.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(slotSize, forKey: .slotSize)

--- a/Sources/KiwiDeskCore/Layouts/LayoutSystem.swift
+++ b/Sources/KiwiDeskCore/Layouts/LayoutSystem.swift
@@ -37,6 +37,11 @@ public struct Gaps: Sendable, Equatable, Codable {
         /// Gap between stacked windows (rows).
         public var vertical: CGFloat
 
+        /// The 10 pt default couples to `BorderStyle.width` (5):
+        /// two neighbouring rings each reach their width into this
+        /// gap, so 2 × 5 fills it without overlap. Lowering it
+        /// silently invalidates that rationale — revisit the width
+        /// default and its docs together.
         public init(
             horizontal: CGFloat = 10,
             vertical: CGFloat = 10
@@ -86,15 +91,22 @@ public struct LayoutContext: Sendable {
     public var trackBreaks: Set<WindowID>
     /// Track column weights (#128).
     public var trackWeights: [WindowID: Double]
-    /// Sticky windows exempt from overlap piling (#414).
+    /// Sticky windows exempt from overlap piling (#414). May
+    /// contain ids not in the passed window array (floating
+    /// stickies); layouts only test membership against the ids
+    /// they were handed, so the over-approximation is harmless.
     public var sticky: Set<WindowID>
     /// Screen neighbor topology for clamping and park corners (#878, #881).
     public var screenNeighbors: ScreenNeighbors
     /// App-enforced size bounds confirmed by engine (#677).
     public var sizeBounds: [WindowID: EffectiveSizeBound]
 
-    /// Bypasses generalized size bounds on explicit set commands (#1055,
-    /// owner ruling 2026-08-28).
+    /// Bypasses the GENERALIZED size-bound arm on a forced,
+    /// explicit-apply pass (#1055, owner ruling 2026-08-28) — an
+    /// explicit set past a corroborated bound genuinely re-asks
+    /// the app once. The probe self-terminates: the refusal it
+    /// observes mints the exact entry the next un-forced pass
+    /// consumes.
     public var probesBeyondBounds = false
 
     public var bsp: BspParams

--- a/Sources/KiwiDeskCore/Layouts/LayoutSystem.swift
+++ b/Sources/KiwiDeskCore/Layouts/LayoutSystem.swift
@@ -1,21 +1,16 @@
 import CoreGraphics
 import Foundation
 
-/// A layout algorithm: a pure function from a flat window array
-/// to per-window geometry. No trees, no containers — this is the
-/// core KiwiDesk idea.
+/// Pure function layout algorithm from flat window array to geometry.
 public protocol LayoutSystem: Sendable {
-    /// Calculates frames for tiled windows inside the context's
-    /// bounds. Windows not present in the result keep their
-    /// current frame (e.g. floating mode returns [:]).
+    /// Computes frames for tiled windows inside context bounds.
     func calculateGeometry(
         for windows: [WindowID],
         in context: LayoutContext
     ) -> [WindowID: CGRect]
 }
 
-/// Gap configuration (Rift-style): outer gaps per screen edge,
-/// inner gaps between adjacent windows.
+/// Gap configuration with outer edge gaps and inner inter-window gaps.
 public struct Gaps: Sendable, Equatable, Codable {
     public struct Outer: Sendable, Equatable, Codable {
         public var top: CGFloat
@@ -42,12 +37,6 @@ public struct Gaps: Sendable, Equatable, Codable {
         /// Gap between stacked windows (rows).
         public var vertical: CGFloat
 
-        /// The 10 pt default couples to `BorderStyle.width` (5 pt):
-        /// two neighbouring focus rings each reach their width into
-        /// this gap, so `2 × 5 = 10` fills it edge-to-edge without
-        /// overlap. Lowering this default silently invalidates that
-        /// rationale (rings would overlap with unfocused borders on) —
-        /// revisit the width default and its docs if you change it.
         public init(
             horizontal: CGFloat = 10,
             vertical: CGFloat = 10
@@ -79,76 +68,33 @@ public struct Gaps: Sendable, Equatable, Codable {
     }
 }
 
-/// Everything a layout needs to compute geometry.
+/// Geometry and parameters context for layout calculation.
 public struct LayoutContext: Sendable {
     /// Usable screen area in layout coordinates.
     public var bounds: CGRect
     /// Resolved gaps for this space (override > global).
     public var gaps: Gaps
-    /// The window Scrolling pans to. A render/pan anchor that may
-    /// diverge from the space's own focus: it can carry a
-    /// tiled-sticky traveler that is the frontmost window but not
-    /// the membership-guarded `focused` slot (#431,
-    /// `StateCoordinator.focusAnchor`). Scrolling reads it to
-    /// pan, and Monocle's `park` hide style reads it to pick
-    /// the one member it shows (#881) — Monocle's raise still
-    /// resolves the anchor itself (`restoreMonocleZOrder`), it
-    /// does not read this field.
+    /// Focused window or pan anchor (#431, #881).
     public var focused: WindowID?
-    /// Below this width/height the Overlap Stack kicks in.
+    /// Overlap Stack trigger dimension threshold.
     public var minWindowSize: CGFloat
-    /// Per-window vertical share of a stack column (#67);
-    /// absent = 1.0. Snapshot of `Space.stackWeights`.
+    /// Stack column share per window (#67).
     public var stackWeights: [WindowID: Double]
-    /// The scrolling layout's viewport rest from the last tile
-    /// — the offset and the slot it was measured against (#66,
-    /// #966); `nil` before the space has ever scrolled.
-    /// Snapshot of `Space.scrollRest`.
+    /// Viewport offset and anchor slot from last scrolling tile (#66, #966).
     public var scrollRest: ScrollRest?
-    /// The track layout's break markers (#128): a window in the
-    /// set starts a new track (`TrackLayout.counts`). Snapshot
-    /// of `Space.trackBreaks`.
+    /// Track layout break markers (#128).
     public var trackBreaks: Set<WindowID>
-    /// Per-track size weight, keyed by the track's head window
-    /// (#128). Snapshot of `Space.trackWeights`.
+    /// Track column weights (#128).
     public var trackWeights: [WindowID: Double]
-    /// Sticky windows (#414 v2): members here keep a fully
-    /// tiled slot when a layout overflows into an
-    /// `OverlapStack` pile (`OverlapStack.stickyExempt`) —
-    /// a non-sticky window overflows instead. May contain ids
-    /// not in the passed window array (floating stickies);
-    /// layouts only ever test membership against the ids they
-    /// were handed, so the over-approximation is harmless.
+    /// Sticky windows exempt from overlap piling (#414).
     public var sticky: Set<WindowID>
-    /// Which screen edges have another screen beyond them
-    /// (#878). Scrolling picks its per-edge clamp form from
-    /// this, and Monocle's `park` hide style picks its stash
-    /// corner from the left/right pair (#881); every other
-    /// layout ignores it. Defaults to no neighbors — the
-    /// single-screen verdict, under which every edge is open,
-    /// the clamps behave as they did before the flags existed,
-    /// and the park corner is the bottom-right default.
+    /// Screen neighbor topology for clamping and park corners (#878, #881).
     public var screenNeighbors: ScreenNeighbors
-    /// App-enforced size bounds the engine has confirmed
-    /// (#677), keyed by window. A layout MAY consume one as
-    /// that window's own extent — scrolling re-packs the row
-    /// around the answered span, monocle centers the answered
-    /// size — so the refusal's residue is placed deliberately.
-    /// Only an ask matching the refused one consumes
-    /// (`EffectiveSizeBound.consumedWidth/Height`); defaults
-    /// empty, under which every layout asks exactly what it
-    /// always did — capacity probes and schematic previews
-    /// rightly omit it.
+    /// App-enforced size bounds confirmed by engine (#677).
     public var sizeBounds: [WindowID: EffectiveSizeBound]
 
-    /// True only for a FORCED (explicit-apply) layout pass
-    /// (#1055, owner ruling 2026-08-28): the consume then
-    /// bypasses the GENERALIZED arm — exact refused asks still
-    /// consume — so an explicit `scroll.set_slot_size` past a
-    /// corroborated bound genuinely re-asks the app once,
-    /// keeping the ruling's third falsifier alive. The probe
-    /// self-terminates: the refusal it observes mints the
-    /// exact entry the next un-forced pass consumes.
+    /// Bypasses generalized size bounds on explicit set commands (#1055,
+    /// owner ruling 2026-08-28).
     public var probesBeyondBounds = false
 
     public var bsp: BspParams
@@ -157,8 +103,7 @@ public struct LayoutContext: Sendable {
     public var grid: GridParams
     public var monocle: MonocleParams
     public var track: TrackParams
-    /// The indicator bar's global look; a layout resolves its
-    /// own bar against this to carve the strip.
+    /// Global indicator bar style for strip reservation.
     public var appBarStyle: AppBarStyle
 
     public init(

--- a/Sources/KiwiDeskCore/Layouts/QuitLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/QuitLayout.swift
@@ -1,54 +1,26 @@
 import CoreGraphics
 
-/// Quit-time teardown placement (#197): how remaining managed
-/// windows are arranged when KiwiDesk exits. Lua
-/// `quit.set_layout` → JSON `quit.layout`.
-///
-/// The strategy seam: a future style (center, columns, …) adds
-/// a case here plus its own pure target function in the
-/// `QuitGridLayout` pattern — `WindowGather.targets` switches
-/// over this enum. `grid` is the only accepted value today.
+/// Quit teardown window layout styles (#197).
 public enum QuitLayoutStyle: String, Codable, Sendable,
     CaseIterable
 {
     case grid
 }
 
-/// The `grid` quit layout: a per-display round-robin grid with
-/// an `overflow_all`-style cascade in **every** cell (the
-/// normal grid layout piles only the last cell). Pure math
-/// over one display's flat window list; the state walk lives
-/// in `WindowGather` (Teardown).
+/// Round-robin cascading grid quit layout math (#197, #281).
 public enum QuitGridLayout {
-    /// Standard stack depth a cell targets before the grid
-    /// grows a dimension (`quit.grid_target_depth`, #281). Not
-    /// a hard maximum: past the 4×4 cap, cells keep cascading.
+    /// Default stack depth per cell before grid dimension expands (5, #281).
     public static let defaultTargetDepth = 5
-    /// The accepted density range — one source for the
-    /// `quit.set_grid_target_depth` command and the GUI
-    /// stepper, so their bounds cannot drift.
+    /// Accepted grid target depth range (1...20).
     public static let targetDepthRange = 1...20
-    /// Dimension cap: at most 4×4 = 16 cells per display. A
-    /// teardown safety boundary (min window size, cascade
-    /// reachability, no live manager after quit), not a visual
-    /// preference — deliberately not configurable. The 2×2…4×4
-    /// span and its 4T/9T growth thresholds are restated as
-    /// prose in `BehaviorSection` (help + live summary),
-    /// `docs/user-guide.md`, and `docs/lua-reference.md` —
-    /// changing the cap or the formula means updating those
-    /// four sites too.
+    /// Teardown dimension ceiling (4x4 = 16 cells max per display).
     public static let maxDimension = 4
 
-    /// Grid dimension for `count` windows:
-    /// `clamp(ceil(sqrt(count / targetDepth)), 2, maxDimension)`.
-    /// One formula, no branch list — at the standard target 5:
-    /// ≤20 → 2×2, ≤45 → 3×3, above → 4×4 (capped).
+    /// Calculates grid dimension for `count` windows with `targetDepth` depth.
     public static func dimension(
         for count: Int,
         targetDepth: Int
     ) -> Int {
-        // Range enforcement lives at the command/GUI edges;
-        // the pure math only guards the division.
         let depth = max(targetDepth, 1)
         let needed = (Double(count) / Double(depth))
             .squareRoot()
@@ -56,11 +28,7 @@ public enum QuitGridLayout {
         return min(max(Int(needed), 2), maxDimension)
     }
 
-    /// Round-robin cell buckets: window `i` lands in cell
-    /// `i % cells` (row-major). The shared partition behind
-    /// `frames` and `raiseOrder` — both MUST agree, or the
-    /// raise circle stacks a different pile than the one
-    /// placed.
+    /// Partitions windows into round-robin cell buckets.
     private static func buckets(
         for windows: [WindowID],
         targetDepth: Int
@@ -79,19 +47,8 @@ public enum QuitGridLayout {
         return buckets
     }
 
-    /// Round-robin targets for one display: window `i` lands
-    /// in cell `i % cells` (row-major over `axFrame`), and
-    /// each cell's pile cascades like `overflow_all`
-    /// (`OverlapStack.frames`, fit to the cell) so no pile
-    /// spills into the row below.
-    ///
-    /// Frames alone don't fix stacking — the quit path raises
-    /// every window in `raiseOrder` after placing, which is
-    /// what makes each pile's title bars visible.
-    ///
-    /// `axFrame` is the display's visible frame in AX
-    /// (top-left-origin) coordinates; the returned rects are
-    /// AX too.
+    /// Computes target rects for windows arranged in round-robin cascading
+    /// cells.
     public static func frames(
         for windows: [WindowID],
         in axFrame: CGRect,
@@ -133,24 +90,7 @@ public enum QuitGridLayout {
         return result
     }
 
-    /// The deterministic raise circle for one display: cell
-    /// by cell (row-major — quadrant 1, 2, 3, 4), each pile
-    /// top slot first and deepest slot last. Raising in this
-    /// order makes the final stacking independent of whatever
-    /// z-order (and focus) existed at quit: within a pile
-    /// every title bar stays visible, and a later row always
-    /// sits above the row before it, so even a degenerate
-    /// pile that spills downward cannot bury the next row's
-    /// headers.
-    ///
-    /// That is what the ORDER buys, and it is the whole of what
-    /// this function promises — the stacking that actually
-    /// results is the caller's. `restackForTeardown` drops one
-    /// member before raising (the frontmost app's key window,
-    /// which no quiet raise can beat) and is bounded by a wall
-    /// clock, so in that member's pile the two guarantees above
-    /// do not hold. Read them as properties of the circle, not
-    /// of every quit (#688).
+    /// Deterministic raise circle order across quit grid cells (#688).
     public static func raiseOrder(
         for windows: [WindowID],
         targetDepth: Int
@@ -162,12 +102,7 @@ public enum QuitGridLayout {
         ).flatMap { $0 }
     }
 
-    /// Pins a cascaded frame's origin so at least `minSize`
-    /// of the window stays inside `axFrame`. Deep piles in
-    /// bottom-row cells (past 4×4 the cascade depth is
-    /// unbounded) and minSize-floored cells on tiny displays
-    /// would otherwise push title bars off-screen —
-    /// unrecoverable once no manager is alive.
+    /// Pins frame origin so at least `minSize` stays inside visible `axFrame`.
     private static func pinned(
         _ frame: CGRect,
         in axFrame: CGRect,

--- a/Sources/KiwiDeskCore/Layouts/QuitLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/QuitLayout.swift
@@ -13,7 +13,12 @@ public enum QuitGridLayout {
     public static let defaultTargetDepth = 5
     /// Accepted grid target depth range (1...20).
     public static let targetDepthRange = 1...20
-    /// Teardown dimension ceiling (4x4 = 16 cells max per display).
+    /// Teardown dimension ceiling (4×4), a safety boundary and
+    /// deliberately not configurable. The 2×2…4×4 span and its
+    /// growth thresholds are restated as prose in
+    /// `BehaviorSection`, `docs/user-guide.md` and
+    /// `docs/lua-reference.md` — changing the cap or the formula
+    /// updates those sites too.
     public static let maxDimension = 4
 
     /// Calculates grid dimension for `count` windows with `targetDepth` depth.
@@ -28,7 +33,9 @@ public enum QuitGridLayout {
         return min(max(Int(needed), 2), maxDimension)
     }
 
-    /// Partitions windows into round-robin cell buckets.
+    /// Round-robin cell buckets — the shared partition behind
+    /// `frames` and `raiseOrder`: both MUST agree, or the raise
+    /// circle stacks a different pile than the one placed.
     private static func buckets(
         for windows: [WindowID],
         targetDepth: Int
@@ -90,7 +97,12 @@ public enum QuitGridLayout {
         return result
     }
 
-    /// Deterministic raise circle order across quit grid cells (#688).
+    /// Deterministic raise circle order across quit-grid cells.
+    /// The order is the whole promise — the resulting stacking is
+    /// the caller's: `restackForTeardown` drops one member (the
+    /// unbeatable key window) and is wall-clock bounded, so read
+    /// the guarantees as properties of the circle, not of every
+    /// quit (#688).
     public static func raiseOrder(
         for windows: [WindowID],
         targetDepth: Int

--- a/Sources/KiwiDeskCore/Layouts/StackLayout+Domain.swift
+++ b/Sources/KiwiDeskCore/Layouts/StackLayout+Domain.swift
@@ -1,7 +1,11 @@
 /// Stack layout shared domain rules: weight domain, partition, and resize
 /// math (#44, #67).
 extension StackLayout {
-    /// Renormalization floor applied when reading stack weight (#67).
+    /// Renormalization floor applied when READING a stack weight
+    /// (#67). Deliberately below `weightRange.lowerBound`: the
+    /// command never stores a value this small, so the floor only
+    /// defends against a future writer — do not collapse the two
+    /// constants.
     public static let weightFloor: Double = 0.05
     /// Clamp for resize command stored weights (#67).
     public static let weightRange: ClosedRange<Double> = 0.1...10
@@ -15,8 +19,11 @@ extension StackLayout {
         public let blockedByOther: Int?
     }
 
-    /// Safety margin (pt) added to minimum size before deriving weight clamp
-    /// (#925).
+    /// Safety margin (pt) added to a minimum before deriving its
+    /// weight clamp (#925): the cascade check sits at exact
+    /// equality with the clamp's fixed point, so float rounding
+    /// alone could tip a clamped write into a pile. A quarter
+    /// point is invisible on screen and decisively inside.
     public static let minSizeMargin: Double = 0.25
 
     /// Single authority for interactive weight step math (#67, #128).

--- a/Sources/KiwiDeskCore/Layouts/StackLayout+Domain.swift
+++ b/Sources/KiwiDeskCore/Layouts/StackLayout+Domain.swift
@@ -1,61 +1,25 @@
-/// The stack layout's shared domain rules (#44/#67), split from
-/// `StackLayout` for file size (AGENTS.md §2): the weight
-/// domain, the master/stack partition, and the effective-ratio
-/// authorities consumed by both the layout math and the
-/// interactive resize paths — single sources so the write side
-/// and the render side cannot drift apart (parity rule).
+/// Stack layout shared domain rules: weight domain, partition, and resize
+/// math (#44, #67).
 extension StackLayout {
-    /// Renormalization floor applied when *reading* a stack
-    /// weight (#67) — shared with the `resize` command so the
-    /// command's step math and the layout's distribution can
-    /// never disagree on the domain. Deliberately below
-    /// `weightRange.lowerBound`: the command never stores a
-    /// value this small, so the floor only defends against a
-    /// future writer — do not collapse the two constants.
+    /// Renormalization floor applied when reading stack weight (#67).
     public static let weightFloor: Double = 0.05
-    /// Clamp for what the `resize` command *stores* (#67).
+    /// Clamp for resize command stored weights (#67).
     public static let weightRange: ClosedRange<Double> = 0.1...10
 
-    /// What one interactive weight step did besides the value:
-    /// whether a shrink stopped at the stepped share's own
-    /// minimum, and which OTHER index's minimum capped a grow —
-    /// the inputs the refusal cues render (#933). `nil`
-    /// `blockedByOther` with an unchanged value on a grow means
-    /// only the store clamp (`weightRange`) engaged, which is a
-    /// domain bound, not a size limit — no cue.
+    /// Outcome of an interactive weight step (#933).
     public struct WeightStepOutcome: Equatable, Sendable {
         public let value: Double
-        /// A shrink was truncated at the stepped share's own
-        /// minimum size (fires on the first attempt that LANDS
-        /// on the minimum, not only once already there).
+        /// Shrink was truncated at stepped share's own minimum size.
         public let hitOwnMinimum: Bool
-        /// The other index whose minimum size capped a grow.
+        /// Other index whose minimum size capped a grow.
         public let blockedByOther: Int?
     }
 
-    /// Safety margin (pt) added to a minimum before deriving
-    /// its weight clamp. The layout's cascade check
-    /// (`maxColumnTotal` over the SAME span) sits at exact
-    /// equality with the clamp's fixed point, so float rounding
-    /// alone could tip a clamped-at-minimum write over the
-    /// cliff into an `OverlapStack` pile — the #925 failure
-    /// one epsilon wide. A quarter point is invisible on
-    /// screen and decisively inside the guard.
+    /// Safety margin (pt) added to minimum size before deriving weight clamp
+    /// (#925).
     public static let minSizeMargin: Double = 0.25
 
-    /// One interactive weight step (#67/#128): the new value
-    /// for `weights[index]` after a `resize` of `delta` points
-    /// over a span of `span`. The single authority for the
-    /// step math shared by the stack's `"y"` path and both
-    /// track knobs — with heights h = A·w/W, dh/dw =
-    /// A·(W−w)/W², so the exact step for dh = delta is
-    /// dw = delta·W²/(A·(W−w)). Growing is capped where the
-    /// smallest OTHER share would drop below `minSize` (past
-    /// that cliff the layout cascades and extra weight only
-    /// ratchets invisibly), never forced below the current
-    /// value so an overflowed group stays editable downwards;
-    /// the result clamps to `weightRange`. Callers pass
-    /// already-floored weights (`weightFloor`).
+    /// Single authority for interactive weight step math (#67, #128).
     public static func weightStep(
         weights: [Double],
         at index: Int,
@@ -75,17 +39,8 @@ extension StackLayout {
         ).value
     }
 
-    /// The per-share form of `weightStep` (#933): `minSizes`
-    /// carries each index's own effective minimum (the global
-    /// `min_window_size` raised by that window's learned
-    /// app-enforced bound, #677), so a shrink clamps at the
-    /// stepped window's own floor while a grow caps where the
-    /// FIRST other share would drop below ITS floor — the two
-    /// directions read different windows' minimums, which the
-    /// single-`minSize` form cannot express. Callers pass the
-    /// span the layout actually divides (gap-adjusted); a raw
-    /// region span lets the stored value cross the layout's
-    /// cascade check by exactly the gaps (#925's residue).
+    /// Per-share interactive weight step respecting individual size floors
+    /// (#933, #677, #925).
     public static func weightStep(
         weights: [Double],
         at index: Int,
@@ -150,19 +105,8 @@ extension StackLayout {
         )
     }
 
-    /// The span a weighted group actually divides (#933): the
-    /// pre-outer-gap region span minus the outer gaps on the
-    /// weighted axis and one inner gap per boundary — the same
-    /// arithmetic the layouts perform on their `usable` rect.
-    /// The interactive weight clamps must divide THIS span,
-    /// never the raw region: a raw span lets a
-    /// clamped-at-minimum write cross the layouts' cascade
-    /// checks by exactly the gaps (#925's residue), and the
-    /// hand-copied subtraction is precisely the drift that
-    /// shipped it — so every weight clamp and heal divides
-    /// this one copy (the track paths through
-    /// `TrackLayout.acrossSpan`/`alongSpan`, which own the
-    /// axis→gap selection the same way).
+    /// Usable span after outer and inner gaps for weighted division
+    /// (#933, #925).
     public static func weightedSpan(
         region: Double,
         outer: Double,
@@ -172,28 +116,17 @@ extension StackLayout {
         region - outer - innerGap * Double(max(count - 1, 0))
     }
 
-    /// The largest weight total a zone can carry along its
-    /// axis (`span`) before its smallest share drops below
-    /// `minSize` — the single authority behind both the
-    /// layout's cascade check and the resize command's growth
-    /// cap, so the two formulas cannot drift apart (#67
-    /// review; parity rule).
+    /// Largest weight total before smallest share drops below `minSize` (#67).
     public static func maxColumnTotal(
         smallestWeight: Double,
         span: Double,
         minSize: Double
     ) -> Double {
-        // No (or nonsense) minimum → no cliff, matching the
-        // old `share < minSize` comparison for minSize ≤ 0.
         guard minSize > 0 else { return .infinity }
         return smallestWeight * span / minSize
     }
 
-    /// The master/stack partition of a tiled window array —
-    /// the single authority consumed by `calculateGeometry`
-    /// and the `resize` command (#67 review: a third
-    /// hand-mirror of this rule had crept in). `stack` is nil
-    /// while everything still fits in the master zone.
+    /// Master/stack partition of tiled windows (#67).
     public static func partition(
         _ windows: [WindowID],
         masterCount: Int
@@ -208,8 +141,8 @@ extension StackLayout {
         return (windows[..<boundary], windows[boundary...])
     }
 
-    /// The column (zone) of `partition` holding `member`, or
-    /// nil when it is not in `windows`.
+    /// Column (zone) of `partition` containing `member` (nil if not in
+    /// windows).
     public static func column(
         containing member: WindowID,
         in windows: [WindowID],

--- a/Sources/KiwiDeskCore/Localization/LocalizationManager.swift
+++ b/Sources/KiwiDeskCore/Localization/LocalizationManager.swift
@@ -18,9 +18,19 @@ public final class LocalizationManager: ObservableObject {
         reload()
     }
 
-    /// Effective locale code (`nil` for inline English fallback, #659).
+    /// Effective locale code (`nil` = inline English). Reads
+    /// `Locale.preferredLanguages`, never `Locale.current`: inside
+    /// the packaged `.app` the resolved locale answered
+    /// `CFBundleDevelopmentRegion` (English) whatever the system
+    /// language, because the bundle declared no other localization
+    /// — and it never reproduced under `swift run`, which has no
+    /// Info.plist at all (#659; `build-app.sh` also declares
+    /// `CFBundleLocalizations`, and the two ship together).
     public var effectiveLocale: String? {
         if let selection {
+            // Explicit English: no en.json ships, so it resolves
+            // to inline English everywhere — never the OS
+            // language. Distinct from nil (System default).
             if selection == "en" { return nil }
             return available.contains(selection)
                 ? selection : nil

--- a/Sources/KiwiDeskCore/Localization/LocalizationManager.swift
+++ b/Sources/KiwiDeskCore/Localization/LocalizationManager.swift
@@ -1,29 +1,16 @@
 import Foundation
 
-/// Locale lookup for every user-facing string in the GUI
-/// (issue #9). English is the source of truth, inlined at every
-/// call site (`L("key", "English")`); a locale file only needs
-/// to carry the keys it translates — any key it omits falls
-/// back to the English argument, per-key.
-///
-/// Lives in `KiwiDeskCore` (not the GUI target) so both the
-/// SwiftUI settings window and the AppKit quick menu
-/// (`StatusItemController`) can call the same lookup.
+/// Locale lookup for user-facing GUI strings with inline English fallback
+/// (#9).
 @MainActor
 public final class LocalizationManager: ObservableObject {
     public static let shared = LocalizationManager()
 
-    /// `nil` means "System default" — the macOS UI locale when a
-    /// matching locale file ships, else English. A non-nil value
-    /// is an explicit user pick (persisted by the GUI layer via
-    /// `LocalizationPreference`, backed by `UserDefaults`; this
-    /// manager does not read or write that store itself).
+    /// Explicit user selection (`nil` for system default).
     @Published public private(set) var selection: String?
-    /// The locale codes shipped as `Resources/Locales/*.json`,
-    /// excluding `en`.
+    /// Available locale codes from bundled `Resources/Locales/*.json`.
     public let available: [String]
 
-    /// The effective locale's key -> translation dictionary.
     private var strings: [String: String] = [:]
 
     private init() {
@@ -31,39 +18,9 @@ public final class LocalizationManager: ObservableObject {
         reload()
     }
 
-    /// The locale actually in effect right now: the explicit
-    /// selection if shipped, else the macOS UI language if
-    /// shipped, else English (`nil` meaning English — there is
-    /// no `en.json` to load; English lives inline at call
-    /// sites).
-    ///
-    /// "System default" reads `Locale.preferredLanguages` — the
-    /// user's ordered language list — and not
-    /// `Locale.current.language`, which is the *resolved* locale
-    /// for this process. Inside the packaged `.app` that
-    /// resolution answered `CFBundleDevelopmentRegion` (English)
-    /// whatever the system language was, because the bundle
-    /// declared no other localization, so this branch could not
-    /// return anything else (#659). It never reproduced under
-    /// `swift run`, which has no `Info.plist` at all.
-    ///
-    /// `scripts/build-app.sh` now also declares
-    /// `CFBundleLocalizations`, and the two changes ship
-    /// together. Scoping the claim honestly: `preferredLanguages`
-    /// is documented as the *user's* list rather than the
-    /// bundle-resolved one, so the matcher change alone may well
-    /// be what fixes this path — that was not measured inside a
-    /// packaged build. The plist is independently right (it is
-    /// what makes macOS treat KiwiDesk as multilingual at all,
-    /// including its per-app language entry in System Settings),
-    /// which is why it is not worth unpicking which half carries
-    /// the fix.
+    /// Effective locale code (`nil` for inline English fallback, #659).
     public var effectiveLocale: String? {
         if let selection {
-            // Explicit English: no `en.json` ships (English lives
-            // inline), so it resolves to the empty dictionary —
-            // inline English everywhere — never to the OS
-            // language. Distinct from `nil` (System default).
             if selection == "en" { return nil }
             return available.contains(selection)
                 ? selection : nil
@@ -74,24 +31,12 @@ public final class LocalizationManager: ObservableObject {
         )
     }
 
-    /// Looks up `key` in the effective locale; returns `english`
-    /// when the locale has no translation for it (per-key
-    /// fallback) or when the effective locale is English.
+    /// Looks up translation for `key`, falling back to `english`.
     public func string(_ key: String, _ english: String) -> String {
         strings[key] ?? english
     }
 
-    /// The interpolating counterpart of `string(_:_:)`: resolves
-    /// the template (translation-or-English, same per-key
-    /// fallback) then fills it with `args` via `String(format:)`.
-    /// Templates use POSITIONAL specifiers (`%1$@`, `%2$d`, …),
-    /// never bare `%@`/`%d` — positional lets a translation
-    /// reorder an argument relative to the surrounding words,
-    /// which is the entire reason this overload exists instead
-    /// of `+`-concatenating a prefix and a value (issue #9
-    /// review: a concatenated fragment can never be reordered by
-    /// a translation, no matter how the target language's
-    /// grammar wants it).
+    /// Looks up format template and interpolates positional `args` (#9).
     public func string(
         _ key: String,
         _ english: String,
@@ -101,18 +46,13 @@ public final class LocalizationManager: ObservableObject {
         return String(format: template, arguments: args)
     }
 
-    /// Updates the explicit selection and reloads the effective
-    /// locale's strings. Pass `nil` to restore "System default".
-    /// Persisting the choice (`LocalizationPreference`) is the
-    /// caller's job (`SettingsModel+Language.swift`).
+    /// Updates explicit locale selection and reloads translations.
     public func select(_ locale: String?) {
         selection = locale
         reload()
     }
 
-    /// Injects a persisted selection at startup, before any view
-    /// reads `string(_:_:)`, without re-publishing twice — call
-    /// this once, ahead of building the UI.
+    /// Seeds persisted locale selection at startup.
     public func adoptPersistedSelection(_ locale: String?) {
         selection = locale
         reload()
@@ -124,24 +64,14 @@ public final class LocalizationManager: ObservableObject {
     }
 }
 
-/// Shorthand call-site lookup: `L("menu.quit", "Quit KiwiDesk")`.
-/// Delegates to `LocalizationManager.shared`. The single-letter
-/// name is the deliberate convention (matches the terse `L(_:_:)`
-/// idiom used by other gettext-style i18n APIs) — exempted from
-/// swift-format's lower-camel-case rule below.
+/// Shorthand string lookup with inline English fallback (#9).
 // swift-format-ignore: AlwaysUseLowerCamelCase
 @MainActor
 public func L(_ key: String, _ english: String) -> String {
     LocalizationManager.shared.string(key, english)
 }
 
-/// The interpolating overload: `L("monitor_chip.move_to",
-/// "Move to %1$@", display.name)`. The template's positional
-/// specifiers (`%1$@`, `%2$d`, …) let a translation reorder an
-/// argument, unlike a `+`-concatenated prefix/suffix pair — use
-/// this instead of building a sentence out of literal
-/// concatenation whenever a value needs to sit inside English
-/// prose. See `docs/translating.md` for the convention.
+/// Shorthand string lookup with positional argument interpolation (#9).
 // swift-format-ignore: AlwaysUseLowerCamelCase
 @MainActor
 public func L(

--- a/Sources/KiwiDeskCore/Models/WindowModel.swift
+++ b/Sources/KiwiDeskCore/Models/WindowModel.swift
@@ -15,6 +15,10 @@ public struct WindowID: Hashable, Sendable, Codable,
 }
 
 /// Running application identity and localized display name.
+/// `bundleID` is lower-cased on the way in: LaunchServices treats
+/// bundle identifiers case-insensitively, so a stored config
+/// value and the live `NSRunningApplication` value must compare
+/// in one case. `name` is presentation only — never matching.
 public struct AppRef: Sendable, Equatable {
     public let bundleID: String?
     public let name: String
@@ -76,8 +80,10 @@ public struct ManagedWindow: Sendable, Equatable {
         self.isFullscreen = isFullscreen
     }
 
-    /// Reconstructs snapshot with a new `WindowID` for native tab switches
-    /// (#308).
+    /// Reconstructs the snapshot with a new `WindowID` for native
+    /// tab switches (#308) — kept beside the field list so the
+    /// mirror lives in one place; a `WindowManager` round-trip
+    /// test guards a forgotten field.
     public func withID(_ newID: WindowID) -> ManagedWindow {
         ManagedWindow(
             id: newID,

--- a/Sources/KiwiDeskCore/Models/WindowModel.swift
+++ b/Sources/KiwiDeskCore/Models/WindowModel.swift
@@ -1,10 +1,7 @@
 import CoreGraphics
 import Foundation
 
-/// Stable identifier of a managed window.
-///
-/// Wraps the system `CGWindowID` so the rest of the codebase never
-/// deals with raw integers.
+/// Stable identifier of a managed window wrapping `CGWindowID`.
 public struct WindowID: Hashable, Sendable, Codable,
     CustomStringConvertible
 {
@@ -17,23 +14,7 @@ public struct WindowID: Hashable, Sendable, Codable,
     public var description: String { "window#\(raw)" }
 }
 
-/// Identity and display name of a running application, captured
-/// once when KiwiDesk attaches to the app.
-///
-/// `bundleID` is the stable match key that app rules
-/// (`float_rules`, `app_rules`) and the app launcher
-/// (`pull_or_spawn`) target: canonical, locale-independent, and
-/// unaffected by bundle renames — unlike the localized display
-/// name, which is presentation, not identity. It is lower-cased
-/// on the way in because LaunchServices treats bundle
-/// identifiers case-insensitively, so a stored config value and
-/// the live `NSRunningApplication.bundleIdentifier` compare in
-/// one case. Nil for unbundled helper processes, which cannot be
-/// targeted by a rule (accepted limitation — see
-/// docs/design-decisions.md).
-///
-/// `name` is the localized display name, for the menu bar,
-/// diagnostics, and logging only — never for matching.
+/// Running application identity and localized display name.
 public struct AppRef: Sendable, Equatable {
     public let bundleID: String?
     public let name: String
@@ -44,76 +25,31 @@ public struct AppRef: Sendable, Equatable {
     }
 }
 
-/// How widely a window sticks across Spaces (#414/#445).
-///
-/// A sticky window is a real member of exactly one space (the
-/// flat-array invariant) — stickiness only DERIVES its presence
-/// elsewhere and exempts it from the inactive-space stash. The
-/// scope decides *where* that presence extends:
-///
-/// - `.none`: an ordinary window, hidden with its home space.
-/// - `.global`: every space of EVERY monitor (the original #414
-///   sticky). Wears the `infinity` mark.
-/// - `.display`: every space of ONE monitor — its home space's
-///   display (#445). Follows to another monitor only via an
-///   explicit cross-display `move_to_space`, which re-homes it.
-///   Wears the `pin.fill` mark.
-///
-/// The home DISPLAY is not stored: it is derived from the home
-/// space's display on demand, so a re-home needs no bookkeeping.
+/// Stickiness scope across Spaces (#414, #445).
 public enum StickyScope: String, Sendable, Equatable, CaseIterable {
     case none
     case global
     case display
 }
 
-/// A snapshot of one application window tracked by KiwiDesk.
-///
-/// This is pure state: it never talks to the Accessibility API.
-/// The event loop keeps these snapshots up to date.
+/// Pure state snapshot of a window tracked by KiwiDesk.
 public struct ManagedWindow: Sendable, Equatable {
     public let id: WindowID
     public let pid: pid_t
     public var appName: String
-    /// The owning app's bundle identifier — the key app rules
-    /// match on (see `AppRef`). Nil for unbundled processes.
+    /// Owning app bundle ID for rule matching.
     public var appBundleID: String?
     public var title: String
     public var frame: CGRect
     public var isFloating: Bool
-    /// Sticky scope: present on every space of every monitor
-    /// (`.global`) or of just its home monitor (`.display`),
-    /// instead of hiding with its home space (#414/#445).
-    /// Orthogonal to `isFloating` — a per-window-instance value
-    /// set by `make_sticky` / `make_display_sticky` / the toggles,
-    /// never by detection. The window remains a member of exactly
-    /// one space (the flat-array invariant); stickiness only
-    /// exempts it from the inactive-space stash and derives its
-    /// presence elsewhere.
+    /// Stickiness across spaces (#414, #445).
     public var stickyScope: StickyScope
 
-    /// Whether the window is sticky in ANY scope — the predicate
-    /// the many "sticky at all" read sites want (pile exemption,
-    /// z-order, indicator set). Scope-specific behavior (stash
-    /// exemption, traveler injection, move guard) reads
-    /// `stickyScope` directly.
+    /// True if window is sticky in any scope.
     public var isSticky: Bool { stickyScope != .none }
-    /// A transient overlay — a launcher/panel that floats for a
-    /// structural reason (accessory activation policy, non-standard
-    /// panel subrole, or a raised CGWindow layer), NOT because a
-    /// `float_rules` entry matched. Such windows (Spotlight,
-    /// Raycast, Alfred) take focus momentarily and must not receive
-    /// a KiwiDesk focus ring, unlike a user-floated standard window
-    /// (#300). Classified once at track time (`EventLoop.track`).
+    /// Transient launcher or accessory panel without focus ring (#300).
     public var isTransientOverlay: Bool
-    /// Native (green-button) fullscreen: the window owns a
-    /// dedicated macOS Space but stays a member of its home
-    /// Space (no `.windowDestroyed` fires). It fills the
-    /// display, so a focus ring would show only at the rounded
-    /// corners — never draw one (jankyborders skips fullscreen
-    /// windows too). Snapshotted from `kAXFullScreenAttribute`
-    /// at track time and refreshed on reconcile — pure state,
-    /// no AX in the border path.
+    /// Native fullscreen state (`kAXFullScreenAttribute`).
     public var isFullscreen: Bool
 
     public init(
@@ -140,13 +76,8 @@ public struct ManagedWindow: Sendable, Equatable {
         self.isFullscreen = isFullscreen
     }
 
-    /// A copy carrying a different id, every other field preserved.
-    /// `id` is a `let` (a window's identity is immutable), so a
-    /// native-tab re-key (#308) — where the tracked `CGWindowID`
-    /// changes as the active tab switches but the window is the
-    /// same — must reconstruct the snapshot. Kept next to the field
-    /// list so the mirror lives in one place; a `WindowManager`
-    /// round-trip test guards it against a forgotten field.
+    /// Reconstructs snapshot with a new `WindowID` for native tab switches
+    /// (#308).
     public func withID(_ newID: WindowID) -> ManagedWindow {
         ManagedWindow(
             id: newID,

--- a/Sources/KiwiDeskCore/Profiles/Profile.swift
+++ b/Sources/KiwiDeskCore/Profiles/Profile.swift
@@ -1,92 +1,43 @@
 import Foundation
 
-/// A saved KiwiDesk configuration: layout modes per space plus
-/// all tiling settings, valid for one or more concrete monitor
-/// combinations (#36).
+/// Saved KiwiDesk configuration for monitor setups (#36).
 public struct Profile: Codable, Sendable, Equatable {
-    /// Format version of the profile schema (#902).
-    /// Format 0 = unversioned legacy (v0.9.7 and earlier).
-    ///
-    /// **2** since the scroll-duration rename (#1020):
-    /// `settings.animations.scroll_speed` became
-    /// `scroll_duration`. The bump is not bookkeeping — it is
-    /// what RUNS the crossing. `ConfigMigration.needsMigration`
-    /// short-circuits on `format >= targetFormat`, so a profile
-    /// written by 1.0.1 (`format: 1`) would skip every step and
-    /// keep the retired key, which decodes to the DEFAULT rather
-    /// than failing (`AnimationSettings` uses
-    /// `decodeIfPresent`). Leaving this at 1 loses the user's
-    /// tuned value silently.
+    /// Format version of profile schema (#902, #1020). Format 0 = unversioned.
     public static let currentFormat = 2
 
     public var format: Int
     public var name: String
-    /// The monitor combinations this profile covers. All entries
-    /// share one length; the profile's screen count.
+    /// Monitor combinations this profile covers (uniform screen count).
     public var monitorSets: [MonitorSet]
-    /// Spaces assigned to the *Main* role — the current main
-    /// display, resolved live. Hardware-agnostic, so stored once
-    /// at profile level, not per set.
+    /// Spaces assigned to Main role on current main display.
     public var mainSpaces: [SpaceID]
-    /// Marks this profile as its screen count's default (the
-    /// dirty-load fallback when no set matches exactly).
+    /// Default profile for this screen count.
     public var isDefault: Bool
-    /// Marks this profile as the beginner `Starter` setup seed
-    /// (#466/#485). While it is the active baseline, a monitor
-    /// change that no stored set covers recomposes the *setup*
-    /// at the live display count instead of a workflow Standard,
-    /// so the five-per-display shape survives every reconnect.
-    /// Survives edits (a tweaked mode keeps the identity) but not
-    /// a "save as new" — an explicitly named copy is the user's
-    /// own profile. Legacy/other profiles decode to `false`.
+    /// Marks starter setup baseline (#466, #485).
     public var isStarterSetup: Bool
-    /// Persisted display order of the profile's spaces (#75).
-    /// This is the authoritative order for the Spaces list and
-    /// for the reconcile rehome fallback on profile switch.
-    /// New spaces append; existing profiles without this key
-    /// decode to `[]` and fall back to the derived order.
-    ///
-    /// Authority: `gui.json` owns live display order across the
-    /// session; `Profile.spaces` owns per-profile order,
-    /// consulted when that profile is loaded. The two stay in
-    /// sync because `apply(profile:)` seeds live order from
-    /// this list and both save paths (`persistProfile`,
-    /// `overwriteProfile`) capture the resulting live order
-    /// back here.
+    /// Authoritative display order of spaces for this profile (#75).
     public var spaces: [SpaceID]
-    /// The explicitly designated rehome target (#68): windows
-    /// from spaces this profile doesn't declare land here when
-    /// the profile is loaded. nil (or a dangling reference)
-    /// falls back to the stored order's first surviving space
-    /// — the pre-#68 rule, so legacy profiles keep behaving.
+    /// Designated rehome target when spaces are missing (#68).
     public var fallbackSpace: SpaceID?
     /// Layout mode per space.
     public var spaceModes: [SpaceID: LayoutMode]
     public var settings: TilingSettings
     public var savedAt: Date
-    /// Per-profile sparse keybinding override (#55). nil
-    /// inherits the base modes (gui.json) entirely; present,
-    /// it shadows by mode name then combo (O4 soft).
+    /// Sparse keybinding overrides (#55).
     public var layers: KeyLayerOverride?
-    /// Per-profile sparse app→space rule override (#109). nil
-    /// inherits the global `app_rules` base entirely;
-    /// present, it shadows per app — with a null tombstone to
-    /// un-pin an app the base pins.
+    /// Sparse app-to-space rule overrides (#109).
     public var appRules: AppRuleOverride?
-    /// Sparse additions/removals over the global `float_rules`.
+    /// Sparse additions/removals over global `float_rules`.
     public var floatRules: RuleListOverride?
-    /// Hidden sparse additions/removals over global `ignore_rules`.
+    /// Sparse additions/removals over global `ignore_rules`.
     public var ignoreRules: RuleListOverride?
 
-    /// Derived from the sets — never stored separately.
+    /// Number of monitors covered by profile sets.
     public var monitorCount: Int {
         monitorSets.first?.monitors.count ?? 0
     }
 
-    /// Every space the profile declares — by ordered list, mode,
-    /// Main role, or a monitor pin. The one definition of "this
-    /// profile's spaces", so an authoritative load prunes to
-    /// exactly what the editor shows.
+    /// All spaces declared across ordered list, modes, Main, or pins.
     public var declaredSpaces: Set<SpaceID> {
         var all = Set(spaces)
         all.formUnion(spaceModes.keys)
@@ -97,13 +48,7 @@ public struct Profile: Codable, Sendable, Equatable {
         return all
     }
 
-    /// Authoritative display order for this profile's spaces.
-    ///
-    /// Returns `spaces` when non-empty, with any declared space
-    /// absent from the list appended (sorted numerically then
-    /// lexically) — guards against hand-edited JSON gaps.
-    /// Falls back to sorted `declaredSpaces` for legacy profiles
-    /// that predate the `spaces` key.
+    /// Authoritative display order with unlisted declared spaces appended.
     public var orderedSpaces: [SpaceID] {
         if spaces.isEmpty {
             return SpaceID.numericLexicalSorted(

--- a/Sources/KiwiDeskCore/Profiles/Profile.swift
+++ b/Sources/KiwiDeskCore/Profiles/Profile.swift
@@ -2,7 +2,12 @@ import Foundation
 
 /// Saved KiwiDesk configuration for monitor setups (#36).
 public struct Profile: Codable, Sendable, Equatable {
-    /// Format version of profile schema (#902, #1020). Format 0 = unversioned.
+    /// Format version of the profile schema (#902); 0 =
+    /// unversioned legacy. 2 since the scroll-duration rename
+    /// (#1020) — and the bump is what RUNS the crossing:
+    /// `needsMigration` short-circuits on it, and the retired key
+    /// decodes to the DEFAULT rather than failing, so leaving this
+    /// at 1 loses the user's tuned value silently.
     public static let currentFormat = 2
 
     public var format: Int
@@ -13,9 +18,16 @@ public struct Profile: Codable, Sendable, Equatable {
     public var mainSpaces: [SpaceID]
     /// Default profile for this screen count.
     public var isDefault: Bool
-    /// Marks starter setup baseline (#466, #485).
+    /// Marks the starter-setup baseline (#466, #485). Survives
+    /// edits (a tweaked mode keeps the identity) but not a "save
+    /// as new" — an explicitly named copy is the user's own.
     public var isStarterSetup: Bool
-    /// Authoritative display order of spaces for this profile (#75).
+    /// Authoritative display order of this profile's spaces
+    /// (#75). Authority split: `gui.json` owns LIVE order across
+    /// the session; this owns per-profile order, consulted on
+    /// load. They stay in sync because `apply(profile:)` seeds
+    /// live order from here and both save paths capture the
+    /// resulting live order back.
     public var spaces: [SpaceID]
     /// Designated rehome target when spaces are missing (#68).
     public var fallbackSpace: SpaceID?

--- a/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
+++ b/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
@@ -126,8 +126,13 @@ public final class ProfileManager {
         }
     }
 
-    /// Renames a stored profile via atomic move, preventing APFS
-    /// case-only collision deletion.
+    /// Renames a stored profile via an atomic move — NOT
+    /// write-new-then-remove-old: on case-insensitive APFS a
+    /// case-only rename resolves both names to ONE file, and the
+    /// remove leg would delete the just-renamed profile. Accepted
+    /// non-atomicity: if the name-field rewrite after the move
+    /// fails, the file sits at the new name with the old name
+    /// inside — a tiny window, traded for the case safety.
     func rename(from old: String, to new: String) throws {
         guard old != new else { return }
         var profile = try read(name: old)

--- a/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
+++ b/Sources/KiwiDeskCore/Profiles/ProfileManager.swift
@@ -1,18 +1,13 @@
 import Foundation
 
-/// The outcome of matching the live monitors against the saved
-/// profiles (#36). Either an exact set matches (adopt clean),
-/// the count's default user profile applies (load dirty), or
-/// nothing does and the caller composes the built-in Standard
-/// (#53). No near-match adaptation.
+/// Outcome of matching live monitors against saved profiles (#36, #53).
 public enum ProfileMatch: Equatable {
     case exact(Profile)
     case countDefault(Profile)
     case none
 }
 
-/// Thrown for profile names that cannot become file names, and
-/// for renames that would clobber an existing profile.
+/// Thrown for invalid profile names or name collisions.
 public enum ProfileError: Error, CustomStringConvertible {
     case invalidName(String)
     case nameTaken(String)
@@ -27,16 +22,14 @@ public enum ProfileError: Error, CustomStringConvertible {
     }
 }
 
-/// Persists profiles and picks the right one when the monitor
-/// setup changes.
+/// Persists profiles and selects matching configurations for monitor setups.
 @MainActor
 public final class ProfileManager {
     public private(set) var currentName: String?
-    /// The built-in Standard currently resolving (no saved
-    /// profile covers the live screen count), if any.
+    /// Built-in Standard currently resolving (nil if covered by saved
+    /// profile).
     public private(set) var currentStandard: String?
-    /// True when the live state diverged from the saved
-    /// profile (e.g. after a monitor change).
+    /// True when live state diverged from saved profile.
     public private(set) var isDirty = false
 
     let directory: URL
@@ -48,8 +41,6 @@ public final class ProfileManager {
         self.directory = directory
     }
 
-    // MARK: - Persistence
-
     public func list() -> [String] {
         let contents =
             (try? FileManager.default.contentsOfDirectory(
@@ -59,25 +50,19 @@ public final class ProfileManager {
             contents
             .filter { $0.hasSuffix(".json") }
             .map { String($0.dropLast(5)) }
-            // read() rejects invalid names, so listing them
-            // (e.g. a hand-placed dot-file) would only log
-            // "invalid" on every allProfiles() pass.
             .filter(Self.isValidName)
             .sorted()
     }
 
-    /// Every profile file with its decode outcome, in one disk
-    /// pass: a readable `Profile`, or the error that makes it
-    /// broken. The single source `allProfiles`, `brokenProfiles`,
-    /// and the config-issue scan all derive from (#246).
+    /// Every profile file with its decode outcome (#246).
     func scan() -> [(name: String, result: Result<Profile, Error>)] {
         list().map { name in
             (name, Result { try read(name: name) })
         }
     }
 
-    /// Every readable profile, sorted by name. Unreadable files
-    /// are skipped (and logged), never fatal.
+    /// Every readable profile, sorted by name (unreadable files
+    /// skipped/logged).
     public func allProfiles() -> [Profile] {
         scan().compactMap { name, result in
             switch result {
@@ -90,15 +75,12 @@ public final class ProfileManager {
         }
     }
 
-    /// On-disk path of a profile file, for Reveal in Finder
-    /// (#246). Validated like every other path; the file may or
-    /// may not exist.
+    /// On-disk path of a profile file (#246).
     public func fileURL(name: String) throws -> URL {
         url(for: try validated(name))
     }
 
-    /// Saves the profile; the first profile of its screen count
-    /// is auto-flagged as that count's default.
+    /// Saves the profile; auto-flags as count's default if first for count.
     func save(_ profile: Profile) throws {
         var profile = profile
         if !profile.isDefault,
@@ -120,13 +102,7 @@ public final class ProfileManager {
         return profile
     }
 
-    /// Deletes a profile. A count left without a default gets
-    /// the alphabetically-first remaining profile flagged; the
-    /// last profile of a count simply reverts the count to the
-    /// built-in Standard. A count that still has a default
-    /// (hand-edited duplicates) is left alone. When the deleted
-    /// file was unreadable its count is unknown, so every
-    /// orphaned count is repaired.
+    /// Deletes a profile, repairing orphaned count defaults if needed.
     func delete(name: String) throws {
         let deleted = try? read(name: name)
         try FileManager.default.removeItem(
@@ -150,22 +126,8 @@ public final class ProfileManager {
         }
     }
 
-    /// Renames a stored profile via an atomic file move, then
-    /// rewrites the JSON's own name field. NOT write-new-then-
-    /// remove-old: on a case-insensitive volume (default APFS)
-    /// a case-only rename ("work" → "Work") resolves both
-    /// names to ONE file, and the remove leg would delete the
-    /// just-renamed profile. `moveItem` handles the case
-    /// change in place; any other existing destination is
-    /// rejected, never clobbered (`fileExists` matches case-
-    /// insensitively there, so "a" → "b" beside "B.json" is
-    /// caught too). Same-name is a no-op. Carries the adopted
-    /// `currentName` along. The `KiwiCore` facade chases
-    /// external references (native-Space bindings). Accepted
-    /// non-atomicity: if the name-field rewrite after the
-    /// move fails, the file is at the new name with the old
-    /// name inside — a tiny window (same directory, just
-    /// proven writable), traded for the case-safety above.
+    /// Renames a stored profile via atomic move, preventing APFS
+    /// case-only collision deletion.
     func rename(from old: String, to new: String) throws {
         guard old != new else { return }
         var profile = try read(name: old)
@@ -185,8 +147,7 @@ public final class ProfileManager {
         if currentName == old { currentName = new }
     }
 
-    /// Re-designates a count's default: flags `name`, clears
-    /// the flag on every other profile of the same count.
+    /// Re-designates a count's default profile.
     func setDefault(name: String) throws {
         var chosen = try read(name: name)
         chosen.isDefault = true
@@ -201,12 +162,8 @@ public final class ProfileManager {
         }
     }
 
-    /// `base`, or `base_1`, `base_2`, … up to the next free
-    /// name — repeated preset Applies accumulate copies (#53).
-    /// Case-insensitive, matching the rename path: profile
-    /// files live on case-insensitive APFS, so "My Setup"
-    /// passing a case-sensitive check would silently overwrite
-    /// "my setup.json" (QA round 2 review).
+    /// Next available case-insensitive name suffix (`base`, `base_1`, ...)
+    /// (#53, APFS case safety).
     public func freeName(base: String) -> String {
         let taken = Set(list().map { $0.lowercased() })
         guard taken.contains(base.lowercased()) else {
@@ -221,26 +178,13 @@ public final class ProfileManager {
         return "\(base)_\(suffix)"
     }
 
-    /// Reads a profile without touching current/dirty state.
-    ///
-    /// Migrates the file first when it was written by a build
-    /// whose vocabulary this one no longer reads
-    /// (`ConfigMigration`). The rewrite is best-effort: a config
-    /// directory we cannot write to must not turn a readable
-    /// profile into a broken one, and the migration is
-    /// idempotent, so the next launch simply tries again with
-    /// the in-memory copy carrying the read either way.
+    /// Reads a profile with atomic best-effort `ConfigMigration` rewrite.
     public func read(name: String) throws -> Profile {
         let file = url(for: try validated(name))
         var data = try Data(contentsOf: file)
         if let migrated = ConfigMigration.migrated(data) {
             data = migrated
-            // The SECOND writer of a profile file, beside
-            // `write(_:)`. Deliberately not routed through it:
-            // that one encodes a decoded `Profile`, which would
-            // silently drop any key this build does not know,
-            // and a migration must preserve what it did not come
-            // for. It writes the migrated BYTES instead.
+            // Writes migrated raw bytes directly to preserve unknown keys.
             try? migrated.write(to: file, options: .atomic)
         }
         let decoder = JSONDecoder()
@@ -248,10 +192,7 @@ public final class ProfileManager {
         return try decoder.decode(Profile.self, from: data)
     }
 
-    /// Names become file names inside the profiles directory:
-    /// path separators, traversal, hidden-file prefixes, and
-    /// blank names are rejected at this boundary — every caller
-    /// (CLI, Lua, IPC, GUI) funnels through here.
+    /// Validates profile filename boundaries (no slashes, nulls, dot-files).
     public static func isValidName(_ name: String) -> Bool {
         let trimmed = name.trimmingCharacters(
             in: .whitespacesAndNewlines
@@ -272,8 +213,6 @@ public final class ProfileManager {
         return name
     }
 
-    // MARK: - State
-
     /// Marks the live state as diverged (transient state).
     func markDirty() {
         isDirty = true
@@ -286,30 +225,21 @@ public final class ProfileManager {
         isDirty = false
     }
 
-    /// Records that a built-in Standard is resolving; always a
-    /// dirty (transient) state until the user saves.
+    /// Records that a built-in Standard is resolving (dirty state).
     func adoptStandard(named name: String) {
         currentName = nil
         currentStandard = name
         isDirty = true
     }
 
-    /// Back to the nothing-adopted state — for Reset All
-    /// Settings (#634), after the profile files were trashed:
-    /// a `currentName` pointing at a deleted file would make
-    /// every re-apply path report a read failure.
+    /// Resets adoption state for Reset All Settings (#634).
     func resetAdoption() {
         currentName = nil
         currentStandard = nil
         isDirty = false
     }
 
-    /// The non-adopting write: persists the JSON only, touching
-    /// no `current`/`dirty` state. `save()` layers adoption on
-    /// top; the edit-without-activating paths
-    /// (`overwriteProfile`, `copyProfile` #82) write through
-    /// here directly so editing a stored profile never
-    /// switches the live layout (#18).
+    /// Non-adopting write for background profile editing (#18, #82).
     func write(_ profile: Profile) throws {
         let name = try validated(profile.name)
         try FileManager.default.createDirectory(

--- a/Sources/KiwiDeskCore/Profiles/ScreenClass.swift
+++ b/Sources/KiwiDeskCore/Profiles/ScreenClass.swift
@@ -1,46 +1,26 @@
 import CoreGraphics
 import Foundation
 
-/// What SHAPE a display is, which is what decides the layouts a
-/// starter setup gives it (#678 Phase 4 pass 11, turn 15b).
-///
-/// Measured in **points**, never pixels. A 5K 27" and a 1440p 27"
-/// both report 2560 pt and want identical layouts, while a Retina
-/// laptop reports 1728 pt and wants laptop layouts despite having
-/// more pixels than either. `Display.frame` is already the point
-/// space windows are laid out in, so it is the one input.
-///
-/// The four cases are disjoint only because they are tested in
-/// the order `allCases` lists them — `pivoted` before `ultrawide`
-/// before `laptop` — so a case added here states where in that
-/// order it goes. `ScreenClassTests` pins the order and the
-/// boundaries.
+/// Display shape classification for starter layout assignment (#678,
+/// `ScreenClassTests`). Measured in points from `Display.frame`.
 public enum ScreenClass: String, Sendable, CaseIterable, Codable {
-    /// Taller than wide. Detected by aspect rather than size:
-    /// `height > width` is unambiguous and needs no threshold.
+    /// Taller than wide.
     case pivoted
     /// Wide enough to hold three or four full columns.
     case ultrawide
-    /// Too narrow for a two-way split to leave usable halves.
+    /// Too narrow for a two-way split.
     case laptop
-    /// The 2K / 4K middle, where most desktop layouts work.
+    /// The 2K / 4K middle.
     case desktop
 
-    /// At or above this width a screen is `ultrawide` whatever
-    /// its aspect — 3440 pt holds three or four full columns.
+    /// Width threshold for ultrawide class (3000 pt).
     public static let ultrawideWidth: CGFloat = 3000
-    /// …as is anything this wide relative to its height, which
-    /// catches a short ultrawide that misses the width test.
+    /// Aspect ratio threshold for ultrawide class (2.1).
     public static let ultrawideAspect: CGFloat = 2.1
-    /// Below this width a two-way split leaves 864 pt per window
-    /// and a three-window BSP is already under the 300 pt
-    /// minimum in one axis — tiling that fights you.
+    /// Upper width bound for laptop class (1900 pt).
     public static let laptopWidth: CGFloat = 1900
 
-    /// The verdict for a size in points. Sizes with a
-    /// non-positive dimension answer `desktop`: nothing sensible
-    /// can be derived from them, and the caller that produced one
-    /// has a worse problem than its layout list.
+    /// Classifies display dimensions in points.
     public static func of(_ size: CGSize) -> ScreenClass {
         guard size.width > 0, size.height > 0 else { return .desktop }
         if size.height > size.width { return .pivoted }
@@ -53,69 +33,22 @@ public enum ScreenClass: String, Sendable, CaseIterable, Codable {
         return .desktop
     }
 
-    /// The verdict for a connected display. Reads `frame`, not
-    /// `visibleFrame`: the menu bar and the Dock are chrome the
-    /// user can move or hide, and a screen does not change shape
-    /// when they do.
+    /// Classifies a connected display by its `frame.size`.
     public static func of(_ display: Display) -> ScreenClass {
         of(display.frame.size)
     }
 
-    /// The layouts this shape benefits from, **best first**, so a
-    /// screen granted a share of *n* takes the first *n* behind
-    /// its lead.
-    ///
-    /// **The first space is not drawn from this list**, in the
-    /// same way and for the same reason `floating` is not in it
-    /// (below): what a screen OPENS in depends on the other
-    /// screens — the narrowest leads Monocle and the rest lead
-    /// Scrolling — which is a rule about the SETUP that no single
-    /// shape can answer. `StarterAllocation.lead(_:of:)` owns it
-    /// end to end, and it can hand Monocle to a shape this list
-    /// leaves it out of.
-    ///
-    /// Absences are as deliberate as the entries. `track` is out
-    /// of `desktop` — a layout no one uses is worse than one they
-    /// discover later — and out of `laptop`, which has no width
-    /// to give it. `monocle` is out of `desktop` and `ultrawide`,
-    /// which are the shapes that least need it. `bsp` appears
-    /// only under `desktop`, the one class wide enough to take
-    /// four windows before anything gets cramped; at 3440 pt it
-    /// produces absurd 1700 pt-wide windows and at 1728 pt it
-    /// produces unusable ones.
-    ///
-    /// **`floating` is not in any list**, deliberately. It is not
-    /// a layout a shape wants more or less of — every setup gets
-    /// exactly one Floating space and it goes on the largest
-    /// screen with room beside it, which is a rule about the
-    /// SETUP rather than about a screen. `StarterAllocation` owns
-    /// it end to end.
-    ///
-    /// It used to sit last in all four lists and the allocator
-    /// filtered it back out before reading them, so the entry and
-    /// its position were decorative — and the guard pinning
-    /// "floating is always last" passed on data no production
-    /// path consumed (architect review, 2026-08-11).
+    /// Candidate layout modes for this shape, ordered best first
+    /// (`StarterAllocation`, architect review 2026-08-11).
     public var layouts: [LayoutMode] {
         switch self {
         case .laptop:
-            // Scrolling is the real laptop answer: full-width
-            // windows, one keystroke apart. Monocle is what a
-            // small screen is best at.
             [.scrolling, .monocle]
         case .desktop:
-            // Grid leads because it is the one you can predict —
-            // two windows are two halves, four are quarters.
             [.grid, .stack, .bsp, .scrolling]
         case .ultrawide:
-            // Track is why Track exists. Grid replaces Scrolling,
-            // which solves "not enough width" — the one problem
-            // this screen does not have.
             [.track, .grid, .stack]
         case .pivoted:
-            // Everything that assumes width has to flip; a
-            // pivoted screen is usually the reference screen
-            // (docs, logs, chat), so Monocle belongs too.
             [.stack, .grid, .monocle]
         }
     }

--- a/Sources/KiwiDeskCore/Profiles/ScreenClass.swift
+++ b/Sources/KiwiDeskCore/Profiles/ScreenClass.swift
@@ -1,8 +1,13 @@
 import CoreGraphics
 import Foundation
 
-/// Display shape classification for starter layout assignment (#678,
-/// `ScreenClassTests`). Measured in points from `Display.frame`.
+/// Display shape classification for starter layout assignment
+/// (#678). Measured in POINTS from `Display.frame` — a 5K and a
+/// 1440p 27" want identical layouts; `visibleFrame` is chrome the
+/// user can move, and a screen does not change shape when they
+/// do. The four cases are disjoint only because they are tested
+/// in `allCases` order — a case added here states where in that
+/// order it goes (`ScreenClassTests` pins order and boundaries).
 public enum ScreenClass: String, Sendable, CaseIterable, Codable {
     /// Taller than wide.
     case pivoted
@@ -38,8 +43,14 @@ public enum ScreenClass: String, Sendable, CaseIterable, Codable {
         of(display.frame.size)
     }
 
-    /// Candidate layout modes for this shape, ordered best first
-    /// (`StarterAllocation`, architect review 2026-08-11).
+    /// Candidate layouts for this shape, best first. The ABSENCES
+    /// are as deliberate as the entries: `track` is out of
+    /// desktop/laptop, `monocle` out of desktop/ultrawide, `bsp`
+    /// only under desktop (absurd at 3440 pt, unusable at
+    /// 1728 pt). `floating` is in NO list — one Floating space per
+    /// setup is a rule about the SETUP, owned end to end by
+    /// `StarterAllocation` (architect review, 2026-08-11), which
+    /// also owns each screen's LEAD before this list is read.
     public var layouts: [LayoutMode] {
         switch self {
         case .laptop:

--- a/Sources/KiwiDeskCore/Profiles/StarterTuning.swift
+++ b/Sources/KiwiDeskCore/Profiles/StarterTuning.swift
@@ -1,22 +1,9 @@
 import CoreGraphics
 import Foundation
 
-/// How a starter setup's layouts are tuned for the hardware
-/// (#678 Phase 4 pass 11, turn 15b).
-///
-/// **The MAIN screen's class decides, for the whole profile.**
-/// That is not a preference: `TilingSettings` is profile-wide, so
-/// a laptop beside a 27" has exactly one gap value and one stack
-/// ratio to give, and the only question is which screen names
-/// them. Per-space overrides are what express the rest, and are
-/// where a user who wants a different answer on one screen goes.
-/// Do not read this as a per-display seam waiting to be built —
-/// making it one would put a second config behind every value the
-/// Settings window shows.
+/// Starter layout parameter defaults tuned for the main screen's shape (#678).
 public enum StarterTuning {
-    /// The beginner tuning every class starts from: a comfortable
-    /// gap, the stack's single-master 80/20 split, and track's
-    /// new-window-opens-its-own-track.
+    /// Baseline tuning for starter profiles.
     static func base() -> TilingSettings {
         var settings = TilingSettings()
         settings.gapsGlobal = .uniform(8)
@@ -28,81 +15,25 @@ public enum StarterTuning {
         return settings
     }
 
-    /// The Scrolling slot a starter setup opens with, as a
-    /// fraction of the scroll axis (#1018).
-    ///
-    /// Explicit rather than `.auto`, which resolves near-full and
-    /// shows one window with a sliver of the next — the shape
-    /// that reads as "my windows were squashed into one" instead
-    /// of "the neighbours are one keystroke away". Just under a
-    /// half puts two side by side with the gap between them
-    /// visible, which is the picture that teaches the mode.
-    ///
-    /// **One profile-wide value, not a per-space override.**
-    /// A first-run profile full of overrides is a second config
-    /// the user has to understand before changing the first, and
-    /// `StarterTuning`'s whole premise is that the main screen
-    /// names the tuning — see this type's doc comment.
-    ///
-    /// On a laptop this resolves to about 830 pt, which is close
-    /// to the 864 pt half `ScreenClass.laptopWidth` calls "tiling
-    /// that fights you" — and that is not a contradiction: a
-    /// tiled half is all the room that window will ever get,
-    /// while a scrolling slot is a comfortable column with its
-    /// neighbour visible beside it and the rest one keystroke
-    /// away. The threshold is about permanence, not width.
+    /// Starter Scrolling slot fraction on standard displays (48%, #1018).
     static let standardSlot = 0.48
-    /// …and the ultrawide answer, where 48 % of 3440 pt is a
-    /// 1650 pt column: wider than anything wants to be. Three
-    /// readable columns instead. `ScrollSize.auto`'s own doc
-    /// names this screen as the case that should set an explicit
-    /// size, which is what this is.
-    ///
-    /// **Read from the MAIN screen, so the two mixed setups are
-    /// ruled here rather than left to fall out** (#1018). An
-    /// ultrawide SECONDARY keeps `standardSlot` and so does get
-    /// that 1650 pt column; an ultrawide MAIN imposes 30 % on a
-    /// laptop secondary, about 518 pt — above the 420 pt
-    /// `minWindowSize` this same branch sets, so it is tight
-    /// rather than infeasible. Both are the profile-wide
-    /// constraint doing exactly what it says: `TilingSettings`
-    /// has ONE `slotSize` to give, one screen has to name it, and
-    /// a per-space override is where a user who wants the other
-    /// answer goes. Making this per-display is the seam this
-    /// type's doc comment forbids.
+    /// Starter Scrolling slot fraction on ultrawide displays (30%, #1018).
     static let ultrawideSlot = 0.3
 
-    /// The base, tuned for the main screen's shape.
+    /// Generates settings tuned for `mainShape` screen class.
     public static func settings(
         mainShape: ScreenClass
     ) -> TilingSettings {
         var settings = base()
         switch mainShape {
         case .laptop:
-            // A laptop cannot spare 40 pt of chrome per edge.
             settings.gapsGlobal = .uniform(6)
             settings.appBarStyle.thickness = 28
             settings.spaceBarStyle.thickness = 28
-        // Nothing here turns the App Bar on, though turn 15b's
-        // laptop card says to. It is already on: `LayoutAppBar`
-        // defaults `enabled` true for monocle and scrolling —
-        // which are exactly this class's two layouts — and it is
-        // a per-LAYOUT switch, so it follows the layout that
-        // hides windows rather than the size of the screen.
-        // Setting it here would have been a no-op that read like
-        // a decision, and it would have implied the wrong model:
-        // that a 27" running Monocle should go without the bar.
         case .desktop:
-            // At 2560 pt a three-column grid gives 850 pt cells,
-            // under a comfortable browser width — so two columns,
-            // and Dynamic grows the grid as windows arrive rather
-            // than committing up front.
             settings.grid.columns = 2
             settings.grid.rows = 2
         case .ultrawide:
-            // One master on a 3440 pt screen is an absurdly wide
-            // pane; the auto limit and a bigger minimum keep
-            // tracks readable rather than multiplying.
             settings.stack.masterCount = 2
             settings.track.autoTracks = true
             settings.minWindowSize = 420
@@ -110,11 +41,6 @@ public enum StarterTuning {
                 clamping: ultrawideSlot
             )
         case .pivoted:
-            // Everything that assumes width has to flip. The
-            // Space Bar needs no move — its default edge is
-            // already `.top`, which is the horizontal edge a
-            // pivoted screen wants, since a vertical bar would
-            // eat the narrow axis.
             settings.stack.stackPosition = .bottom
             settings.scrolling.orientation = .vertical
             settings.grid.splitDirection = .vertical

--- a/Sources/KiwiDeskCore/Profiles/StarterTuning.swift
+++ b/Sources/KiwiDeskCore/Profiles/StarterTuning.swift
@@ -15,9 +15,20 @@ public enum StarterTuning {
         return settings
     }
 
-    /// Starter Scrolling slot fraction on standard displays (48%, #1018).
+    /// Starter Scrolling slot fraction on standard displays
+    /// (#1018). Explicit rather than `.auto` (which resolves
+    /// near-full and reads as "my windows were squashed into
+    /// one"): just under a half puts two slots side by side with
+    /// the gap visible — the picture that teaches the mode.
     static let standardSlot = 0.48
-    /// Starter Scrolling slot fraction on ultrawide displays (30%, #1018).
+    /// Starter Scrolling slot fraction on ultrawide displays
+    /// (#1018) — 48% of 3440 pt is a 1650 pt column. Read from the
+    /// MAIN screen, so the two mixed setups are ruled: an
+    /// ultrawide SECONDARY keeps `standardSlot` (and that wide
+    /// column); an ultrawide MAIN imposes 30% on a laptop
+    /// secondary (~518 pt — tight, above the 420 pt minimum this
+    /// branch sets). One `slotSize` per profile; per-space
+    /// overrides are the other answer's home.
     static let ultrawideSlot = 0.3
 
     /// Generates settings tuned for `mainShape` screen class.
@@ -30,6 +41,12 @@ public enum StarterTuning {
             settings.gapsGlobal = .uniform(6)
             settings.appBarStyle.thickness = 28
             settings.spaceBarStyle.thickness = 28
+        // Nothing here turns the App Bar on, though the design
+        // card says to: `LayoutAppBar` already defaults enabled
+        // for monocle and scrolling — this class's two layouts —
+        // and it is a per-LAYOUT switch. Setting it here would be
+        // a no-op that reads like a decision, implying a 27"
+        // running Monocle should go without the bar.
         case .desktop:
             settings.grid.columns = 2
             settings.grid.rows = 2

--- a/Sources/KiwiDeskCore/Service/LoginItemManager.swift
+++ b/Sources/KiwiDeskCore/Service/LoginItemManager.swift
@@ -1,11 +1,19 @@
 import Foundation
 import ServiceManagement
 
-/// Authority for KiwiDesk login item registration via `SMAppService.mainApp`
-/// (#342, #96).
+/// Authority for the KiwiDesk login item via `SMAppService`
+/// (#342, #96). Not the only auto-start: the `kiwidesk service`
+/// LaunchAgent sets `RunAtLoad`, so it also launches at login,
+/// invisibly to this toggle — the #196 instance lock dedupes the
+/// two into one process. Read-through: never a cached bool, so a
+/// change made in System Settings is seen on the next poll.
 public enum LoginItemManager {
     /// Live registration state mapped from the OS.
     public static var current: LoginItemState {
+        // Location first, unconditionally: a copy at a path that
+        // cannot be a stable login item is `.unavailable` whatever
+        // `SMAppService` reports — even if a prior install left a
+        // stale registration.
         if let reason = unavailableReason(for: Bundle.main.bundleURL) {
             return .unavailable(reason)
         }
@@ -47,7 +55,13 @@ public enum LoginItemManager {
         SMAppService.openSystemSettingsLoginItems()
     }
 
-    /// Pure mapping from OS `SMAppService.Status` to `LoginItemState`.
+    /// Pure mapping from the OS status. `.notFound` folds to
+    /// `.notRegistered` — it is the ordinary pre-registration
+    /// state for `mainApp` (verified on 26.x), so a registerable
+    /// app offers to turn it on rather than greying; the terminal
+    /// `.notFound` is caught by `current`'s location check. An
+    /// unknown future status also folds there: offer, log, re-read
+    /// — the switch flips back cleanly on failure.
     static func state(from status: SMAppService.Status) -> LoginItemState {
         switch status {
         case .enabled: return .enabled

--- a/Sources/KiwiDeskCore/Service/LoginItemManager.swift
+++ b/Sources/KiwiDeskCore/Service/LoginItemManager.swift
@@ -1,61 +1,18 @@
 import Foundation
 import ServiceManagement
 
-/// The authority for the KiwiDesk **login item** (#342).
-///
-/// Wraps `SMAppService.mainApp` — the modern (macOS 13+) login-item
-/// API — so the app registers *itself* as a login item the user
-/// toggles in System Settings ▸ General ▸ Login Items, rather than
-/// hand-writing a `~/Library/LaunchAgents` plist and shelling out
-/// to `launchctl` (the `ServiceManager` path, which stays for its
-/// own separate crash-supervision purpose).
-///
-/// Not the *only* thing that can auto-start the app: the advanced
-/// `kiwidesk service` LaunchAgent sets `RunAtLoad`, so it also
-/// launches at login, independently of and invisibly to this
-/// toggle. The two can both be active (the #196 instance lock
-/// dedupes them into one process); this manager owns only the
-/// login-item half.
-///
-/// The GUI toggle is **read-through**: it never caches a bool, it
-/// reads `current` (which reflects `SMAppService`'s live status),
-/// so a change made in System Settings ▸ Login Items directly is
-/// seen on the next poll with no second source of truth.
-///
-/// Core returns *structure* (`LoginItemState`), never a rendered
-/// sentence — the GUI narrates the state at its own boundary (#96).
+/// Authority for KiwiDesk login item registration via `SMAppService.mainApp`
+/// (#342, #96).
 public enum LoginItemManager {
-    /// The live registration state, mapped from the OS.
-    ///
-    /// `.notFound` is the state macOS reports for `mainApp` *before*
-    /// the first registration (verified on 26.x), so it normally
-    /// means "registerable, just not on yet" — `state(from:)` folds
-    /// it to `.notRegistered`. The one exception is a location where
-    /// registration genuinely cannot succeed — a bare non-bundled
-    /// binary (device-QA `.build` run) or a Gatekeeper-translocated
-    /// download — and there `.notFound` is terminal, so it surfaces
-    /// as `.unavailable` (fix: move the app to Applications).
+    /// Live registration state mapped from the OS.
     public static var current: LoginItemState {
-        // Location first, unconditionally: a copy at a path that
-        // can't be a stable login item (a bare binary, or a
-        // Gatekeeper-translocated read-only download) is
-        // `.unavailable` whatever `SMAppService` reports — even if
-        // a prior install left a stale registration. Only a
-        // registerable location consults the live status.
         if let reason = unavailableReason(for: Bundle.main.bundleURL) {
             return .unavailable(reason)
         }
         return state(from: SMAppService.mainApp.status)
     }
 
-    /// Why the bundle at `url` cannot register, or `nil` when it
-    /// can. A bare binary launched directly (its bundle URL is the
-    /// containing dir, not an `.app`) is `.notBundled`; a
-    /// Gatekeeper-translocated `.app` at a read-only randomized path
-    /// is `.translocated`; a normal `.app` returns `nil`, so its
-    /// `.notFound` is read as the ordinary pre-registration state.
-    /// Pure over its argument so all three cases are unit-testable
-    /// without touching the real bundle.
+    /// Why bundle at `url` cannot register (nil if registerable).
     static func unavailableReason(
         for url: URL
     ) -> LoginItemUnavailable? {
@@ -66,12 +23,7 @@ public enum LoginItemManager {
         return nil
     }
 
-    /// Registers or unregisters the app as a login item and returns
-    /// the resulting state, so a read-through control can refresh
-    /// from one call. A failure (e.g. run as a bare binary rather
-    /// than a bundled `.app`, where `SMAppService` has nothing to
-    /// register) is logged and folded into the returned state — the
-    /// toggle then reflects OS truth rather than the attempted flip.
+    /// Registers or unregisters the app as a login item and returns result.
     @discardableResult
     public static func setEnabled(_ enabled: Bool) -> LoginItemState {
         do {
@@ -90,23 +42,12 @@ public enum LoginItemManager {
         return current
     }
 
-    /// Opens System Settings ▸ General ▸ Login Items — the one
-    /// action that resolves a `.requiresApproval` state.
+    /// Opens System Settings ▸ General ▸ Login Items.
     public static func openSystemSettingsLoginItems() {
         SMAppService.openSystemSettingsLoginItems()
     }
 
-    /// Pure mapping from the OS status to our model, kept separate
-    /// so it is unit-testable without touching the real
-    /// registration. `.notFound` folds to `.notRegistered` — it is
-    /// the pre-registration state for `mainApp`, so a registerable
-    /// app should offer to turn it on, not grey out (the terminal
-    /// `.notFound` is caught by the location check in `current`,
-    /// which is the only path that produces `.unavailable`). A
-    /// genuinely unknown future status also folds to
-    /// `.notRegistered`: offer to enable rather than grey with a
-    /// location caption that would not fit — a failed `register()`
-    /// then logs and re-reads, flipping the switch back cleanly.
+    /// Pure mapping from OS `SMAppService.Status` to `LoginItemState`.
     static func state(from status: SMAppService.Status) -> LoginItemState {
         switch status {
         case .enabled: return .enabled
@@ -118,46 +59,33 @@ public enum LoginItemManager {
     }
 }
 
-/// The four states the "Open at Login" control can be in — the
-/// structure Core hands the GUI, which renders the sentence.
+/// Registration states for login item control (#96).
 public enum LoginItemState: Equatable, Sendable {
-    /// Not a login item; the toggle reads off.
+    /// Not registered as login item.
     case notRegistered
-    /// A login item and active; the toggle reads on.
+    /// Registered and active.
     case enabled
-    /// The user asked for it, but macOS needs them to confirm it in
-    /// System Settings ▸ Login Items. The toggle reads on (it
-    /// reflects intent) with a status line + a jump button.
+    /// User enabled, awaiting approval in System Settings.
     case requiresApproval
-    /// Registration cannot succeed from where the app is running,
-    /// so the toggle greys out (grey, don't hide, #171). The
-    /// associated reason picks the caption — the two causes need
-    /// different fixes.
+    /// Registration unavailable from current launch path (#171).
     case unavailable(LoginItemUnavailable)
 
-    /// Whether the switch shows as on. `.requiresApproval` counts as
-    /// on: the user said yes, macOS just hasn't confirmed.
+    /// True if enabled or awaiting approval.
     public var isOn: Bool {
         self == .enabled || self == .requiresApproval
     }
 
-    /// The reason the running copy can't register, or `nil` when it
-    /// can. Lets `AutoStartManager` fold the unavailability out of
-    /// the state without re-matching the enum case.
+    /// Unavailability reason if unavailable, nil otherwise.
     public var unavailableReason: LoginItemUnavailable? {
         if case .unavailable(let reason) = self { return reason }
         return nil
     }
 }
 
-/// Why `SMAppService` can't register the running copy — each maps to
-/// a different caption at the GUI boundary (#96), because the fix
-/// differs.
+/// Reasons why `SMAppService` cannot register the running binary (#96).
 public enum LoginItemUnavailable: Hashable, Sendable {
-    /// A bare executable with no `.app` wrapper — the device-QA
-    /// `.build/release` path. Fix: run the packaged app.
+    /// Bare executable without an `.app` bundle wrapper.
     case notBundled
-    /// A Gatekeeper-translocated read-only copy (a still-quarantined
-    /// download run in place). Fix: move it to Applications.
+    /// Gatekeeper-translocated read-only copy.
     case translocated
 }

--- a/Sources/KiwiDeskCore/Service/ServiceManager.swift
+++ b/Sources/KiwiDeskCore/Service/ServiceManager.swift
@@ -1,18 +1,7 @@
 import Foundation
 
-/// launchd service control (`kiwidesk service start|stop|
-/// restart`). Writes a LaunchAgent referencing the installed
-/// binary and drives it via `launchctl bootstrap`/`bootout` —
-/// no Homebrew services dependency.
-///
-/// This is the advanced/CLI crash-supervision path, distinct from
-/// the user-facing login item (`LoginItemManager`, `SMAppService`).
-/// Note the overlap: the plist below sets `RunAtLoad`, so a loaded
-/// service ALSO auto-starts at login, independently of and
-/// invisibly to the "Open at Login" toggle. If `RunAtLoad` is ever
-/// reconsidered, weigh it against that toggle being the primary
-/// login mechanism (#342). The #196 instance lock keeps the two
-/// launch triggers from spawning two processes.
+/// launchd service management and crash supervision (`kiwidesk service`)
+/// (#342, #196).
 public enum ServiceManager {
     public static let label = "org.kiwidesk.KiwiDesk"
 
@@ -23,8 +12,7 @@ public enum ServiceManager {
             )
     }
 
-    /// LaunchAgent contents for a given executable path.
-    /// Exposed for tests.
+    /// Generates LaunchAgent plist content for `executable` (#1068).
     public static func plistContent(
         executable: String
     ) -> String {
@@ -44,13 +32,7 @@ public enum ServiceManager {
             <true/>
             <key>KeepAlive</key>
             <dict>
-                <!-- Restart a crash, never a clean exit. The
-                     second-launch path depends on this: it
-                     exits SUCCESSFULLY so launchd lets it rest
-                     (`secondLaunchExitStatus`, #1068). Setting
-                     this true, or dropping the condition,
-                     re-opens an infinite respawn that steals
-                     focus every throttle. -->
+                <!-- Restart a crash, never a clean exit (#1068). -->
                 <key>SuccessfulExit</key>
                 <false/>
             </dict>
@@ -59,10 +41,7 @@ public enum ServiceManager {
         """
     }
 
-    /// The result of a service verb: a line to print plus whether
-    /// it succeeded, so the CLI can map a real launchctl failure
-    /// to a non-zero exit while the ordinary already-running /
-    /// not-running cases stay exit 0 (#328).
+    /// Result of a service command operation (#328).
     public struct Outcome {
         public let message: String
         public let ok: Bool
@@ -73,18 +52,7 @@ public enum ServiceManager {
         }
     }
 
-    // MARK: - Commands
-
-    /// Bootstraps the agent, relaunches it when the job is loaded
-    /// but idle, or no-ops when a process is already running. The
-    /// plist is always (re)written first so a moved binary is
-    /// picked up on the next `start`.
-    ///
-    /// The loaded-but-idle case matters: quitting via the quick
-    /// menu exits cleanly, and `KeepAlive{SuccessfulExit=false}`
-    /// leaves launchd holding the job registered without a process
-    /// — a bare `isLoaded()` check would then wrongly report
-    /// "already running" and never bring it back (#341).
+    /// Starts or relaunches the LaunchAgent service (#341).
     public static func start() -> Outcome {
         if let failure = writePlist() {
             return Outcome(failure, ok: false)
@@ -106,9 +74,7 @@ public enum ServiceManager {
         }
     }
 
-    /// Boots out the agent, or reports cleanly when nothing is
-    /// loaded — never leaking launchctl's "re-run as root" noise
-    /// for the ordinary not-running case (#328).
+    /// Stops and unloads the LaunchAgent service (#328).
     public static func stop() -> Outcome {
         guard isLoaded() else {
             return Outcome(
@@ -127,15 +93,7 @@ public enum ServiceManager {
             )
     }
 
-    /// The explicit kill-and-relaunch path: boots out any prior
-    /// registration (result discarded — it may not be loaded)
-    /// and bootstraps fresh.
-    ///
-    /// Reports honestly whether it actually *restarted* a loaded
-    /// job or merely *started* one that wasn't running — a plain
-    /// "restarted" would otherwise claim it stopped something that
-    /// was never there (matches the loaded-aware wording `start`
-    /// and `stop` already give, #328).
+    /// Boots out and re-bootstraps the LaunchAgent service (#328).
     public static func restart() -> Outcome {
         if let failure = writePlist() {
             return Outcome(failure, ok: false)
@@ -147,8 +105,7 @@ public enum ServiceManager {
         return Outcome(restartMessage(wasLoaded: wasLoaded), ok: true)
     }
 
-    /// Reports whether the agent is loaded and, if launchd has it
-    /// running, its pid. A query — always exit 0.
+    /// Returns human-readable status outcome for CLI (#328, #341).
     public static func status() -> Outcome {
         let (status, output) = printState()
         guard status == 0 else {
@@ -163,23 +120,14 @@ public enum ServiceManager {
         )
     }
 
-    /// The agent's launchd state as structure (#576), for the
-    /// `AutoStartManager` facade. A blocking `launchctl print`
-    /// spawn like the other verbs — the facade calls it off the
-    /// main actor. Distinct from `status()`, which renders the CLI
-    /// sentence; this returns the machine value the facade folds.
+    /// Structured LaunchAgent service status for `AutoStartManager` (#576).
     public static func currentStatus() -> ServiceStatus {
         let (exit, output) = printState()
         return serviceStatus(printExit: exit, output: output)
     }
 
-    // MARK: - Helpers (pure — unit-tested)
-
-    /// Maps a `launchctl print` exit + output to structure. A
-    /// non-zero exit means the job isn't loaded in this domain; a
-    /// zero exit means loaded, with a pid only when a process is
-    /// actually running (#341). Pure so the mapping is testable
-    /// without spawning launchctl.
+    /// Parses `launchctl print` exit code and output into `ServiceStatus`
+    /// (#341).
     static func serviceStatus(
         printExit: Int32,
         output: String
@@ -193,10 +141,7 @@ public enum ServiceManager {
         )
     }
 
-    /// What `start` must do given the agent's launchd state.
-    /// Loaded-but-idle (registered, no pid) means the process was
-    /// quit while the job stayed registered, so it is relaunched
-    /// rather than reported as already running (#341).
+    /// Action required for `start` based on current launchd state (#341).
     enum StartAction: Equatable {
         case bootstrap
         case kickstart
@@ -211,8 +156,7 @@ public enum ServiceManager {
         return pid != nil ? .alreadyRunning : .kickstart
     }
 
-    /// The `status` line for a loaded agent: names the pid when
-    /// launchd is running the process, else flags loaded-but-idle.
+    /// Formats status message for loaded agent.
     static func statusMessage(pid: Int32?) -> String {
         if let pid {
             return "KiwiDesk service is running (pid \(pid))"
@@ -220,24 +164,20 @@ public enum ServiceManager {
         return "KiwiDesk service is loaded but not running"
     }
 
-    /// The `restart` line: a genuine restart when the job was
-    /// already loaded, otherwise a plain start so the CLI never
-    /// claims to have stopped a service that wasn't running.
+    /// Formats restart message distinguishing fresh starts from restarts.
     static func restartMessage(wasLoaded: Bool) -> String {
         wasLoaded
             ? "KiwiDesk service restarted"
             : "KiwiDesk service was not running — started it"
     }
 
-    /// Extracts the `pid = N` line from `launchctl print` output.
+    /// Parses PID from `launchctl print` output.
     static func parsePID(from output: String) -> Int32? {
         for raw in output.split(separator: "\n") {
             let line = raw.trimmingCharacters(in: .whitespaces)
             guard line.hasPrefix("pid = ") else { continue }
             let value = line.dropFirst("pid = ".count)
                 .trimmingCharacters(in: .whitespaces)
-            // Keep scanning if this line's value is malformed
-            // rather than giving up on the whole output.
             if let pid = Int32(value) { return pid }
         }
         return nil

--- a/Sources/KiwiDeskCore/Service/ServiceManager.swift
+++ b/Sources/KiwiDeskCore/Service/ServiceManager.swift
@@ -32,7 +32,11 @@ public enum ServiceManager {
             <true/>
             <key>KeepAlive</key>
             <dict>
-                <!-- Restart a crash, never a clean exit (#1068). -->
+                <!-- Restart a crash, never a clean exit: the
+                     second launch exits SUCCESSFULLY so launchd
+                     lets it rest (#1068). Setting this true, or
+                     dropping the condition, re-opens an infinite
+                     respawn that steals focus every throttle. -->
                 <key>SuccessfulExit</key>
                 <false/>
             </dict>

--- a/Sources/KiwiDeskCore/State/StateCoordinator+WindowCreated.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+WindowCreated.swift
@@ -69,8 +69,15 @@ extension StateCoordinator {
                 }
             }
         }
-        // Returning windows do not steal focus; transient overlays never get
-        // focus grant (#636, #300, #671).
+        // A RETURNING window joins its space without stealing an
+        // existing focus (#636): the re-track burst arrives in
+        // arbitrary per-pid order, so the focus REPORT — never
+        // re-track order — is the authority. A transient overlay
+        // is granted nothing (#300/#671), asked of STATE, not the
+        // snapshot (a remembered-tiled restore above may have just
+        // cleared it); and it beats the `focused == nil` arm, so
+        // an overlay spawning into a focusless space leaves it
+        // nil — a popup is not a settle target.
         if windows[window.id]?.isTransientOverlay != true,
             !effects.hadRememberedSpace
                 || workspaces[target]?.focused == nil
@@ -79,7 +86,13 @@ extension StateCoordinator {
         }
     }
 
-    /// Screen home for arrivals crossing displays (#1010, #671).
+    /// Screen home for arrivals crossing displays (#1010) — the
+    /// verdict is `screenHome`'s one copy; what this adds is the
+    /// arrival's own gate: a WATCHED DEPARTURE. A `.restored`
+    /// memory is KiwiDesk's own filing, never an observed move —
+    /// after an undock macOS piles windows onto the built-in
+    /// screen, and following THAT frame would discard the very
+    /// layout the snapshot exists to put back (#671).
     private func arrivalScreenHome(
         of window: ManagedWindow?,
         remembered: SpaceMemory?,

--- a/Sources/KiwiDeskCore/State/StateCoordinator+WindowCreated.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+WindowCreated.swift
@@ -1,41 +1,19 @@
 import Foundation
 
-/// The `.windowCreated` fold — placement (track rule / spawn
-/// placement / dormant break marker) and the focus decision.
-/// Split from `StateCoordinator.apply` for the file ceiling
-/// (§2.1), like `+Intents` and `+EffectiveMembers`.
+/// The `.windowCreated` fold — placement and initial focus decision (§2.1).
 extension StateCoordinator {
     mutating func applyWindowCreated(
         _ window: ManagedWindow,
         effects: inout AppliedEffects
     ) {
-        // Dropping the record IS the "was this minimized?" test
-        // (#40/#673) — one container, so the answer cannot drift
-        // from the thing it is derived from. Unconditional, so a
-        // recycled `CGWindowID` cannot inherit a dead window's
-        // record either.
+        // Forget record to test if window was minimized (#40, #673).
         effects.appearedWasMinimized = forgetMinimized(window.id)
         effects.hadRememberedSpace =
             rememberedSpaces[window.id] != nil
         windows.upsert(window)
         restoreFloatOverride(of: window)
         restoreStickyIntent(of: window)
-        // SCREEN WINS (#1010). A window that came back on a
-        // display OTHER than the one its remembered space lays
-        // out on was carried across screens while it was away —
-        // `move_to_desktop` onto another screen's Desktop, or the
-        // same gesture in Mission Control. The Desktop the user
-        // just chose is the more recent intent, so the arrival
-        // takes the space that display shows. Without this the
-        // retile carries the window back to the remembered
-        // space's screen and macOS re-assigns its Desktop to
-        // match the frame, undoing the move a second after the
-        // Desktop is revealed. The ruling — what it covers, and
-        // why the two alternatives lost — is
-        // `docs/design-decisions.md`'s.
-        //
-        // The screen input is CONSUMED here (see
-        // `arrivalDisplay`): it belongs to this arrival alone.
+        // Screen wins on multi-monitor Desktop moves (#1010).
         let arrival = arrivalDisplay
         arrivalDisplay = nil
         let remembered = rememberedSpaces[window.id]
@@ -70,9 +48,7 @@ extension StateCoordinator {
                     guard let window = windows[id] else {
                         return false
                     }
-                    // A fullscreen member occupies no slot
-                    // (#670): it left the tiled derivations,
-                    // so fill-then-spill must not count it.
+                    // Fullscreen window occupies no tiled slot (#670).
                     return !window.isFloating
                         && !window.isFullscreen
                 }
@@ -85,49 +61,16 @@ extension StateCoordinator {
                     ?? spawnPlacements[mode]
                     ?? .afterFocused
             )
-            // A floating window spawned into an `own_track`
-            // space carries a dormant break marker, matching
-            // what the mode-entry seed gives every window
-            // (`setMode`): when a float re-check heals it to
-            // tiled (#160), it opens its own track at its slot
-            // instead of silently merging into its array
-            // neighbor's track. `focused_track` stays
-            // markerless — joining by position is that rule's
-            // meaning.
+            // Floating window in own_track space gets dormant break marker
+            // (#160).
             if track?.newWindow == .ownTrack {
                 workspaces.withSpace(target) {
                     $0.trackBreaks.insert(window.id)
                 }
             }
         }
-        // A RETURNING window (remembered space — a
-        // native-switch re-track, wake restore, app relaunch)
-        // joins its space without stealing an existing focus
-        // (#636): the re-track burst arrives in arbitrary
-        // per-pid order, so the last-created window won the
-        // ring while the OS had focused another — the focus
-        // report, not re-track order, is the authority. A
-        // fresh spawn (or deminiaturize, which clears the
-        // memory) still takes focus, and so does the first
-        // returner into a space whose members all left with
-        // it (`focused == nil`) — the settle fallback needs a
-        // target even when no focus report ever arrives.
-        //
-        // A TRANSIENT OVERLAY is granted nothing here — only the
-        // GRANT, never the slot, and the argument for stopping
-        // exactly there is the #300 entry in
-        // `docs/design-decisions.md` (#671).
-        //
-        // Two things it does not say, both local to this fold.
-        // The flag is asked of STATE, not of the incoming
-        // snapshot: a remembered-tiled restore above clears it
-        // (`setFloating`), and such a window is ordinary again.
-        // And this beats the `focused == nil` arm above, so an
-        // overlay spawning into a space with no focus leaves it
-        // nil — which is the wanted answer (a popup is not a
-        // settle target) at the price of a space that reports no
-        // focused window until a real one arrives, or a space
-        // switch re-seeds it.
+        // Returning windows do not steal focus; transient overlays never get
+        // focus grant (#636, #300, #671).
         if windows[window.id]?.isTransientOverlay != true,
             !effects.hadRememberedSpace
                 || workspaces[target]?.focused == nil
@@ -136,32 +79,12 @@ extension StateCoordinator {
         }
     }
 
-    /// The space an arrival prefers over the one it remembered,
-    /// when its own screen disagrees with that space's (#1010).
-    /// The verdict is `screenHome(of:leaving:landingOn:)`'s —
-    /// one copy, shared with the Desktop verb that asks the same
-    /// question before the window leaves; this adds only the
-    /// gate that is the ARRIVAL's own.
-    ///
-    /// That gate is a **watched departure**. A `.restored`
-    /// memory is KiwiDesk's own filing for a window it was not
-    /// tracking (`StateSnapshot.adopt`), never an observation of
-    /// one moving: the ruling rests on the user's recent intent,
-    /// and a restore carries none. After an undock macOS piles
-    /// windows onto the built-in screen, and following THAT
-    /// frame would discard the very layout the snapshot exists
-    /// to put back. No remembered space at all — a fresh spawn,
-    /// an `app_rules` target — is a placement nobody
-    /// contradicted, and is likewise left alone.
+    /// Screen home for arrivals crossing displays (#1010, #671).
     private func arrivalScreenHome(
         of window: ManagedWindow?,
         remembered: SpaceMemory?,
         arrival: DisplayID?
     ) -> SpaceID? {
-        // STATE's record, never the incoming snapshot (#671):
-        // the float and sticky restores above may just have
-        // changed the answer, and the optional is the state read
-        // itself — an untracked window is re-homed by nothing.
         guard let window,
             case .departed(let home)? = remembered
         else { return nil }

--- a/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
@@ -4,7 +4,10 @@ import Foundation
 /// Debounces `windowMoved` events to detect user window drags and drops (#45).
 @MainActor
 public final class DragCoordinator {
-    /// Fired once per finished drag: `(windowId, startFrame, endFrame)`.
+    /// Fired once per finished drag with the gesture's start and
+    /// final frames — the start frame is what tells a move (same
+    /// size) from a resize, and it is the window's REAL size, not
+    /// its slot: constrained apps never match their slot exactly.
     public var onDragEnd:
         @MainActor (WindowID, _ start: CGRect, _ end: CGRect)
             -> Void = { _, _, _ in }
@@ -42,7 +45,12 @@ public final class DragCoordinator {
 
     public init() {}
 
-    /// Ingests `windowMoved` event and schedules debounce settle (#45, #933).
+    /// Ingests a `windowMoved` event and schedules the debounce
+    /// settle (#45). The gesture's start frame comes from
+    /// `previous`, the caller's pre-event state: AX throttles move
+    /// notifications, so a fast gesture's FIRST event already sits
+    /// mid-flight — measuring from it loses everything before
+    /// (#933: a fast border drag resized only part of the way).
     public func windowMoved(
         _ id: WindowID,
         frame: CGRect,
@@ -84,8 +92,11 @@ public final class DragCoordinator {
     }
 
     #if DEBUG
-        /// Pending settle task for async test synchronization (#994;
-        /// tests.md).
+        /// Pending settle task for async test synchronization
+        /// (#994; tests.md ▸ Async tests). Awaiting it does NOT
+        /// mean the drag ended: a settle finding the button still
+        /// down reschedules itself, and after the drop it is nil,
+        /// whose await returns at once. Assert on `onDragEnd`.
         func settleTask(for id: WindowID) -> Task<Void, Never>? {
             pending[id]
         }

--- a/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCoordinator.swift
@@ -1,95 +1,48 @@
 import CoreGraphics
 import Foundation
 
-/// Detects the end of a user window drag.
-///
-/// AX only reports `windowMoved` — there is no "drag ended"
-/// event — so a drag end is inferred by debouncing: when a
-/// window stops emitting move events for `settleDelay`, the
-/// drop happened. Frame updates caused by our own animations
-/// are filtered out via `isAnimating`, and a gesture can only
-/// start while the mouse button is down — programmatic moves
-/// (apps repositioning their own windows, late AX echoes)
-/// never count as drags (issue #45).
+/// Debounces `windowMoved` events to detect user window drags and drops (#45).
 @MainActor
 public final class DragCoordinator {
-    /// Fired once per finished drag with the frame at the
-    /// gesture's start and the final frame. The start frame
-    /// tells a move (same size) from a resize (size changed)
-    /// — the window's real size, not its slot, because apps
-    /// with size constraints never match their slot exactly.
+    /// Fired once per finished drag: `(windowId, startFrame, endFrame)`.
     public var onDragEnd:
         @MainActor (WindowID, _ start: CGRect, _ end: CGRect)
             -> Void = { _, _, _ in }
 
-    /// Fired for every user-driven move while the button is
-    /// down — live feedback (drag ghost / drop zone), not
-    /// debounced. Trailing AX events after the release only
-    /// reach onDragEnd. Same (start, current) frame pair as
-    /// onDragEnd.
+    /// Fired for live user moves while mouse button is held.
     public var onDragMove:
         @MainActor (WindowID, _ start: CGRect, _ frame: CGRect)
             -> Void = { _, _, _ in }
 
-    /// Filters out our own animation-driven move events.
+    /// Filters out internal animation moves.
     public var isAnimating: @MainActor (WindowID) -> Bool = {
         _ in false
     }
 
-    /// Whether the user still holds the mouse button. A
-    /// gesture can only end after the release: fast drags
-    /// stop emitting AX moves long before the drop, and
-    /// standing still mid-drag is not a drop either.
-    /// Injected to keep this type AppKit-free and testable.
+    /// Mouse button pressed state check (injected for testing).
     public var isMousePressed: @MainActor () -> Bool = {
         false
     }
 
-    /// The live pointer location in Cocoa (bottom-left) screen
-    /// coordinates. Injected to keep this type AppKit-free and
-    /// testable — drag tests place the cursor without moving the
-    /// real mouse. Wired to `NSEvent.mouseLocation` in `wireDrag`.
-    /// The drop target is keyed on this, not the dragged frame's
-    /// center, so it reaches the destination display the instant
-    /// the pointer does (#492).
+    /// Cursor location in Cocoa coordinates for drop target resolution (#492).
     public var cursorLocation: @MainActor () -> CGPoint = {
         .zero
     }
 
-    /// Quiet time after the last move event (seconds).
+    /// Quiet time after last move event before drop is considered settled
+    /// (seconds).
     public var settleDelay: TimeInterval = 0.35
-    /// Recheck interval while waiting for the release.
+    /// Recheck interval while waiting for mouse release.
     public var releasePollDelay: TimeInterval = 0.1
 
     private var pending: [WindowID: Task<Void, Never>] = [:]
     private var latestFrames: [WindowID: CGRect] = [:]
-    /// First frame of the gesture in flight, per window.
+    /// First frame of in-flight gesture per window.
     private var startFrames: [WindowID: CGRect] = [:]
 
     public init() {}
 
-    /// Feed every `windowMoved` event here.
-    ///
-    /// `validated` marks events the caller already classified
-    /// as part of a user gesture (the mouse-resize path, see
-    /// KiwiCore.isResizeGesture). Unvalidated moves can only
-    /// START a gesture while the mouse button is down: apps
-    /// repositioning their own windows (a brand-new window
-    /// right after the open) and AX echoes outliving the echo
-    /// grace arrive with the button up, and reading them as
-    /// drags swaps windows in the array and re-tiles them into
-    /// the wrong slots (issue #45).
-    ///
-    /// `previous` is the frame the window had BEFORE this
-    /// event (the caller's state, written by the last event).
-    /// A gesture's start frame is taken from it, because AX
-    /// throttles move/resize notifications: a fast gesture's
-    /// FIRST event already sits mid-flight — or, released
-    /// quickly, at the final frame — so measuring the gesture
-    /// from that event's own frame loses everything before it
-    /// (#933: a fast border drag resized only part of the
-    /// way). Nil (or a first-ever event) falls back to the
-    /// event frame, the old behavior.
+    /// Ingests `windowMoved` event and schedules debounce settle (#45, #933).
     public func windowMoved(
         _ id: WindowID,
         frame: CGRect,
@@ -97,17 +50,12 @@ public final class DragCoordinator {
         previous: CGRect? = nil
     ) {
         guard !isAnimating(id) else {
-            // Our own animation: forget any pending drag so
-            // a retile never counts as a user drop.
             pending[id]?.cancel()
             pending[id] = nil
             latestFrames[id] = nil
             startFrames[id] = nil
             return
         }
-        // A real drag always emits its first move while the
-        // button is still down; trailing events after the
-        // release join the gesture already in flight.
         if startFrames[id] == nil, !validated,
             !isMousePressed()
         {
@@ -136,23 +84,8 @@ public final class DragCoordinator {
     }
 
     #if DEBUG
-        /// The settle timeline pending for `id`, so a test can
-        /// await the settle instead of polling a clock for its
-        /// effect (#994; `.claude/rules/tests.md` ▸ Async tests).
-        /// Debug-only so a production read fails the release
-        /// build rather than a review: this is `schedule`'s
-        /// bookkeeping, never a drag-in-flight predicate. This
-        /// type publishes no such predicate — a site that needs
-        /// one adds it rather than reaching for this.
-        ///
-        /// What awaiting it does **not** mean: that the drag
-        /// ENDED. A settle finding the button still down
-        /// reschedules itself on `releasePollDelay`, so a handle
-        /// read mid-gesture completes its own poll leg having
-        /// fired nothing; and after the drop it is nil, whose
-        /// `await` returns at once and asserts nothing. Read it
-        /// while the gesture under test is the one in flight,
-        /// and assert on `onDragEnd`.
+        /// Pending settle task for async test synchronization (#994;
+        /// tests.md).
         func settleTask(for id: WindowID) -> Task<Void, Never>? {
             pending[id]
         }

--- a/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
@@ -1,91 +1,43 @@
 import CoreGraphics
 import Foundation
 
-/// Debounce + per-gesture bookkeeping for the live cross-display
-/// "make-room" drag (#504).
-///
-/// While a tiled window is dragged, the cursor crossing onto a
-/// display OTHER than the one its space lives on arms a dwell
-/// timer; only when the cursor has stayed on that display for
-/// `dwell` does `onCross` fire, and KiwiCore eager-moves the
-/// window's membership there (the Space-Bar-spring model, #372,
-/// keyed on displays). The dwell is the flip-flop guard: a cursor
-/// skimming the display seam — or an overflow-inducing crossing
-/// bouncing straight back — never re-tiles both displays per
-/// mouse event; AX frame-sets are the slow path (AGENTS.md §5).
-///
-/// AppKit-free by injection (`displayAt`), like DragCoordinator:
-/// tests place the cursor and describe displays without screens.
+/// Debounce and gesture bookkeeping for cross-display drag movement (#504,
+/// #372).
 @MainActor
 public final class DragCrossingCoordinator {
-    /// How long the cursor must stay on a foreign display before
-    /// the membership moves. Long enough to ride out a seam skim,
-    /// short enough to read as immediate.
+    /// Dwell delay before cross-display window migration triggers (0.15s).
     public var dwell: TimeInterval = 0.15
 
-    /// Resolves the display under a Cocoa (bottom-left) screen
-    /// point. Wired to an NSScreen lookup in `wireDragCrossing`;
-    /// injected so drag tests can fake a display topology.
+    /// Resolves display ID under Cocoa screen point. Injected for unit
+    /// testing.
     public var displayAt: @MainActor (CGPoint) -> DisplayID? = {
         _ in nil
     }
 
-    /// Fired once per debounced crossing with the display the
-    /// cursor settled on. KiwiCore re-checks eligibility there —
-    /// state may have shifted during the dwell.
+    /// Callback invoked when debounced display crossing fires.
     var onCross: @MainActor (WindowID, DisplayID) -> Void = {
         _,
         _ in
     }
 
-    /// What one drag gesture accumulated. Cleared by
-    /// `endGesture` / `revertLiveCrossing` at drop or cancel.
     private struct Gesture {
-        /// The window's home before the FIRST crossing — the
-        /// abnormal-cancel restore point. Later crossings keep
-        /// the original record.
         var originSpace: SpaceID?
         var originIndex = 0
-        /// Whether any crossing actually moved membership this
-        /// gesture. Read by the drop path to skip the resize
-        /// interpretation (#492's clamp gotcha, live edition).
         var crossed = false
-        /// A sticky refusal already flashed its pill this
-        /// gesture; later dwell fires stay silent.
         var stickyRefused = false
     }
     private var gestures: [WindowID: Gesture] = [:]
-    /// A single slot, not per-window: only one window is ever
-    /// user-dragged at a time, so `schedule` may displace another
-    /// window's dwell without harm. `gestures` stays per-window
-    /// because ids must not inherit stale bookkeeping.
     private var pending:
         (window: WindowID, display: DisplayID, task: Task<Void, Never>)?
 
     #if DEBUG
-        /// The armed dwell's timeline, so a test can await the
-        /// crossing instead of polling a clock for its effect
-        /// (#994; `.claude/rules/tests.md` ▸ Async tests).
-        /// Debug-only so a production read fails the release
-        /// build rather than a review — `pending` is the
-        /// bookkeeping it belongs to.
-        ///
-        /// What awaiting it does **not** mean: that a crossing
-        /// FIRED. `fire` clears the slot, the handle also
-        /// completes for a dwell that was disarmed (the cursor
-        /// came home, `cancelPending`, `rekey`), and it is nil
-        /// whenever none is armed — whose `await` returns at
-        /// once and asserts nothing. `onCross` is the fact.
+        /// Timeline handle for async crossing testing (#994, `tests.md`).
         var dwellTask: Task<Void, Never>? { pending?.task }
     #endif
 
     public init() {}
 
-    /// Feed every live drag move. Schedules a dwell when the
-    /// cursor sits on a display other than `homeDisplay`
-    /// (the dragged window's current space's display), keeps an
-    /// already-armed dwell for the SAME display running, and
-    /// disarms when the cursor returns home or resolves nowhere.
+    /// Feeds live drag motion updates and schedules crossing dwell timer.
     func moved(
         _ id: WindowID,
         cursor: CGPoint,
@@ -107,17 +59,14 @@ public final class DragCrossingCoordinator {
         schedule(id, display: cursorDisplay)
     }
 
-    /// Disarms a pending dwell for `id` (cursor back home, a
-    /// Space Bar target armed, or the gesture stopped looking
-    /// like a move).
+    /// Disarms pending dwell timer for `id`.
     func cancelPending(for id: WindowID) {
         guard let pending, pending.window == id else { return }
         pending.task.cancel()
         self.pending = nil
     }
 
-    /// Records the home to restore on an abnormal cancel. Only
-    /// the FIRST crossing of a gesture writes it.
+    /// Records pre-crossing origin space and slot for abnormal revert (#504).
     func recordOriginIfNeeded(
         _ id: WindowID,
         space: SpaceID,
@@ -130,7 +79,7 @@ public final class DragCrossingCoordinator {
         gestures[id] = gesture
     }
 
-    /// The pre-crossing home, for the abnormal-cancel revert.
+    /// Returns pre-crossing home space and index.
     func origin(for id: WindowID) -> (space: SpaceID, index: Int)? {
         guard let space = gestures[id]?.originSpace else {
             return nil
@@ -144,15 +93,11 @@ public final class DragCrossingCoordinator {
         gestures[id] = gesture
     }
 
-    /// Whether membership already moved displays this gesture.
+    /// Returns whether window crossed displays during current gesture (#492).
     func hasCrossed(_ id: WindowID) -> Bool {
         gestures[id]?.crossed == true
     }
 
-    /// Defense in depth only: sticky windows never arm the dwell
-    /// (`updateDragCrossing` filters them), so this fires solely
-    /// when a window BECAME sticky mid-dwell. Per-gesture, not
-    /// per-display — revisit if the sticky exclusion is relaxed.
     func markStickyRefused(_ id: WindowID) {
         var gesture = gestures[id] ?? Gesture()
         gesture.stickyRefused = true
@@ -163,11 +108,7 @@ public final class DragCrossingCoordinator {
         gestures[id]?.stickyRefused == true
     }
 
-    /// Retargets a gesture's bookkeeping onto a native-tab
-    /// rekeyed id (#308) — the id swapped in place mid-drag, and
-    /// the revert must find the origin under the NEW id. Any
-    /// pending dwell dies with the old id: the gesture is being
-    /// aborted, not continued.
+    /// Retargets gesture bookkeeping across native-tab rekeys (#308).
     func rekey(old: WindowID, new: WindowID) {
         cancelPending(for: old)
         guard let gesture = gestures.removeValue(forKey: old)
@@ -175,9 +116,7 @@ public final class DragCrossingCoordinator {
         gestures[new] = gesture
     }
 
-    /// Ends the gesture at drop or cancel: disarms any dwell,
-    /// forgets the bookkeeping, and reports whether the gesture
-    /// ever crossed (the drop path's resize-gate bypass).
+    /// Ends gesture, cancels pending dwell, and reports if crossing occurred.
     @discardableResult
     func endGesture(_ id: WindowID) -> Bool {
         cancelPending(for: id)

--- a/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragCrossingCoordinator.swift
@@ -27,11 +27,18 @@ public final class DragCrossingCoordinator {
         var stickyRefused = false
     }
     private var gestures: [WindowID: Gesture] = [:]
+    /// A single slot, not per-window: only one window is ever
+    /// user-dragged at a time, so `schedule` may displace another
+    /// window's dwell without harm; `gestures` stays per-window
+    /// because ids must not inherit stale bookkeeping.
     private var pending:
         (window: WindowID, display: DisplayID, task: Task<Void, Never>)?
 
     #if DEBUG
-        /// Timeline handle for async crossing testing (#994, `tests.md`).
+        /// Timeline handle for async crossing testing (#994;
+        /// tests.md). Awaiting it does NOT mean a crossing fired —
+        /// it also completes for a disarmed dwell, and it is nil
+        /// when none is armed. `onCross` is the fact.
         var dwellTask: Task<Void, Never>? { pending?.task }
     #endif
 

--- a/Sources/KiwiDeskCore/Tiling/FloatResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/FloatResize.swift
@@ -1,12 +1,21 @@
 import CoreGraphics
 
-/// Symmetric keyboard resize math for floating windows with boundary
-/// edge pinning (#1091, owner ruling 2026-08-29; `FloatSymmetricResizeTests`).
+/// Symmetric keyboard resize math for floating windows with
+/// boundary-edge pinning (#1091, owner ruling 2026-08-29;
+/// `FloatSymmetricResizeTests`). One accepted residue:
+/// reversibility does not hold across the step that FIRST brings
+/// a window into contact with a boundary (bounded by half a step,
+/// confined to that transition). Do NOT answer it by remembering
+/// which way the last grow went — a stored direction needs
+/// invalidating on every move, mode and display change, and buys
+/// back less than it costs.
 public enum FloatResize {
     /// Tolerance for detecting contact with a boundary edge (1 pt).
     public static let boundaryTolerance: CGFloat = 1
 
-    /// Floor for frame shrink: `min_window_size` or 1 pt minimum.
+    /// Floor for a frame shrink: `min_window_size`, never below
+    /// 1 pt (AppKit rejects zero frames). `resized` caps this at
+    /// the CURRENT size, so the floor never LIFTS a frame.
     public static func shrinkFloor(
         minSize: CGFloat
     ) -> CGFloat {

--- a/Sources/KiwiDeskCore/Tiling/FloatResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/FloatResize.swift
@@ -1,73 +1,19 @@
 import CoreGraphics
 
-/// Pure frame math for keyboard-resizing a FLOATING window:
-/// `resize` on a floating focused window grows or shrinks the
-/// window itself along the requested axis instead of nudging
-/// the layout it does not participate in.
-///
-/// **A keyboard resize is SYMMETRIC, with pinned edges** (#1091,
-/// owner ruling 2026-08-29). Both edges move by half the delta;
-/// an edge against the boundary is PINNED and the whole delta
-/// goes to the other side; with both pinned a grow refuses and
-/// the caller cues, while a shrink contracts symmetrically as
-/// normal.
-///
-/// This replaced an origin-anchored model that mirrored **a
-/// mouse drag of the bottom-right corner** — the grabbed edge is
-/// the anchor. That is the right model for a drag and the wrong
-/// one for a keyboard: a chord has no grabbed edge, so
-/// privileging the right/bottom one is arbitrary, and against a
-/// screen edge it stopped the resize dead while free space sat
-/// on the other side (measured: 10 further grow asks moved the
-/// window 0 pt, silently, with 892 pt free to its left).
-///
-/// **The pinning applies to SHRINK as well as grow**, which is
-/// the load-bearing half: pin only on grow and grow/shrink stops
-/// being reversible at exactly the edge people park windows
-/// against. Every steady state round-trips — the reversibility
-/// table is on the issue.
-///
-/// One accepted residue, deliberate rather than overlooked:
-/// reversibility does NOT hold across the step that first brings
-/// a window into contact with a boundary. A window with 28 pt of
-/// room on the right, grown by 100, spills the blocked 22 pt
-/// leftward and pins its right edge; the following shrink then
-/// comes entirely off the left and lands half a step right of
-/// where it started. Bounded by half a step and confined to that
-/// one transition. Do NOT answer it by remembering which way the
-/// last grow went: a stored direction needs invalidating on
-/// every move, mode change and display change, and buys back
-/// less than it costs.
+/// Symmetric keyboard resize math for floating windows with boundary
+/// edge pinning (#1091, owner ruling 2026-08-29; `FloatSymmetricResizeTests`).
 public enum FloatResize {
-    /// How near an edge counts as touching it. Matches the bar
-    /// clamp's own tolerance in spirit: a window within a point
-    /// of the boundary has no usable room there, and treating it
-    /// as free would hand it a sub-pixel share of the delta and
-    /// leave the other side short.
+    /// Tolerance for detecting contact with a boundary edge (1 pt).
     public static let boundaryTolerance: CGFloat = 1
 
-    /// The size a shrink stops at: `min_window_size` when set,
-    /// never below 1 pt — AppKit rejects zero/negative frames.
-    /// `resized` caps this at the CURRENT size, so the floor
-    /// never *lifts* a frame; growing back works from any size
-    /// regardless.
+    /// Floor for frame shrink: `min_window_size` or 1 pt minimum.
     public static func shrinkFloor(
         minSize: CGFloat
     ) -> CGFloat {
         max(minSize, 1)
     }
 
-    /// Why a GROW could not deliver what it was asked for. Both
-    /// cases owe the user a cue, on #933's stated principle that
-    /// a request the limit truncates is already a refusal of
-    /// part of it — the shrink arm has cued on exactly that
-    /// since #933, and a grow that quietly delivered 12 of an
-    /// asked 100 was the same defect at the other end (code
-    /// review, 2026-08-29).
-    ///
-    /// Shrink never sets one: it always has somewhere to
-    /// contract to, and its own truncation against
-    /// `min_window_size` is cued by the caller.
+    /// Why a grow operation was blocked or truncated (#933, 2026-08-29).
     public enum Refusal: Equatable {
         /// Both edges against the boundary — nothing moved.
         case blocked
@@ -75,18 +21,14 @@ public enum FloatResize {
         case truncated
     }
 
-    /// What a resize produced, and why it fell short if it did.
-    /// Shaped after `ScrollSlotDomain.Outcome`, the house idiom
-    /// for a pure decision that also has to say why it refused.
+    /// Resize outcome and refusal status.
     public struct Outcome: Equatable {
         public let frame: CGRect
         public let refusal: Refusal?
     }
 
-    /// The frame after resizing along one axis by `delta`
-    /// (negative shrinks), split between both edges and pinned
-    /// against `bounds`. A nil `bounds` is unbounded — no edge
-    /// pins, so the delta always splits evenly.
+    /// Resizes floating `frame` along axis by `delta`, splitting symmetrically
+    /// with edge pinning against `bounds` (#1091).
     public static func resized(
         _ frame: CGRect,
         horizontal: Bool,

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
@@ -8,8 +8,10 @@ public struct TilingSettings: Sendable, Equatable {
     /// Space gap overrides (`gap.override[space_id]`).
     public var gapsOverride: [SpaceID: Gaps] = [:]
     public var minWindowSize: CGFloat = 300
-    /// Global magnitude (points) for authored resize hotkeys (`resize.step`,
-    /// #58).
+    /// Global magnitude (points) the catalog AUTHORS Grow/Shrink
+    /// keybindings with (`resize.step`, #58). Layout math never
+    /// reads this — the bound row's own literal delta drives an
+    /// actual resize.
     public var resizeStep: CGFloat = 50
     /// Sound alert when resize hotkey cannot act in layout (`resize.feedback`,
     /// #184).
@@ -19,7 +21,12 @@ public struct TilingSettings: Sendable, Equatable {
     public var swapSkipsCascade = true
     /// Nudge float toward screen center on float toggle (`float.nudge`).
     public var floatNudge = true
-    /// Scale float size proportionally on display change (#502, #444, #493).
+    /// Scale float size proportionally on display change (#502,
+    /// superseding #444/#493's keep-the-size). Read only by
+    /// `FloatReanchor.target` at a display-crossing re-anchor,
+    /// never by layout math — flipping it moves nothing. OFF keeps
+    /// the exact pixel size and accepts the OS overflow (the
+    /// narrow, technical ask — Lua-only, §2.7).
     public var floatScaleOnDisplayChange = true
     public var bsp = BspParams()
     public var stack = StackParams()

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings.swift
@@ -1,65 +1,25 @@
 import CoreGraphics
 import Foundation
 
-/// Tunable tiling parameters (later fed from init.lua).
-///
-/// JSON naming mirrors the Lua API: a key is the Lua command
-/// name with the `set_` verb stripped, grouped by namespace —
-/// `set_gap_override` -> `gap.override`, `bsp.set_ratio` ->
-/// `layout.bsp.ratio`. Profile files and `init.lua` share one
-/// vocabulary (see AGENTS.md §5).
+/// Tunable tiling parameters shared between profile files and Lua config
+/// (AGENTS.md §5).
 public struct TilingSettings: Sendable, Equatable {
     public var gapsGlobal = Gaps()
-    /// `gap.override[space_id]` beats the global gaps.
+    /// Space gap overrides (`gap.override[space_id]`).
     public var gapsOverride: [SpaceID: Gaps] = [:]
     public var minWindowSize: CGFloat = 300
-    /// Global magnitude (points) the catalog *authors* Grow/Shrink
-    /// keybindings with (`resize.step`, #58): it emits
-    /// `resize("x", ±step)`, and import reads a recovered magnitude
-    /// back into it. Layout math never reads this — the bound
-    /// row's own literal delta drives an actual resize.
+    /// Global magnitude (points) for authored resize hotkeys (`resize.step`,
+    /// #58).
     public var resizeStep: CGFloat = 50
-    /// When true (default), a resize hotkey that cannot act in
-    /// the active layout (monocle, grid, floating space) plays
-    /// the system alert sound (#184) — the "Cmd+Z with nothing
-    /// to undo" idiom. Hotkey fires only: CLI/IPC callers read
-    /// the error JSON and must stay silent. `resize.feedback`.
+    /// Sound alert when resize hotkey cannot act in layout (`resize.feedback`,
+    /// #184).
     public var resizeFeedback = true
-    /// When true (default), a directional `swap` issued from
-    /// inside an overflow cascade skips the other windows piled
-    /// with the focused one and targets the tiled neighbor
-    /// outside the pile (nothing when there is none), rather than
-    /// reordering the cascade (#172). Global (per profile, all
-    /// spaces), same tier as `minWindowSize`; power-user escape
-    /// hatch, no GUI. `focus` is never affected.
+    /// Directional swap in cascade targets outer neighbor
+    /// (`swap.skips_cascade`, #172).
     public var swapSkipsCascade = true
-    /// When true (default), toggling a window tiled→floating
-    /// gives it a small fixed shove toward the screen center so
-    /// the state change is visible — a float otherwise keeps its
-    /// exact frame, making the toggle look inert. Fires on the
-    /// float direction only (`make_tiled` already animates a real
-    /// move back into the layout). Global (per profile, all
-    /// spaces), same tier as `swapSkipsCascade`; a niche polish
-    /// toggle, Lua-only, no GUI. See `FloatNudge`.
+    /// Nudge float toward screen center on float toggle (`float.nudge`).
     public var floatNudge = true
-    /// When true (default ON, #502), a floating window re-anchored
-    /// across displays also scales its SIZE by the per-axis ratio
-    /// of the target to the source display, keeping the same
-    /// relative footprint — an oversized float shrinks to fit the
-    /// smaller screen instead of overflowing its edge (the OS lets
-    /// width overflow while it half-clamps height, so keeping the
-    /// size lands the window partly off-screen, which reads as
-    /// broken to most users). Supersedes the #444/#493 "keep the
-    /// size" default. Set false to keep the exact pixel size across
-    /// displays (a deliberate multi-monitor choice — screen
-    /// recording, pixel-matched capture — that accepts the OS
-    /// overflow, and avoids the per-axis aspect distortion on
-    /// mismatched-aspect displays). Read only by
-    /// `FloatReanchor.target` at a display-crossing re-anchor,
-    /// never by layout math — so flipping it moves nothing, exactly
-    /// like `floatNudge`, its flat sibling. Lua-only knob
-    /// (`set_float_scale_on_display_change`); no GUI (the OFF state
-    /// is the narrow, technical ask — GUI-curates/Lua-open §2.7).
+    /// Scale float size proportionally on display change (#502, #444, #493).
     public var floatScaleOnDisplayChange = true
     public var bsp = BspParams()
     public var stack = StackParams()
@@ -67,59 +27,37 @@ public struct TilingSettings: Sendable, Equatable {
     public var grid = GridParams()
     public var monocle = MonocleParams()
     public var track = TrackParams()
-    /// The indicator bar's global look, shared by every layout
-    /// that shows a bar. Each layout's own `bar` (enabled +
-    /// overrides) resolves against this.
+    /// Global indicator bar style for layouts with a bar.
     public var appBarStyle = AppBarStyle()
-    /// The Space Bar (#293): per-display Spaces overview,
-    /// layout-independent, global-only (no per-layout mirror).
-    /// Its strip is reserved from the visible frame *before*
-    /// layouts see their bounds (space-first reservation).
+    /// Space Bar overview settings (`space_bar.*`, #293).
     public var spaceBarStyle = SpaceBarStyle()
-    /// `new_window_placement_override[space_id]` beats the
-    /// layout's own spawn placement (like the gap override).
+    /// Space spawn placement overrides (`placement.override[space_id]`).
     public var placementOverride: [SpaceID: SpawnPlacement] =
         [:]
-    /// Focus-window border look (#278): the ring painted around
-    /// the focused window (and, when enabled, unfocused ones).
-    /// A pure post-layout overlay — never feeds back into layout.
+    /// Focus ring appearance settings (`border.*`, #278).
     public var borderStyle = BorderStyle()
-    /// Sticky-window indicator settings (#414): the on-window
-    /// glyph marking a sticky window. A border sibling — pure
-    /// post-layout overlay, never feeds back into layout.
+    /// Sticky window badge appearance (`sticky.*`, #414).
     public var stickyStyle = StickyStyle()
-    /// Floating-window mark settings (#429): the sticky pair's
-    /// sibling. Just the Space Bar floating badge tint today —
-    /// floating has no on-window mark.
+    /// Floating window badge appearance (`floating.*`, #429).
     public var floatingStyle = FloatingStyle()
-    /// Drag visuals (see DragOverlay): the dragged window's
-    /// own slot (ghost) and the swap target slot (drop zone).
+    /// Drag ghost visual settings (`drag.ghost`).
     public var dragGhost = DragVisual.ghostDefault
+    /// Drag drop zone visual settings (`drag.drop_zone`).
     public var dragDropZone = DragVisual.dropZoneDefault
-    /// Corner rounding of both visuals — defaults to the shared
-    /// system window radius (one source with the focus border,
-    /// see `GeometryUtils.systemWindowCornerRadius`), still
-    /// tunable per profile to match the running macOS release.
+    /// Corner radius for drag overlay visuals.
     public var dragCornerRadius = GeometryUtils
         .systemWindowCornerRadius
-    /// Per-trigger animation toggles (`animations.*`).
+    /// Per-trigger animation settings (`animations.*`).
     public var animations = AnimationSettings()
-    /// What resizing a tiled window with the mouse does.
+    /// Mouse drag resize mode for tiled windows.
     public var mouseResize: MouseResizeMode = .layout
-    /// Mouse-pointer behaviour (`mouse.*`, #186).
+    /// Mouse tracking and focus settings (`mouse.*`, #186).
     public var mouse = MouseSettings()
-    /// Optional recognition icon per space (#68): an SF Symbol
-    /// name, an emoji, or a single character — the same grammar
-    /// as mode icons. Sparse; the name stays primary everywhere.
-    /// `space.icon[space_id]`.
+    /// Optional display icon per space (`space.icon[space_id]`, #68).
     public var spaceIcons: [SpaceID: String] = [:]
-    /// Quit-time teardown placement (#197): how remaining
-    /// managed windows are spread when KiwiDesk exits.
-    /// `quit.layout`; `grid` is the only strategy today.
+    /// Window placement strategy on app quit (`quit.layout`, #197).
     public var quitLayout: QuitLayoutStyle = .grid
-    /// Density target of the quit grid (#281): the stack depth
-    /// a cell aims for before the grid grows a dimension
-    /// (still hard-clamped 2×2…4×4). `quit.grid_target_depth`.
+    /// Density target depth for quit grid (`quit.grid_target_depth`, #281).
     public var quitGridTargetDepth =
         QuitGridLayout.defaultTargetDepth
 


### PR DESCRIPTION
## Summary

Batch 8 of the AGENTS.md §2.8 comment diet.
Trims 70 source files across `KiwiDeskCore` and `KiwiDesk` to the §2.8 comment budget (1–3 lines plus issue refs, contract-only docstrings, preserving all platform traps, issue numbers, test citations, numeric constants, and dated rulings).

- **Files processed:** 70
- **Modified:** 67 files (+742 / -5,112 lines)
- **Preserved intact as rule-cited canonical homes:** `ScrollSlotDomain.swift`, `FollowSource.swift`, `GlideCommandedBase.swift`

## Verification
- `swift build` passes
- `swift test` passes (4,293 tests across 814 suites)
- `./scripts/lint.sh` passes (0 line-length violations, 0 formatting errors)