### PR TITLE
chore(comments): trim codebase to §2.8 budget (batch 10)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Common/HelpButton.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/HelpButton.swift
@@ -1,43 +1,17 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The contextual-help affordance (#94): a small circled `?`
-/// beside a settings row's label, opening a click popover with
-/// a sentence or two of explanation.
+/// Contextual help button opening an explanatory popover (#94).
 ///
-/// A click popover, not a hover-only tooltip: visible and
-/// discoverable, a real focusable button (keyboard and
-/// VoiceOver reach it), dismissible and re-readable — the
-/// System Settings pattern. `.help` rides along as a cheap
-/// hover fallback. Help is optional reading: a row's label and
-/// options must stay understandable without ever opening it.
-///
-/// Placement rule: the `?` sits IMMEDIATELY AFTER the field's
-/// label text, inside the shared `settingsLabelColumn` frame —
-/// the question is born at the label, so the affordance sits
-/// where the confusion starts. Exceptions (documented in
-/// design-decisions "Shared controls"): unlabeled controls and
-/// the Customize popover's override rows trail instead.
+/// Follows standard placement inside `settingsLabelColumn`.
 struct HelpButton: View {
-    /// The explanation. Inline Markdown (`**bold**`) renders in
-    /// the popover, so a 2–3-option field folds per-option text
-    /// into this one popover (option name bold, one line each)
-    /// instead of hanging a `?` off every segment.
+    /// Markdown-supported explanation text.
     let explanation: String
-    /// Optional field name folded into the VoiceOver label, so
-    /// the rotor reads "Help: Wrap focus" instead of a list of
-    /// indistinguishable "Help" buttons (#251). Omit where one
-    /// `?` is unambiguous in its row.
+    /// Accessible subject label (#251).
     var subject: String? = nil
     @State private var shown = false
-    /// The transient popover already dismisses on this very
-    /// click's mouse-down; without the stamp the mouse-up
-    /// action would immediately reopen it, making the button
-    /// unable to ever close its own popover.
     @State private var dismissed = Date.distantPast
 
-    /// Popover text measure — comfortable for 2–4 short lines
-    /// without ballooning over the pane.
     private static let textWidth: CGFloat = 260
 
     var body: some View {
@@ -51,9 +25,6 @@ struct HelpButton: View {
         }
         .buttonStyle(.plain)
         .controlSize(.small)
-        // The same hover chip every icon-only borderless
-        // button here carries — a bare glyph has nothing to
-        // catch the eye drifting past the bordered control.
         .hoverHighlight(cornerRadius: 4, padding: 2)
         .popover(isPresented: $shown, arrowEdge: .bottom) {
             Text(rich)
@@ -71,11 +42,6 @@ struct HelpButton: View {
             subject.map { L("help.button.for", "Help: %1$@", $0) }
                 ?? L("help.button", "Help")
         )
-        // A short action hint, not the content — VoiceOver
-        // reads the explanation inside the popover after
-        // activating, and `.help` above already exposes the
-        // full text; duplicating it here would announce it
-        // twice on every focus pass.
         .accessibilityHint(
             L(
                 "help.button.hint",
@@ -84,9 +50,7 @@ struct HelpButton: View {
         )
     }
 
-    /// Markdown-parsed body. `inlineOnlyPreservingWhitespace`
-    /// keeps the hand-authored newlines between per-option
-    /// lines while rendering `**bold**`.
+    /// Markdown-parsed body preserving whitespace formatting.
     private var rich: AttributedString {
         (try? AttributedString(
             markdown: explanation,
@@ -97,10 +61,6 @@ struct HelpButton: View {
         )) ?? AttributedString(explanation)
     }
 
-    /// The hover tooltip carries the same text with the
-    /// Markdown markers stripped. The extra replace only bites
-    /// when the Markdown parse failed and `rich` kept the raw
-    /// markers; a successful parse has none left.
     private var plain: String {
         String(rich.characters)
             .replacingOccurrences(of: "**", with: "")

--- a/Sources/KiwiDesk/Settings/Components/Common/HelpButton.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/HelpButton.swift
@@ -10,6 +10,10 @@ struct HelpButton: View {
     /// Accessible subject label (#251).
     var subject: String? = nil
     @State private var shown = false
+    /// The transient popover already dismisses on this very
+    /// click's mouse-down; without the stamp the mouse-up action
+    /// would immediately reopen it — the button unable to ever
+    /// close its own popover.
     @State private var dismissed = Date.distantPast
 
     private static let textWidth: CGFloat = 260
@@ -42,6 +46,9 @@ struct HelpButton: View {
             subject.map { L("help.button.for", "Help: %1$@", $0) }
                 ?? L("help.button", "Help")
         )
+        // A short action hint, not the content: `.help` already
+        // exposes the full text, and duplicating it here would
+        // announce it twice per focus pass.
         .accessibilityHint(
             L(
                 "help.button.hint",

--- a/Sources/KiwiDesk/Settings/Components/Common/PermissionPausedBanner.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/PermissionPausedBanner.swift
@@ -1,37 +1,12 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// A non-dismissible banner shown across the whole dashboard
-/// whenever macOS Accessibility permission is missing: window
-/// management is fully paused, so every tiling control below is
-/// silently inert. Unlike the keybinding-conflict nudge this
-/// tracks a persistent fact — there is no dismiss (hiding "nothing
-/// works" while it's still true would be a grey-don't-hide
-/// violation).
-///
-/// The rows below stay EDITABLE while it shows, which is the
-/// whole reason the banner says "paused" rather than greying the
-/// dashboard out: a setup prepared before the grant lands is
-/// waiting the moment it does. That is also why the banner is the
-/// only thing on screen that changes — greying every control
-/// would say the app is broken, when what is true is that one
-/// switch is off.
+/// Warning banner displayed when macOS Accessibility permission is missing.
 struct PermissionPausedBanner: View {
-    /// The "Open System Settings" action — the macOS pane
-    /// directly, not the tour's grant step (#678 Phase 4 pass 9;
-    /// `AppDelegate`'s wiring carries why the two routes differ).
-    /// Passed directly rather than through the model: this view
-    /// has no reactive state of its own — visibility is gated
-    /// externally in `chrome()` by `model.permissionPaused`.
+    /// Action opening macOS System Settings (`AppDelegate`, #678 Phase 4).
     let onResolve: () -> Void
 
     var body: some View {
-        // Center-aligned, not `.top`: the message is a single
-        // line and the action button is taller than it, so a
-        // top alignment leaves the icon + text hugging the top
-        // while the button sits centered (the
-        // KeybindingConflictBanner uses `.top` only because its
-        // text can wrap to several lines).
         HStack(alignment: .center, spacing: 10) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(SettingsTheme.warningInk)
@@ -45,13 +20,6 @@ struct PermissionPausedBanner: View {
             .font(.callout)
             .foregroundStyle(SettingsTheme.warningInk)
             .frame(maxWidth: .infinity, alignment: .leading)
-            // ONE key with the onboarding button, not a twin of
-            // it (l10n audit, 2026-08-11): `onboarding.grant.body`
-            // QUOTES this label in its numbered steps, so two keys
-            // holding one English let a later round split the
-            // quote from the button it quotes — in one language,
-            // invisibly. Renamed out of `onboarding.` because this
-            // banner outlives onboarding.
             Button(
                 L(
                     "common.open_system_settings",
@@ -63,12 +31,6 @@ struct PermissionPausedBanner: View {
             .settingsActionButton()
         }
         .padding(12)
-        // A solid warning surface, not `.orange.opacity(0.12)`:
-        // an opacity wash takes its result from whatever is
-        // behind it, so the bar drifted with the page and could
-        // not be given a dark counterpart at all. The pair also
-        // holds 4.5:1 for `warningInk` on it, which a wash over an
-        // unknown backdrop cannot promise.
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(SettingsTheme.warningSurface)

--- a/Sources/KiwiDesk/Settings/Components/Common/PermissionPausedBanner.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/PermissionPausedBanner.swift
@@ -1,7 +1,12 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Warning banner displayed when macOS Accessibility permission is missing.
+/// Warning banner displayed when macOS Accessibility permission
+/// is missing. Non-dismissible (hiding "nothing works" while true
+/// is a grey-don't-hide violation), and the rows below stay
+/// EDITABLE — the banner says "paused" rather than greying the
+/// dashboard, so a setup prepared before the grant is waiting the
+/// moment it lands.
 struct PermissionPausedBanner: View {
     /// Action opening macOS System Settings (`AppDelegate`, #678 Phase 4).
     let onResolve: () -> Void
@@ -20,6 +25,10 @@ struct PermissionPausedBanner: View {
             .font(.callout)
             .foregroundStyle(SettingsTheme.warningInk)
             .frame(maxWidth: .infinity, alignment: .leading)
+            // ONE key with the onboarding button, not a twin
+            // (l10n audit 2026-08-11): `onboarding.grant.body`
+            // QUOTES this label in its steps. Renamed out of
+            // `onboarding.` because this banner outlives it.
             Button(
                 L(
                     "common.open_system_settings",
@@ -31,6 +40,9 @@ struct PermissionPausedBanner: View {
             .settingsActionButton()
         }
         .padding(12)
+        // A solid warning surface, never an opacity wash: a wash
+        // takes its result from whatever is behind it, drifts with
+        // the page, and cannot promise 4.5:1 for `warningInk`.
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(SettingsTheme.warningSurface)

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsRowShape.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsRowShape.swift
@@ -1,30 +1,9 @@
 import SwiftUI
 
-/// A labelled row's ARRANGEMENT, and the one place the settings
-/// tree decides it (#678 turn 17a).
+/// Layout container switching between inline and stacked row layouts
+/// (`SettingsMetrics.labelColumn`, `SettingsRowShapeTests`, #678 turn 17a).
 ///
-/// Wide enough, a row is a label in the shared column
-/// (`SettingsMetrics.labelColumn`) with its control hanging off
-/// that axis — which is what makes controls of one kind line up
-/// down a whole section. Below the row breakpoint the label goes
-/// ABOVE and the control takes the full width, because the
-/// alternative at 820 pt is a segmented control that wraps or a
-/// menu clipped to its chevron, and 17a's order forbids both:
-/// preview first, then row layout, then chrome, and controls
-/// never.
-///
-/// **The switch is `AnyLayout`, deliberately, not an `if`.** Both
-/// arrangements draw the same two children, so the layout swap
-/// keeps their identity — a menu stays open, a focused field
-/// keeps focus, and the reflow animates instead of the row being
-/// torn down and rebuilt as the user drags the window edge. An
-/// `if stacked { VStack } else { HStack }` is two subtrees and
-/// loses all three.
-///
-/// Every shared row shape routes through this
-/// (`SettingsRowShapeTests` holds the label column's one
-/// application site, so a row hand-framing `labelColumn` beside
-/// it reds).
+/// Uses `AnyLayout` to preserve view identity and focus across window resize.
 struct SettingsRowShape<Label: View, Control: View>: View {
     @Environment(\.settingsWidth) private var width
     @Environment(\.settingsLabelColumn) private var labelColumn
@@ -33,10 +12,6 @@ struct SettingsRowShape<Label: View, Control: View>: View {
 
     var body: some View {
         let stacked = width.stacksRows
-        // Default HStack spacing on the wide arm: the rows this
-        // replaced were plain `HStack {}`, and the label axis is
-        // shared app-wide, so a spacing of its own here would
-        // move every section's control line by a few points.
         let layout =
             stacked
             ? AnyLayout(
@@ -45,12 +20,6 @@ struct SettingsRowShape<Label: View, Control: View>: View {
             : AnyLayout(HStackLayout())
         layout {
             label
-                // `nil` when stacked — the modifier stays in the
-                // chain either way rather than becoming an `if`,
-                // which would put the label in a
-                // `_ConditionalContent` and give away the
-                // identity the `AnyLayout` above is here to
-                // keep.
                 .frame(
                     width: stacked ? nil : labelColumn,
                     alignment: .leading
@@ -60,21 +29,8 @@ struct SettingsRowShape<Label: View, Control: View>: View {
     }
 }
 
-/// The label side of a row: the text, plus the #94 `?` where the
-/// row carries one. Extracted with the shape because the two
-/// always ship together — every caller built this identical
-/// `HStack(spacing: 4)` — and because the help button's
-/// placement rule ("label-adjacent, inside the shared column")
-/// is one decision, not six copies of one.
-///
-/// The text is drawn, not spoken. Every control that sits in
-/// this shape names ITSELF — a slider through
-/// `SettingsSlider.label`, a dropdown through its own title, a
-/// segmented picker through its track — so read aloud as well
-/// the label is the same words twice, once standing alone and
-/// once as the control's name (the `LayoutPreviewPanel` ruling,
-/// code review 2026-08-11, applied at the seam). The `?` stays
-/// a rotor stop of its own; it is not the label's twin.
+/// Row label container displaying text and optional help button (#94,
+/// `LayoutPreviewPanel`).
 struct SettingsRowLabel: View {
     let label: String
     var help: String? = nil

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsRowShape.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsRowShape.swift
@@ -20,6 +20,10 @@ struct SettingsRowShape<Label: View, Control: View>: View {
             : AnyLayout(HStackLayout())
         layout {
             label
+                // `nil` when stacked — the modifier stays in the
+                // chain rather than becoming an `if`, which would
+                // wrap the label in `_ConditionalContent` and give
+                // away the identity `AnyLayout` is here to keep.
                 .frame(
                     width: stacked ? nil : labelColumn,
                     alignment: .leading
@@ -29,8 +33,11 @@ struct SettingsRowShape<Label: View, Control: View>: View {
     }
 }
 
-/// Row label container displaying text and optional help button (#94,
-/// `LayoutPreviewPanel`).
+/// Row label container displaying text and optional help button
+/// (#94). The text is drawn, not spoken: every control in this
+/// shape names ITSELF, so read aloud as well the label would be
+/// the same words twice (the `LayoutPreviewPanel` ruling, code
+/// review 2026-08-11, applied at the seam).
 struct SettingsRowLabel: View {
     let label: String
     var help: String? = nil

--- a/Sources/KiwiDesk/Settings/Components/Common/StepperRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/StepperRow.swift
@@ -1,43 +1,21 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// A stepper row in the duration rows' shape: label leading,
-/// the value trailing as an **editable field** (type a number
-/// or use the arrows) plus the stepper arrows — the native
-/// System-Settings numeric layout, with the value reading as
-/// changeable, not a static readout. An optional `suffix` (e.g.
-/// "ms") sits between the field and the arrows.
+/// Numeric stepper row with direct text editing field
+/// (`HelpButton`, #94, #275).
 struct StepperRow: View {
     let label: String
     @Binding var value: Int
     let range: ClosedRange<Int>
     let step: Int
     let suffix: String?
-    /// Hide the visual label, leaving value + arrows only (#275):
-    /// for a section whose header already names the sole control,
-    /// restating it on the row is native-atypical (Dock "Size").
-    /// `label` still feeds the accessibility label of both the
-    /// field and the arrows, so VoiceOver is unaffected — the
-    /// control is left-aligned under the
-    /// header instead of trailing an empty label column.
+    /// Hide visual label while preserving accessibility labels (#275).
     let labelHidden: Bool
-    /// Optional #94 `?` popover, label-adjacent like the other
-    /// row kinds. Ignored while `labelHidden` — a floating `?`
-    /// with no visible subject reads unanchored; such sections
-    /// carry their help on the header instead.
+    /// Optional contextual help explanation (#94).
     let help: String?
-    /// The field edits a string proxy so intermediate/empty
-    /// typing never clobbers `value`; it commits (parse +
-    /// clamp) on Return or focus loss, matching the rename
-    /// field's commit discipline.
     @State private var text: String
     @FocusState private var focused: Bool
-    /// Also parse+clamp on every keystroke, not just on commit.
-    /// For a row whose adjacent action reads `value` directly:
-    /// clicking that action on macOS doesn't blur the field, so
-    /// without this the action would use the last committed value
-    /// while a newer number sits unread onscreen. Off for plain
-    /// settings, where commit-on-blur is the native rhythm.
+    /// Parse and clamp on keystrokes rather than solely on blur/commit.
     let liveCommit: Bool
 
     init(
@@ -50,8 +28,6 @@ struct StepperRow: View {
         help: String? = nil,
         liveCommit: Bool = false
     ) {
-        // The drop is deliberate (see `help` above) — make the
-        // contract self-enforcing rather than silent.
         assert(
             !(labelHidden && help != nil),
             "StepperRow drops help when labelHidden — carry "
@@ -82,12 +58,6 @@ struct StepperRow: View {
             }
             TextField("", text: $text)
                 .labelsHidden()
-                // The field is a control of its own beside the
-                // arrows, and an empty title names it nothing:
-                // the arrows said "Title length, 40" while the
-                // field the user types into said only its
-                // digits (#812). Same name as the arrows; its
-                // value is the text itself.
                 .accessibilityLabel(label)
                 .frame(width: 48)
                 .multilineTextAlignment(.trailing)
@@ -117,16 +87,10 @@ struct StepperRow: View {
                     suffix.map { "\(value) \($0)" }
                         ?? "\(value)"
                 )
-            // Label hidden → nothing anchors the control to the
-            // leading edge, so a trailing spacer keeps it left
-            // under the section header instead of centering.
             if labelHidden {
                 Spacer()
             }
         }
-        // Keep the field in step with arrow taps / external
-        // changes — but never while the user is mid-edit, or a
-        // background write would discard their partial entry.
         .onChange(of: value) { _, now in
             if !focused { text = "\(now)" }
         }

--- a/Sources/KiwiDesk/Settings/Components/Common/StepperRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/StepperRow.swift
@@ -15,7 +15,11 @@ struct StepperRow: View {
     let help: String?
     @State private var text: String
     @FocusState private var focused: Bool
-    /// Parse and clamp on keystrokes rather than solely on blur/commit.
+    /// Parse and clamp on keystrokes rather than solely on
+    /// blur/commit — for a row whose adjacent action reads `value`
+    /// directly: clicking that action on macOS doesn't blur the
+    /// field, so the action would use the last committed value
+    /// while a newer number sits unread onscreen.
     let liveCommit: Bool
 
     init(
@@ -58,6 +62,10 @@ struct StepperRow: View {
             }
             TextField("", text: $text)
                 .labelsHidden()
+                // The field is its own control beside the arrows,
+                // and an empty title names it nothing — it said
+                // only its digits (#812). Same name as the arrows;
+                // its value is the text itself.
                 .accessibilityLabel(label)
                 .frame(width: 48)
                 .multilineTextAlignment(.trailing)
@@ -91,6 +99,9 @@ struct StepperRow: View {
                 Spacer()
             }
         }
+        // Keep the field in step with arrow taps and external
+        // changes — but never mid-edit, or a background write
+        // would discard the user's partial entry.
         .onChange(of: value) { _, now in
             if !focused { text = "\(now)" }
         }

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/DragVisualsEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/DragVisualsEditor.swift
@@ -1,8 +1,12 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Drag-and-drop visuals editor card for ghost and drop zone settings
-/// (`GapsBordersGates`, #68 §3.14, #231, #754).
+/// Drag-and-drop visuals editor card for ghost and drop zone
+/// settings (`GapsBordersGates`, #68 §3.14, #231, #754). Twin
+/// columns, each preview above its own controls; static previews
+/// — no live drag (#123). The colour rows left for Advanced
+/// Colours in #678 Phase 3; what stays is what only a column can
+/// answer.
 struct DragVisualsEditor: View {
     @ObservedObject var model: SettingsModel
 
@@ -56,6 +60,9 @@ struct DragVisualsEditor: View {
         visual: Binding<DragVisual>,
         enabledReason: GapsBordersGates.InertReason?
     ) -> some View {
+        // The header `?` is the gate's live anchor (#527): with
+        // the visual off the column below is dimmed, and help
+        // inside a greyed block is dead.
         SettingsSection(
             control,
             caption: caption,

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/DragVisualsEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/DragVisualsEditor.swift
@@ -1,22 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Drag-and-drop visuals (#68 §3.14, restructured #231, #754):
-/// Ghost | Drop-zone as two side-by-side columns inside the
-/// Drag & drop card. Each column leads with its own live
-/// preview and puts its controls directly beneath, so tuning a
-/// column's border width never scrolls its preview off-screen —
-/// the whole reason the previews were split out of one shared
-/// strip. Genuinely distinct runtime visuals users routinely
-/// want different, edited by comparison, so twin columns state
-/// the pairing once (the System-Settings Displays/Desktop
-/// pattern). Static previews — no live drag (#123).
-///
-/// Both border WIDTHS and the shared corner radius left for the
-/// Borders card in #754, where two rows now decide them for all
-/// three strokes at once; the two alignment pickers left the GUI
-/// entirely there (GUI_REMOVED_2026-08). What stays in a column
-/// is what only that column can answer.
+/// Drag-and-drop visuals editor card for ghost and drop zone settings
+/// (`GapsBordersGates`, #68 §3.14, #231, #754).
 struct DragVisualsEditor: View {
     @ObservedObject var model: SettingsModel
 
@@ -63,36 +49,19 @@ struct DragVisualsEditor: View {
         }
     }
 
-    /// One self-contained column: preview leads, its controls
-    /// below.
-    ///
-    /// It no longer narrows the label axis (#231's
-    /// `dragColumnLabelColumn`, pushed in through the
-    /// environment). That existed so a half-width column could
-    /// still hold a slider with real travel, and #754 took the
-    /// last slider out — what remains is toggles, which draw
-    /// their own labels and never read the axis. The metric
-    /// itself stays: Advanced Colours' twin drag columns pass
-    /// it directly as `labelWidth:`.
+    /// Renders individual column with gated controls (#527).
     private func column(
         control: SettingsControl,
         caption: String,
         visual: Binding<DragVisual>,
         enabledReason: GapsBordersGates.InertReason?
     ) -> some View {
-        // The header `?` is the gate's live anchor (#527): with
-        // the visual off the column below the Enabled toggle is
-        // dimmed, and help inside a greyed block is dead.
         SettingsSection(
             control,
             caption: caption,
             subsection: true,
             help: enabledReason.map(GapsBordersGateHelp.sentence)
         ) {
-            // The ghost preview moved to the detail PANEL
-            // (`GapsBordersPanelPreview`) — one screen must
-            // not state one fact twice; the Advanced Colours
-            // mirror keeps its own mount.
             DragVisualControls(
                 visual: visual,
                 enabledReason: enabledReason
@@ -102,21 +71,12 @@ struct DragVisualsEditor: View {
     }
 }
 
-/// The border + fill switches shared by ghost and drop zone —
-/// whether each part is drawn at all, which is the one question
-/// only this column can answer. The two COLOUR rows left in
-/// #678 Phase 3 for Advanced Colours; the border WIDTH left in
-/// #754 for the shared master, which is why Border no longer
-/// gates anything below it here.
+/// Border and fill toggle switches for drag ghost and drop zone
+/// (`GreyOut`, #171, #520, #754).
 struct DragVisualControls: View {
     @Binding var visual: DragVisual
     let enabledReason: GapsBordersGates.InertReason?
 
-    /// The one gate the column implies and did not enforce
-    /// (#520): with the visual off nothing it draws exists. The
-    /// column's preview already prints "disabled" beside it, so
-    /// the controls were the only surface still claiming to
-    /// matter. Greyed, never hidden (#171).
     var body: some View {
         Toggle(L("drag.enabled", "Enabled"), isOn: $visual.enabled)
         Divider()

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FocusBorderEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FocusBorderEditor.swift
@@ -28,6 +28,9 @@ struct FocusBorderEditor: View {
     }
 
     var body: some View {
+        // The header `?` is the gate's live anchor (#527): every
+        // help affordance inside the greyed block is dead, so the
+        // why-off explanation must live outside it.
         SettingsSection(
             SettingsCatalog.gapsAndBorders.focusBorder,
             caption: L(
@@ -56,6 +59,11 @@ struct FocusBorderEditor: View {
             isOn: style.unfocusedEnabled
         )
         Divider()
+        // A noun phrase like its true siblings (Width, Corners),
+        // NOT the "Show X" family — that family gates an element,
+        // this toggles a trait (#358); and the verb form was
+        // ambiguous in German ("Leuchten anzeigen" reads as "show
+        // lamps"). ui-designer verdict 2026-07-26.
         Toggle(
             L("border.glow", "Glow effect"),
             isOn: style.glow
@@ -70,6 +78,10 @@ struct FocusBorderEditor: View {
             title: L("border.glow_size.auto", "Auto glow size"),
             isOn: AutoSentinel.binding(
                 style.glowSize,
+                // Auto is the width-scaled formula's 0 sentinel
+                // (#551); take over from where auto left off — a
+                // fixed restore snapped the ring visibly at
+                // non-default widths.
                 restore: BorderStyle.glowBlur(
                     for: style.wrappedValue.clampedWidth
                 ).rounded()

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FocusBorderEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FocusBorderEditor.swift
@@ -1,19 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// This Profile ▸ Gaps & Borders ▸ Focus border (#278). Leads
-/// the drag visuals since #754 — the ring is the stroke seen all
-/// day. Order per the settled design: enable toggle → live
-/// two-window preview → unfocused toggle → glow (preview leads
-/// editor, AGENTS §2.7). The ring's WIDTH and CORNERS are the
-/// masters in the card above, which every stroke shares, so
-/// neither is drawn a second time here.
-///
-/// The two ring COLOURS left in #678 Phase 3 — every colour
-/// KiwiDesk has now renders once, in Advanced Colours. What stays
-/// is the ring's structure, and the unfocused toggle stays with
-/// it: it decides whether a second ring is drawn at all, which is
-/// this card's question, not a tint.
+/// Editor view for focus border settings (#278, #678 Phase 3, #754).
 struct FocusBorderEditor: View {
     @ObservedObject var model: SettingsModel
 
@@ -25,9 +13,7 @@ struct FocusBorderEditor: View {
         GapsBordersGates(settings: model.config.settings)
     }
 
-    /// The block gate: the whole card is inert while the ring is
-    /// off. Resolved once at the container so its grey and its
-    /// sentence stay one decision (#678).
+    /// Block gate for entire card when focus border is disabled (#678).
     private var blockReason: GapsBordersGates.InertReason? {
         gates.containerReason(for: .focusBorder)
     }
@@ -36,16 +22,12 @@ struct FocusBorderEditor: View {
         blockReason.map(GapsBordersGateHelp.sentence) ?? ""
     }
 
-    /// The glow-size row's gate, inside a live block: greyed while
-    /// the glow effect is off.
+    /// Glow size row gate when glow effect is disabled.
     private var glowSizeReason: GapsBordersGates.InertReason? {
         gates.inertReason(for: .borders(.borderGlowSize))
     }
 
     var body: some View {
-        // The header `?` is the gate's live anchor (#527): every
-        // help affordance inside the greyed block is dead, so the
-        // why-off explanation must live outside it.
         SettingsSection(
             SettingsCatalog.gapsAndBorders.focusBorder,
             caption: L(
@@ -59,9 +41,6 @@ struct FocusBorderEditor: View {
                 L("border.enabled", "Show focus border"),
                 isOn: style.enabled
             )
-            // The ring preview moved to the detail PANEL
-            // (`GapsBordersPanelPreview`, #678 redesign spec); the
-            // Advanced Colours mirror keeps its own mount.
             controls.modifier(
                 GreyOut(active: blockReason != nil, help: blockHelp)
             )
@@ -77,15 +56,6 @@ struct FocusBorderEditor: View {
             isOn: style.unfocusedEnabled
         )
         Divider()
-        // A render trait of the ring like Width and Corners — a soft
-        // bloom in the focused ring's hue (#358). Sits with the other
-        // styling traits, no caption (the live preview above shows
-        // it on toggle); a11y gets the descriptive gloss. A noun
-        // phrase like its true siblings (Width, Corners), NOT the
-        // "Show X" family — that family gates an element other
-        // controls configure, while this toggles a trait; and the
-        // verb form was ambiguous in German ("Leuchten anzeigen"
-        // reads as "show lamps"). ui-designer verdict 2026-07-26.
         Toggle(
             L("border.glow", "Glow effect"),
             isOn: style.glow
@@ -96,30 +66,14 @@ struct FocusBorderEditor: View {
                 "Soft glow around the focus border"
             )
         )
-        // Directly below the toggle that gates it (topic
-        // grouping); Auto is the width-scaled formula's 0
-        // sentinel, the AutoSentinel face (#551). The `enabled &&`
-        // conjunction is NOT about dim-compounding (the
-        // isInsideGreyOut flag already prevents that) — it keeps
-        // this gate inactive while the whole block is off, so
-        // its "Turn on Glow effect" hover can't shadow the
-        // block-level "Turn on Show focus border" explanation.
         AutoGatedGroup(
             title: L("border.glow_size.auto", "Auto glow size"),
             isOn: AutoSentinel.binding(
                 style.glowSize,
-                // Take over from where auto left off — a fixed
-                // restore snapped the ring visibly at non-default
-                // widths (auto reaches 12 at width 20). Always
-                // inside the 1-20 GUI band (the formula caps
-                // at 12).
                 restore: BorderStyle.glowBlur(
                     for: style.wrappedValue.clampedWidth
                 ).rounded()
             ),
-            // Glow off greys the group (resolver reason); with
-            // glow on, `nil` hands greying back to the auto
-            // sentinel, so auto-size still dims its own slider.
             gatedIsInert: glowSizeReason != nil ? true : nil,
             gatedHelp:
                 glowSizeReason

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersRowOrder.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersRowOrder.swift
@@ -1,28 +1,7 @@
-/// Display order for the Gaps & Borders area's rows (#678
-/// Phase 3). Geometry only — every colour this feature draws
-/// moved to Advanced Colours, so no colour row appears here.
-///
-/// The area's five containers each own one decision:
-///
-/// - `.gaps` — the outer and inner master sliders, each with a
-///   per-edge / per-axis drawer beneath it.
-/// - `.borders` — the two decisions all three strokes share,
-///   each written to every stroke: the width master and the
-///   Square/Rounded corner master (#754). The container spans
-///   this area and Advanced Colours, which is where the same
-///   group's tints render.
-/// - `.focusBorder` — the ring: its unfocused twin, glow, and
-///   the fit-layout-gaps action. The enable toggle owns the
-///   container gate.
-/// - `.stickyWindows` — the one on-window sticky mark toggle.
-/// - `.dragAndDrop` — the ghost and drop-zone visual columns.
-///
-/// `GapsAndBordersCensusRenderTests` pins each list against the
-/// census, so a row moves by editing the census rather than a
-/// view.
+/// Display order for Gaps & Borders settings rows
+/// (`GapsAndBordersCensusRenderTests`, #678 Phase 3, #754).
 enum GapsBordersRowOrder {
-    /// Outer master then its four edges, inner master then its
-    /// two axes — the order the editor stacks them.
+    /// Outer and inner gap slider setting keys.
     static let gaps: [SettingKey] = [
         .gaps(.outer),
         .gaps(.outerTop),
@@ -34,19 +13,13 @@ enum GapsBordersRowOrder {
         .gaps(.innerVertical),
     ]
 
-    /// The width master, then the Square/Rounded corner master.
-    /// Each is a `(master)` row over several stored leaves and
-    /// none of those leaves names a row of its own — the ring's
-    /// width and corner style included, since #754 asks about
-    /// all three strokes at once or not at all.
+    /// Border width and corner master setting keys (#754).
     static let borders: [SettingKey] = [
         .borders(.borderWidthMaster),
         .borders(.borderCornerMaster),
     ]
 
-    /// The enable toggle first (it owns the container gate),
-    /// then the unfocused twin, the glow, and the fit-gaps
-    /// action. Width and Corners left for `.borders` in #754.
+    /// Focus border setting keys (#754).
     static let focusBorder: [SettingKey] = [
         .borders(.borderEnabled),
         .borders(.borderUnfocusedEnabled),
@@ -61,10 +34,7 @@ enum GapsBordersRowOrder {
         .borders(.stickyMark)
     ]
 
-    /// The ghost column, then the drop-zone column — each
-    /// column's enable, border and fill. Alignment, border
-    /// width and the corner radius all left the GUI in #754;
-    /// what stays is what only a column can answer.
+    /// Drag-and-drop visual setting keys (#754).
     static let dragAndDrop: [SettingKey] = [
         .borders(.dragGhostEnabled),
         .borders(.dragGhostBorder),
@@ -74,7 +44,7 @@ enum GapsBordersRowOrder {
         .borders(.dragDropZoneFill),
     ]
 
-    /// Every row this area draws, by container.
+    /// Row order mapped by container.
     static let byContainer: [SettingsContainer: [SettingKey]] = [
         .gaps: gaps,
         .borders: borders,
@@ -83,18 +53,7 @@ enum GapsBordersRowOrder {
         .dragAndDrop: dragAndDrop,
     ]
 
-    /// Containers drawn as BESPOKE views rather than a `ForEach`
-    /// over the list above.
-    ///
-    /// All five are: the gaps drawers, the shared card's two
-    /// masters, the ring preview and its auto-gated glow group,
-    /// the single sticky toggle, and the two-column drag
-    /// layout are hand-built, not list-walked. So
-    /// the lists exist to record membership for the placement
-    /// table and search — and the guard holds that membership —
-    /// but editing one moves nothing on screen (the edge `gui.md`
-    /// warns about). A container that becomes a real `ForEach`
-    /// leaves this set in the same change.
+    /// Containers rendered with bespoke SwiftUI views (`gui.md`).
     static let bespokeContainers: Set<SettingsContainer> = [
         .gaps,
         .borders,

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersRowOrder.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersRowOrder.swift
@@ -53,7 +53,11 @@ enum GapsBordersRowOrder {
         .dragAndDrop: dragAndDrop,
     ]
 
-    /// Containers rendered with bespoke SwiftUI views (`gui.md`).
+    /// Containers rendered with bespoke SwiftUI views: the lists
+    /// above record membership for the placement table and search,
+    /// but editing one moves nothing on screen (the edge `gui.md`
+    /// warns about). A container that becomes a real `ForEach`
+    /// leaves this set in the same change.
     static let bespokeContainers: Set<SettingsContainer> = [
         .gaps,
         .borders,

--- a/Sources/KiwiDesk/Settings/Components/Icons/IconPicker.swift
+++ b/Sources/KiwiDesk/Settings/Components/Icons/IconPicker.swift
@@ -2,14 +2,8 @@ import AppKit
 import KiwiDeskCore
 import SwiftUI
 
-/// The icon chooser (#68 §6.4), one component for mode icons
-/// and space icons: search-first (keywords, not just symbol
-/// names), a Recents row persisted app-wide, an exact-name
-/// escape hatch (any valid SF Symbol name typed into the
-/// search appears as a result), single-character queries offer
-/// "Use as text", and the header previews the selection at its
-/// destination size. The icon stays one string — a symbol
-/// name, an emoji, or a single character; empty = default.
+/// Icon picker for mode and space icons supporting emoji and SF Symbols
+/// (`IconCatalog`, #68 §6.4).
 struct IconPicker: View {
     @Binding var icon: String
     /// How the popover header previews the selection.
@@ -19,9 +13,7 @@ struct IconPicker: View {
     @State private var search = ""
     @State private var tab: IconTab = .emoji
 
-    /// Browse tabs (#68 §6.4): emoji first — space icons are
-    /// the picker's most frequent use and lean emoji. Search
-    /// stays global across both vocabularies.
+    /// Browse tabs for curated emoji and symbol collections (#68 §6.4).
     enum IconTab: String, CaseIterable, Identifiable {
         case emoji = "Emoji"
         case symbols = "Symbols"
@@ -43,10 +35,7 @@ struct IconPicker: View {
     }
 
     enum IconPreview {
-        /// An 18 pt menu-bar mock, light and dark side by
-        /// side — the glyph's job is being legible up there.
         case menuBar
-        /// Row-chip size, for space icons.
         case chip
     }
 
@@ -214,9 +203,8 @@ struct IconPicker: View {
 
     // MARK: - Result sections
 
-    /// Escape hatches ahead of the curated grid: the query as
-    /// a literal SF Symbol name, and a single character (incl.
-    /// emoji) as a text icon.
+    /// Result escape hatches for plain text and raw SF Symbol names
+    /// (#68 §6.4).
     @ViewBuilder private var specialResults: some View {
         let query = search.trimmed
         if !query.isEmpty {
@@ -258,8 +246,6 @@ struct IconPicker: View {
         }
     }
 
-    /// `title` nil renders the bare grid — used for the tab
-    /// grids, where the segmented control already names it.
     @ViewBuilder private func gridSection(
         _ title: String?,
         choices: [IconChoice]
@@ -280,9 +266,7 @@ struct IconPicker: View {
         }
     }
 
-    /// Clearing is a control, not a choice (§6.4): it acts on
-    /// the current selection, so it sits beside the tabs
-    /// instead of posing as a grid cell under Recents.
+    /// Clear button to reset icon to default (#68 §6.4).
     private var clearButton: some View {
         Button {
             icon = ""
@@ -314,9 +298,6 @@ struct IconPicker: View {
         }
         .settingsActionButton()
         .help(glyph)
-        // The glyph's own name (an emoji, or an SF Symbol's
-        // dotted name): a picture button says nothing
-        // otherwise (#812).
         .accessibilityLabel(glyph)
     }
 

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/ConflictText.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/ConflictText.swift
@@ -1,23 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The GUI boundary where a Core `Conflict` becomes readable
-/// text (#96). Core detects conflicts in actor-free code that
-/// cannot reach `L()` (it is `@MainActor`), so it names what
-/// clashed and this file says it in the user's language — the
-/// canonical → label split `KeybindingCatalog` already uses.
-///
-/// The banner's own sentences live in
-/// `SettingsModel+ConflictMessages`, which renders the same
-/// structure at a different length. This file owns the per-row
-/// tooltip.
+/// Keybinding conflict tooltip and localized system shortcut names (#96).
 enum ConflictText {
-    /// The tooltip for one row, or nil when the row is empty,
-    /// unique, or valid. Takes the config because the clashing
-    /// row's name is the stored ENGLISH canonical and must be
-    /// narrated through the catalog roster (#96) — the banner
-    /// fix's own defect class, amplified here the day the ⚠️
-    /// became a popover (l10n review 2026-08-10).
+    /// Tooltip text for conflicting keybinding row (`KeybindingCatalog`, #96).
     @MainActor
     static func tooltip(
         for binding: KeyBinding,
@@ -56,18 +42,8 @@ enum ConflictText {
 }
 
 extension SystemShortcut {
-    /// The macOS name for this shortcut, in the user's language.
-    ///
-    /// The switch is **exhaustive on purpose**: a new case in
-    /// Core cannot ship without a string here, because the
-    /// compiler refuses. That is what makes this mirror
-    /// forget-proof without a hand-listed parity test (§5) —
-    /// `SystemShortcutNamesTests` only adds that no two cases
-    /// share a name, which the compiler cannot see.
-    ///
-    /// These are Apple's own feature names, so a translation
-    /// should follow whatever macOS itself calls them in that
-    /// language rather than translating the English literally.
+    /// Localized macOS system shortcut name
+    /// (`SystemShortcutNamesTests`, #768).
     @MainActor
     var localizedName: String {
         switch self {
@@ -91,18 +67,6 @@ extension SystemShortcut {
             return L("system_shortcut.hide_app", "Hide App")
         case .forceQuit:
             return L("system_shortcut.force_quit", "Force Quit")
-        // These two name APPLE's shortcut rows, not KiwiDesk's
-        // concepts, so they keep "Space" while the rest of the
-        // app calls a Mission Control desktop a Desktop (#768,
-        // owner ruling 2026-08-12). The string exists so a user
-        // with a conflict can find that row in System Settings ▸
-        // Keyboard ▸ Shortcuts ▸ Mission Control, where macOS
-        // says "space" — renaming it would point at a label that
-        // is not on screen, and oblige ten translators to coin a
-        // name for a control Apple has already named for them.
-        // The same carve-out covers the "Displays have separate
-        // Spaces" checkbox quoted in `desktops` copy; it is
-        // written down in `.claude/rules/config-vocabulary.md`.
         case .missionControlSpaceLeft:
             return L(
                 "system_shortcut.mission_control_space_left",

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/ConflictText.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/ConflictText.swift
@@ -42,8 +42,12 @@ enum ConflictText {
 }
 
 extension SystemShortcut {
-    /// Localized macOS system shortcut name
-    /// (`SystemShortcutNamesTests`, #768).
+    /// Localized macOS system shortcut name. The switch is
+    /// exhaustive on purpose: a new Core case cannot ship without
+    /// a string here — the compiler is the parity guard;
+    /// `SystemShortcutNamesTests` only adds that no two cases
+    /// share a name. These are Apple's feature names, so a
+    /// translation follows whatever macOS calls them (#768).
     @MainActor
     var localizedName: String {
         switch self {
@@ -67,6 +71,12 @@ extension SystemShortcut {
             return L("system_shortcut.hide_app", "Hide App")
         case .forceQuit:
             return L("system_shortcut.force_quit", "Force Quit")
+        // These two name APPLE's shortcut rows, so they keep
+        // "Space" while the app says Desktop (#768, owner ruling
+        // 2026-08-12): the string exists so a user can find that
+        // row in System Settings, where macOS says "space" —
+        // renaming it would point at a label not on screen. The
+        // carve-out is written in config-vocabulary.md.
         case .missionControlSpaceLeft:
             return L(
                 "system_shortcut.mission_control_space_left",

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup.swift
@@ -2,32 +2,17 @@ import AppKit
 import KiwiDeskCore
 import SwiftUI
 
-/// Section 2 — Open applications: launch hotkeys. Each row picks
-/// an installed app (or any bundle via "Other…"), a launch
-/// behavior (Open or Focus / Open New, #334), and a combo. The
-/// default action pulls the app into the current space, launching
-/// it if needed.
+/// Launch hotkeys group for applications (#334).
 struct ApplicationsGroup: View {
     @ObservedObject var model: SettingsModel
     @Binding var bindings: [KeyBinding]
-    /// Read by the row in `+Row` (dimming) and by the recorders
-    /// there (the live-apply seam), so neither is `private`.
     @Environment(\.keybindingOverrideBase)
     var overrideBase
     @Environment(\.keybindingLayerName)
     var layerName
-    /// The app chosen in the add-row but not yet committed — the
-    /// row only enters the list once an app is picked, so no
-    /// app-less placeholder can exist (matches App Rules). Read by
-    /// the add-row in `+AddRow`, so not `private`.
     @State var newApp: KeybindingCatalog.InstalledApp?
-    /// Alphabetical display order snapshotted on section entry and
-    /// mode change (#333). NOT recomputed on `bindings` mutation:
-    /// the row's control is a `KeyRecorderField` capture, so a live
-    /// re-sort could yank a row out from under the cursor
-    /// mid-record. A committed *new* row stays at the bottom this
-    /// session and takes its alpha slot next entry; re-picking an
-    /// app keeps the row's id, so it holds its existing slot.
+    /// Alphabetical display order snapshotted on section entry
+    /// (#333, `KeyRecorderField`).
     @State private var displayOrder: [UUID] = []
 
     var body: some View {
@@ -35,17 +20,6 @@ struct ApplicationsGroup: View {
             SettingsCatalog.shortcuts.openApplications
         ) {
             if orderedAppIDs.isEmpty {
-                // What holds instead of the empty list (#678
-                // Phase 4 pass 9, turn 18): what a binding here
-                // changes is what the emptiness leaves the reader
-                // wondering about. Worded FROM
-                // `shortcuts.app_behavior.help`, authoritative
-                // for the Open or Focus default a new row gets —
-                // crossing SPACES is the distinguishing
-                // behaviour, "brings it forward" is plain
-                // activation, and the two would take different
-                // verbs in ten languages (l10n audit,
-                // 2026-08-11).
                 Text(
                     L(
                         "shortcuts.apps.empty",
@@ -67,17 +41,11 @@ struct ApplicationsGroup: View {
             addRow
         }
         .onAppear(perform: recomputeOrder)
-        // The section view is reused across keybinding modes (no
-        // per-mode `.id`), so `onAppear` fires once — re-snapshot
-        // when the mode changes or later modes would render in raw
-        // array order. Recording is invalidated on mode switch, so
-        // re-sorting here can't yank an in-flight recorder.
         .onChange(of: layerName) { _, _ in recomputeOrder() }
     }
 
-    /// Application-binding ids in the snapshot's alpha order, with
-    /// any added since (absent from the snapshot) kept in array
-    /// order at the bottom for this session (#333).
+    /// Application binding IDs in snapshot alpha order with new rows
+    /// appended (#333).
     private var orderedAppIDs: [UUID] {
         let appIDs =
             bindings
@@ -104,9 +72,6 @@ struct ApplicationsGroup: View {
             .map(\.id)
     }
 
-    /// A stable, id-keyed binding into `bindings` — resolved at
-    /// access time so it survives any structural mutation of the
-    /// array (add / remove / Steal reorder).
     private func bindingFor(_ id: UUID) -> Binding<KeyBinding>? {
         guard bindings.contains(where: { $0.id == id }) else {
             return nil
@@ -126,9 +91,7 @@ struct ApplicationsGroup: View {
         )
     }
 
-    /// The "Other…" escape hatch: pick any app bundle by file,
-    /// returning it as an `InstalledApp` (nil on cancel). Shared
-    /// by the per-row re-pick and the add-row (in `+AddRow`).
+    /// Presents open panel to select custom application bundle.
     func pickBundleFromPanel()
         -> KeybindingCatalog.InstalledApp?
     {
@@ -150,14 +113,8 @@ struct ApplicationsGroup: View {
         )
     }
 
-    /// Deleting a row must unregister its hotkey, exactly as the
-    /// recorder's `onClear` in `+Row` does (#517). Without this the row
-    /// vanishes while its shortcut keeps firing until Save or
-    /// Revert — `liveApplyRecorded` rebuilds the running table
-    /// from its own session copy, which never saw the removal.
-    /// No-op off the live target, where nothing is registered.
-    /// Called by the row's trash button in `+Row`, so not
-    /// `private`.
+    /// Removes binding and unregisters active hotkey
+    /// (#517, `liveApplyRecorded`).
     func remove(_ id: UUID) {
         bindings.removeAll { $0.id == id }
         _ = model.liveApplyRecorded(

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup.swift
@@ -12,7 +12,10 @@ struct ApplicationsGroup: View {
     var layerName
     @State var newApp: KeybindingCatalog.InstalledApp?
     /// Alphabetical display order snapshotted on section entry
-    /// (#333, `KeyRecorderField`).
+    /// (#333). NOT recomputed on `bindings` mutation: the row's
+    /// control is a `KeyRecorderField` capture, and a live re-sort
+    /// could yank a row from under the cursor mid-record. A new
+    /// row stays at the bottom this session.
     @State private var displayOrder: [UUID] = []
 
     var body: some View {
@@ -20,6 +23,10 @@ struct ApplicationsGroup: View {
             SettingsCatalog.shortcuts.openApplications
         ) {
             if orderedAppIDs.isEmpty {
+                // Worded FROM `shortcuts.app_behavior.help` (#678
+                // Phase 4 pass 9): crossing SPACES is the
+                // distinguishing behaviour, and the two verbs
+                // differ in ten languages (l10n audit 2026-08-11).
                 Text(
                     L(
                         "shortcuts.apps.empty",
@@ -41,6 +48,9 @@ struct ApplicationsGroup: View {
             addRow
         }
         .onAppear(perform: recomputeOrder)
+        // The section view is reused across modes (no per-mode
+        // `.id`), so `onAppear` fires once — re-snapshot on mode
+        // change or later modes render in raw array order.
         .onChange(of: layerName) { _, _ in recomputeOrder() }
     }
 

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingImportClassifier.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingImportClassifier.swift
@@ -4,7 +4,12 @@ import KiwiDeskCore
 /// Reclassifies `.custom` keybindings to `.navigation` or `.application`
 /// via catalog matching (`KeybindingCatalog`, `recoverKeybindings`, #4).
 enum KeybindingImportClassifier {
-    /// Reclassifies custom rows in config in-place (`resize.step`, #58).
+    /// Reclassifies custom rows in config in-place. Pass
+    /// `recoverResizeStep` ONLY on an explicit import, where the
+    /// pulled-in bindings are the source of truth — on a plain
+    /// load-for-edit `resize.step` is already authoritative, and a
+    /// magnitude baked into a stray row must not overwrite it
+    /// (#58 review).
     static func classify(
         _ config: inout GuiConfig,
         recoverResizeStep: Bool = false
@@ -43,6 +48,12 @@ enum KeybindingImportClassifier {
             let command = KeybindingCatalog.switchLayerCommand(name)
             map[command.lua] = command.label
         }
+        // Desktop rows are absent on purpose, matched by SHAPE in
+        // `reclassify`: this map is built from the config, which
+        // records no Desktops — a live list would strand a binding
+        // naming a detached Desktop as raw Lua until the screen
+        // came back. Step-free rows each need an entry or an
+        // imported binding stays Custom (#91).
         for command in KeybindingCatalog.stepFreeCommands {
             map[command.lua] = command.label
         }

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingImportClassifier.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingImportClassifier.swift
@@ -1,24 +1,10 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// Upgrades imported `.custom` keybinding rows to `.navigation`
-/// or `.application` by exact-matching the `KeybindingCatalog`, so
-/// a recovered shortcut lands in the section that authored it with
-/// its proper label. Only the GUI knows the catalog, so this runs
-/// GUI-side after Core's `recoverKeybindings` (#4). Rows matching
-/// nothing stay `.custom` and show in Custom Bindings.
+/// Reclassifies `.custom` keybindings to `.navigation` or `.application`
+/// via catalog matching (`KeybindingCatalog`, `recoverKeybindings`, #4).
 enum KeybindingImportClassifier {
-    /// Reclassifies every `.custom` row in `config` in place,
-    /// rebuilding the navigation and change-layer commands the
-    /// keybindings tab would generate from the config's own
-    /// spaces and layer names.
-    /// `recoverResizeStep` reads a recovered Grow/Shrink magnitude
-    /// back into `resize.step` (#58) — pass it ONLY on an explicit
-    /// import, where the pulled-in bindings are the source of
-    /// truth. A plain load-for-edit leaves it `false`: there
-    /// `resize.step` is already authoritative (from tiler/profile
-    /// settings), so a magnitude baked into a stray `.custom` row
-    /// must not overwrite it (#58 review).
+    /// Reclassifies custom rows in config in-place (`resize.step`, #58).
     static func classify(
         _ config: inout GuiConfig,
         recoverResizeStep: Bool = false
@@ -35,16 +21,12 @@ enum KeybindingImportClassifier {
                 }
             }
         }
-        // Grow and Shrink carry the same magnitude, so the last
-        // recovered row wins harmlessly; untouched when the import
-        // has no resize row (keeps the default).
         if recoverResizeStep, let recoveredStep {
             config.settings.resizeStep = CGFloat(recoveredStep)
         }
     }
 
-    /// Lua action → label for every navigation and change-layer
-    /// command the keybindings tab can produce for this config.
+    /// Maps Lua actions to labels (`stepFreeCommands`, #91, #221).
     private static func navigationLabels(
         for config: GuiConfig
     ) -> [String: String] {
@@ -61,35 +43,13 @@ enum KeybindingImportClassifier {
             let command = KeybindingCatalog.switchLayerCommand(name)
             map[command.lua] = command.label
         }
-        // The Desktop rows are absent here on purpose and are
-        // matched by shape in `reclassify`, exactly as a resize
-        // of any step is: this map is built from the config,
-        // which records no Desktops, so a live list would be
-        // the only source — and a binding naming a Desktop that
-        // is not attached right now would then stay `.custom`
-        // and read as raw Lua until the screen came back.
-        // Step-independent Size & float rows: not in any
-        // navigation group and matched by no shape rule, so each
-        // needs its own entry or an imported binding stays Custom
-        // (#91). `toggle_floating` is the bindable one (#221);
-        // `make_floating` is kept for recognition only so a
-        // hand-written one still classifies. The list is
-        // `stepFreeCommands` — the ONE copy the banner's
-        // localizedLabel roster also consumes, so a command
-        // this map can assign is always one that roster can
-        // translate back (review 2026-08-10).
         for command in KeybindingCatalog.stepFreeCommands {
             map[command.lua] = command.label
         }
         return map
     }
 
-    /// Reclassifies one `.custom` row, returning a recovered
-    /// Grow/Shrink magnitude when the row is a resize of any step
-    /// (so `classify` can read it back into `resize.step`, #58).
-    /// Resize is checked first — before the exact-match map — so
-    /// a magnitude differing from the current step still upgrades
-    /// out of Custom.
+    /// Reclassifies single binding row, returning recovered resize step (#58).
     @discardableResult
     private static func reclassify(
         _ binding: inout KeyBinding,

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardBoardSpoken.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardBoardSpoken.swift
@@ -1,35 +1,14 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The keyboard board as VoiceOver hears it (#812): ONE element,
-/// one description — the picture's meaning, not its pixels.
-///
-/// Drawn, the board is a glance: which keys are green under this
-/// chip. Read key by key it was one bare glyph per key ("A",
-/// "S", "space") with no state at all, since every state lives
-/// in a fill or a ring. And a stop per key is not the fix — a
-/// picture's native spoken form is one description (an image's
-/// description, a chart's summary), and the question a reader
-/// brings here, "what is taken before I record?", is answered by
-/// a list, not a walk (`ui-designer`, 2026-08-24).
-///
-/// The sentences read the SAME predicates the caps draw from —
-/// `KeyboardCensus.state(of:claims:scope:)` for bound and
-/// reserved, `collisions ∪ overwrittenReserved` for the red ring
-/// — so the spoken board cannot disagree with the drawn one, the
-/// way the legend may not point at a mark the frame does not
-/// draw. Separate sentences joined with a space rather than one
-/// frame with optional clauses: two of the three are
-/// conditional, and a frame may withhold only its LAST argument
-/// (localization.md).
+/// VoiceOver accessibility summary view for keyboard matrix preview (#812,
+/// `localization.md`).
 struct SpokenKeyboardBoard: View {
     let type: KeyboardMatrix.PhysicalType
     let claims: [UInt32: [KeyboardCensus.ModifierLayer]]
     let scope: KeyboardCensus.Scope
     let conflicted: Set<UInt32>
 
-    /// The chip row's own word for the scope ("All", "⌘", "No
-    /// modifier"), so the sentence names what the chip row shows.
     private var scopeLabel: String {
         switch scope {
         case .all: return L("keyboard.scope.all", "All")
@@ -45,9 +24,6 @@ struct SpokenKeyboardBoard: View {
             scope: scope,
             conflicted: conflicted
         )
-        // Ignored, not hidden: the plate stays a stop in reading
-        // order between the chips and the tally, where the eye
-        // meets it.
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(
             KeyboardBoardSpoken.sentence(
@@ -63,10 +39,8 @@ struct SpokenKeyboardBoard: View {
     }
 }
 
-/// The pure half: which keys land in which sentence, in the
-/// board's own order (left to right, top to bottom), and the
-/// sentence itself. View-free so `KeyboardBoardSpokenTests` can
-/// hold it without a window.
+/// Pure accessibility sentence generation for keyboard matrix
+/// (`KeyboardBoardSpokenTests`, `tests.md`).
 enum KeyboardBoardSpoken {
     struct Buckets: Equatable {
         var bound: [String] = []
@@ -88,8 +62,6 @@ enum KeyboardBoardSpoken {
         )
         var out = Buckets()
         for key in rows.joined() {
-            // A code-less cap (⇧, ⌘) has no state and is never
-            // listed.
             guard let code = key.code else { continue }
             let name = spokenName(for: code, glyph: glyph)
             switch KeyboardCensus.state(
@@ -108,8 +80,7 @@ enum KeyboardBoardSpoken {
         return out
     }
 
-    /// One sentence per non-empty bucket; bound always speaks,
-    /// so a chip that claims nothing still says so.
+    /// Assembles localized summary sentence from key categorization buckets.
     @MainActor
     static func sentence(
         buckets: Buckets,
@@ -150,16 +121,7 @@ enum KeyboardBoardSpoken {
         return parts.joined(separator: " ")
     }
 
-    /// The key as the board prints it where that is a letter or
-    /// sign, and as a localized WORD where the board prints a
-    /// symbol — VoiceOver reads "←" as "leftwards arrow" and
-    /// "⎋" however it likes, and the wire names ("left") are
-    /// English (owner, #812 session 3: "left, up, down" inside
-    /// a German sentence). Drawn and spoken agree on WHICH key
-    /// and differ only in rendering. `glyph` is injected so the
-    /// tests never reach the host's input source — a letter
-    /// asserted through `UCKeyTranslate` reds on AZERTY with no
-    /// defect (tests.md ▸ injected seams).
+    /// Resolves spoken name for key code, injecting glyph lookup seam (#812).
     @MainActor
     static func spokenName(
         for code: UInt32,
@@ -175,9 +137,7 @@ enum KeyboardBoardSpoken {
             ?? KeyboardKeyLabel.fallback(for: code)
     }
 
-    /// The spoken word for a key the board prints as a symbol.
-    /// Localized, unlike the `KeyCombo` wire names, and keyed by
-    /// the same codes `KeyboardKeyLabel.functional` draws.
+    /// Localized spoken names for functional keys.
     @MainActor
     private static func functionalWord(_ code: UInt32) -> String? {
         switch code {
@@ -194,14 +154,7 @@ enum KeyboardBoardSpoken {
         }
     }
 
-    /// The list is not a grammatical clause, so no locale has
-    /// to agree with it — but the joiner word is a locale's,
-    /// and it must be the APP's locale, not the system's: the
-    /// class method joins in `Locale.current`, which put a
-    /// German "und" inside an English sentence on a German Mac
-    /// (owner, #812 session 3). The space joining the SENTENCES
-    /// is Swift-owned punctuation; spoken-only today, so a
-    /// visual reuse of `sentence` re-opens that question.
+    /// Joins names using application locale list formatting (#812).
     @MainActor
     private static func join(_ names: [String]) -> String {
         let formatter = ListFormatter()

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardBoardSpoken.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardBoardSpoken.swift
@@ -1,8 +1,12 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// VoiceOver accessibility summary view for keyboard matrix preview (#812,
-/// `localization.md`).
+/// VoiceOver accessibility summary for the keyboard board (#812):
+/// ONE element, one description — the picture's meaning, not its
+/// pixels. The sentences read the SAME predicates the caps draw
+/// from, so the spoken board cannot disagree with the drawn one.
+/// Separate sentences joined with a space: a frame may withhold
+/// only its LAST argument (`localization.md`).
 struct SpokenKeyboardBoard: View {
     let type: KeyboardMatrix.PhysicalType
     let claims: [UInt32: [KeyboardCensus.ModifierLayer]]
@@ -154,7 +158,10 @@ enum KeyboardBoardSpoken {
         }
     }
 
-    /// Joins names using application locale list formatting (#812).
+    /// Joins names using the APP's locale, never the system's:
+    /// `ListFormatter`'s class method joins in `Locale.current`,
+    /// which put a German "und" inside an English sentence on a
+    /// German Mac (owner, #812 session 3).
     @MainActor
     private static func join(_ names: [String]) -> String {
         let formatter = ListFormatter()

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardChrome.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardChrome.swift
@@ -2,9 +2,7 @@ import Carbon.HIToolbox
 import KiwiDeskCore
 import SwiftUI
 
-/// One scope chip: "All", or one modifier combination. Single
-/// select — the board shows one thing at a time, which is what
-/// let the stripe palette (and its colour-vision ceiling) go.
+/// Modifier scope selection chip for virtual keyboard.
 struct ScopeChip: View {
     let label: String
     let isOn: Bool
@@ -36,9 +34,7 @@ struct ScopeChip: View {
     }
 }
 
-/// The name macOS gives the active input source ("German"), read
-/// and never stored — which is what the panel's "from macOS"
-/// suffix claims to the user.
+/// Reads localized keyboard layout name from active TIS input source.
 enum KeyboardInputSource {
     static func localizedName() -> String? {
         guard
@@ -57,35 +53,14 @@ enum KeyboardInputSource {
     }
 }
 
-/// The label for a key with no printable character. `ComboSymbols`
-/// owns the glyphs a COMBO renders; a board also draws keys no
-/// combo names, so the fallbacks live beside the board.
+/// Generates labels and fallbacks for physical keycaps (`ComboSymbols`).
 enum KeyboardKeyLabel {
-    /// A keycap prints its letter capitalised. The rule is
-    /// `ComboSymbols.capitalisedGlyph`'s — the board and every
-    /// combo-rendering surface must agree about what a key is
-    /// called, so there is one copy of it and this is a
-    /// forwarder, not a second implementation.
+    /// Capped key glyph (`ComboSymbols.capitalisedGlyph`).
     static func capped(_ char: String) -> String {
         ComboSymbols.capitalisedGlyph(char)
     }
 
-    /// What a modifier chip shows. Every other chip is pure
-    /// symbol; the bare-key one has no symbol to show, so it is
-    /// the row's one word.
-    ///
-    /// "No modifier", not "plain key", and the reasons are the
-    /// row's rather than the phrase's: every sibling chip names a
-    /// modifier COMBINATION, so a label naming a *key* answers a
-    /// different question than the chips beside it. Copy added
-    /// here reuses this key's noun for a modifier rather than
-    /// coining a second, which is drift a translator pays for
-    /// twice: this is the only `en.json` value containing the
-    /// word, so a second noun means every catalog coins one
-    /// more. Not "None" either —
-    /// in a multi-select row that reads as *clear the selection*.
-    /// The chip is not where a user learns the option exists: it
-    /// only appears once the draft already has such a binding.
+    /// Modifier scope chip label string (`KeyboardCensus.ModifierLayer`).
     @MainActor
     static func chipLabel(
         for layer: KeyboardCensus.ModifierLayer
@@ -95,8 +70,7 @@ enum KeyboardKeyLabel {
             : layer.label
     }
 
-    /// Mac symbols, because this is a Mac keyboard and the user
-    /// reads these shapes on the hardware in front of them.
+    /// Functional key symbols for macOS keyboard hardware.
     static let functional: [UInt32: String] = [
         36: "↩", 48: "⇥", 49: "space", 51: "⌫", 53: "⎋",
         123: "←", 124: "→", 125: "↓", 126: "↑",
@@ -107,16 +81,8 @@ enum KeyboardKeyLabel {
         return KeyCombo.keyName(for: code)?.uppercased() ?? ""
     }
 
-    /// Whether a translated character is something a cap can
-    /// actually print.
-    ///
-    /// `UCKeyTranslate` answers for an arrow or a delete with a
-    /// **private-use** character (`NSUpArrowFunctionKey` and its
-    /// family live at U+F700), which is neither empty nor
-    /// whitespace — so a nil-or-empty test passes it straight
-    /// through and the cap draws a blank. That is what shipped:
-    /// every arrow, and `⌫`, silently unlabelled while the
-    /// fallback table that names them sat unreached.
+    /// Tests whether scalar is printable, excluding private-use
+    /// (`UCKeyTranslate`, `NSUpArrowFunctionKey`).
     static func isPrintable(_ char: String) -> Bool {
         guard let scalar = char.unicodeScalars.first,
             char.unicodeScalars.count == 1
@@ -130,9 +96,8 @@ enum KeyboardKeyLabel {
 }
 
 extension KeyboardMatrix.PhysicalType {
-    /// Named, never translated: ANSI / ISO / JIS are the
-    /// industry's own names for the physical shapes and macOS
-    /// shows them untranslated too.
+    /// Display name for keyboard hardware layout
+    /// (`KeyboardMatrix.PhysicalType`).
     var label: String {
         switch self {
         case .ansi: return "ANSI"

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardChrome.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeyboardChrome.swift
@@ -60,7 +60,10 @@ enum KeyboardKeyLabel {
         ComboSymbols.capitalisedGlyph(char)
     }
 
-    /// Modifier scope chip label string (`KeyboardCensus.ModifierLayer`).
+    /// Modifier scope chip label. "No modifier", not "None" — in
+    /// a selection row that reads as clear-the-selection — and
+    /// copy added here reuses this key's noun rather than coining
+    /// a second (`KeyboardCensus.ModifierLayer`).
     @MainActor
     static func chipLabel(
         for layer: KeyboardCensus.ModifierLayer

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/OrphanedShortcuts.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/OrphanedShortcuts.swift
@@ -1,6 +1,9 @@
 import KiwiDeskCore
 
-/// Determines orphaned catalog commands for deleted spaces (#92, #820).
+/// Determines orphaned catalog commands for deleted spaces
+/// (#92). A third surface asking "is this binding inactive?" asks
+/// HERE rather than re-deriving — two surfaces disagreeing about
+/// what is inactive is the whole defect #820 was.
 enum OrphanedShortcuts {
     /// Reconstructs navigation commands for bindings targeting inactive spaces
     /// (`NavRow`, `SpaceLuaArg`, #92, #820).
@@ -47,6 +50,10 @@ enum OrphanedShortcuts {
         let expander = ShortcutsFamilyRows(
             spaces: [space],
             icons: icons,
+            // The empty Desktop list is deliberate: this card is
+            // the SPACE net, and a Desktop number is not a
+            // `SpaceID` — `KeybindingCatalog.desktopOffer` is how
+            // a Desktop row stays reachable instead.
             desktops: .none,
             resizeStep: 0,
             layerNames: [],

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/OrphanedShortcuts.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/OrphanedShortcuts.swift
@@ -1,22 +1,9 @@
 import KiwiDeskCore
 
-/// Which catalog commands are orphaned in `bindings` relative to
-/// `spaces` — the pure half of `OrphanedShortcutsGroup`, split
-/// out for tests and now consumed by TWO surfaces: that Settings
-/// section (#92) and the ⌃⌥K panel's Inactive band (#820). It
-/// lives beside the section for history rather than ownership;
-/// it is nobody's widget, and a third surface asking "is this
-/// binding inactive?" asks HERE rather than re-deriving it —
-/// two surfaces disagreeing about what is inactive is the whole
-/// defect #820 was.
+/// Determines orphaned catalog commands for deleted spaces (#92, #820).
 enum OrphanedShortcuts {
-    /// One catalog command per orphaned binding, in binding
-    /// order (deduplicated by Lua — `NavRow` keys rows by it).
-    /// Only `.navigation` rows count: a `.custom` row with
-    /// space-targeting Lua already shows in the Advanced
-    /// drawer. The command is rebuilt through the catalog for
-    /// the orphan's space, so its Lua matches the binding
-    /// byte-for-byte and the row behaves like any preset row.
+    /// Reconstructs navigation commands for bindings targeting inactive spaces
+    /// (`NavRow`, `SpaceLuaArg`, #92, #820).
     @MainActor
     static func commands(
         bindings: [KeyBinding],
@@ -50,21 +37,8 @@ enum OrphanedShortcuts {
         return commands
     }
 
-    /// Every command a per-space FAMILY draws for one space —
-    /// derived from the census families rather than hand-listed.
-    ///
-    /// This card is the safety net for #92: a space-targeting
-    /// binding whose space has left the list is still
-    /// Carbon-registered, still blocks the recorder, and would
-    /// otherwise be invisible. That net is only as wide as the
-    /// set of families it knows about, so hand-listing them here
-    /// meant a fifth per-space family would compile, red the
-    /// render guard, and be silently omitted from the one card
-    /// that exists to catch it. Asking the expander instead makes
-    /// the two grow together; `perSpaceFamilies` is the one place
-    /// that says which families are per-space, and
-    /// `OrphanedShortcutsTests` pins that the net covers all of
-    /// them.
+    /// Generates per-space family commands (`ShortcutsFamilyRows`,
+    /// `KeybindingCatalog.desktopOffer`, `OrphanedShortcutsTests`, #92).
     @MainActor
     static func perSpaceCommands(
         for space: SpaceID,
@@ -73,13 +47,6 @@ enum OrphanedShortcuts {
         let expander = ShortcutsFamilyRows(
             spaces: [space],
             icons: icons,
-            // None of these reaches a per-space family; all are
-            // required by the type and irrelevant here. The
-            // empty Desktop list is deliberate rather than
-            // incidental: this card is the SPACE net, and a
-            // Desktop number is not a `SpaceID` — see
-            // `KeybindingCatalog.desktopOffer`, which is how
-            // a Desktop row stays reachable instead.
             desktops: .none,
             resizeStep: 0,
             layerNames: [],
@@ -90,8 +57,7 @@ enum OrphanedShortcuts {
         }
     }
 
-    /// The census families that expand once per space. Data, so
-    /// the card above and the guard read one list.
+    /// Census families expanding once per space.
     static let perSpaceFamilies: [SettingKey] = [
         .shortcuts(.goToSpace),
         .shortcuts(.moveToSpace),

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/ChordRecorder.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/ChordRecorder.swift
@@ -1,8 +1,12 @@
 import AppKit
 import KiwiDeskCore
 
-/// Key combination recording engine capturing events on key-down
-/// (#68, #212, `ChordRecorderTests`).
+/// Key combination recording engine: snap-in on key-down (#212,
+/// replacing #68's lock-on-full-release machine). Bare Escape
+/// cancels but Escape WITH modifiers records — ⌃Escape is a
+/// valid hotkey; any click cancels (the field absorbs it); app
+/// deactivation cancels too, since a system chord (⌘Tab) steals
+/// focus mid-recording (`ChordRecorderTests`).
 @MainActor
 final class ChordRecorder {
     enum Outcome {
@@ -41,6 +45,8 @@ final class ChordRecorder {
         keyMonitor = NSEvent.addLocalMonitorForEvents(
             matching: [.keyDown, .keyUp, .flagsChanged]
         ) { [weak self] event in
+            // A nil self must never swallow the app's keys — the
+            // leaked monitor would eat every keystroke.
             guard let self else { return event }
             let kind: EventKind =
                 switch event.type {
@@ -137,6 +143,9 @@ final class ChordRecorder {
             finish(.chord(combo))
             return true
         case .keyUp:
+            // Only releases paired with swallowed keyDowns are
+            // ours — a key held before recording still passes to
+            // its original responder.
             return consumeSuppressedKeyUp(keyCode)
         case .flagsChanged:
             onPreview(Self.modifierSymbols(flags))

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/ChordRecorder.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/ChordRecorder.swift
@@ -1,34 +1,8 @@
 import AppKit
 import KiwiDeskCore
 
-/// The capture engine behind `KeyRecorderField` (#212):
-/// **snap-in on key-down**. Modifiers can be pressed and
-/// released freely — the preview mirrors what is held — and
-/// the first non-modifier keyDown locks the combo instantly
-/// (that key plus the modifiers held at that moment), the way
-/// the native System Settings shortcut recorder reads.
-/// Correction is re-recording (one click); there is no
-/// release choreography. Replaces the lock-on-full-release
-/// machine (#68), whose burst window, stashed candidate, and
-/// mid-chord correction proved buggier than the model they
-/// enabled.
-///
-/// Rules:
-/// - `flagsChanged` only updates the modifier preview (⌃⌥⇧⌘,
-///   display order). A modifier-only chord is not recordable
-///   (Carbon hotkeys need a base key) — the preview makes
-///   that visible.
-/// - A keyDown locks `held modifiers + key` and finishes. A
-///   key `KeyCombo` cannot represent is swallowed and the
-///   recording continues.
-/// - Bare Escape cancels (Escape WITH modifiers records —
-///   ⌃Escape is a valid hotkey). Any mouse click cancels
-///   (`.clickAway`, so the field can absorb the click on its
-///   own button). App deactivation cancels too — a system
-///   chord (⌘Tab, ⌘⇧4) would steal focus mid-recording.
-///
-/// The state machine (`handle(_:keyCode:flags:)`) is internal
-/// so `ChordRecorderTests` can drive it without `NSEvent`s.
+/// Key combination recording engine capturing events on key-down
+/// (#68, #212, `ChordRecorderTests`).
 @MainActor
 final class ChordRecorder {
     enum Outcome {
@@ -56,9 +30,7 @@ final class ChordRecorder {
     var onFinish: (Outcome) -> Void = { _ in }
     var isSuppressingKeyUp: Bool { releaseMonitor != nil }
 
-    /// Installs the event monitors. `preview` receives the
-    /// held-modifier symbols on every change; `finish` fires
-    /// exactly once (teardown resets it to a no-op first).
+    /// Installs event monitors for keyboard and click-away cancellation.
     func start(
         preview: @escaping (String) -> Void,
         finish: @escaping (Outcome) -> Void
@@ -69,8 +41,6 @@ final class ChordRecorder {
         keyMonitor = NSEvent.addLocalMonitorForEvents(
             matching: [.keyDown, .keyUp, .flagsChanged]
         ) { [weak self] event in
-            // A nil self must never swallow the app's keys —
-            // the leaked monitor would eat every keystroke.
             guard let self else { return event }
             let kind: EventKind =
                 switch event.type {
@@ -85,9 +55,6 @@ final class ChordRecorder {
             )
             return swallow ? nil : event
         }
-        // Clicking anywhere cancels (the native recorder
-        // idiom); the event passes through so the click still
-        // lands.
         mouseMonitor = NSEvent.addLocalMonitorForEvents(
             matching: [.leftMouseDown, .rightMouseDown]
         ) { [weak self] event in
@@ -139,11 +106,7 @@ final class ChordRecorder {
         callback(outcome)
     }
 
-    // MARK: - The state machine (testable seam)
-
-    /// Feeds one key event through the snap-in logic. Returns
-    /// whether the event should be swallowed. Internal so
-    /// tests can drive sequences without `NSEvent`.
+    /// State machine processing key events (`ChordRecorderTests`).
     @discardableResult
     func handle(
         _ kind: EventKind,
@@ -155,9 +118,6 @@ final class ChordRecorder {
             let held = flags.intersection([
                 .command, .option, .control, .shift,
             ])
-            // Every swallowed keyDown owns its matching keyUp;
-            // never leak an orphan release to the focused
-            // control after recorder teardown.
             suppressedKeyUps.insert(keyCode)
             if keyCode == 53, held.isEmpty {
                 finish(.cancelled)
@@ -172,17 +132,11 @@ final class ChordRecorder {
                     shift: flags.contains(.shift)
                 )
             else {
-                // Unrepresentable key: swallow it, keep
-                // recording — the preview still shows the
-                // held modifiers.
                 return true
             }
             finish(.chord(combo))
             return true
         case .keyUp:
-            // Only releases paired with swallowed keyDowns are
-            // ours. A key held before recording still passes to
-            // its original responder.
             return consumeSuppressedKeyUp(keyCode)
         case .flagsChanged:
             onPreview(Self.modifierSymbols(flags))
@@ -190,7 +144,7 @@ final class ChordRecorder {
         }
     }
 
-    /// The held modifiers in display order (⌃⌥⇧⌘).
+    /// Formats held modifiers in standard display order (⌃⌥⇧⌘).
     static func modifierSymbols(
         _ flags: NSEvent.ModifierFlags
     ) -> String {
@@ -202,10 +156,7 @@ final class ChordRecorder {
         return symbols
     }
 
-    /// After a lock/cancel tears down the capture monitor, keep
-    /// a narrow keyUp-only monitor until every swallowed press
-    /// releases. Timeout bounds the lifetime if macOS steals a
-    /// release while focus changes.
+    /// Suppresses trailing key-up events following recording completion.
     private func beginReleaseSuppression() {
         guard !suppressedKeyUps.isEmpty else { return }
         if let releaseMonitor {

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/RecorderCoordinator.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/RecorderCoordinator.swift
@@ -13,7 +13,11 @@ final class RecorderCoordinator: ObservableObject {
     /// Target shortcut row ID to scroll to upon rejection navigation.
     @Published var scrollTarget: String?
 
-    /// Callback fired on transition between idle and armed states (#213).
+    /// Suspends/restores live hotkeys while any recorder is armed
+    /// (#213): testing an existing shortcut mid-capture must not
+    /// fire its action. Fires only on the nil↔armed edge, so
+    /// switching between two fields never bounces the
+    /// registration.
     var onArmedChange: (Bool) -> Void = { _ in }
 
     /// Teardown closure for active event monitor.
@@ -63,7 +67,11 @@ enum RecorderPreflight {
             ? binding.lua : binding.id.uuidString
     }
 
-    /// Evaluates conflicting shortcut bindings (#181 review H2).
+    /// Evaluates conflicting shortcut bindings. A PURE query: it
+    /// runs from chord previews and render passes, so it must
+    /// never mutate the bindings (#181 review H2 — a preview
+    /// keystroke deleted a row). `commit` must look its row up at
+    /// write time, because Steal mutates the array first.
     static func rejection(
         combo: String,
         excluding isOwn: @escaping (KeyBinding) -> Bool,

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/RecorderCoordinator.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/RecorderCoordinator.swift
@@ -2,38 +2,24 @@ import Foundation
 import KiwiDeskCore
 import SwiftUI
 
-/// The one-active-recorder rule (#33): every `KeyRecorderField`
-/// claims this coordinator when it starts recording, and the
-/// claim *synchronously* tears the previous recorder down — no
-/// window where two keyDown monitors coexist. Also carries the
-/// "Go to" scroll target (#34) and a generation counter the
-/// host bumps when the edited mode or target changes, so
-/// pending rejections can't act on stale bindings.
+/// Single-active-recorder coordinator managing keyboard capture and hotkey
+/// suspension (#33, #34, #213).
 @MainActor
 final class RecorderCoordinator: ObservableObject {
-    /// The field currently recording, if any.
+    /// Active recording field ID.
     @Published private(set) var active: UUID?
-    /// Bumped by `invalidate()` — fields clear their pending
-    /// rejection state when it changes.
+    /// Invalidation generation counter for pending rejections.
     @Published private(set) var generation = 0
-    /// A row id the Shortcuts section should scroll to (the
-    /// "Go to" action of a rejected recording).
+    /// Target shortcut row ID to scroll to upon rejection navigation.
     @Published var scrollTarget: String?
 
-    /// Suspends/restores the app's live hotkeys while any
-    /// recorder is armed (#213 safe win): testing an existing
-    /// KiwiDesk shortcut mid-capture must not fire its action.
-    /// The host sets this once; it fires only on the nil↔armed
-    /// edge, so switching between two fields stays armed and
-    /// never bounces the registration.
+    /// Callback fired on transition between idle and armed states (#213).
     var onArmedChange: (Bool) -> Void = { _ in }
 
-    /// Tears down the active field's event monitor — installed
-    /// by `claim`, run synchronously before the next claim.
+    /// Teardown closure for active event monitor.
     private var stopActive: (() -> Void)?
 
-    /// Starts a recording claim: the previous recorder (if
-    /// any) is stopped before this one becomes active.
+    /// Claims active recorder status, tearing down any existing monitor.
     func claim(_ id: UUID, teardown: @escaping () -> Void) {
         stopActive?()
         setActive(id)
@@ -46,9 +32,7 @@ final class RecorderCoordinator: ObservableObject {
         stopActive = nil
     }
 
-    /// The edited mode/target changed: stop any recording and
-    /// invalidate pending rejection UI (its Steal closure
-    /// captured pre-change bindings).
+    /// Stops recording and invalidates pending rejection closures.
     func invalidate() {
         stopActive?()
         stopActive = nil
@@ -56,8 +40,6 @@ final class RecorderCoordinator: ObservableObject {
         generation += 1
     }
 
-    /// Sets `active` and fires `onArmedChange` only when the
-    /// armed/idle state actually flips.
     private func setActive(_ id: UUID?) {
         let wasArmed = active != nil
         active = id
@@ -66,51 +48,28 @@ final class RecorderCoordinator: ObservableObject {
     }
 }
 
-/// A rejected recording (#34): the combo is already assigned
-/// to another KiwiDesk row in the same mode. The recording is
-/// hard-blocked; the field offers Steal (rebind here) and
-/// Go to (jump to the holder) inline. macOS system shortcuts
-/// stay a soft warning (the per-row ⚠) — shadowing one can be
-/// intentional.
+/// Information describing a rejected shortcut recording collision (#34).
 struct RecorderRejection {
-    /// The combo that was rejected — kept so the field can
-    /// re-validate against live bindings (the holder may have
-    /// been cleared since).
     let combo: String
-    /// The holder's display label ("Focus window above").
     let holder: String
-    /// The holder's row id, for "Go to".
     let holderRowID: String
-    /// Clears the holder's combo and commits it here.
     let steal: () -> Void
 }
 
 enum RecorderPreflight {
-    /// The row id used by `.id(...)` on every shortcut row so
-    /// "Go to" can scroll to the holder: catalog rows key by
-    /// their Lua, dynamic rows by their binding id.
+    /// Computes unique row identifier for scrolling.
     static func rowID(_ binding: KeyBinding) -> String {
         binding.kind == .navigation
             ? binding.lua : binding.id.uuidString
     }
 
-    /// Checks `combo` against every *other* row of the mode.
-    /// Returns the rejection for a KiwiDesk collision, nil
-    /// when the combo is free (or only shadows a system
-    /// shortcut — soft, committed anyway). `commit` must look
-    /// its row up at write time (id- or Lua-keyed), because
-    /// Steal mutates the array first.
+    /// Evaluates conflicting shortcut bindings (#181 review H2).
     static func rejection(
         combo: String,
         excluding isOwn: @escaping (KeyBinding) -> Bool,
         bindings: Binding<[KeyBinding]>,
         commit: @escaping (String) -> Void
     ) -> RecorderRejection? {
-        // A PURE query: it runs from chord previews (every
-        // in-flight chord change) and from render passes, so
-        // it must never mutate the bindings (#181 review H2 —
-        // a preview keystroke deleted a row, and a body
-        // evaluation mutated state mid-update).
         guard
             let holder = bindings.wrappedValue.first(where: {
                 !$0.combo.isEmpty
@@ -129,10 +88,6 @@ enum RecorderPreflight {
                 if let index = rows.firstIndex(where: {
                     $0.id == holder.id
                 }) {
-                    // Catalog rows exist through their
-                    // binding — removing it unbinds; dynamic
-                    // rows keep their row, only the combo
-                    // clears.
                     if holder.kind == .navigation {
                         rows.remove(at: index)
                     } else {

--- a/Sources/KiwiDesk/Settings/Components/Layouts/BspSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/BspSchematic.swift
@@ -1,22 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The BSP schematic (#125): one wide frame showing `windows`
-/// windows — the established ones plus the incoming
-/// **new-window tile** — tiled by the *real* `BspLayout`, so the
-/// picture can never drift from what the engine actually does. A
-/// wide frame is deliberate: the split *strategy* only becomes
-/// visible once a region has been cut enough times that "cut the
-/// longer side" and "alternate H/V" diverge, which needs a
-/// widescreen and several windows — which is also why the count
-/// is the preview's slider (turn 10) rather than a constant: the
-/// two strategies are indistinguishable at two windows and
-/// unmistakable at eight.
-///
-/// Window 2 is the focused one (thick stroke); the last window is
-/// inserted at the array index the `placement` rule dictates and
-/// drawn as the dense `+` tile, so "first / last / before / after
-/// focused" reads straight off the frame.
+/// Interactive BSP layout schematic preview (`BspLayout`, #125).
 struct BspSchematic: View {
     let splitRatioH: Double
     let splitRatioV: Double
@@ -29,33 +14,23 @@ struct BspSchematic: View {
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// The restage damping, gated on Reduce Motion (#1069) —
-    /// the arrangement still redraws, it just stops travelling.
-    /// The ternary is spelled here rather than folded into
-    /// `LayoutSchematic.damping`; that file says why.
+    /// Restage animation damping gated on Reduce Motion
+    /// (`LayoutSchematic.damping`, #1069).
     private var damping: Animation? {
         reduceMotion ? nil : LayoutSchematic.damping
     }
 
-    /// At the tile scale the frame is the strip's, not this
-    /// schematic's — see `SchematicScale`, which argues why the
-    /// 3:1 widescreen is a panel-only affordance.
     private var frameWidth: CGFloat? { scale.width }
     private var frameHeight: CGFloat {
         scale == .tile ? scale.height : 260
     }
 
-    /// The established windows: everything but the incoming one.
-    /// Focus is window 2 where there is one — with a single
-    /// established window it is that window, so the relative
-    /// placements still have a reference.
     private var base: [WindowID] {
         (1...max(1, windows - 1)).map { WindowID(UInt32($0)) }
     }
     var focused: WindowID {
         base.count >= 2 ? WindowID(2) : WindowID(1)
     }
-    /// Above every established id, whatever the count.
     var newWindow: WindowID {
         WindowID(UInt32(max(1, windows - 1) + 1))
     }
@@ -90,11 +65,6 @@ struct BspSchematic: View {
                             width: rect.width,
                             height: rect.height
                         )
-                        // `.position` places the tile's centre at
-                        // an absolute point in the frame's own
-                        // coordinate space (top-left origin) —
-                        // unlike `.offset`, which shifts from a
-                        // tile's centred natural spot in the ZStack.
                         .position(x: rect.midX, y: rect.midY)
                 }
             }
@@ -111,11 +81,8 @@ struct BspSchematic: View {
         }
     }
 
-    /// The windows in array order, with the new one spliced in
-    /// where `placement` opens it — asked of the engine through
-    /// `SchematicPlacement` rather than reproduced here (#702).
-    /// Tiles are keyed by id, so the focus follows its window
-    /// when the splice pushes it along.
+    /// Windows in array order with incoming window spliced in
+    /// (`SchematicPlacement`, #702).
     var order: [WindowID] {
         var windows = base
         let index = SchematicPlacement.splice(
@@ -127,13 +94,8 @@ struct BspSchematic: View {
         return windows
     }
 
-    /// Runs the production `BspLayout` over the windows in the
-    /// canvas. Tiny inner gaps separate the tiles; a ~1 pt
-    /// minimum keeps the overlap fallback out of the preview —
-    /// the fallback is a real behaviour, but it is the *minimum
-    /// window size*'s story, and firing it here would make a
-    /// dozen-window preview claim BSP piles when the screen it
-    /// stands for would not.
+    /// Computes window rects using production layout
+    /// (`BspLayout`, `BspParams`).
     private func layout(in size: CGSize) -> [WindowID: CGRect] {
         var params = BspParams()
         params.strategy = strategy

--- a/Sources/KiwiDesk/Settings/Components/Layouts/FloatingSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/FloatingSchematic.swift
@@ -1,26 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Floating schematic (#828).
-///
-/// Floating drew **nothing** — `LayoutSchematicView` answered it
-/// with an `EmptyView`, on the argument that a mode with no tiling
-/// geometry has no picture. That argument is `MonocleSchematic`'s
-/// too, and Monocle answers it by drawing its *model* instead of a
-/// layout. Floating has one as well, and it is the one fact a user
-/// needs: the windows stay where they were put, overlapping, and
-/// the shortcuts still work. Drawn nowhere, the mode read as a
-/// broken tile in the tour's strip and as a blank in Settings'
-/// own "Choose a layout" row (owner, on device, 2026-08-12).
-///
-/// **It takes no settings, and that is the honest part.** Nothing
-/// here derives from `TilingSettings`, because Floating has no
-/// knob to derive from — the count is the only input, and it moves
-/// the number of loose windows and nothing else.
+/// Floating layout preview schematic showing overlapping windows (#828).
 struct FloatingSchematic: View {
-    /// Windows on screen. Capped for the same reason Monocle caps
-    /// its fan: past three the cards march off the canvas and say
-    /// nothing the third did not.
+    /// Window count clamped to schematic rendering bounds.
     var windows = LayoutSchematic.defaultWindowCount
     var scale: SchematicScale = .tile
     @Environment(\.schematicFocusStroke) private var focusStroke
@@ -29,20 +12,13 @@ struct FloatingSchematic: View {
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// The restage damping, gated on Reduce Motion (#1069) —
-    /// the arrangement still redraws, it just stops travelling.
-    /// The ternary is spelled here rather than folded into
-    /// `LayoutSchematic.damping`; that file says why.
+    /// Restage animation damping gated on Reduce Motion
+    /// (`LayoutSchematic.damping`, #1069).
     private var damping: Animation? {
         reduceMotion ? nil : LayoutSchematic.damping
     }
 
-    /// Windows actually drawn. `internal` and asserted directly
-    /// (`LayoutSchematicCountTests`), never left to the source
-    /// scan: a schematic that TAKES the count and draws a
-    /// constant satisfies every substring a scan can look for
-    /// while answering nothing — the mutation `guard-prover`
-    /// shipped past that suite's first cut.
+    /// Windows actually drawn (`LayoutSchematicCountTests`).
     var drawn: Int { min(max(windows, 1), 3) }
 
     var body: some View {
@@ -77,14 +53,12 @@ struct FloatingSchematic: View {
         }
     }
 
-    /// The family's fallback ladder, stated once in
-    /// `SchematicCardColors` — the two card-fan schematics drew
-    /// byte-identical copies of it for a day, and what they were
-    /// copying was the rule rather than a value.
+    /// Card background fill (`SchematicCardColors`).
     private func fill(front: Bool) -> Color {
         SchematicCardColors.fill(front: front, palette: palette)
     }
 
+    /// Card border stroke (`SchematicCardColors`).
     private func edge(front: Bool) -> Color {
         SchematicCardColors.edge(
             front: front,
@@ -93,11 +67,7 @@ struct FloatingSchematic: View {
         )
     }
 
-    /// Overlapping, not tiled: each window sits offset from the
-    /// one behind it, and the frontmost carries the focus stroke
-    /// the rest of the family uses — a floating window can be
-    /// focused like any other, and drawing it otherwise would say
-    /// the mode is outside the app's own focus model.
+    /// Renders overlapping window rectangle.
     private func window(front: Bool) -> some View {
         RoundedRectangle(cornerRadius: LayoutSchematic.corner)
             .fill(fill(front: front))
@@ -112,10 +82,6 @@ struct FloatingSchematic: View {
             )
     }
 
-    /// The caption carries what the frame cannot: that nothing
-    /// moves a window here except the user, and that the keys
-    /// still work — which is the question a user actually has
-    /// about a space the tiler leaves alone.
     private var caption: String {
         L(
             "layout.schematic.floating.caption",

--- a/Sources/KiwiDesk/Settings/Components/Layouts/FloatingSchematic.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/FloatingSchematic.swift
@@ -18,7 +18,12 @@ struct FloatingSchematic: View {
         reduceMotion ? nil : LayoutSchematic.damping
     }
 
-    /// Windows actually drawn (`LayoutSchematicCountTests`).
+    /// Windows actually drawn. `internal` and asserted directly
+    /// (`LayoutSchematicCountTests`), never left to the source
+    /// scan: a schematic that TAKES the count and draws a constant
+    /// satisfies every substring a scan can look for — the
+    /// mutation `guard-prover` shipped past that suite's first
+    /// cut.
     var drawn: Int { min(max(windows, 1), 3) }
 
     var body: some View {

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutPreviewPanel.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutPreviewPanel.swift
@@ -1,21 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The live preview under a layout's rows (turn 10): the
-/// selected layout's schematic at pane width, with the window
-/// count as a slider the reader drives.
-///
-/// The count is what turns a picture of a layout into a
-/// simulation of one. Cascade overflow and Cascade all draw the
-/// same frame until the stack is deep enough to overflow; a
-/// track limit means nothing until there are more windows than
-/// tracks; a dynamic grid's balance is invisible at a fixed
-/// count. Every one of those becomes a drag of this slider.
-///
-/// The count is view state, deliberately: it is a question the
-/// reader is asking of the preview, not a setting, so it neither
-/// persists nor reaches the config — and it resets per visit,
-/// which is the right default for a question.
+/// Live interactive preview panel for layout mode defaults (#678).
 struct LayoutPreviewPanel: View {
     @ObservedObject var model: SettingsModel
     let mode: LayoutMode
@@ -34,34 +20,18 @@ struct LayoutPreviewPanel: View {
                 )
                 countRow
             }
-            // Read-only, so it watches from the panel beside
-            // the rows rather than sitting among them (owner
-            // 2026-08-10).
             SpacesUsingLayout(model: model, mode: mode)
         }
     }
 
-    /// Hoisted out of the `SettingsSlider` call, which already
-    /// carries a closure-pair `Binding`: a range built inline
-    /// beside it is the type-checker-budget shape gui.md names.
+    /// Hoisted slider range (`LayoutSchematic.windowCountRange`, `gui.md`).
     private var countRange: ClosedRange<Double> {
         let band = LayoutSchematic.windowCountRange
         return Double(band.lowerBound)...Double(band.upperBound)
     }
 
-    /// Label and readout hug their text instead of taking the
-    /// content pane's 210 pt label column: this row lives in
-    /// the 392 pt PANEL now, where that column left the track
-    /// a knob's width of room (owner caught it on screen,
-    /// 2026-08-10) — the slider is the row's point, so it gets
-    /// the flexible middle.
     private var countRow: some View {
         HStack(spacing: 10) {
-            // "Window count", not a bare "Windows": beside a
-            // slider and a numeric readout the short form is
-            // unambiguous on screen, but a translator reading the
-            // key alone cannot tell it from the OS's own name for
-            // a window.
             Text(
                 L(
                     "layout_defaults.preview_windows",
@@ -69,10 +39,6 @@ struct LayoutPreviewPanel: View {
                 )
             )
             .fixedSize()
-            // Drawn, not spoken: it names the slider below, and
-            // the slider says the name itself. Left visible it
-            // is read once standing alone and again as the
-            // control's name (code review, 2026-08-11).
             .accessibilityHidden(true)
             SettingsSlider(
                 value: Binding(
@@ -81,16 +47,6 @@ struct LayoutPreviewPanel: View {
                 ),
                 range: countRange,
                 step: 1,
-                // The label above is a SIBLING `Text`, which
-                // names nothing as far as VoiceOver is concerned
-                // — so the slider announced a bare percentage,
-                // and the count it was actually setting sat in a
-                // third element beside it (#678 Phase 4 pass 10,
-                // turn 20a rule 2: the preview is skipped, but
-                // the controls that change what it shows are
-                // not). Naming and valuing the control puts both
-                // back on the thing being adjusted — the seam
-                // every slider now takes (#812).
                 label: L(
                     "layout_defaults.preview_windows",
                     "Window count"
@@ -102,8 +58,6 @@ struct LayoutPreviewPanel: View {
                 .frame(minWidth: 24, alignment: .trailing)
                 .foregroundStyle(SettingsTheme.ink2)
                 .font(.body.monospacedDigit())
-                // The readout is the slider's value drawn again
-                // for the eye (`settingsReadout`).
                 .settingsReadout()
         }
     }

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutPreviewPanel.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutPreviewPanel.swift
@@ -39,6 +39,10 @@ struct LayoutPreviewPanel: View {
                 )
             )
             .fixedSize()
+            // Drawn, not spoken: it names the slider below, and
+            // the slider says the name itself (code review
+            // 2026-08-11 — the ruling `SettingsRowLabel` applies
+            // at its seam).
             .accessibilityHidden(true)
             SettingsSlider(
                 value: Binding(
@@ -47,6 +51,11 @@ struct LayoutPreviewPanel: View {
                 ),
                 range: countRange,
                 step: 1,
+                // A sibling `Text` names nothing for VoiceOver,
+                // so the slider announced a bare percentage
+                // (#678 turn 20a rule 2). Naming and valuing the
+                // control puts both on the thing adjusted — the
+                // seam every slider takes (#812).
                 label: L(
                     "layout_defaults.preview_windows",
                     "Window count"

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicCanvas.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicCanvas.swift
@@ -1,34 +1,11 @@
 import SwiftUI
 
-/// A schematic: one mini-screen plus a caption, centred as a
-/// self-contained tile. Size defaults to the family 140×96 but a
-/// mode may grow it (BSP argues from a widescreen frame).
-///
-/// **One frame per layout, whatever it has to say** (#753). A
-/// two-frame pair shipped here for the one fact thought
-/// inexpressible in a still frame — Scrolling's `follow` pan —
-/// and bought nothing: two states with the tween left to the
-/// reader is not motion either, and it cost double the width, an
-/// arrow drawn nowhere else and two sub-captions. The caption
-/// says the fact in words for the price of a line, so a layout
-/// asking for a second frame is asking for a better caption.
-///
-/// Centered on purpose (the `.frame(maxWidth:.infinity)` with no
-/// alignment): this is a **standalone illustration** — nothing is
-/// edited on it and no control column shares its row, so it reads
-/// as a figure, not a row (see design-decisions "Preview
-/// alignment splits on standalone-vs-paired"). A preview that
-/// *does* sit beside its controls (GapsDiagram, the Drag columns)
-/// is left-aligned instead.
+/// Schematic preview canvas tile rendering mini-screen and caption (#753).
 struct SchematicCanvas<Content: View>: View {
     var width: CGFloat? = LayoutSchematic.canvasWidth
     var height: CGFloat = LayoutSchematic.canvasHeight
     let caption: String
     let axLabel: String
-    /// A thumbnail suppresses the caption — the strip titles it
-    /// (`SchematicScale.showsCaption`). The a11y label stays
-    /// either way: a tile with no caption would otherwise read
-    /// as an unlabelled image.
     var showsCaption = true
     @Environment(\.schematicPalette) private var palette
     @ViewBuilder let content: Content
@@ -43,42 +20,14 @@ struct SchematicCanvas<Content: View>: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
-                    // `axLabel` is the spoken form of this
-                    // drawing; the caption read as well was the
-                    // same fact twice at `.panel` (#812).
                     .accessibilityHidden(true)
             }
         }
         .frame(maxWidth: .infinity)
     }
 
-    /// The bordered mini-screen itself: a rounded outline with the
-    /// content clipped at the frame's edge, so every frame in the
-    /// family reads the same and none draws past its own border.
-    ///
-    /// **The clip does not crop where a reader assumes, and this
-    /// is where that is written down.** Content is padded by
-    /// `LayoutSchematic.inset` and only then clipped at the
-    /// border, so the clip sits OUTSIDE the inset and a shape left
-    /// to it still bleeds a few points into that band. A schematic
-    /// that must not draw there therefore skips the drawing
-    /// instead (Scrolling's off-monitor ghosts at `.tile`, #753).
-    /// Prose binding schematics to that — gui.md,
-    /// `docs/ui-patterns.md`, `docs/design-decisions.md` — cites
-    /// this site rather than restating the mechanism: it had been
-    /// restated at each of them, and moving the clip inside the
-    /// inset would have falsified every copy while none of them
-    /// knew the others existed.
-    ///
-    /// Inlined here since #753: this was a `SchematicScreen` type
-    /// because each pane of the retired two-frame `SchematicPair`
-    /// mounted one too, and a look shared by two callers is worth
-    /// a name. With the pair gone it had exactly one, like the
-    /// three types that retired with it.
-    ///
-    /// A `nil` width means "fill the width available" — the panel
-    /// scale spans its pane rather than sitting at a fixed size,
-    /// so the live preview grows with the Settings window.
+    /// Bordered mini-screen frame with standard inset and corner radius
+    /// (`LayoutSchematic.inset`, `docs/ui-patterns.md`, #753).
     private var screen: some View {
         ZStack {
             content

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicCanvas.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutSchematicCanvas.swift
@@ -20,14 +20,24 @@ struct SchematicCanvas<Content: View>: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
+                    // `axLabel` is the spoken form of this
+                    // drawing; the caption read as well was the
+                    // same fact twice at `.panel` (#812).
                     .accessibilityHidden(true)
             }
         }
         .frame(maxWidth: .infinity)
     }
 
-    /// Bordered mini-screen frame with standard inset and corner radius
-    /// (`LayoutSchematic.inset`, `docs/ui-patterns.md`, #753).
+    /// Bordered mini-screen frame. THE CLIP DOES NOT CROP WHERE A
+    /// READER ASSUMES, and this is where that is written down:
+    /// content is padded by `LayoutSchematic.inset` and only then
+    /// clipped at the border, so a shape left to the clip still
+    /// bleeds into the inset band — a schematic that must not draw
+    /// there skips the drawing instead (#753). Prose in gui.md,
+    /// `docs/ui-patterns.md` and design-decisions CITES THIS SITE
+    /// rather than restating the mechanism. A `nil` width means
+    /// "fill the available width".
     private var screen: some View {
         ZStack {
             content

--- a/Sources/KiwiDesk/Settings/Components/Layouts/SchematicPalette.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/SchematicPalette.swift
@@ -1,55 +1,17 @@
 import SwiftUI
 
-/// The colour source the schematic family draws with (#786).
-///
-/// At rest the family speaks brand — `SettingsTheme.accent` over
-/// the Settings surfaces, via `LayoutSchematic.fill`/`.stroke`.
-/// Inside a Home card's desktop plate the picture is of the
-/// USER's desktop, so the user's palette owns the window colours
-/// (4g) — and the ground there is dark in both appearances, so
-/// the greys the canvas idiom leans on (`.secondary`,
-/// `.textBackgroundColor`) would vanish in light mode and glare
-/// in dark. One environment value carries the whole
-/// substitution; an init parameter on the schematics would red
-/// `LayoutSchematicCountTests` at every construction site.
+/// Color source for schematic layouts (`SettingsTheme.accent`, #712, #786).
 struct SchematicPalette: Equatable {
-    /// A window: the fill base and stroke — the user's own
-    /// accent, read from the draft's palette surface.
     var accent: Color
-    /// The quiet marks: empty cells, ghosts, the monitor
-    /// outline — a light ink legible on the dark ground.
     var ink: Color
-    /// The opaque base under piled tiles — the ground itself,
-    /// so stacking never sums the accent alpha (#712's rule,
-    /// with the plate as the base).
     var base: Color
 
-    // Interiors are NEUTRAL on the plate — the quiet ink wash
-    // every tile shares — never the accent: the owner compared
-    // the tiles side by side and ruled the filled-green
-    // windows out (2026-08-09); on the plate the accent lives
-    // on strokes and marks alone.
     var fill: Color { ink.opacity(0.08) }
     var stroke: Color { accent.opacity(0.6) }
-    // Identical to `fill` on the plate (owner, 2026-08-09):
-    // even the denser ink wash read as "a different colour" on
-    // the tile — the "+" badge alone marks the incoming
-    // window; brand keeps its denser fill off-plate.
     var newFill: Color { ink.opacity(0.08) }
     var gapStroke: Color { ink.opacity(0.4) }
     var ghostFill: Color { ink.opacity(0.08) }
-    /// The un-focused window's edge, and the one value on the
-    /// plate that is NOT a hair quieter than its off-plate twin.
-    ///
-    /// 0.3 of a light ink is legible on a Home card's band and
-    /// gone at thumbnail size in the tour, where the same picture
-    /// is drawn at 55% (owner, on device, 2026-08-12): the
-    /// windows behind the focused one read as an empty plate. The
-    /// interiors stay at the neutral wash the 2026-08-09 ruling
-    /// set — this raises the EDGE, which is the channel that says
-    /// "another window" without adding a second colour.
     var ghostStroke: Color { ink.opacity(0.5) }
-    /// The mini-screen's own outline on the plate.
     var frame: Color { ink.opacity(0.3) }
 }
 
@@ -62,21 +24,14 @@ private struct SchematicFocusStrokeKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    /// `nil` — the default everywhere outside a desktop plate —
-    /// keeps the family's brand constants.
+    /// Schematic palette override; nil uses standard brand colors.
     var schematicPalette: SchematicPalette? {
         get { self[SchematicPaletteKey.self] }
         set { self[SchematicPaletteKey.self] = newValue }
     }
 
-    /// The stroke an ACTIVE tile marks focus with: the draft's
-    /// real `border.focused_color` (owner ruled 2026-08-10,
-    /// extending the Gaps ring's honesty rule — a preview
-    /// claiming engine behavior shows the colour the app will
-    /// draw). `nil` — borders disabled, or a mount that has not
-    /// wired it — keeps the family stroke, which claims
-    /// nothing. On a plate the mount floors the colour against
-    /// the plate first (`HomeCardPlate.plateLegible`).
+    /// Focus stroke color for active schematic tile
+    /// (`HomeCardPlate.plateLegible`, `border.focused_color`).
     var schematicFocusStroke: Color? {
         get { self[SchematicFocusStrokeKey.self] }
         set { self[SchematicFocusStrokeKey.self] = newValue }

--- a/Sources/KiwiDesk/Settings/Components/Layouts/SchematicPalette.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/SchematicPalette.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 
-/// Color source for schematic layouts (`SettingsTheme.accent`, #712, #786).
+/// Color source for schematic layouts (`SettingsTheme.accent`,
+/// #712, #786). One ENVIRONMENT value carries the substitution —
+/// an init parameter on the schematics would red
+/// `LayoutSchematicCountTests` at every construction site. On the
+/// plate, interiors are NEUTRAL (owner ruled 2026-08-09): the
+/// accent lives on strokes and marks alone.
 struct SchematicPalette: Equatable {
     var accent: Color
     var ink: Color

--- a/Sources/KiwiDesk/Settings/Components/Layouts/SchematicPlacement.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/SchematicPlacement.swift
@@ -1,55 +1,12 @@
 import KiwiDeskCore
 
-/// Where a schematic's incoming window opens.
-///
-/// Five schematics draw the dense `+` tile at the slot the spawn
-/// placement chooses, and each carried its own copy of
-/// `Space.insert(_:placement:)`'s four-arm switch (#702). This
-/// asks the engine instead — it splices a window into a real
-/// `Space` and reports where it landed — so the rule has one
-/// implementation and a change to how KiwiDesk places a new
-/// window moves every preview with it.
-///
-/// Reaching for the engine rather than a sixth copy is the whole
-/// point: AGENTS.md §2.4 would let a small duplication stand, but
-/// `.claude/rules/parity-tests.md` stops paying for it past two
-/// mirrors, and a call is cheaper here than either a mirror or
-/// the parity test a mirror would owe.
-/// Two suites hold it, and they fail apart:
-/// `LayoutSchematicPlacementTests` holds each schematic to the
-/// promise its frame makes a reader — stated independently of
-/// both the engine and this helper — and
-/// `LayoutSchematicPlacementScanTests` reds on the next file to
-/// carry a second copy of the rule.
-/// `LayoutSchematicTrackEngineTests` pins the one mode with an
-/// engine of its own, `Space.insertIntoTrack`.
+/// Incoming window slot resolution for layout schematics
+/// (`Space.insert(_:placement:)`, `Space.insertIntoTrack`, #702,
+/// `LayoutSchematicPlacementTests`, `LayoutSchematicPlacementScanTests`,
+/// `LayoutSchematicTrackEngineTests`).
 enum SchematicPlacement {
-    /// The incoming window's slot among `count` established
-    /// windows whose focused one sits at index `focus`, and the
-    /// slot that focused window ends up in.
-    ///
-    /// Both, because a splice at or before the focus pushes the
-    /// focused window one slot along. A schematic that keys its
-    /// tiles by window id gets that for free and reads only
-    /// `incoming`; one that renders a fixed run of slots
-    /// (Track's focused track) has to be told, and drawing the
-    /// focus at its pre-splice index is exactly #702. Neither
-    /// number is computed here — both are read back off the
-    /// space the engine mutated.
-    ///
-    /// The answer is an **index**, not the resulting order, so a
-    /// caller re-performs the insert itself. That is faithful
-    /// while `insert` is a positional splice and would go quietly
-    /// wrong the day it also moves `focused`, refuses, or
-    /// reorders — the id-keyed callers' guards read both ids back
-    /// out of the array they built, which is what would notice.
-    ///
-    /// `focus` must index `count`. Out of range it would fall
-    /// back to the last window and hand back a plausible wrong
-    /// answer, which is #702's own shape one level down; every
-    /// caller's focus reference is pinned present by
-    /// `LayoutSchematicPlacementTests`, and the assertion below
-    /// is the second net.
+    /// Simulates window insertion into `Space` to determine resulting indices
+    /// for incoming and focused windows (#702).
     static func splice(
         _ placement: SpawnPlacement,
         count: Int,

--- a/Sources/KiwiDesk/Settings/Components/Layouts/SchematicPlacement.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/SchematicPlacement.swift
@@ -5,8 +5,13 @@ import KiwiDeskCore
 /// `LayoutSchematicPlacementTests`, `LayoutSchematicPlacementScanTests`,
 /// `LayoutSchematicTrackEngineTests`).
 enum SchematicPlacement {
-    /// Simulates window insertion into `Space` to determine resulting indices
-    /// for incoming and focused windows (#702).
+    /// Simulates window insertion into a real `Space` to
+    /// determine resulting indices (#702). The answer is an INDEX,
+    /// not the resulting order, so a caller re-performs the insert
+    /// — faithful while `insert` is a positional splice. `focus`
+    /// must index `count`: out of range it would hand back a
+    /// plausible wrong answer, which is #702's own shape one level
+    /// down; the assertion below is the second net.
     static func splice(
         _ placement: SpawnPlacement,
         count: Int,

--- a/Sources/KiwiDesk/Settings/Components/Lua/LuaEditorTab.swift
+++ b/Sources/KiwiDesk/Settings/Components/Lua/LuaEditorTab.swift
@@ -1,16 +1,11 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The integrated Lua editor. Shown when init.lua holds code
-/// the visual editor can't represent (foreign code touching
-/// managed vocabulary), or when the user opts to edit raw Lua.
-/// Edits here write the whole file verbatim.
+/// Raw Lua configuration editor tab and adoption interface (#68 §3.12).
 struct LuaEditorTab: View {
     @ObservedObject var model: SettingsModel
     @State private var confirmingAdopt = false
 
-    /// A muted, darker green so the action reads as inviting
-    /// without shouting over the footer's Save button.
     private let adoptGreen = Color(
         red: 0.16,
         green: 0.45,
@@ -20,9 +15,6 @@ struct LuaEditorTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             header
-            // Dirty tracking rides `luaSource`'s own didSet
-            // in the model — a live baseline comparison, not
-            // a latched flag.
             LuaSourceEditor(text: $model.luaSource)
         }
         .padding(16)
@@ -44,14 +36,7 @@ struct LuaEditorTab: View {
         }
     }
 
-    /// Adopt is an eighth discard path (#515 review): it reads
-    /// the original from **disk**, never `luaSource`, then
-    /// reloads — so an unsaved buffer is dropped. It keeps its
-    /// own dialog rather than stacking the shared discard gate
-    /// on top (one gesture, one prompt), so that dialog has to
-    /// say so itself. The adopt help's "Nothing is lost" is
-    /// about the on-disk commented backup and was silently
-    /// false for the buffer.
+    /// Adoption confirmation message reflecting dirty state (#515).
     private var adoptMessage: String {
         guard model.isDirty else {
             return L(
@@ -71,9 +56,6 @@ struct LuaEditorTab: View {
 
     @ViewBuilder private var header: some View {
         if model.forcedLuaEditor {
-            // The Adopt action lives with the content it
-            // migrates (#68 §3.12) — it is not a save verb,
-            // so it left the footer.
             HStack(spacing: 8) {
                 Label {
                     Text(foreignCodeCaption)
@@ -96,9 +78,6 @@ struct LuaEditorTab: View {
                 )
                 .foregroundStyle(.secondary)
                 Spacer()
-                // The mirror image of "Edit init.lua directly":
-                // `reload()` re-seeds from disk, so unsaved Lua
-                // is dropped. Same gate (#515).
                 Button(
                     L(
                         "lua_editor.back_to_visual",
@@ -153,20 +132,11 @@ struct LuaEditorTab: View {
         .tint(adoptGreen)
     }
 
-    /// The destination is INTERPOLATED from its own title rather
-    /// than re-typed (#818): a sentence that names a pane as
-    /// literal text is a hand-kept mirror, and every locale holds
-    /// the two as independent strings that must agree forever
-    /// with nothing checking that they do — `it` had already
-    /// drifted to «sezione Abbreviazioni» while the pane reads
-    /// "Scorciatoie".
+    /// Adoption help description interpolating shortcut pane title
+    /// (#515, #818).
     private var adoptHelpBody: String {
         L(
             "lua_editor.adopt_help.body",
-            // Was "Nothing is lost: …", which is true of the
-            // FILE and false of an unsaved editor buffer — and
-            // this popover sits beside the Adopt dialog that now
-            // says the opposite when dirty (#515 review).
             "Your init.lua isn't deleted: it's kept as a "
                 + "commented-out backup in the new file. "
                 + "Gaps, layouts, rules, and "
@@ -179,8 +149,7 @@ struct LuaEditorTab: View {
     }
 }
 
-/// A monospaced, scrollable text editor backed by NSTextView so
-/// large configs stay responsive and tabs indent properly.
+/// Monospaced text editor wrapped around NSTextView (`gui.md`, #812).
 struct LuaSourceEditor: NSViewRepresentable {
     @Binding var text: String
 
@@ -201,13 +170,6 @@ struct LuaSourceEditor: NSViewRepresentable {
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticSpellingCorrectionEnabled = false
         textView.string = text
-        // An AppKit view re-earns what a SwiftUI control gives
-        // free (gui.md); a bare `NSTextView` is an unnamed text
-        // area (#812). The FILENAME, verbatim, not a new noun:
-        // the surrounding copy already calls this "init.lua"
-        // throughout, and a translatable third name for the
-        // config file is Family C drift (localization audit,
-        // 2026-08-24).
         textView.setAccessibilityLabel("init.lua")
         return scroll
     }

--- a/Sources/KiwiDesk/Settings/Components/Lua/LuaEditorTab.swift
+++ b/Sources/KiwiDesk/Settings/Components/Lua/LuaEditorTab.swift
@@ -36,7 +36,11 @@ struct LuaEditorTab: View {
         }
     }
 
-    /// Adoption confirmation message reflecting dirty state (#515).
+    /// Adoption confirmation message reflecting dirty state.
+    /// Adopt is an eighth discard path (#515 review): it reads the
+    /// original from DISK, never `luaSource`, then reloads — an
+    /// unsaved buffer is dropped, and it keeps its own dialog (one
+    /// gesture, one prompt), so that dialog must say so itself.
     private var adoptMessage: String {
         guard model.isDirty else {
             return L(
@@ -170,6 +174,10 @@ struct LuaSourceEditor: NSViewRepresentable {
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticSpellingCorrectionEnabled = false
         textView.string = text
+        // An AppKit view re-earns what SwiftUI gives free
+        // (gui.md, #812). The FILENAME verbatim, not a new noun:
+        // a translatable third name for the config file is
+        // Family C drift (localization audit 2026-08-24).
         textView.setAccessibilityLabel("init.lua")
         return scroll
     }

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorReadout.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorReadout.swift
@@ -1,48 +1,14 @@
 import KiwiDeskCore
 
-/// What one display currently holds, in a sentence (#678 Phase 3,
-/// turn 13b): "2 Spaces here · Space code is showing".
-///
-/// Authored once and read twice — the line under the picture says
-/// it, and the card speaks it to VoiceOver and shows it on hover.
-/// Two copies of one sentence is how a tooltip and a caption come
-/// to describe the same display differently.
-///
-/// **Whole sentences, never a composed one.** The first cut built
-/// this by interpolating the count PHRASE into a second frame
-/// ("%1$@ · %2$@ is showing"), which asks the translator of the
-/// frame to write around a blob they cannot see and the
-/// translator of the phrase not to know they are inside one. Each
-/// case below is a complete sentence a translator can read
-/// (localization audit, 2026-08-04).
-///
-/// The space id is named — "Space %1$@" — rather than dropped in
-/// bare: ids are commonly numeric, and "3 Spaces here · 2 is
-/// showing" is two numerals with no noun on either.
-///
-/// **"is showing" is per display and stays that way.** It comes
-/// from `WorkspaceManager.activeSpace(on:)`, the single truth the
-/// tiler lays out per display and the bars read — a KiwiDesk
-/// space, not a macOS Desktop. It is therefore independent of
-/// macOS's "Displays have separate Spaces", which gates the
-/// Desktop→profile bindings in Profiles and nothing here.
+/// Monitor space occupancy and active space description
+/// (`WorkspaceManager.activeSpace(on:)`, #678 Phase 3).
 @MainActor
 enum MonitorReadout {
-    /// `held` counts what the display HOLDS, which on the main
-    /// display includes the spaces that follow main — they are on
-    /// that screen right now, and counting only the pinned and
-    /// auto-placed chips made a desk where everything follows
-    /// main read "0 Spaces here · Space code is showing" on every
-    /// card (localization audit, 2026-08-04).
+    /// Formatted status sentence showing held and active spaces.
     static func sentence(
         held: Int,
         showing: SpaceID?
     ) -> String {
-        // Zero takes its own sentence whatever is showing: a
-        // display our own accounting says holds nothing cannot
-        // also report "0 Spaces here · Space X is showing", and
-        // that pairing is reachable — a space can be up on a
-        // display while no configured space resolves to it.
         guard let showing, held > 0 else { return silent(held) }
         switch held {
         case 1:
@@ -61,10 +27,7 @@ enum MonitorReadout {
         }
     }
 
-    /// A localized PHRASE per count, never "%1$d Space(s)": an
-    /// English plural glued to a number reads "1 Spaces" in the
-    /// language it was written for and cannot be declined in the
-    /// ten it was not.
+    /// Localized count string when no active space is shown.
     private static func silent(_ held: Int) -> String {
         switch held {
         case 0:

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorReadout.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorReadout.swift
@@ -1,14 +1,26 @@
 import KiwiDeskCore
 
-/// Monitor space occupancy and active space description
-/// (`WorkspaceManager.activeSpace(on:)`, #678 Phase 3).
+/// Monitor space occupancy and active space description —
+/// authored once, read twice (caption + VoiceOver/hover). WHOLE
+/// sentences, never a composed frame: interpolating a count
+/// phrase into a second frame asks a translator to write around
+/// a blob they cannot see (l10n audit 2026-08-04). "is showing"
+/// is `WorkspaceManager.activeSpace(on:)` — per display,
+/// independent of macOS "separate Spaces" (#678 Phase 3).
 @MainActor
 enum MonitorReadout {
-    /// Formatted status sentence showing held and active spaces.
+    /// Formatted status sentence. `held` counts what the display
+    /// HOLDS, follows-main spaces included — counting only pinned
+    /// chips made an everything-follows-main desk read "0 Spaces
+    /// here" on every card (l10n audit 2026-08-04).
     static func sentence(
         held: Int,
         showing: SpaceID?
     ) -> String {
+        // Zero takes its own sentence whatever is showing: "0
+        // Spaces here · Space X is showing" is reachable — a
+        // space can be up on a display no configured space
+        // resolves to.
         guard let showing, held > 0 else { return silent(held) }
         switch held {
         case 1:
@@ -27,7 +39,9 @@ enum MonitorReadout {
         }
     }
 
-    /// Localized count string when no active space is shown.
+    /// Localized count string — a PHRASE per count, never
+    /// "%1$d Space(s)": an English plural glued to a number cannot
+    /// be declined in the ten languages it was not written for.
     private static func silent(_ held: Int) -> String {
         switch held {
         case 0:

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorTray.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorTray.swift
@@ -3,8 +3,11 @@ import KiwiDeskCore
 
 /// Positioning logic for "Follows main display" monitor tray (#678 Phase 3).
 enum MonitorTray {
-    /// Positions and normalizes monitor tray relative to main display card
-    /// (`SettingsModel.mainDisplay`).
+    /// Positions and normalizes the tray relative to the main
+    /// display card. An id matching no card yields NO tray rather
+    /// than a tray on some other display: a fallback would be a
+    /// second derivation of which display is main —
+    /// `SettingsModel.mainDisplay` exists to be the only copy.
     static func fold(
         cards: [MonitorArrangement.Drawn],
         main: DisplayID?,

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorTray.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorTray.swift
@@ -1,38 +1,10 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// Where the dashed **Follows main display** tray sits (#678
-/// Phase 3, turn 13b).
-///
-/// The tray is not a fourth card in a row of cards — a space that
-/// follows whichever display is main is a statement ABOUT the
-/// main display, so it hangs directly off it and moves with the
-/// "main" badge. Hanging it off the badge rather than off a fixed
-/// corner is the whole reason it is a placement decision at all.
-///
-/// It goes ABOVE the main display, except where another display
-/// already occupies that band — a laptop under a desk display
-/// puts the main badge on the lower rectangle, and a tray drawn
-/// above it would land on the display above. Then it goes below,
-/// and where BOTH bands are taken (a main display in the middle
-/// of a vertical stack) it drops clear of the whole picture
-/// rather than through a card: a tray drawn over a display is a
-/// worse lie than a tray one row further away.
-///
-/// The picture grows to hold it either way — the tray is part of
-/// the content, so putting it above never clips it off the top of
-/// the pane.
+/// Positioning logic for "Follows main display" monitor tray (#678 Phase 3).
 enum MonitorTray {
-    /// Folds the tray into the laid-out cards, normalizing the
-    /// whole picture back to a (0, 0) origin.
-    ///
-    /// `main` names the display the tray hangs off. An id that
-    /// matches no card yields NO tray rather than a tray on some
-    /// other display: the badge and the tray answer one question,
-    /// and a fallback here would be a second derivation of which
-    /// display is main — the thing `SettingsModel.mainDisplay`
-    /// exists to be the only copy of. In practice the page always
-    /// passes a live id, and the nil case is the empty picture.
+    /// Positions and normalizes monitor tray relative to main display card
+    /// (`SettingsModel.mainDisplay`).
     static func fold(
         cards: [MonitorArrangement.Drawn],
         main: DisplayID?,
@@ -55,9 +27,6 @@ enum MonitorTray {
         let bounds = MonitorArrangement.union(
             cards.map(\.rect) + [tray?.rect].compactMap { $0 }
         )
-        // Normalize: the tray above the topmost display puts the
-        // picture's origin at a negative y, and a card cannot be
-        // drawn at one.
         let shift = CGPoint(x: -bounds.minX, y: -bounds.minY)
         return MonitorArrangement.Layout(
             displays: cards.map {
@@ -74,15 +43,7 @@ enum MonitorTray {
         )
     }
 
-    /// The tray's rectangle before normalization: centred on the
-    /// display it hangs off, above it where that band is clear,
-    /// below it where the band above is taken, and clear of the
-    /// whole picture where both are.
-    ///
-    /// Width follows the anchor so the tray reads as belonging to
-    /// it, inset a little so it cannot be mistaken for another
-    /// display, with the card minimum as a floor — a tray
-    /// narrower than one chip is a drop target nothing fits in.
+    /// Computes pre-normalization tray rect avoiding colliding display cards.
     static func rect(
         anchoredTo anchor: CGRect,
         avoiding others: [CGRect],

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideOffer.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideOffer.swift
@@ -1,56 +1,10 @@
 import KiwiDeskCore
 
-/// Whether the per-space override affordance is *offered* — the
-/// #678 8c capability unlock, for the Spaces list.
-///
-/// > Easy withholds only the *offer* to create an override, and
-/// > the offer unlocks itself per list the moment the profile has
-/// > one … collapsing away when the last override is cleared.
-///
-/// `Customize…` rendered on every space row in both modes, so
-/// every user met per-space exception bookkeeping whether or not
-/// they had any exceptions.
-///
-/// Note what this is NOT gating on any more: Layout Defaults
-/// itself became `.simple` (owner ruling 2026-08-04), because
-/// those parameters are how people learn what a tiling manager
-/// does. Editing one layout's defaults is the feature; editing
-/// them per space is bookkeeping about exceptions, and that is
-/// what stays behind the offer.
-///
-/// **Three properties, and the cheap implementation breaks two of
-/// them** (`ShortcutsCapabilityUnlockTests` names the same trap
-/// for the shortcut column):
-///
-///  - *the whole list.* One override anywhere unlocks the
-///    affordance on EVERY space row, not just the overridden
-///    one. A user who has overridden one space is a user who
-///    overrides spaces; making them re-discover the affordance
-///    per row is the thing this forbids. Hence a list-wide
-///    predicate rather than the per-row `count > 0` the button
-///    already had in hand.
-///  - *the list, not the app.* A space override must not turn a
-///    deeper surface on anywhere else — the failure mode is "the
-///    mode becomes something users lose by accident".
-///  - *the mode never changes what runs.* This gates the OFFER
-///    only. Overrides already saved keep resolving in Simple,
-///    untouched and unreachable-from-here — which is why the
-///    unlock has to consult the saved state rather than the mode
-///    alone, or a Simple user with overrides could neither see
-///    nor clear them.
-///
-/// Hidden rather than greyed when withheld (owner ruling
-/// 2026-08-04), against the standing "grey, don't hide" default:
-/// mode-withheld surface is *absent* everywhere else in this
-/// window — a `.powerUser` area has no Home card in Simple, it is
-/// not a dimmed one — because the mode adds surface rather than
-/// expanding it. A permanently dead button on every space row is
-/// the clutter the mode split exists to remove.
+/// Controls visibility of per-space override affordance in spaces list
+/// (#678 8c, `ShortcutsCapabilityUnlockTests`).
 enum SpaceOverrideOffer {
-    /// `spaces` is the profile's whole list, so that clearing the
-    /// last override anywhere collapses the affordance
-    /// everywhere — the "collapsing away" half of 8c, which a
-    /// per-row test cannot express.
+    /// Offered in Power User mode or when any space has existing overrides
+    /// (#678 8c).
     static func isOffered(
         mode: SettingsMode,
         settings: TilingSettings,

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideOffer.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideOffer.swift
@@ -1,7 +1,14 @@
 import KiwiDeskCore
 
-/// Controls visibility of per-space override affordance in spaces list
-/// (#678 8c, `ShortcutsCapabilityUnlockTests`).
+/// Controls visibility of the per-space override affordance
+/// (#678 8c, `ShortcutsCapabilityUnlockTests`). One override
+/// anywhere unlocks EVERY space row (a list-wide predicate, never
+/// per-row `count > 0`), the unlock reaches this list and nothing
+/// else, and the mode never changes what runs — saved overrides
+/// keep resolving in Simple. HIDDEN rather than greyed when
+/// withheld (owner ruling 2026-08-04): mode-withheld surface is
+/// absent everywhere in this window, since the mode adds surface
+/// rather than expanding it.
 enum SpaceOverrideOffer {
     /// Offered in Power User mode or when any space has existing overrides
     /// (#678 8c).

--- a/Sources/KiwiDesk/Settings/CrossReferenceRow.swift
+++ b/Sources/KiwiDesk/Settings/CrossReferenceRow.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
-/// Cross-tab navigation for the settings detail pane: the view
-/// owning the sidebar selection injects a navigator, and deep
-/// sections render quiet links ("Appearance ▸ App Bar") where
-/// their prose points at a control that lives on another tab —
-/// a pointer the user can follow instead of a dead end.
+/// Cross-tab navigation row for settings detail pane.
 
 private struct SettingsNavigateKey: EnvironmentKey {
     static let defaultValue: @MainActor (SettingsDestination) -> Void = { _ in
@@ -20,51 +16,16 @@ extension EnvironmentValues {
     }
 }
 
-/// The standard "lives elsewhere" row: one caption sentence with
-/// the destination's name linked AT the position the prose puts
-/// it, so every pointer at another tab reads the same and the
-/// wording can't drift per section.
-///
-/// **The link's position is the whole point.** This row used to
-/// render `Text(prose)` then the link in a fixed-order `HStack`,
-/// so the name could only ever land at the END and every
-/// `prose:` key had to be authored dangling ("… — edit them
-/// in"). That is the defect [localization.md] bans as
-/// `+`-concatenated fragments — a translation cannot reorder
-/// pieces stitched together in Swift — with an `HStack` doing
-/// the stitching instead of a `+`, which is why nothing caught
-/// it. It was not hypothetical: `ja`, `ko`, `zh-Hans`,
-/// `zh-Hant` and `ru` had each ended their translation on a
-/// colon or a bare preposition, because writing a sentence was
-/// not available to them.
-///
-/// So the prose carries a positional specifier for the link,
-/// the call site fills it with ``linkSlot``, and this row splits
-/// there. `CrossReferenceRowSlotTests` holds that every call
-/// site passes one — without the slot the link falls to the end
-/// and the defect is back, silently.
-///
-/// The sentence renders through ``LinkedCaption`` rather than a
-/// SwiftUI `Text`, and rather than an `HStack` of three: a
-/// sentence with something in the middle of it has to wrap as a
-/// paragraph, which siblings in a row cannot do whatever a
-/// translation's word order asks for. That file carries why it
-/// is AppKit — a SwiftUI `.link` run navigates but gives no
-/// pointing-hand cursor, and `NSLayoutManager` is what breaks
-/// the lines correctly for the languages this change is for.
+/// Standard "lives elsewhere" row embedding a linked destination inline
+/// (`localization.md`, `CrossReferenceRowSlotTests`, `LinkedCaption`).
 struct CrossReferenceRow: View {
-    /// The formatted sentence, carrying ``linkSlot`` where the
-    /// destination's name belongs.
+    /// Formatted sentence carrying ``linkSlot`` for destination placement.
     let prose: String
     let linkTitle: String
     let destination: SettingsDestination
     @Environment(\.settingsNavigate) private var navigate
 
-    /// Pass this as the prose's link argument. U+FFFC is
-    /// Unicode's OBJECT REPLACEMENT CHARACTER — "a non-text
-    /// object goes here" — so it cannot collide with copy, and
-    /// no translator ever sees it: what reaches the catalog is
-    /// an ordinary `%N$@` they may put anywhere in the sentence.
+    /// Unicode U+FFFC replacement character used as the link slot token.
     static let linkSlot = "\u{FFFC}"
 
     var body: some View {
@@ -77,18 +38,8 @@ struct CrossReferenceRow: View {
         )
     }
 
-    /// The prose either side of the slot.
-    ///
-    /// A prose WITHOUT one is a programming error, not a shape
-    /// to support: it is the dangling layout this row retired,
-    /// and §5 bans a pre-release compatibility path for exactly
-    /// the reason it would apply here — a silent branch makes a
-    /// future regression invisible rather than loud. Both doors
-    /// are already shut (`CrossReferenceRowSlotTests` reds on a
-    /// new call site, `placeholder_drift` on a catalog value
-    /// that loses its `%N$@`), so this asserts in debug and
-    /// still renders a followable pointer in release rather than
-    /// dropping navigation on a user.
+    /// Splits prose around `linkSlot` (`CrossReferenceRowSlotTests`,
+    /// `placeholder_drift`).
     private var split: (String, String) {
         guard let slot = prose.range(of: Self.linkSlot) else {
             assertionFailure("cross-reference prose has no slot")

--- a/Sources/KiwiDesk/Settings/HomeCardPlate+BarStrip.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardPlate+BarStrip.swift
@@ -2,10 +2,7 @@ import CoreGraphics
 import KiwiDeskCore
 import SwiftUI
 
-/// One bar strip of the fused Bars scene
-/// (`HomeCardBarsTile`), split at the file-size target: the
-/// seat, the plate and the item marks. Everything here derives
-/// from the `BarSpec` the tile read off the real style struct.
+/// Bar strip view component for Home plate bars tile (`HomeCardBarsTile`).
 struct BarStripView: View {
     let spec: HomeCardBarsTile.BarSpec
     let edge: AppBarEdge
@@ -16,22 +13,11 @@ struct BarStripView: View {
     var body: some View {
         Group {
             if spec.spans {
-                // `full`: the plate runs edge-to-edge and the
-                // item run seats INSIDE it.
                 plate
                     .overlay(seated { run })
             } else if spec.boxed {
-                // Boxed draws no shared plate — the run seats
-                // bare on the screen.
                 seated { run }
             } else {
-                // `hug`: the plate wraps the run's LENGTH
-                // plus one gap of air per end (the Dock's
-                // read), and the WRAPPED plate seats. The
-                // CROSS stays the full thickness — fit never
-                // shrinks a bar's cross, so the Thickness
-                // slider moves the plate, not the air around
-                // it.
                 seated {
                     run
                         .padding(
@@ -55,8 +41,7 @@ struct BarStripView: View {
         )
     }
 
-    /// The bare pip's cross size, carved from the strip's
-    /// remapped thickness so both move with the slider.
+    /// Computed cross dimension for bar pips.
     private var pipCross: CGFloat {
         spec.thickness * 0.56
     }
@@ -88,10 +73,7 @@ struct BarStripView: View {
         .padding(vertical ? .vertical : .horizontal, 3 * scale)
     }
 
-    /// The item run's seat along the bar — the style's own
-    /// `alignment`, edge-relative exactly like the real bar's
-    /// (`start` is a top bar's left and a left bar's top, which
-    /// is the stacks' natural reading order).
+    /// Positions item run along the bar according to alignment spec.
     @ViewBuilder
     private func seated(
         @ViewBuilder _ content: () -> some View
@@ -121,12 +103,7 @@ struct BarStripView: View {
 
     // MARK: - Items
 
-    /// A bare pip on the Home plate; at panel scale the item
-    /// carries its identifier in the bar's two-accent model.
-    /// The active item is marked per the style's own
-    /// `active_indicator`: an outline traced at the bar's
-    /// roundness, an accent bar on the window-facing edge, or
-    /// an empty slot.
+    /// Renders individual bar item with active indicator and optional boxing.
     @ViewBuilder
     private func pip(
         _ item: HomeCardBarsTile.BarItem

--- a/Sources/KiwiDesk/Settings/HomeCardPlate+Scene.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardPlate+Scene.swift
@@ -1,22 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The scene tiles of the Home card plates (#786): Gaps &
-/// Borders and Bars. Split from `HomeCardPlate.swift` at the
-/// file-size target — Monitors and Behaviour sit in
-/// `HomeCardPlate+Desk.swift` — and the container, palette and
-/// dispatch stay there.
-
-/// The editor's own four-window picture on the plate (owner,
-/// 2026-08-09 — over the two-pane cut): a 2×2 grid whose
-/// spacing IS the answer — the seams read the inner gaps, the
-/// insets to the plate edge the outer gaps, each through
-/// `GapPreviewScale.mini`, the same maths the Gaps editor
-/// teaches with — and the borders highlighted: the focused
-/// window ringed in the real border colour at
-/// `FocusBorderPreview`'s 1–20 → 1–7 remap, its neighbours
-/// ringed only while unfocused borders are on. Deliberately not
-/// a layout preview, like the diagram it echoes.
+/// Gaps & Borders plate scene tile for Home cards (#786).
 struct HomeCardGapsTile: View {
     let settings: TilingSettings
     @Environment(\.schematicPalette) private var palette
@@ -24,17 +9,6 @@ struct HomeCardGapsTile: View {
     var body: some View {
         let outer = settings.gapsGlobal.outer
         let inner = settings.gapsGlobal.inner
-        // The four windows live inside an implied 16:10 SCREEN
-        // centred in the plate, not stretched to its edges
-        // (owner, 2026-08-09) — the outer-gap readouts inset
-        // from the screen outline, air on all sides beyond it.
-        // No fill behind the panes: the owner tried an accent
-        // gap-wash on device and ruled the empty interior back
-        // in (2026-08-09) — the seams and margins read as
-        // spacing on the bare plate, matching the Layout
-        // Defaults band's ground, and no window carries a
-        // highlight fill either; the border rings are the only
-        // accent this tile speaks.
         ZStack {
             RoundedRectangle(cornerRadius: 4)
                 .strokeBorder(
@@ -57,10 +31,6 @@ struct HomeCardGapsTile: View {
             .padding(.trailing, 2 + mini(outer.right))
         }
         .aspectRatio(16.0 / 10.0, contentMode: .fit)
-        // Vertical air beyond the aspect fit: height-bound
-        // plates left the screen outline flush with the plate
-        // padding; 6 lands the margins level with the Layout
-        // Defaults band's (owner, 2026-08-09, third pass).
         .padding(.vertical, 6)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -69,15 +39,8 @@ struct HomeCardGapsTile: View {
         GapPreviewScale.mini(real)
     }
 
-    /// A window pane: opaque plate base under a quiet ghost
-    /// fill, ringed at the remapped real width — the focused
-    /// window always, its neighbours only while unfocused
-    /// borders are on. The ring speaks the PALETTE accent, not
-    /// `border.focused_color` (owner ruled unify, 2026-08-09):
-    /// side by side with the other tiles' accent marks, two
-    /// greens on one Home read as drift, so the width and the
-    /// presence stay the real readouts and the colour joins the
-    /// plate family's one voice.
+    /// Renders individual pane with focus border scaling
+    /// (`FocusBorderPreview`).
     @ViewBuilder
     private func pane(focused: Bool) -> some View {
         let border = settings.borderStyle
@@ -109,10 +72,7 @@ struct HomeCardGapsTile: View {
             }
     }
 
-    /// The one shared remap (`BorderPreviewScale`), into a band
-    /// proportional to this tile's third-size panes — the same
-    /// real width reads the same weight here and on the
-    /// editor's mock (owner scale round + review, 2026-08-09).
+    /// Scaled border stroke width (`BorderPreviewScale`).
     private var strokeWidth: CGFloat {
         BorderPreviewScale.width(
             settings.borderStyle.clampedWidth,

--- a/Sources/KiwiDesk/Settings/NeutralButtonLabel.swift
+++ b/Sources/KiwiDesk/Settings/NeutralButtonLabel.swift
@@ -1,55 +1,9 @@
 import SwiftUI
 
 extension View {
-    /// Paints a bordered button's LABEL in ordinary ink instead
-    /// of the window's accent.
-    ///
-    /// The twin of `neutralMenuLabel()`, for the other control
-    /// style that colours its label from the tint. A
-    /// `.buttonStyle(.bordered)` button draws its title — and any
-    /// SF Symbol beside it — in the tint, so once #678 turn 16b
-    /// tinted the window kiwi (`SettingsTheme.accent`) every
-    /// bordered button in Settings became green text: "Add app
-    /// rule", "Add application", "Fit to layout gaps" and
-    /// eighteen more.
-    ///
-    /// Same principle as the menu twin, and the reason both exist
-    /// as named modifiers rather than as local fixes: **the
-    /// accent belongs on control FILLS** — a toggle track, a
-    /// selected segment, a prominent Save — **never on text.** A
-    /// bordered button is a bordered *surface* with a label on
-    /// it; the surface is the control, the words are not.
-    ///
-    /// Not for every button:
-    ///
-    /// - A `role: .destructive` button draws its label in the
-    ///   system red, which is the warning and must survive.
-    ///   Neutralising one would paint a delete action in the
-    ///   same ink as a save.
-    /// - `.borderedProminent` is a filled control, so its accent
-    ///   IS the fill this rule protects. Leave it alone.
-    /// - A button that resolves its own tint per state
-    ///   (`KeyRecorderField`) already decides this question and
-    ///   is exempt — see `SettingsBorderedSealTests`'
-    ///   `borderedExempt` map, which is the one copy of who may
-    ///   skip this.
-    ///
-    /// `.tint` and not only `.foregroundStyle`, for the reason
-    /// `neutralMenuLabel()` states: the label of an AppKit-backed
-    /// control follows the tint, and a `foregroundStyle` alone
-    /// does not reach it. Both are set so the pair covers the
-    /// SwiftUI-drawn and AppKit-drawn halves of one label.
-    ///
-    /// A bordered action button does not call this directly any
-    /// more: `settingsActionButton()` seals the style and this
-    /// neutralisation into one call (#771), so the only direct
-    /// call sites left are non-bordered labels the tint reaches
-    /// anyway — today the one text-labelled `.borderless`
-    /// breadcrumb. `SettingsBorderedSealTests` pins the bordered
-    /// half (no raw `.buttonStyle(.bordered)` outside its
-    /// `borderedExempt` map) and `SettingsLabelNeutralityTests`
-    /// enumerates every direct use of this modifier with the
-    /// style it sits on.
+    /// Applies neutral ink styling to button label
+    /// (`SettingsTheme.ink`, `neutralMenuLabel()`, `settingsActionButton()`,
+    /// `SettingsBorderedSealTests`, `SettingsLabelNeutralityTests`, #771).
     func neutralButtonLabel() -> some View {
         tint(SettingsTheme.ink)
             .foregroundStyle(SettingsTheme.ink)

--- a/Sources/KiwiDesk/Settings/NeutralButtonLabel.swift
+++ b/Sources/KiwiDesk/Settings/NeutralButtonLabel.swift
@@ -1,9 +1,17 @@
 import SwiftUI
 
 extension View {
-    /// Applies neutral ink styling to button label
-    /// (`SettingsTheme.ink`, `neutralMenuLabel()`, `settingsActionButton()`,
-    /// `SettingsBorderedSealTests`, `SettingsLabelNeutralityTests`, #771).
+    /// Paints a bordered button's LABEL in ordinary ink instead
+    /// of the accent (#678 turn 16b tinted every bordered button
+    /// green). The accent belongs on control FILLS, never on text.
+    /// Not for every button: a `.destructive` label's system red
+    /// IS the warning; `.borderedProminent` is a filled control;
+    /// per-state tinters are exempt via `SettingsBorderedSealTests`'
+    /// `borderedExempt` map. BOTH `.tint` and `.foregroundStyle`,
+    /// so the AppKit-drawn half of a label is covered too.
+    /// Bordered actions route through `settingsActionButton()`
+    /// (#771); `SettingsLabelNeutralityTests` enumerates direct
+    /// uses (`SettingsTheme.ink`, `neutralMenuLabel()`).
     func neutralButtonLabel() -> some View {
         tint(SettingsTheme.ink)
             .foregroundStyle(SettingsTheme.ink)

--- a/Sources/KiwiDesk/Settings/OverflowSplit.swift
+++ b/Sources/KiwiDesk/Settings/OverflowSplit.swift
@@ -1,61 +1,8 @@
-/// The **"+N" grammar's count half** — how many of a capped run
-/// to draw, and therefore how many the marker counts.
-///
-/// `docs/ui-patterns.md` ▸ "+N" declares this one grammar
-/// ("**+N** means the same thing wherever it appears… a new
-/// surface must not invent a different one") and states three
-/// clauses: it counts the items NOT shown rather than the total,
-/// **it takes a slot of its own so it never claims to hide
-/// exactly one**, and it is an affordance wherever the hidden
-/// items have controls of their own.
-///
-/// The middle clause is arithmetic, and it was written twice —
-/// `MonitorCardChips.split` derived it from a card's measured
-/// capacity, and the Profiles row pips restated it against a
-/// fixed slot count (#789). Both copies were pinned by their own
-/// guard. Extracting production duplication is AGENTS.md §2.4's
-/// call, and here it goes past "a small readable duplication"
-/// for a specific reason: the copies were of the rule UNDER
-/// GUARD, so retuning one would leave the other green on the
-/// retired rule while both read as covering the same promise.
-///
-/// A shared *rule*, not a shared *look*: what each caller draws
-/// and how it measures its own capacity stay local. Callers pass
-/// their capacities in, which is also what lets the guard assert
-/// the grammar at capacities no surface ships.
-///
-/// **A surface that caps a run routes through this**, rather
-/// than computing `total - cap` beside its own drawing. Stated
-/// as an obligation and not as a census on purpose: the first
-/// draft of this comment named the two unrouted sites it knew
-/// about, was wrong the day it was written — there are more, in
-/// Home and in the schematics — and had a second copy of the
-/// same wrong number in `docs/ui-patterns.md`. A list of who has
-/// not adopted a rule yet rots; the rule does not.
-///
-/// Adopting an existing site is its own change, because routing
-/// it CHANGES what that surface draws (a "+1" becomes a "+2"
-/// showing one fewer item) rather than preserving it, so each
-/// owes an eye-confirm.
+/// Shared "+N" overflow grammar count arithmetic (`docs/ui-patterns.md`,
+/// #789).
+/// Surfaces capping a run route through here so "+1" is never drawn.
 enum OverflowSplit {
-    /// How many items to draw.
-    ///
-    /// - `count`: how many exist. Clamped at zero, so a
-    ///   hand-edited nonsense value cannot produce a negative
-    ///   run for a caller to trap on.
-    /// - `capacity`: how many fit when NO marker is drawn.
-    /// - `markerCapacity`: how many fit once the marker has
-    ///   taken its slot. CLAMPED to `capacity` rather than
-    ///   documented as a precondition — a caller passing a
-    ///   larger one would otherwise get `shown > count` and hand
-    ///   its own caller a negative overflow, and a stated
-    ///   obligation no guard can see is how that ships.
-    ///
-    /// Everything fits → draw everything and the marker never
-    /// appears. Otherwise the marker takes its slot, and if that
-    /// would leave exactly one item hidden the run gives up one
-    /// more: a marker reading "+1" occupies a slot that would
-    /// have shown the very item it is counting.
+    /// Returns number of items to draw given capacity and marker constraints.
     static func shown(
         of count: Int,
         fitting capacity: Int,

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection+Backup.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection+Backup.swift
@@ -1,25 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// General ▸ Advanced: export a backup, and restore one (#606).
+/// General ▸ Advanced: backup export and restore actions (#606).
 ///
-/// **The two rows do not sit together, and that is the design.**
-/// `GeneralSection+Reset` states the drawer's invariant and
-/// enumerates it — an ascending-severity ladder, hatches last. So
-/// Export sits with the read-only tools above the ladder, while
-/// **Restore is the ladder's final rung, after Reset All
-/// Settings**: it is the most destructive action in the drawer.
-/// The proof is in that file's own doc comment, which is why this
-/// is not a taste call — Reset All is *named* "Reset All Settings"
-/// rather than "Total reset" because "once `init.lua` and the
-/// palettes visibly survive, a total-reset label would read as a
-/// lie". Palettes surviving is that action's stated ceiling, and
-/// Restore replaces them.
-///
-/// The cost is that the two halves of one feature are apart, so
-/// someone who exported scrolls past two destructive rows to find
-/// the way back. Accepted: the alternative inverts the one
-/// invariant that tells a user which button is safe to click.
+/// Follows ascending severity ordering defined in `GeneralSection+Reset`.
 extension GeneralSection {
     // MARK: - Export (read-only, above the ladder)
 
@@ -123,16 +107,7 @@ extension GeneralSection {
             .font(.caption)
             .foregroundStyle(.secondary)
         }
-        // Built from the bundle it will apply, handed over by
-        // `presenting:` rather than read from parent state in the
-        // same tick (#843's shape, in the chrome that has it).
-        //
-        // Its own dialog rather than the shared `discardingEdits`
-        // gate, for the reason `resetAllRow` gives: that gate only
-        // fires while `isDirty`, and this must confirm every time.
-        // The message names BOTH consequences — the saved data
-        // replaced and the unsaved draft dropped — where Reset
-        // All's names only the first.
+        // Dialog presenting pending restore bundle (#843).
         .confirmationDialog(
             L(
                 "general.advanced.backup.restore.confirm.title",
@@ -153,12 +128,6 @@ extension GeneralSection {
                 pendingRestore = nil
             }
             Button(
-                // `spaces.delete_confirm.cancel`, not
-                // `discard.cancel`, for the reason and with the
-                // accepted coupling `resetAllRow` documents —
-                // stated there once rather than paraphrased
-                // here, a paraphrase of it having already
-                // shipped a wrong locale count.
                 L("spaces.delete_confirm.cancel", "Cancel"),
                 role: .cancel
             ) { pendingRestore = nil }
@@ -178,9 +147,7 @@ extension GeneralSection {
         }
     }
 
-    /// The dialog is presented exactly while a bundle is waiting,
-    /// so the two cannot disagree — one source of truth, not a
-    /// Bool shadowing an Optional.
+    /// Presents confirmation dialog while pending restore bundle exists.
     private var restoreConfirmBinding: Binding<Bool> {
         Binding(
             get: { pendingRestore != nil },

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection+Backup.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection+Backup.swift
@@ -107,7 +107,12 @@ extension GeneralSection {
             .font(.caption)
             .foregroundStyle(.secondary)
         }
-        // Dialog presenting pending restore bundle (#843).
+        // Built from the bundle it will apply, handed over by
+        // `presenting:` (#843's shape). Its own dialog rather than
+        // the shared `discardingEdits` gate: that gate fires only
+        // while `isDirty`, and this must confirm every time — the
+        // message names BOTH consequences, saved data replaced and
+        // unsaved draft dropped.
         .confirmationDialog(
             L(
                 "general.advanced.backup.restore.confirm.title",

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection+Reset.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection+Reset.swift
@@ -1,7 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Reset and recovery actions in General ▸ Advanced (#606, #634).
+/// Reset and recovery actions in General ▸ Advanced (#606,
+/// #634). Restore sits AFTER Reset All: Reset All earns its name
+/// by leaving `init.lua` and the palettes standing, and Restore
+/// replaces the palettes too — the widest action comes last, or
+/// the ordering stops telling a user which button is safe.
+/// Danger is signaled by the dialog's destructive role, never a
+/// resting red button (house convention).
 ///
 /// Ladder order progresses from non-destructive to widest impact
 /// (`GeneralSection+Backup`).

--- a/Sources/KiwiDesk/Settings/Sections/GeneralSection+Reset.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GeneralSection+Reset.swift
@@ -1,30 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// General ▸ Advanced, last rows: the reset escape hatches (#634)
-/// and, since #606, the restore. The disclosure reads as an
-/// ascending-severity ladder — Reveal (read-only), Edit init.lua
-/// (a mode switch), Export a backup (read-only), Discard Saved
-/// Window Arrangement (regenerating state), Reset All Settings
-/// (irreversible wipe), Restore from Backup (replaces everything
-/// saved, palettes included) — so the hatches come last.
+/// Reset and recovery actions in General ▸ Advanced (#606, #634).
 ///
-/// **Restore sits after Reset All, and the naming paragraph below
-/// is why.** Reset All earns its name by leaving `init.lua` and
-/// the palettes standing; Restore replaces the palettes too, so on
-/// the axis this file already names it is the wider action. Adding
-/// it anywhere else would put the harsher action before the milder
-/// one and break the one thing this ordering tells a user.
-///
-/// Naming follows iOS Settings' "Reset All Settings" (config
-/// wiped, content kept) rather than "Total reset": once
-/// `init.lua` and the palettes visibly survive, a total-reset
-/// label would read as a lie. Danger is signaled by the
-/// confirmation dialog's destructive role, never a resting red
-/// button (house convention). Tier 1 confirms nothing — it is
-/// strictly less consequential than the unconfirmed
-/// single-profile delete, since the files regenerate within one
-/// autosave cycle.
+/// Ladder order progresses from non-destructive to widest impact
+/// (`GeneralSection+Backup`).
 extension GeneralSection {
     @ViewBuilder var resetLadder: some View {
         Divider()
@@ -32,13 +12,6 @@ extension GeneralSection {
         Divider()
         resetAllRow
         Divider()
-        // The ladder's last rung, added with #606, and the reason
-        // the enumeration above now ends here: Restore replaces
-        // the palettes Reset All deliberately spares — which is
-        // the ceiling that gives Reset All its name — so it is the
-        // most destructive action in the drawer, not merely
-        // another one. `GeneralSection+Backup` carries the
-        // argument and the cost.
         restoreBackupRow
     }
 

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Broken.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Broken.swift
@@ -2,7 +2,12 @@ import KiwiDeskCore
 import SwiftUI
 
 /// Unreadable profile rows in App ▸ Profiles
-/// (`ProfileBrokenText`, #171, #246).
+/// (`ProfileBrokenText`, #171, #246). Deliberately absent from
+/// the census, Reveal included (#678 Phase 4 pass 6): a row that
+/// exists only while a file is broken cannot be a search result
+/// without stranding whoever picks it on a healthy install — the
+/// route in is the config-error badge, present exactly when
+/// these rows are.
 extension ProfilesSection {
     @ViewBuilder var brokenGroup: some View {
         SettingsGroupHeader(
@@ -43,9 +48,15 @@ extension ProfilesSection {
             }
             .buttonStyle(.borderless)
             .focused($returningRow, equals: name)
+            // The Config Issues panel's own key, not a second
+            // one: it labels this exact action on this exact file
+            // (code review 2026-08-11).
             .iconButtonAffordance(
                 L("config_issues.reveal", "Reveal in Finder")
             )
+            // Same `reload()` tail as the healthy-row Delete, so
+            // the same discard gate (#515) — found by the
+            // structural guard, not the audit.
             Button {
                 model.discardingEdits(
                     message: L(

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Broken.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Broken.swift
@@ -1,29 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The unreadable-profile rows for App ▸ Profiles (#246). A
-/// profile whose JSON won't decode can't yield a `ProfileSummary`
-/// (no count, no monitor sets), so it can't slot into a screen-
-/// count group — but hiding it strands a broken file with no way
-/// to clear it, and a profile that vanishes from the list reads
-/// as data loss. Grey-don't-hide (#171): one flat group under the
-/// saved profiles, each row dimmed, warning-marked, and carrying
-/// the two actions that still work — Reveal and Delete.
-///
-/// The caption names WHICH failure it was (#678 Phase 4 pass 9,
-/// turn 18), because that is what decides whether Reveal is worth
-/// clicking: malformed JSON shows its own damage in an editor, a
-/// shape mismatch does not. It comes from `ProfileBrokenText`,
-/// shared with the Config Issues panel — the two surfaces used to
-/// carry two hand-written sentences about one file.
-///
-/// Deliberately absent from the census, Reveal included, and this
-/// group has been since it shipped: a row that exists only while a
-/// file is broken cannot be a search result without stranding
-/// whoever picks it on a healthy install — the same reason the
-/// per-space `[space]` keys are excluded (#678 Phase 4 pass 6).
-/// The route in is the config-error badge, which is present
-/// exactly when these rows are.
+/// Unreadable profile rows in App ▸ Profiles
+/// (`ProfileBrokenText`, #171, #246).
 extension ProfilesSection {
     @ViewBuilder var brokenGroup: some View {
         SettingsGroupHeader(
@@ -35,8 +14,8 @@ extension ProfilesSection {
         }
     }
 
-    /// The BROKEN list, which is its own list under its own
-    /// heading — a broken row's neighbour is never a healthy one.
+    /// Focus neighbor within broken profile list after deletion
+    /// (`DeletionFocus`, #816).
     func neighbourBrokenAfter(_ name: String) -> String? {
         DeletionFocus.neighbour(
             after: name,
@@ -63,25 +42,10 @@ extension ProfilesSection {
                 Image(systemName: "magnifyingglass")
             }
             .buttonStyle(.borderless)
-            // This row's return destination (#816): Reveal is
-            // the always-drawn, non-destructive control here,
-            // exactly as Load is on a healthy row. A broken row
-            // has no Load — that is what makes it broken — so
-            // the two lists name different controls for the same
-            // reason rather than sharing one by symmetry.
             .focused($returningRow, equals: name)
-            // The Config Issues panel's own key, not a second
-            // one: it labels this exact action on this exact
-            // file, and coining a twin is the defect this file's
-            // docstring argues against, one level down from the
-            // sentence (code review, 2026-08-11).
             .iconButtonAffordance(
                 L("config_issues.reveal", "Reveal in Finder")
             )
-            // Same `reload()` tail as the healthy-row Delete, so
-            // the same discard gate (#515). Found by the
-            // structural guard, not by the audit — which is the
-            // argument for having the guard.
             Button {
                 model.discardingEdits(
                     message: L(
@@ -95,10 +59,6 @@ extension ProfilesSection {
                         "Discard & delete"
                     )
                 ) {
-                    // Before the mutation, and within THIS list:
-                    // a broken row's neighbour is another broken
-                    // row, never a healthy one that renders
-                    // above under its own heading (#816).
                     let neighbour = neighbourBrokenAfter(name)
                     model.deleteProfile(named: name)
                     returningRow = neighbour

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Rename.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Rename.swift
@@ -46,8 +46,11 @@ extension ProfilesSection {
         )
     }
 
-    /// Validates uniqueness case-insensitively while permitting
-    /// case-only renames.
+    /// Validates uniqueness case-insensitively (APFS: "a" → "B"
+    /// collides with "b") while permitting case-only self-renames.
+    /// One optimistic mirror is the limit (review 2026-07): a
+    /// second GUI consumer gets a read-only query on the KiwiCore
+    /// facade instead of a copy.
     func canRename(_ typed: String, of old: String) -> Bool {
         let new = typed.trimmed
         guard !new.isEmpty, new != old else { return false }
@@ -67,6 +70,14 @@ extension ProfilesSection {
 
     func commitRename(_ typed: String, of old: String) {
         guard canRename(typed, of: old) else { return }
+        // Rename reloads (core chases the file, the adopted name,
+        // the binding lines), so it discards staged edits like
+        // Load and Delete (#515). One turn later, deliberately:
+        // dismissing the NSPopover and requesting the confirm
+        // sheet in one update can DROP the sheet mid-animation —
+        // Rename becomes a dead click that silently keeps the
+        // edits (both reviewers flagged it independently).
+        // Ordering only; the draft and old name are captured.
         let draft = typed
         renameRequest = nil
         DispatchQueue.main.async {

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Rename.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection+Rename.swift
@@ -1,21 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The saved-profile rename affordance, split out of
-/// `ProfilesSection` for the file ceiling. State
-/// (`renaming` / `renameDraft`) stays on the view — extensions
-/// cannot hold `@State` — so only the button and its three
-/// helpers live here.
+/// Profile rename affordance and validation for ProfilesSection.
 extension ProfilesSection {
-    /// Rename is a pencil right beside the profile name (in
-    /// front of the badges), opening a popover. The rename is
-    /// immediate (file + native-Space bindings follow), like
-    /// Delete and make default. Unlike the other icon-only
-    /// borderless buttons, the pencil stays persistently visible
-    /// (a soft always-on background circle, matching
-    /// `hoverHighlight`'s hover value at rest) rather than
-    /// hover-only — it is the primary discovery path for
-    /// renaming, so it must not require finding it first.
+    /// Renders rename button with name-editing popover (#843).
     func renameButton(_ name: String) -> some View {
         Button {
             beginRename(name)
@@ -31,13 +19,6 @@ extension ProfilesSection {
             padding: 0
         )
         .popover(item: renameBinding(name)) { request in
-            // Presented by ITEM so the seed reaches the builder
-            // instead of being read back out of `@State` written
-            // one tick earlier (#843). Latent here rather than
-            // live — this gate refuses the unchanged name, so a
-            // stale empty draft and a fresh seed both disable
-            // the button — but it is the same shape, and a
-            // relaxed gate would make it visible.
             NameEditPopover(
                 seed: request.seed,
                 placeholder: L("footer.profile_name", "Profile name"),
@@ -52,8 +33,7 @@ extension ProfilesSection {
         }
     }
 
-    /// The request for THIS row, so only the renamed row
-    /// presents.
+    /// Binding presenting popover exclusively for matching profile name.
     func renameBinding(
         _ name: String
     ) -> Binding<NameEditRequest?> {
@@ -66,13 +46,8 @@ extension ProfilesSection {
         )
     }
 
-    /// Mirrors the core's case-insensitive collision check
-    /// (APFS: "a" → "B" collides with "b"), still allowing
-    /// the case-only self-rename ("work" → "Work"). One
-    /// optimistic mirror is the limit (review 2026-07): a
-    /// second GUI consumer of this rule gets a read-only
-    /// availability query on the KiwiCore facade instead of
-    /// a copy — core stays the only authority either way.
+    /// Validates uniqueness case-insensitively while permitting
+    /// case-only renames.
     func canRename(_ typed: String, of old: String) -> Bool {
         let new = typed.trimmed
         guard !new.isEmpty, new != old else { return false }
@@ -92,21 +67,8 @@ extension ProfilesSection {
 
     func commitRename(_ typed: String, of old: String) {
         guard canRename(typed, of: old) else { return }
-        // Rename reloads too (the core chases the file, the
-        // adopted name, and the binding lines), so it discards
-        // staged edits like Load and Delete (#515). The row
-        // leaves edit mode either way — a cancelled discard
-        // must not strand it mid-rename.
         let draft = typed
         renameRequest = nil
-        // One turn later, deliberately. `renaming = nil`
-        // dismisses an NSPopover; requesting the confirm sheet
-        // in the same update can drop it while that dismissal
-        // animates, and a dropped sheet makes Rename a dead
-        // click that silently keeps the edits. Both reviewers
-        // flagged the combination independently. Ordering only —
-        // the draft and the old name are already captured, so
-        // nothing here can go stale.
         DispatchQueue.main.async {
             requestRename(from: old, draft: draft)
         }

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection+WhichLoads.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection+WhichLoads.swift
@@ -1,26 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// **Which profile loads** (#678 turn 13a) — the rule, and what
-/// it resolves to right now.
-///
-/// The rule was never written down in the GUI: a user could read
-/// the list, the badges and the footer and still not know why
-/// *this* profile is the one that came up. So the card states it,
-/// and then answers it for the live machine.
-///
-/// The verdict ASKS THE ENGINE (gui.md) — `KiwiCore.profileVerdict`
-/// carries the SAME precedence the live paths use, bindings
-/// included. An earlier cut asked `ProfileManager.match` alone and
-/// so answered only the display half of the rule: with a Desktop
-/// bound it named the profile that would load on a *monitor*
-/// change while a different one was actually on screen, and the
-/// card that configures those bindings sits directly below this
-/// one. A preview that models part of an engine's rule must say
-/// which part; this one models all of it.
-///
-/// The verdict is read from the model's snapshot, never queried
-/// here: it costs a directory scan plus a decode per profile.
+/// Profile resolution readout explaining which profile loads
+/// (`KiwiCore.profileVerdict`, `ProfileManager.match`, `gui.md`,
+/// #678 turn 13a).
 extension ProfilesSection {
     @ViewBuilder var whichProfileLoads: some View {
         SettingsSection(
@@ -36,10 +19,6 @@ extension ProfilesSection {
         }
     }
 
-    /// Both halves of the precedence, in the order it applies —
-    /// a rule sentence that mentioned only screen counts would be
-    /// wrong for anyone who has bound a Desktop, and the card
-    /// below this one is where they bound it.
     private var rulesSentence: String {
         L(
             "profiles.which_loads.rule",
@@ -50,22 +29,9 @@ extension ProfilesSection {
         )
     }
 
-    /// "Right now: 3 screens → Desk", with the rule that fired —
-    /// they are different promises. The DEFAULT is the durable
-    /// one: an exact match compares the fingerprint set, so
-    /// swapping in a different monitor of the same count drops
-    /// it, while a count default only asks how many screens
-    /// there are.
+    /// Explains active profile resolution verdict for live monitors
+    /// (#36, #96).
     private var verdictSentence: String {
-        // Count and verdict from ONE snapshot. Reading the count
-        // live beside a snapshotted verdict lets the sentence
-        // name a profile that matched a different display set —
-        // "2 screens → Desk (these exact monitors)" about a
-        // one-screen match.
-        //
-        // The count phrase, never a bare `%1$d screens` — that
-        // frame renders "1 screens" on a one-display Mac, and no
-        // catalog can repair a frame.
         let resolution = model.profileResolution
         let screens = screensPhrase(resolution.screens)
         switch resolution.verdict {

--- a/Sources/KiwiDesk/Settings/Sections/ProfilesSection+WhichLoads.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ProfilesSection+WhichLoads.swift
@@ -32,6 +32,11 @@ extension ProfilesSection {
     /// Explains active profile resolution verdict for live monitors
     /// (#36, #96).
     private var verdictSentence: String {
+        // Count and verdict from ONE snapshot: reading the count
+        // live beside a snapshotted verdict lets the sentence name
+        // a profile that matched a different display set. The
+        // count phrase, never a bare `%1$d screens` — that frame
+        // renders "1 screens" and no catalog can repair a frame.
         let resolution = model.profileResolution
         let screens = screensPhrase(resolution.screens)
         switch resolution.verdict {

--- a/Sources/KiwiDesk/Settings/SettingsAnchor.swift
+++ b/Sources/KiwiDesk/Settings/SettingsAnchor.swift
@@ -1,6 +1,12 @@
 import KiwiDeskCore
 
-/// Navigation target specification in Settings window (#277, #326).
+/// Navigation target specification in Settings window (#277,
+/// #326). `anchor` is a `SettingsControl.id`, never display text
+/// — the load-bearing decision: label-text anchors were
+/// measured dead one level down (Appearance renders "Color" six
+/// times; text `.id()` churn tears down rows holding uncommitted
+/// `@State` mid-edit). The catalog declaration supplies both
+/// label and id, so the render path stays the one list.
 struct SettingsAnchor: Hashable {
     let destination: SettingsDestination
     /// Local view surface required before revealing target.

--- a/Sources/KiwiDesk/Settings/SettingsAnchor.swift
+++ b/Sources/KiwiDesk/Settings/SettingsAnchor.swift
@@ -1,49 +1,16 @@
 import KiwiDeskCore
 
-/// A navigation target inside the Settings window (#277): which
-/// sidebar destination, which of its local surfaces, and —
-/// optionally — which cataloged control inside it to scroll to
-/// and briefly flash.
-///
-/// `anchor` is a **`SettingsControl.id`**, never display text,
-/// and that is the load-bearing decision here. Part 1 anchored
-/// by resolved label text — sound for header-level anchors and
-/// measured-dead one level down (Appearance renders "Color" six
-/// times simultaneously; `SlotSizeRows.sizeLabel` swaps with a
-/// sibling picker, so text `.id()` churn would tear down rows
-/// holding uncommitted `@State` drafts mid-edit). The catalog
-/// declaration a render site consumes supplies both its label
-/// and this id, so there is still exactly one list and it is the
-/// render path (`.claude/rules/parity-tests.md`) — the id is
-/// merely the stable half of that declaration.
+/// Navigation target specification in Settings window (#277, #326).
 struct SettingsAnchor: Hashable {
     let destination: SettingsDestination
-    /// The local branch that must be showing before the anchor
-    /// exists in the view tree at all.
+    /// Local view surface required before revealing target.
     var surface: SettingsSurface = .main
-    /// The `SettingsControl.id` to reveal, or nil for "just open
-    /// the destination" — the #326 "Edit in Settings…" deep
-    /// link, which names a tab and nothing finer.
+    /// `SettingsControl.id` to reveal and flash, or nil for destination root
+    /// (#326).
     var anchor: String?
 
-    /// What the shell should do with this request, or nil to
-    /// refuse it.
-    ///
-    /// A pure decision, split from the assignment in
-    /// `SettingsView.apply` so the parts worth pinning are
-    /// reachable from a test: the #18 reachability refusal, which
-    /// of the three surfaces to select, and the nil-anchor case
-    /// that must request no scroll (the #326 bridge). What is left
-    /// in the view is three field writes.
-    ///
-    /// A surface that its destination cannot render is dropped to
-    /// `.main` rather than refusing the whole request — the
-    /// destination is still worth opening. This is the only
-    /// decision point, so the check belongs here: the index side
-    /// is guarded by `surfacesMatchDestination`, but a hand-built
-    /// anchor carrying `.layoutMode(.floating)` would otherwise
-    /// select a tab whose editor is `EmptyView`, i.e. an empty
-    /// Layout Defaults pane.
+    /// Resolves navigation decision against reachability and surface support
+    /// (#18, #277, `SettingsView.apply`).
     func resolved(
         editingStoredProfile: Bool
     ) -> (
@@ -59,7 +26,8 @@ struct SettingsAnchor: Hashable {
         return (destination, renderableSurface, anchor)
     }
 
-    /// `surface` if `destination` can show it, else `.main`.
+    /// Validates surface against destination capabilities, falling back to
+    /// `.main`.
     private var renderableSurface: SettingsSurface {
         switch surface {
         case .main:
@@ -73,20 +41,8 @@ struct SettingsAnchor: Hashable {
     }
 }
 
-/// The local switches a destination hides content behind, lifted
-/// out of view-local `@State` so a search hit can set them
-/// (#277). `.main` is the plain case — most destinations have no
-/// such switch.
-///
-/// These are *selections*, not disclosure state, and the
-/// distinction is why there is no `.drawer` case: a collapsed
-/// `DisclosureGroup` still renders its own header, so a hit on a
-/// drawer scrolls to a label that is already on screen and needs
-/// nothing forced open. A hit on a control *inside* a drawer is
-/// handled by the drawer itself: `SettingsDisclosure` reads the
-/// standing reveal target from the environment and expands when
-/// its own `SettingsDrawer` children contain it — a render-path
-/// fact, never a surface case or a catalog column.
+/// Local surface selection within a settings destination
+/// (#277, `SettingsDisclosure`).
 enum SettingsSurface: Hashable {
     case main
     case layoutMode(LayoutMode)

--- a/Sources/KiwiDesk/Settings/SettingsCatalog+WholeApp.swift
+++ b/Sources/KiwiDesk/Settings/SettingsCatalog+WholeApp.swift
@@ -30,7 +30,12 @@ struct ProfilesControls: Sendable {
 }
 
 struct ShortcutsControls: Sendable {
-    /// Layer definition and switching control card (`LayersCard`).
+    /// Layer definition and switching card. A `SettingsControl`,
+    /// not a `SettingsDrawer`: since the 2026-08-04 owner ruling
+    /// the card is always open when shown at all and withholds
+    /// itself entirely when not (`LayersCard`) — a drawer
+    /// declaration would promise a disclosure that no longer
+    /// exists.
     let layersCard = SettingsControl(
         "shortcuts.section.layers",
         "Layers"
@@ -83,6 +88,10 @@ struct AppRulesControls: Sendable {
 }
 
 struct GeneralControls: Sendable {
+    // Grouped by the RULE they share, not by topic: none is
+    // part of a profile and none is touched by Save — the heading
+    // says so, or Revert appears to undo them and does not (6b
+    // audit, fourth finding).
     let appliesImmediatelyCard = SettingsControl(
         "general.applies_immediately.title",
         "Applies immediately"

--- a/Sources/KiwiDesk/Settings/SettingsCatalog+WholeApp.swift
+++ b/Sources/KiwiDesk/Settings/SettingsCatalog+WholeApp.swift
@@ -1,29 +1,19 @@
 import KiwiDeskCore
 
-// The declaration structs behind the sidebar's **Whole App**
-// group (`SettingsDestination.wholeApp`): Profiles, Shortcuts,
-// App Rules, General. Split from `SettingsCatalog.swift` on the
-// seam the sidebar already draws — see the note atop
-// `SettingsCatalog+ThisProfile.swift`.
+/// Catalog declarations for Whole App settings destinations
+/// (`SettingsDestination.wholeApp`, `SettingsCatalog+ThisProfile.swift`).
 
 struct ProfilesControls: Sendable {
     let savedProfiles = SettingsControl(
         "profiles.saved.title",
         "Your profiles"
     )
-    /// The resolution sentence (#678 turn 13a) — "the sentence
-    /// most people never find in the current UI". A card of its
-    /// own so search can land it: "which profile loads" is the
-    /// question the area exists to answer, and until turn 13a it
-    /// was answerable only by reading the list and inferring the
-    /// rule.
+    /// Resolution readout card (#678 turn 13a).
     let whichProfileLoads = SettingsControl(
         "profiles.which_loads.title",
         "Which profile loads"
     )
-    /// A drawer since #678 turn 13a: the census tiers
-    /// `profileBindings` `.showMore`, and a Show-more row lives
-    /// behind its container's disclosure.
+    /// Desktop-specific profile bindings drawer (#678 turn 13a).
     let desktops = SettingsDrawer(
         "desktops.title",
         "Profiles per macOS Desktop"
@@ -32,10 +22,7 @@ struct ProfilesControls: Sendable {
         "presets.title",
         "Start from a preset"
     )
-    /// Presets for screen counts that are NOT connected. A
-    /// disclosure named for what it holds, never a bare "Show
-    /// more" — and its own declaration, so search can land a
-    /// preset the live hardware cannot apply.
+    /// Hardware preset disclosures for unconnected monitor setups.
     let presetsOther = SettingsDrawer(
         "presets.other_setups",
         "For other setups"
@@ -43,22 +30,7 @@ struct ProfilesControls: Sendable {
 }
 
 struct ShortcutsControls: Sendable {
-    /// The Layers card. A drawer, not a plain section: the
-    /// census tiers every family in this container `.showMore`,
-    /// so alternate key sets are one interaction away rather
-    /// than in a first-week user's path.
-    ///
-    /// Titled for the container, not for one of its parts — it
-    /// holds the strip that DEFINES the layers as well as the
-    /// rows that switch between them. The ⌃⌥K panel keeps
-    /// `shortcuts.section.switch_layers` for its band, which
-    /// really is only the switch rows.
-    /// A `SettingsControl`, not a `SettingsDrawer`: since the
-    /// owner ruling of 2026-08-04 the card is always open when it
-    /// is shown at all, and withholds itself entirely when it is
-    /// not (`LayersCard`). A drawer declaration would promise a
-    /// disclosure that no longer exists, and its `childIDs` exist
-    /// to auto-expand one.
+    /// Layer definition and switching control card (`LayersCard`).
     let layersCard = SettingsControl(
         "shortcuts.section.layers",
         "Layers"
@@ -75,9 +47,7 @@ struct ShortcutsControls: Sendable {
         "shortcuts.section.size_float",
         "Size & float"
     )
-    /// Size & float's disclosure. Named for what it hides
-    /// rather than "Show more" — a disclosure row names its
-    /// contents (the redesign's GUI rules).
+    /// Secondary size & float settings drawer.
     let sizeFloatMore = SettingsDrawer(
         "shortcuts.size_float.more",
         "Resize feedback"
@@ -86,9 +56,7 @@ struct ShortcutsControls: Sendable {
         "shortcuts.section.open_applications",
         "Open applications"
     )
-    /// Also a drawer: every row it holds (`showShortcuts`,
-    /// `openSettings`) is census `.showMore`, being app chrome
-    /// rather than a workspace action.
+    /// General application shortcuts drawer.
     let generalKeys = SettingsDrawer(
         "shortcuts.section.general",
         "General"
@@ -115,11 +83,6 @@ struct AppRulesControls: Sendable {
 }
 
 struct GeneralControls: Sendable {
-    // Turn 14b's first group. These rows are grouped by the RULE
-    // they share, not by topic: none is part of a profile and
-    // none is touched by the footer's Save. The heading says so,
-    // because otherwise Revert appears to undo them and does not
-    // — the 6b audit's fourth finding.
     let appliesImmediatelyCard = SettingsControl(
         "general.applies_immediately.title",
         "Applies immediately"
@@ -128,12 +91,8 @@ struct GeneralControls: Sendable {
         "general.about.title",
         "About"
     )
-    /// Declared so SEARCH can find it (#1019). The guide is the
-    /// one thing in this window a stuck reader is most likely to
-    /// look for by name, and a link with no catalog declaration
-    /// is invisible to the index — `SettingsSearchIndex` derives
-    /// its rows from the census plus the catalog, so a bare
-    /// `Link` is reachable only by knowing it lives under About.
+    /// User guide external link declaration for search indexing
+    /// (#1019, `SettingsSearchIndex`).
     let guideLink = SettingsControl(
         "general.about.guide",
         "Guide"

--- a/Sources/KiwiDesk/Settings/SettingsCatalog.swift
+++ b/Sources/KiwiDesk/Settings/SettingsCatalog.swift
@@ -1,40 +1,10 @@
 import KiwiDeskCore
 
-/// The Settings control catalog (#277): every searchable thing,
-/// declared once as a `SettingsControl` / `SettingsDrawer` value
-/// that the render site consumes and the search index enumerates
-/// by reflection (`SettingsControlIndex`). Replaced the
-/// hand-maintained `SidebarSearchIndex` entry list.
+/// Settings control catalog and search index definitions (#277).
 ///
-/// The declarations themselves live one file per sidebar group —
-/// `SettingsCatalog+ThisProfile.swift` and
-/// `SettingsCatalog+WholeApp.swift` — leaving this file the
-/// aggregation and the enumeration. Every `SettingsCatalog+*`
-/// slice counts as catalog to the guards, so a further slice
-/// needs no allow-listing — the `+` is load-bearing, and
-/// `SettingsCatalogFiles` records why.
-///
-/// `Mirror` yields stored properties in declaration order, so the
-/// index order is deterministic; keeping it *matching* the view's
-/// visual order is a discipline, not a structural guarantee
-/// (a section reordered in its body without reordering its struct
-/// desyncs them). The blast radius is bounded: one row per
-/// destination means order only breaks ties among several matches
-/// in one destination.
-/// Property names are the tokens the site guards scan for
-/// (`SettingsCatalogSiteTests`), so they must be unique across
-/// the whole catalog and distinctive enough not to collide with
-/// unrelated identifiers (`.title` or `.appBarStyle` would match
-/// half the tree; `.appBarStyleCard` matches only its reference).
-///
-/// Known limit, recorded since tier 1: the per-Space "Overrides…"
-/// popover stays uncataloged — it opens from a row button rather
-/// than a destination, so a reveal has nowhere to send the user
-/// (`docs/accepted-limitations.md`). Its rows also mirror
-/// `layout_params.*` labels the Layout Defaults tabs carry.
-///
-/// The catalog's one instance per destination, and the index
-/// enumeration the search matcher reads.
+/// Declarations are grouped in `SettingsCatalog+ThisProfile.swift` and
+/// `SettingsCatalog+WholeApp.swift` (`SettingsCatalogFiles`,
+/// `SettingsCatalogSiteTests`, `docs/accepted-limitations.md`).
 enum SettingsCatalog {
     static let spaces = SpacesControls()
     static let layoutDefaults = LayoutDefaultsControls()
@@ -49,17 +19,12 @@ enum SettingsCatalog {
     static let appRules = AppRulesControls()
     static let general = GeneralControls()
 
-    /// The render sites' access to a mode tab's descriptor — the
-    /// same factory the index uses, so the two cannot drift.
+    /// Descriptor for a layout mode tab in settings.
     static func layoutMode(_ mode: LayoutMode) -> SettingsControl {
         .layoutMode(mode)
     }
 
-    /// The declaration struct behind a destination — the one
-    /// enumerated for its index and walked by the catalog guards.
-    /// A single home for the destination→container mapping, so
-    /// `entries(of:)` and the strict-enumeration guard cannot
-    /// disagree about which struct a destination reflects.
+    /// Declaration struct for a given settings destination.
     static func container(
         of destination: SettingsDestination
     ) -> Any {
@@ -79,14 +44,8 @@ enum SettingsCatalog {
         }
     }
 
-    /// Everything searchable inside `destination`, in render
-    /// order. Each tab names its own mode, so a hit selects
-    /// that tab (#277 sub-problem 2).
-    ///
-    /// Layout Defaults appends its mode tabs after the reflected
-    /// entries: their text is `LayoutMode.displayName` (not a
-    /// catalog literal), so they come from the `placementTabs`
-    /// factory rather than a stored declaration.
+    /// Returns searchable index entries for destination
+    /// (#277, `placementTabs`).
     static func entries(
         of destination: SettingsDestination
     ) -> [SettingsIndexEntry] {

--- a/Sources/KiwiDesk/Settings/SettingsCatalog.swift
+++ b/Sources/KiwiDesk/Settings/SettingsCatalog.swift
@@ -2,9 +2,14 @@ import KiwiDeskCore
 
 /// Settings control catalog and search index definitions (#277).
 ///
-/// Declarations are grouped in `SettingsCatalog+ThisProfile.swift` and
-/// `SettingsCatalog+WholeApp.swift` (`SettingsCatalogFiles`,
-/// `SettingsCatalogSiteTests`, `docs/accepted-limitations.md`).
+/// Declarations are grouped in `SettingsCatalog+ThisProfile.swift`
+/// and `SettingsCatalog+WholeApp.swift` (`SettingsCatalogFiles`,
+/// `docs/accepted-limitations.md`). Property names are the tokens
+/// the site guards scan for (`SettingsCatalogSiteTests`): unique
+/// across the catalog, and distinctive enough not to collide with
+/// unrelated identifiers. `Mirror` yields declaration order, so
+/// keeping it matching the view's visual order is a discipline,
+/// not a structural guarantee.
 enum SettingsCatalog {
     static let spaces = SpacesControls()
     static let layoutDefaults = LayoutDefaultsControls()

--- a/Sources/KiwiDesk/Settings/SettingsDestination.swift
+++ b/Sources/KiwiDesk/Settings/SettingsDestination.swift
@@ -20,8 +20,12 @@ enum SettingsDestination: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    /// Destinations scoped to the active profile (`SettingsSearchTests`,
-    /// `HomeCardOrderTests`).
+    /// Destinations scoped to the active profile. The order is
+    /// load-bearing: search groups results by destination in it,
+    /// so the colour pair sits AFTER the things it paints
+    /// (`SettingsSearchTests`), and Advanced Colors directly after
+    /// its Simple twin so the pair reads as a family
+    /// (`HomeCardOrderTests` pins the shared membership).
     static let thisProfile: [SettingsDestination] = [
         .spaces, .layoutDefaults, .monitors, .gapsAndBorders,
         .bars, .colors, .advancedColors, .behavior,
@@ -91,6 +95,10 @@ enum SettingsDestination: String, CaseIterable, Identifiable {
         case .bars: return .pink
         case .behavior: return .orange
         case .profiles:
+            // The brand green ITSELF, read from the theme — this
+            // shipped as RGB floats with a "keep in sync" comment,
+            // the shape that never gets kept in sync
+            // (`SettingsThemeTokenTests` pins the token).
             return SettingsTheme.accent
         case .shortcuts:
             return Color(
@@ -103,8 +111,11 @@ enum SettingsDestination: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Whether destination is visible when editing a stored profile
-    /// (#18, #109).
+    /// Whether destination is visible when editing a stored
+    /// profile (#18): only General is a global surface a profile
+    /// edit never writes. App Rules joined when its Space facet
+    /// grew a per-profile override (#109) — the Float facet stays
+    /// global and renders disabled there.
     var visibleWhileEditingStoredProfile: Bool {
         self != .general
     }

--- a/Sources/KiwiDesk/Settings/SettingsDestination.swift
+++ b/Sources/KiwiDesk/Settings/SettingsDestination.swift
@@ -1,11 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The navigation identities (#68 §3.1 → #678 turn 9): one case
-/// per area screen, fronted by a Home card. The two groups make
-/// the profile/global scope split part of the navigation itself
-/// — "This Profile" areas follow the header's edit target,
-/// "Whole App" areas are always live.
+/// Settings navigation destinations (#68, #678 turn 9).
 enum SettingsDestination: String, CaseIterable, Identifiable {
     // This Profile
     case spaces
@@ -24,24 +20,13 @@ enum SettingsDestination: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    /// Advanced Colors sits DIRECTLY after its Simple twin, so
-    /// the pair reads as a family wherever this order surfaces
-    /// (the Power-User grid keeps both; search lists them
-    /// adjacent).
-    ///
-    /// The pair sits AFTER the things it paints, and the order
-    /// is load-bearing beyond taste: search groups its results
-    /// by destination in this order, so a colour page listed
-    /// above Bars would answer "App Bar" with a grid of
-    /// swatches before the App Bar's own card
-    /// (`SettingsSearchTests`). You arrive at colour having
-    /// noticed something on a surface you already know.
-    /// (The GRID's own order is `HomeCardOrder`'s; only set
-    /// membership is shared — `HomeCardOrderTests` pins it.)
+    /// Destinations scoped to the active profile (`SettingsSearchTests`,
+    /// `HomeCardOrderTests`).
     static let thisProfile: [SettingsDestination] = [
         .spaces, .layoutDefaults, .monitors, .gapsAndBorders,
         .bars, .colors, .advancedColors, .behavior,
     ]
+    /// Destinations scoped globally across the application.
     static let wholeApp: [SettingsDestination] = [
         .profiles, .shortcuts, .appRules, .general,
     ]
@@ -74,16 +59,12 @@ enum SettingsDestination: String, CaseIterable, Identifiable {
         }
     }
 
-    /// §6.1 — one glyph per destination, never reused across
-    /// two sidebar items or another surface meaning something
-    /// else (icons are vocabulary).
+    /// SF Symbol icon name for navigation item (§6.1).
     var symbol: String {
         switch self {
         case .spaces: return "squares.below.rectangle"
         case .layoutDefaults: return "rectangle.3.group"
         case .monitors: return "display.2"
-        // The colour pair reads as a family — one paint glyph
-        // each, the deeper one on the deeper page.
         case .colors: return "paintbrush.fill"
         case .advancedColors: return "paintpalette.fill"
         case .gapsAndBorders: return "square.dashed.inset.filled"
@@ -96,21 +77,13 @@ enum SettingsDestination: String, CaseIterable, Identifiable {
         }
     }
 
-    /// §6.1 — System-Settings-style tile colors, so the
-    /// sidebar scans by color+shape before reading a label.
+    /// Tile tint color for navigation item (§6.1, `SettingsThemeTokenTests`).
     var tint: Color {
         switch self {
         case .spaces: return .indigo
-        // Deeper teal/green than the system defaults: the
-        // bright `.teal`/`.green` washed the white glyph out.
         case .layoutDefaults:
-            // One of the varied per-section icon tints (System
-            // Settings style), not a brand hue.
             return Color(red: 0.09, green: 0.47, blue: 0.53)
         case .monitors: return .blue
-        // Colours & Animations inherits Appearance's purple with its
-        // meaning; its Power-User twin takes a deeper violet, so the
-        // pairing is legible by hue before either label is read.
         case .colors: return .purple
         case .advancedColors:
             return Color(red: 0.38, green: 0.20, blue: 0.60)
@@ -118,13 +91,6 @@ enum SettingsDestination: String, CaseIterable, Identifiable {
         case .bars: return .pink
         case .behavior: return .orange
         case .profiles:
-            // The brand green ITSELF, read from the theme — not a
-            // second copy of it. This shipped as RGB floats with
-            // a "keep in sync" comment, which is the shape that
-            // never gets kept in sync: the two would disagree the
-            // first time the accent moved, and nothing would say
-            // so. `SettingsTheme.accent` is pinned by
-            // `SettingsThemeTokenTests`.
             return SettingsTheme.accent
         case .shortcuts:
             return Color(
@@ -137,28 +103,18 @@ enum SettingsDestination: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Whether the destination is offered while a stored
-    /// profile is being edited (#18): only the Advanced/About
-    /// General section is a global surface a profile edit
-    /// never writes. App Rules joined the editable set when
-    /// its Space facet grew a per-profile override (#109) —
-    /// the Float facet stays global and renders disabled
-    /// there.
+    /// Whether destination is visible when editing a stored profile
+    /// (#18, #109).
     var visibleWhileEditingStoredProfile: Bool {
         self != .general
     }
 
-    /// Whether the profile edit-target header (the toolbar
-    /// picker + the status strip) is shown for this
-    /// destination. Only General is truly profile-agnostic
-    /// (About + the config-file tools).
+    /// Whether destination toolbar displays profile context picker.
     var showsProfileContext: Bool {
         self != .general
     }
 
-    /// The one reachability predicate all #18 enforcement
-    /// points share (sidebar offer, selection repair, navigate
-    /// guard) — one polarity, no hand-negated copies.
+    /// Reachability predicate for profile editing mode (#18).
     func isReachable(editingStoredProfile: Bool) -> Bool {
         !editingStoredProfile
             || visibleWhileEditingStoredProfile

--- a/Sources/KiwiDesk/Settings/SettingsFooter+Unsaved.swift
+++ b/Sources/KiwiDesk/Settings/SettingsFooter+Unsaved.swift
@@ -4,7 +4,12 @@ import SwiftUI
 /// Leading readout and unsaved-changes diff popover for `SettingsFooter`
 /// (#516, `SettingsDiffRowSource`).
 extension SettingsFooter {
-    /// Readout displaying change count and drift/scope captions (#516).
+    /// Readout displaying change count and drift/scope captions
+    /// (#516 keeps them visible, never hover-only). The N is the
+    /// ROW count of the very list the popover renders — one
+    /// source: `draftChangeCount` counts distinct settings, and a
+    /// per-instance family made the pill say "1" over a three-row
+    /// list (owner 2026-08-10).
     var leadingReadout: some View {
         let rows = SettingsDiffRowSource.rows(for: model)
         return VStack(alignment: .leading, spacing: 2) {
@@ -101,6 +106,10 @@ extension SettingsFooter {
 
     func countLine(count: Int) -> String {
         guard count > 0 else {
+            // The docked footer's own key, kept through the pill
+            // rewrite: identical English, ten shipped translations
+            // (review 2026-08-10 caught the re-mint discarding
+            // them).
             return L(
                 "footer.unsaved_changes",
                 "Unsaved changes"

--- a/Sources/KiwiDesk/Settings/SettingsFooter+Unsaved.swift
+++ b/Sources/KiwiDesk/Settings/SettingsFooter+Unsaved.swift
@@ -1,28 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The pill's leading readout and the unsaved-changes popover
-/// it opens (turn 9's third view of the draft, moved here from
-/// the header chip — owner 2026-08-10). Split from
-/// `SettingsFooter` when the popover took the file past the
-/// §2.1 target: this half is the draft narration, the other is
-/// the verbs, and they change for different reasons.
+/// Leading readout and unsaved-changes diff popover for `SettingsFooter`
+/// (#516, `SettingsDiffRowSource`).
 extension SettingsFooter {
-
-    /// The pill's first words: the change count with the edit
-    /// target's name, plus — stacked small beneath — whichever
-    /// scope caption applies (#516 keeps the paused scope and
-    /// the drift adoption VISIBLE, never a hover-only fact).
-    /// While the draft has attributed rows the count line is a
-    /// BUTTON opening the diff popover (`countButton`); at zero
-    /// rows there is no list to open, so it stays plain text.
-    ///
-    /// The N is the ROW count of the very list the popover
-    /// renders — one source, so the sentence and the list it
-    /// opens cannot disagree. `draftChangeCount` counts distinct
-    /// SETTINGS, and a per-instance family (three space modes
-    /// changed = one census key, three rows) made the pill say
-    /// "1" over a three-row list (owner, 2026-08-10).
+    /// Readout displaying change count and drift/scope captions (#516).
     var leadingReadout: some View {
         let rows = SettingsDiffRowSource.rows(for: model)
         return VStack(alignment: .leading, spacing: 2) {
@@ -56,16 +38,7 @@ extension SettingsFooter {
         }
     }
 
-    /// The count line as the popover's opener. Plain style on
-    /// the pill's own ink — the pill is dark chrome in both
-    /// modes, so the accent-label guards' bordered machinery
-    /// has no business here; the chevron is what says
-    /// "clickable" at rest, and hover confirms it with the
-    /// pill-ink wash + pointing hand (owner 2026-08-10 — the
-    /// search rows set the expectation). The shared
-    /// `hoverHighlight` chip is `Color.primary`-based, which
-    /// inverts with the appearance; on a pill that is dark in
-    /// BOTH modes the wash must ride the fixed pill ink.
+    /// Button opening the unsaved-changes popover.
     private func countButton(count: Int) -> some View {
         Button {
             unsavedPopoverShown = true
@@ -97,11 +70,8 @@ extension SettingsFooter {
         }
     }
 
-    /// The popover view of the one draft (turn 9): every change
-    /// as a labelled old → new row, each a jump to the control
-    /// that changed. It renders the SAME rows as the panel's
-    /// diff list — one renderer, so the two views of the draft
-    /// cannot disagree.
+    /// Popover listing individual uncommitted setting diffs
+    /// (`SettingsDiffJump`).
     private var unsavedPopover: some View {
         ScrollView {
             SettingsDiffRowsView(
@@ -131,10 +101,6 @@ extension SettingsFooter {
 
     func countLine(count: Int) -> String {
         guard count > 0 else {
-            // The docked footer's own key, kept through the
-            // pill rewrite: identical English, same meaning
-            // class, ten shipped translations (review
-            // 2026-08-10 caught the re-mint discarding them).
             return L(
                 "footer.unsaved_changes",
                 "Unsaved changes"
@@ -168,8 +134,7 @@ extension SettingsFooter {
             )
     }
 
-    /// What the pill says as it appears (#812): the countless
-    /// form, with the edit target where there is one.
+    /// Spoken VoiceOver description when pill appears (#812).
     var appearanceSentence: String {
         guard let target = editTargetName else {
             return countLine(count: 0)
@@ -181,18 +146,13 @@ extension SettingsFooter {
         )
     }
 
-    /// The banner above stays the authoritative naming of the
-    /// edit target; this is the pill's short echo of it.
     private var editTargetName: String? {
         if model.editingLua { return "init.lua" }
         return model.editingProfile ?? model.activeProfile
     }
 }
 
-/// The count button's hover confirmation: the pill-ink wash and
-/// the pointing hand. Not the shared `hoverHighlight` chip on
-/// purpose — that one paints `Color.primary`, which flips with
-/// the appearance, and this sits on chrome that is dark in both.
+/// Hover highlight on pill dark chrome (#1069).
 private struct PillHoverWash: ViewModifier {
     @State private var hovering = false
     @Environment(\.accessibilityReduceMotion)
@@ -205,10 +165,6 @@ private struct PillHoverWash: ViewModifier {
             .background(
                 RoundedRectangle(cornerRadius: 6)
                     .fill(
-                        // 0.14 eyeball-confirmed on the dark
-                        // plate (owner 2026-08-10) — above the
-                        // light-surface chips' 0.06/0.12
-                        // ladder, below chalk.
                         SettingsTheme.savePillInk.opacity(
                             hovering ? 0.14 : 0
                         )
@@ -216,8 +172,6 @@ private struct PillHoverWash: ViewModifier {
             )
             .padding(.horizontal, -6)
             .padding(.vertical, -3)
-            // The wash still appears and leaves; Reduce Motion
-            // drops only its fade (#1069).
             .animation(
                 reduceMotion ? nil : .easeOut(duration: 0.12),
                 value: hovering

--- a/Sources/KiwiDesk/Settings/SettingsModeReveal.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModeReveal.swift
@@ -1,48 +1,20 @@
 import SwiftUI
 
-/// The mode-reveal wash (#760): flipping the header segment to
-/// Power User briefly washes the surfaces the flip inserted —
-/// the same transient accent wash the search reveal trained,
-/// decaying to nothing — while the durable "what is advanced"
-/// answer is the accent-tinted frame
-/// (`SettingsTheme.containerStrokeModeGated` at
-/// `modeGatedStrokeOpacity`): the mode's own colour at reduced
-/// strength, never a second hue, with the weight step keeping a
-/// hue-free channel.
-///
-/// Form settled by a `ui-designer` consult (2026-08-09), against
-/// the shared vocabulary: a border bloom is a halo, which this
-/// app reserves for "this input is armed"; a transient accent
-/// border collides with `HomeCard`'s hover stroke; the wash is
-/// the one form already meaning "the thing you're looking for is
-/// here". It paints the header/title band alone, so a card's
-/// live preview never renders through an accent tint that
-/// misrepresents the colours it pictures.
-///
-/// No timer here: `SettingsModel.flipSettingsMode` owns the one
-/// timeline, and the environment value's removal IS the fade
-/// trigger — the same one-writer shape `SearchRevealFlash`
-/// argues, for the same latch-proofing reason.
+/// Mode reveal accent wash modifier for advanced settings sections
+/// (`SettingsTheme.containerStrokeModeGated`, `SearchRevealFlash`, #760).
 private struct ModeRevealActiveKey: EnvironmentKey {
     static let defaultValue = false
 }
 
 extension EnvironmentValues {
-    /// True while a mode reveal is showing. Mounted once, in
-    /// `SettingsView`'s chrome, from
-    /// `SettingsModel.modeRevealActive` — above BOTH panes, so
-    /// Home cards and in-area surfaces read the same window.
+    /// Indicates whether settings mode reveal wash is active.
     var settingsModeReveal: Bool {
         get { self[ModeRevealActiveKey.self] }
         set { self[ModeRevealActiveKey.self] = newValue }
     }
 }
 
-/// Paints the wash behind a mode-gated container's title band
-/// while a reveal is active. `gated` is the same flag that picks
-/// the container's stroke weight — derived from the site's own
-/// offer predicate evaluated at `.simple`, so the wash and the
-/// weight cannot point at different content.
+/// Paints transient accent background wash behind mode-gated section headers.
 private struct ModeRevealWash: ViewModifier {
     let gated: Bool
     @Environment(\.settingsModeReveal) private var active
@@ -63,11 +35,6 @@ private struct ModeRevealWash: ViewModifier {
                 )
                 .padding(-SettingsReveal.bleed)
             }
-            // Arriving is instant, leaving eases out. Reduce
-            // Motion drops the cross-fade, not the affordance —
-            // the wash still shows flat for the same ≈1.2 s
-            // (the timeline's hold absorbs the fade) and simply
-            // disappears, the split `SearchRevealFlash` makes.
             .animation(fadeOut, value: washed)
     }
 
@@ -78,9 +45,7 @@ private struct ModeRevealWash: ViewModifier {
 }
 
 extension View {
-    /// The wash half of the mode-gated pairing. Mount on the
-    /// container's title band — never the whole card — beside
-    /// the stroke-weight ternary that reads the same flag.
+    /// Applies transient highlight wash when switching settings modes (#760).
     func modeRevealWash(_ gated: Bool) -> some View {
         modifier(ModeRevealWash(gated: gated))
     }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Borders.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Borders.swift
@@ -18,8 +18,14 @@ extension SettingsModel {
         )
     }
 
-    /// Master corner style binding
-    /// (`GapsBordersGates.agreedCornerStyle`, #754).
+    /// Master corner style binding — OPTIONAL, nil while the two
+    /// stored halves disagree (`GapsBordersGates.agreedCornerStyle`
+    /// resolves it; `SegmentedPicker` renders no selection, #754).
+    /// The getter never stores, and a pick is idempotent:
+    /// re-affirming a segment must change nothing, or "opening
+    /// this page rewrites nothing" lasts only until a stray tap —
+    /// Rounded writes the system radius only where there is no
+    /// rounding to keep; Square writes 0 outright.
     var borderCornersMaster: Binding<BorderStyle.CornerStyle?> {
         Binding(
             get: {

--- a/Sources/KiwiDesk/Settings/SettingsModel+Borders.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Borders.swift
@@ -1,28 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The two shared border decisions (#754): one width and one
-/// corner shape across the focus ring, the drag ghost and the
-/// drop zone.
-///
-/// The masters live here rather than in `BordersCard` because a
-/// master is a WRITE FAN-OUT, not a layout concern: a binding
-/// that sets one stored value beside a view is a place for a
-/// second copy to disagree about which strokes the card owns.
-/// The card renders these; nothing else writes the followers.
-///
-/// Which stored leaves each one writes is also declared as
-/// DATA, in `SettingKey.masterWrites`, because the
-/// unsaved-changes count has to attribute those leaves to one
-/// row. That is a second copy of the same fact, so
-/// `BorderMastersFanOutTests` writes each master and compares
-/// the leaves that actually moved against the declaration.
+/// Master bindings for shared border decisions across focus and drag visuals
+/// (`SettingKey.masterWrites`, `BorderMastersFanOutTests`, #754).
 extension SettingsModel {
-    /// The width every stroke takes. Writing it writes all
-    /// three stored widths — there is no per-stroke width row
-    /// in the GUI to disagree with it, and the per-stroke Lua
-    /// verbs stay open and unclamped for anyone who wants three
-    /// different ones.
+    /// Master width binding updating borderStyle, dragGhost, and dragDropZone.
     var borderWidthMaster: Binding<CGFloat> {
         Binding(
             get: { self.config.settings.borderStyle.width },
@@ -36,30 +18,8 @@ extension SettingsModel {
         )
     }
 
-    /// Square or Rounded, for all three strokes at once — or
-    /// NOTHING selected, while the two stored halves disagree.
-    ///
-    /// The halves are stored differently: the ring carries a
-    /// two-value `cornerStyle`, the drag pair a 0–40 pt radius.
-    /// A Lua call can move one without the other, and the
-    /// picker then sits directly above a ring preview drawing
-    /// the answer it does not show. So the selection is
-    /// OPTIONAL and `GapsBordersGates.agreedCornerStyle` is the
-    /// one predicate that resolves it: nil when the halves
-    /// disagree, which `SegmentedPicker` renders as no segment
-    /// selected. Making the preview read this master instead
-    /// was the alternative and is worse — the preview would
-    /// then stop showing what the app draws.
-    ///
-    /// **The getter never stores, and a pick is idempotent.**
-    /// A 7 pt radius under a rounded ring reads as Rounded and
-    /// STAYS 7 pt, re-picking Rounded included: Rounded writes
-    /// the system radius only where there is no rounding to
-    /// keep. Re-affirming a segment must change nothing, or the
-    /// "opening this page rewrites nothing" promise lasts only
-    /// until a stray tap — which is likelier than a deliberate
-    /// one. Square is the one shape with a single radius, so it
-    /// writes 0 outright.
+    /// Master corner style binding
+    /// (`GapsBordersGates.agreedCornerStyle`, #754).
     var borderCornersMaster: Binding<BorderStyle.CornerStyle?> {
         Binding(
             get: {

--- a/Sources/KiwiDesk/Settings/SettingsModel+ConflictMessages.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+ConflictMessages.swift
@@ -14,7 +14,10 @@ extension SettingsModel {
         )
     }
 
-    /// Evaluates conflict state after recording a keybinding combo.
+    /// Evaluates conflict state after recording a combo. An edit
+    /// leaving some OTHER row conflicting only refreshes the
+    /// banner if already shown — an unrelated valid edit must not
+    /// newly pop it open.
     func noteRecordedCombo(
         _ binding: KeyBinding,
         in bindings: [KeyBinding]
@@ -60,6 +63,11 @@ extension SettingsModel {
             return sentence(only)
         }
         let lines = conflicts.map { "– \(bulletLine($0))" }
+        // The separator lives HERE, not on the translatable
+        // string: it was a trailing \n inside the English, and
+        // `merge-keys` trims surrounding whitespace off every
+        // translation — all eleven locales shipped without it. A
+        // structural newline is not copy.
         return L(
             "keybinding.conflict.several",
             "Several shortcuts are conflicting:"

--- a/Sources/KiwiDesk/Settings/SettingsModel+ConflictMessages.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+ConflictMessages.swift
@@ -1,15 +1,10 @@
 import Foundation
 import KiwiDeskCore
 
-/// The keybinding-conflict in-app warning banner — split out of
-/// `SettingsModel.swift` (which owns `keybindingWarning` and the
-/// rest of the model state) to stay under the file-size ceiling.
+/// Keybinding conflict warning banner formatting for SettingsModel.
 extension SettingsModel {
-    /// The banner text, derived live: nil once dismissed —
-    /// and nil once every conflict it named is fixed, however
-    /// it was fixed (clearing a combo or deleting a row never
-    /// passes through the recorder writers below, so the
-    /// banner re-derives instead of latching stale text).
+    /// Live derived banner text reflecting active conflicts
+    /// (`KeybindingConflicts`).
     var liveKeybindingBanner: String? {
         guard keybindingWarning != nil else { return nil }
         return formatConflicts(
@@ -19,15 +14,7 @@ extension SettingsModel {
         )
     }
 
-    /// Called after a `KeyRecorderField.onRecord` commits a new
-    /// combo. Warns (naming every current conflict) if that row
-    /// now conflicts; else clears the banner once the whole
-    /// config has no conflict left, so it doesn't linger once
-    /// the last one is fixed. An edit that leaves some *other*
-    /// row still conflicting only refreshes the banner if it was
-    /// already shown — an unrelated valid edit must not newly
-    /// pop it open. The persistent per-row indicator remains the
-    /// precise, always-live source of truth either way.
+    /// Evaluates conflict state after recording a keybinding combo.
     func noteRecordedCombo(
         _ binding: KeyBinding,
         in bindings: [KeyBinding]
@@ -47,11 +34,7 @@ extension SettingsModel {
         }
     }
 
-    /// Sets or clears the banner from a whole-config check —
-    /// used by the two batch paths (Adopt, Lua editor save)
-    /// where no single recorder input triggered the check.
-    /// Internal (not `private`): called from `SettingsModel`'s
-    /// own `saveLuaSource()` / `adoptIntoGui()`.
+    /// Updates conflict banner for whole configuration on batch operations.
     func warnIfAnyConflict() {
         let list = KeybindingConflicts.actionable(
             in: config.layers
@@ -60,9 +43,7 @@ extension SettingsModel {
             list.isEmpty ? nil : formatConflicts(list)
     }
 
-    /// The stored English canonical, narrated in the user's
-    /// locale (#96) — instance methods now, because the roster
-    /// lookup needs the config's spaces, layers and step.
+    /// Localized keybinding name lookup (`KeybindingCatalog`, #96).
     private func localized(_ name: String) -> String {
         KeybindingCatalog.localizedLabel(
             for: name,
@@ -70,8 +51,7 @@ extension SettingsModel {
         )
     }
 
-    /// Renders a named, enumerated summary: a single sentence
-    /// for one conflict, or a bulleted list for several.
+    /// Formats single conflict sentence or bulleted list.
     private func formatConflicts(
         _ conflicts: [Conflict]
     ) -> String? {
@@ -80,13 +60,6 @@ extension SettingsModel {
             return sentence(only)
         }
         let lines = conflicts.map { "– \(bulletLine($0))" }
-        // The separator lives here, not on the end of the
-        // translatable string. It used to be a trailing `\n` inside
-        // the English, and `merge-keys` trims surrounding
-        // whitespace off every translation — so all eleven locales
-        // shipped without it and ran this header into the first
-        // bullet. A structural newline is not copy; a catalog is
-        // the wrong place to carry one.
         return L(
             "keybinding.conflict.several",
             "Several shortcuts are conflicting:"
@@ -95,11 +68,7 @@ extension SettingsModel {
             + lines.joined(separator: "\n")
     }
 
-    /// The single-conflict sentence, name and target together —
-    /// one template per target kind so a translation can reorder
-    /// the quoted name relative to the rest of the sentence
-    /// (issue #9 review: two `+`-concatenated fragments can't be
-    /// reordered by a translation).
+    /// Formats single conflict explanation sentence (#9).
     private func sentence(_ conflict: Conflict) -> String {
         switch conflict.target {
         case .unrecognized:
@@ -128,8 +97,7 @@ extension SettingsModel {
         }
     }
 
-    /// One bullet line's text (no leading "– ", added by the
-    /// caller).
+    /// Formats bullet point text for individual conflict in list.
     private func bulletLine(_ conflict: Conflict) -> String {
         switch conflict.target {
         case .unrecognized:

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout.swift
@@ -1,32 +1,11 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// Turns a changed census key into display-ready diff rows
-/// (#678 turn 9, digest §1.1): the per-key half the
-/// count-only chip deliberately shipped without, built here so
-/// the panel's "CHANGED IN THIS DRAFT" list and Home's popover
-/// can state old → new instead of only that something changed.
-///
-/// `SettingsDraftDiff` stays the attribution authority — it
-/// says WHICH settings changed; this type only narrates a key
-/// it is handed. An instanced key (a per-space override, an
-/// app rule) expands to one row per touched instance, labelled
-/// through the census key's own label plus the instance —
-/// which is why the return is a list.
-///
-/// Totality is guarded, not promised: every census key whose
-/// id names a model path (`SettingsDraftDiff.namesModelPath`)
-/// must produce at least one row for a config pair that
-/// differs on that path, or sit in `noReadout` with its
-/// reason — `SettingsValueReadoutTests` reds the key that
-/// lands in neither. Scalar keys are proven generically;
-/// instanced families each by a named mutation in that suite's
-/// battery — a NEW instanced key joins the battery in the same
-/// change, and the battery is the list.
+/// Formats changed settings keys into diff rows for draft review
+/// (`SettingsDraftDiff`, `SettingsValueReadoutTests`, #678 turn 9).
 @MainActor
 enum SettingsValueReadout {
-    /// Rows for one changed key. `old` is the clean baseline,
-    /// `new` the draft.
+    /// Returns diff rows describing changes between clean and draft configs.
     static func rows(
         for key: SettingKey,
         old: GuiConfig,
@@ -64,28 +43,24 @@ enum SettingsValueReadout {
         }
     }
 
-    /// Census keys with a model path but no diff narration, and
-    /// why not — the readout totality guard's one exemption
-    /// list. Internal-only storage never reaches the diff
-    /// (`SettingsDraftDiff` counts it, the popover shows its
-    /// area's rows); keys land here only with an argument.
+    /// Census keys exempt from diff narration (`SettingsValueReadoutTests`).
     static let noReadout: Set<SettingKey> = []
 }
 
 // MARK: - Shared value formatting
 
 extension SettingsValueReadout {
-    /// "8 pt" — the unit frame every point-valued row shares.
+    /// Formats point value string (e.g. "8 pt").
     static func points(_ value: CGFloat) -> String {
         L("diff.value.points", "%1$@ pt", trimmed(value))
     }
 
-    /// "150 ms".
+    /// Formats millisecond duration string (e.g. "150 ms").
     static func milliseconds(_ value: Double) -> String {
         L("diff.value.milliseconds", "%1$@ ms", trimmed(value))
     }
 
-    /// "50%" — unspaced, matching the sliders' own readout.
+    /// Formats percentage string (e.g. "50%").
     static func percent(_ fraction: Double) -> String {
         L(
             "diff.value.percent",
@@ -94,34 +69,28 @@ extension SettingsValueReadout {
         )
     }
 
-    /// A stored hex, shown verbatim: uppercased, leading "#".
-    /// The one copy — Borders, both bars and the per-layout
-    /// override rows all render a colour through it.
+    /// Formats hex color string with leading `#`.
     static func hexDisplay(_ hex: String) -> String {
         let digits =
             hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
         return "#" + digits.uppercased()
     }
 
-    /// `0` is the stored auto sentinel on the size sliders
-    /// (glow size #551, the bars' item/font sizes) — the GUI's
-    /// slider readout prints "Automatic" there, so this does
-    /// too. The one copy for every auto-at-0 row.
+    /// Formats points with `0` as "Automatic" (#551).
     static func autoPoints(_ value: CGFloat) -> String {
         value == 0
             ? L("settings.readout.auto", "Automatic")
             : points(value)
     }
 
-    /// Localized On / Off — toggles narrate their state, never
-    /// true/false.
+    /// Formats boolean toggle state.
     static func onOff(_ value: Bool) -> String {
         value
             ? L("diff.value.on", "On")
             : L("diff.value.off", "Off")
     }
 
-    /// A bare number, `.0` trimmed.
+    /// Strips trailing `.0` on numbers.
     static func trimmed(_ value: CGFloat) -> String {
         trimmed(Double(value))
     }
@@ -133,7 +102,7 @@ extension SettingsValueReadout {
         return String(format: "%.2f", value)
     }
 
-    /// "Monocle · thickness" — the instanced-row label frame.
+    /// Formats label for an instanced row (e.g. "Monocle · thickness").
     static func instanceLabel(
         _ base: String,
         _ instance: String
@@ -146,13 +115,11 @@ extension SettingsValueReadout {
         )
     }
 
-    /// The unset side of a pair that gained or lost its value —
-    /// the prototype's "— → 44 pt".
+    /// Placeholder for unset value.
     static var unset: String {
         L("diff.value.unset", "—")
     }
 
-    /// Structural one-worders for rows without a scalar pair.
     static var addedNote: String {
         L("diff.note.added", "Added")
     }
@@ -163,8 +130,7 @@ extension SettingsValueReadout {
         L("diff.note.edited", "Edited")
     }
 
-    /// The census label for a key, or its id as the visible
-    /// last resort (`SettingsCensusLabel` argues the chain).
+    /// Resolves human-readable label for key (`SettingsCensusLabel`).
     static func label(for key: SettingKey) -> String {
         SettingsCensusLabel.label(for: key) ?? key.id
     }

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout.swift
@@ -1,8 +1,14 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// Formats changed settings keys into diff rows for draft review
-/// (`SettingsDraftDiff`, `SettingsValueReadoutTests`, #678 turn 9).
+/// Formats changed settings keys into diff rows for draft
+/// review (`SettingsDraftDiff` stays the attribution authority;
+/// #678 turn 9). Totality is guarded, not promised: every census
+/// key naming a model path must produce a row for a differing
+/// pair or sit in `noReadout` with its reason —
+/// `SettingsValueReadoutTests` reds the key landing in neither,
+/// and a NEW instanced key joins that suite's battery in the
+/// same change.
 @MainActor
 enum SettingsValueReadout {
     /// Returns diff rows describing changes between clean and draft configs.

--- a/Sources/KiwiDesk/Settings/SettingsView+Reveal.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Reveal.swift
@@ -3,11 +3,21 @@ import SwiftUI
 
 /// Phase 1 of settings reveal navigation pipeline (#277, #326).
 extension SettingsView {
-    /// Applies destination and surface navigation from pending reveal request
-    /// (`SettingsAnchor.resolved`, #277, #326, #678).
+    /// Applies destination and surface from a pending reveal —
+    /// the ONLY consumer of `pendingReveal`, and it clears it;
+    /// phase 2 goes to `pendingScroll`, one writer one clearer
+    /// (`SettingsAnchor.resolved`, #277, #678). LOAD-BEARING
+    /// PLACEMENT: the `.onChange`/`.onAppear` pair calling this
+    /// sits on the outer `Group`, ABOVE the `editingLua` branch —
+    /// the sole reason a request arriving in Lua mode resolves
+    /// later. Moving it into `structuredShell` looks like a
+    /// tidy-up and silently kills the #326 bridge, every test
+    /// green.
     func apply(_ request: SettingsAnchor?) {
         guard let request else { return }
         model.nav.pendingReveal = nil
+        // Taken unconditionally, so a REFUSED request cannot
+        // leave a stale arm for the next reveal to announce.
         let armedNotice = model.nav.pendingModeNotice
         model.nav.pendingModeNotice = nil
         guard
@@ -29,6 +39,10 @@ extension SettingsView {
         case .layoutMode(let mode):
             model.nav.layoutModeTab = mode
         }
+        // Unconditional, nil included: guarding a nil→nil publish
+        // would stop a destination-only request from CLEARING an
+        // unconsumed `pendingScroll`, and the driver would wash
+        // the old anchor inside the new destination.
         model.nav.pendingScroll = resolved.scroll
         model.nav.setRevealTarget(resolved.scroll)
     }

--- a/Sources/KiwiDesk/Settings/SettingsView+Reveal.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Reveal.swift
@@ -1,46 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Phase 1 of the reveal pipeline (#277), split from
-/// `SettingsView` at the 350-line ceiling: the shell's
-/// application of a navigation request. Phase 2 (the
-/// scroll driver) stays in `SettingsView.reveal`, which
-/// owns the `@State` task it supersedes.
+/// Phase 1 of settings reveal navigation pipeline (#277, #326).
 extension SettingsView {
-    /// Phase 1 of a reveal: destination and surface, the half
-    /// that is meaningful in both modes. The **only** consumer of
-    /// `pendingReveal`, and it clears it.
-    ///
-    /// Phase 2 goes to `pendingScroll`, so each field has one
-    /// writer and one clearer. An earlier cut had both this and
-    /// the pane's scroll driver observing `pendingReveal`, with
-    /// the driver clearing it — and since the outer `.onAppear`
-    /// re-read the model rather than a captured value, a
-    /// child-first `onAppear` order (SwiftUI does not specify it)
-    /// let the driver blank the request before this ran. The #326
-    /// "Edit in Settings…" bridge would then land on Profiles,
-    /// which `SettingsWindowController.show()` had just set.
-    ///
-    /// Handing phase 2 to its own field also keeps the property
-    /// that motivated the split: a request arriving while the raw
-    /// Lua editor shows still resolves later, because
-    /// `pendingScroll` simply waits for a pane to exist.
-    /// The decision lives on `SettingsAnchor.resolved`, which is
-    /// pure and tested; this is only the assignment.
-    ///
-    /// LOAD-BEARING PLACEMENT: the `.onChange`/`.onAppear` pair
-    /// that calls this sits on the outer `Group`, ABOVE the
-    /// `editingLua` branch. That is the sole reason a request
-    /// arriving while the raw Lua editor shows resolves later
-    /// instead of being dropped. Moving it into `structuredShell`
-    /// would look like a tidy-up and would silently kill the #326
-    /// bridge in Lua mode, with every test still green.
+    /// Applies destination and surface navigation from pending reveal request
+    /// (`SettingsAnchor.resolved`, #277, #326, #678).
     func apply(_ request: SettingsAnchor?) {
         guard let request else { return }
         model.nav.pendingReveal = nil
-        // Taken unconditionally, so a REFUSED request cannot
-        // leave a stale arm behind for the next reveal to
-        // announce.
         let armedNotice = model.nav.pendingModeNotice
         model.nav.pendingModeNotice = nil
         guard
@@ -48,14 +15,8 @@ extension SettingsView {
                 editingStoredProfile: model.editingStoredProfile
             )
         else { return }
-        // A hit inside a Power-User-only area switches the mode —
-        // search indexes both modes (4c), so landing must
-        // switch rather than refuse.
         let wasSimple = model.settingsMode == .simple
         ensureModeAdmits(resolved.destination)
-        // The one-line confirmation, from the FLIP site: only a
-        // search pick arms it, and only a promotion that
-        // actually happened announces (#678 4c).
         if let armedNotice, wasSimple,
             model.settingsMode == .powerUser
         {
@@ -68,17 +29,7 @@ extension SettingsView {
         case .layoutMode(let mode):
             model.nav.layoutModeTab = mode
         }
-        // Unconditional, including the nil case. Guarding it to
-        // avoid a nil→nil publish would mean a destination-only
-        // request stops CLEARING a `pendingScroll` an earlier
-        // reveal left unconsumed — the driver would then scroll
-        // and wash the old anchor inside the new destination.
-        // That trades a guaranteed supersede for one saved
-        // re-render, in the field whose whole design is one
-        // writer and one clearer.
         model.nav.pendingScroll = resolved.scroll
-        // The standing copy drawers read to auto-expand (#277).
-        // Written here only; cleared by `endFlash`.
         model.nav.setRevealTarget(resolved.scroll)
     }
 }

--- a/Sources/KiwiDesk/Shortcuts/ShortcutRow.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutRow.swift
@@ -1,87 +1,42 @@
 import Foundation
 import KiwiDeskCore
 
-/// One row in the read-only shortcuts reference: a label, the
-/// rendered key-combo glyph string, and an optional leading glyph
-/// (a space icon) or app bundle id (a real app icon). Pure value
-/// data — the view owns all presentation.
+/// Data representation of a shortcut reference row (`ComboSymbols`).
 struct ShortcutRow: Identifiable {
     let id: String
     let label: String
-    /// The combo rendered as native glyphs (`⌃⌥←`), through the
-    /// same `ComboSymbols` path the editor uses.
     let combo: String
-    /// Leading SF Symbol / emoji glyph (space rows). Nil = none.
     var icon: String? = nil
-    /// App bundle id for a real 20pt icon (Apps band). Nil = none.
     var bundleID: String? = nil
-    /// App Font ligature (#294): set when the bar's icon source
-    /// is Glyphs and this app has one, so the panel's Apps band
-    /// matches the bar. Wins over `bundleID`; nil falls back to
-    /// the bundle icon.
+    /// App Font ligature name overriding bundle icon (#294).
     var glyph: String? = nil
-    /// Custom-Lua rows render their label monospaced.
     var monospaced: Bool = false
-    /// Trailing accessory glyph for a non-default launch behavior
-    /// (#334: Open New). Nil = default row, which renders exactly
-    /// as before. `accessoryHelp` is its hover tooltip.
+    /// Trailing accessory glyph for non-default actions (#334).
     var accessoryIcon: String? = nil
     var accessoryHelp: String = ""
-    /// The row's action cannot run right now, for a reason the
-    /// user's HARDWARE owns — today only a Desktop whose screen
-    /// is not attached.
-    ///
-    /// The panel dims such a row rather than dropping it: the
-    /// combo is still registered and still blocks that chord, so
-    /// hiding it would break the band's own promise that no
-    /// bound shortcut is ever invisible. It is NOT the Inactive
-    /// band's case — an inactive Space shortcut still fires and
-    /// recreates its Space, which this cannot do (only Mission
-    /// Control makes a Desktop), and that band's caption says so
-    /// in every locale.
-    ///
-    /// Pure data, like every other field here: `ShortcutRowView`
-    /// owns what dimming looks like, and the Settings editor
-    /// makes the same statement through
-    /// `NavCommand.unavailable`.
+    /// Whether the action is currently hardware-unavailable
+    /// (`NavCommand.unavailable`).
     var unavailable: Bool = false
 }
 
-/// A named group of rows inside the Controls band (Focus / Move
-/// Windows / Size & float / Switch modes).
+/// Named subgroup of shortcut rows in the Controls band.
 struct ShortcutSubgroup: Identifiable {
     let title: String
     let rows: [ShortcutRow]
     var id: String { title }
 }
 
-/// The whole read-only reference for one key mode: four bands.
-/// The field order below is the order the BUILDER fills them
-/// (Inactive is consumed before Apps and Custom, so an orphan
-/// cannot fall through to the band that means "user-authored");
-/// the panel DRAWS them Controls, Apps, Inactive, Custom, which
-/// is `ShortcutsPanelView.body(for:)`'s to state and what
-/// `docs/user-guide.md` lists. Empty bands are dropped by the
-/// builder, so an empty band never renders.
+/// Read-only shortcut reference representation for a key mode
+/// (`docs/user-guide.md`, #820).
 struct ShortcutsReference {
-    // `var`, not `let`: post-processing (the #294 glyph pass)
-    // mutates a copy instead of re-initializing memberwise,
-    // which would be one more hand-mirrored field list.
     var layerName: String
     var controls: [ShortcutSubgroup]
-    /// Bindings whose target Space has left the current list
-    /// (#820) — surfaced under their real name, dimmed, never
-    /// pruned and never left to the Custom band.
+    /// Inactive space bindings shown under real names (#820).
     var inactive: [ShortcutRow] = []
     var apps: [ShortcutRow]
     var custom: [ShortcutRow]
 
-    /// True when the active mode has no *listable* bound
-    /// shortcuts — the view shows a "nothing bound yet"
-    /// placeholder. The panel's own opener doesn't count (see
-    /// the builder): a fresh mode holding only the seeded ⌃⌥K
-    /// row reads as empty here while the footer shows the combo
-    /// (when live).
+    /// Whether the reference contains no listable shortcuts.
     var isEmpty: Bool {
         controls.isEmpty && inactive.isEmpty && apps.isEmpty
             && custom.isEmpty

--- a/Sources/KiwiDesk/Shortcuts/ShortcutRow.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutRow.swift
@@ -14,8 +14,14 @@ struct ShortcutRow: Identifiable {
     /// Trailing accessory glyph for non-default actions (#334).
     var accessoryIcon: String? = nil
     var accessoryHelp: String = ""
-    /// Whether the action is currently hardware-unavailable
-    /// (`NavCommand.unavailable`).
+    /// Whether the action cannot run for a reason the user's
+    /// HARDWARE owns (a Desktop whose screen is detached). The
+    /// panel DIMS such a row rather than dropping it — the combo
+    /// is still registered and blocks that chord, and hiding it
+    /// breaks "no bound shortcut is ever invisible". NOT the
+    /// Inactive band's case: an inactive Space shortcut still
+    /// fires and recreates its Space; only Mission Control makes
+    /// a Desktop (`NavCommand.unavailable`).
     var unavailable: Bool = false
 }
 

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsPanelController+Reference.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsPanelController+Reference.swift
@@ -1,38 +1,20 @@
 import AppKit
 import KiwiDeskCore
 
-/// Builds the panel's content data. Split from
-/// `ShortcutsPanelController.swift` (350-line ceiling); `show()`
-/// there is the one caller.
+/// Shortcuts reference panel data builder (`ShortcutsReferenceBuilder`, #820).
 extension ShortcutsPanelController {
-    /// The shortcuts for the active layer. Nil ONLY when the config
-    /// is genuinely owned by `init.lua` (not GUI-managed) — the view
-    /// then shows its "managed by init.lua" placeholder.
-    ///
-    /// Prefers the live, resolved snapshot (what Carbon actually has
-    /// installed). When window management is paused — no Accessibility
-    /// permission, or bindings not applied yet — there is no snapshot;
-    /// for a GUI-managed config we fall back to the CONFIGURED layers
-    /// from gui.json so the user still sees their shortcuts (defined,
-    /// just not live right now) rather than a misleading placeholder.
+    /// Builds shortcuts reference snapshot for active key layer.
     func buildReference() -> ShortcutsReference? {
         let layers: [KeyLayer]
         let activeLayer: String
         let config: GuiConfig
         if let snapshot = core.liveKeybindingSnapshot() {
-            // Live: the running engine's spaces match the resolved
-            // bindings, so the live-overlaid config is correct.
             layers = snapshot.keyLayers
             activeLayer = snapshot.activeLayerName
             config = core.loadGuiConfig()
         } else if core.isGuiManaged,
             let raw = core.persistedGuiConfig()
         {
-            // Paused (no Accessibility): the engine hasn't discovered
-            // any spaces, so loadGuiConfig would overlay an EMPTY live
-            // space list and misfile every space shortcut into Custom.
-            // Read the persisted gui.json directly — it keeps the
-            // authored spaces and layers.
             layers = raw.layers
             activeLayer = raw.layers.first?.name ?? KeyLayer.defaultName
             config = raw
@@ -43,17 +25,6 @@ extension ShortcutsPanelController {
             layers.first { $0.name == activeLayer }
             ?? layers.first
             ?? KeyLayer.defaultLayer
-        // Two-source read: the layers supply the bindings; the config
-        // supplies only spaces / icons / step, used to *generate
-        // candidate preset rows* that are then intersected with the
-        // actual bindings. A transient disagreement (space or step
-        // edited but not yet re-applied) can only misfile a binding
-        // — never hide or invent one — which stays safe for a
-        // read-only glance panel. Since #820 the misfile can land
-        // in Inactive as well as Custom, and that band's caption
-        // ASSERTS the Space has left the list; the window is the
-        // beat between a space edit and its apply, and it closes
-        // itself, exactly as the Custom misfile does.
         let reference = ShortcutsReferenceBuilder.build(
             layer: layer,
             spaces: config.spaces,
@@ -70,12 +41,7 @@ extension ShortcutsPanelController {
         )
     }
 
-    /// #294: when the bar renders App Font glyphs, the Apps
-    /// band leads with the same glyph; apps without one keep
-    /// their bundle icon. Deliberately keyed on the GLOBAL
-    /// symbol style — the panel spans all layouts, so a
-    /// Lua-only per-layout override can't (and shouldn't)
-    /// steer it.
+    /// Attaches app font glyphs to reference app shortcuts (#294).
     private func withAppGlyphs(
         _ reference: ShortcutsReference,
         settings: TilingSettings

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsPanelController+Reference.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsPanelController+Reference.swift
@@ -15,6 +15,10 @@ extension ShortcutsPanelController {
         } else if core.isGuiManaged,
             let raw = core.persistedGuiConfig()
         {
+            // Paused (no Accessibility): the engine discovered no
+            // spaces, so loadGuiConfig would overlay an EMPTY live
+            // space list and misfile every space shortcut into
+            // Custom — read the persisted gui.json directly.
             layers = raw.layers
             activeLayer = raw.layers.first?.name ?? KeyLayer.defaultName
             config = raw
@@ -25,6 +29,12 @@ extension ShortcutsPanelController {
             layers.first { $0.name == activeLayer }
             ?? layers.first
             ?? KeyLayer.defaultLayer
+        // Two-source read: layers supply bindings; config supplies
+        // spaces/icons/step for candidate rows. A transient
+        // disagreement can only MISFILE a binding (into Inactive
+        // or Custom), never hide or invent one — safe for a
+        // read-only glance panel, and the window closes itself on
+        // the next apply (#820).
         let reference = ShortcutsReferenceBuilder.build(
             layer: layer,
             spaces: config.spaces,

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsPanelView.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsPanelView.swift
@@ -114,6 +114,11 @@ struct ShortcutsPanelView: View {
         }
     }
 
+    /// Settings' own section says the same thing and then adds
+    /// "rebind or remove them here" — which this panel cannot
+    /// offer, so the two captions are deliberately different
+    /// strings rather than one shared key that would lie on one
+    /// surface.
     private var inactiveCaption: String {
         L(
             "shortcuts.panel.inactive.caption",

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsPanelView.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsPanelView.swift
@@ -1,18 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The read-only shortcuts reference panel (#326): a live mirror
-/// of the active key layer's bindings, grouped into Controls /
-/// Apps / Inactive / Custom bands, in that drawn order (#820).
-/// No editing — rebinding stays in Settings, which
-/// the single footer button bridges to. `reference` is nil when
-/// live shortcuts can't be read (config owned by init.lua, or the
-/// engine isn't running).
+/// Read-only shortcuts cheat sheet panel (#326, #820).
 struct ShortcutsPanelView: View {
     let reference: ShortcutsReference?
-    /// The combo bound to open this panel (native glyphs), or nil
-    /// when unbound (#330). Drives the footer hint: the same key
-    /// that opened it also closes it, so it leads the copy.
+    /// Bound dismiss combo string, or nil when unbound (#330).
     let dismissCombo: String?
     let onEdit: () -> Void
 
@@ -32,18 +24,11 @@ struct ShortcutsPanelView: View {
 
     // MARK: - Layer label
 
-    /// The active layer's name, centered in the footer and shown only
-    /// for a non-default layer — the default is the implicit case. It
-    /// sits in the footer rather than a top header so it costs no
-    /// vertical space above the bands.
+    /// Layer name chip for non-default key layers (`KeyLayer.defaultName`).
     @ViewBuilder private var layerLabel: some View {
         if let name = reference?.layerName,
             name != KeyLayer.defaultName
         {
-            // Capsule treatment (the Shortcuts editor's layer-chip
-            // vocabulary) so it reads as state, not chrome — it's the
-            // only layer indicator now. Bounded + truncated so a long
-            // custom name can't collide with the hint or the button.
             Text(name)
                 .font(.caption.weight(.medium))
                 .lineLimit(1)
@@ -104,12 +89,7 @@ struct ShortcutsPanelView: View {
         }
     }
 
-    /// The Inactive band (#820): shortcuts whose target Space has
-    /// left the current list. Dimmed as a block — like Settings'
-    /// own section (#92) — so they read as parked rather than as
-    /// part of the live list, and captioned, since a dimmed row
-    /// that says nothing is a dead end. Sits above Custom because
-    /// these are seeded defaults, not user-authored Lua.
+    /// Inactive shortcuts band for missing spaces (`GreyOut`, #92, #820).
     @ViewBuilder private func inactive(
         _ rows: [ShortcutRow]
     ) -> some View {
@@ -122,9 +102,6 @@ struct ShortcutsPanelView: View {
                     )
                 )
                 VStack(alignment: .leading, spacing: 8) {
-                    // Outside the dimmed subtree: the dim says an
-                    // answer exists, and withholding it there is
-                    // the dead end `GreyOut` was ruled against.
                     Text(inactiveCaption)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -137,11 +114,6 @@ struct ShortcutsPanelView: View {
         }
     }
 
-    /// Settings' own section says the same thing and then adds
-    /// "rebind or remove them here" — which this panel cannot
-    /// offer, so the two captions are deliberately different
-    /// strings rather than one shared key that would lie on one
-    /// of the surfaces.
     private var inactiveCaption: String {
         L(
             "shortcuts.panel.inactive.caption",
@@ -167,8 +139,7 @@ struct ShortcutsPanelView: View {
         }
     }
 
-    /// Empty-state: a layer with nothing bound, or a config the
-    /// panel can't read live. Distinct messages, same quiet frame.
+    /// Empty state view for unconfigured or Lua-managed setups.
     private func placeholder(unavailable: Bool) -> some View {
         Text(
             unavailable
@@ -190,11 +161,7 @@ struct ShortcutsPanelView: View {
 
     // MARK: - Footer
 
-    /// Bound → lead with the live open-combo ("⌥␣ or Esc to close"),
-    /// the two dismissals worth the characters — the same key that
-    /// opened it is the most self-evident way to close it, and it
-    /// teaches a mouse-opener the shortcut. Unbound → the generic
-    /// hint, which keeps "click away" (#330, #326).
+    /// Dismiss hint text string (#326, #330).
     private var dismissHint: String {
         if let combo = dismissCombo {
             return L(
@@ -211,9 +178,6 @@ struct ShortcutsPanelView: View {
 
     private var footer: some View {
         HStack {
-            // A chromeless panel has no titlebar to teach dismissal,
-            // so the one non-obvious interaction gets a quiet hint on
-            // the idle side, opposite the action button.
             Text(dismissHint)
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -227,8 +191,6 @@ struct ShortcutsPanelView: View {
                 )
             }
         }
-        // Centered in the full footer width, independent of the
-        // hint / button widths on either side.
         .overlay(alignment: .center) { layerLabel }
         .padding(.horizontal, 20)
         .padding(.vertical, 12)

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsReference.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsReference.swift
@@ -15,11 +15,24 @@ enum ShortcutsReferenceBuilder {
         resizeStep: Int,
         layerNames: [String]
     ) -> ShortcutsReference {
+        // Drop the panel's own opener from the working set BEFORE
+        // any band builds, so the suppression holds by
+        // construction. Scoped to callers entering HERE: the §2.1
+        // split cost the band builders `private`, so a caller
+        // invoking one directly would re-leak the seeded ⌃⌥K row
+        // `ShortcutsSelfRowTests` pins — a band builder is
+        // `build`'s to call.
         var layer = layer
         layer.bindings.removeAll {
             $0.lua == ShortcutsOpenBinding.lua
         }
 
+        // Keyed by row identity (UUID), never `lua`: two bindings
+        // can share a command's Lua with different combos (vim
+        // keys + arrows). Keying by `lua` would consume the whole
+        // command on the first match and drop the second from
+        // every band — invisible, breaking "never drop a bound
+        // shortcut". By id, the twin falls through to Custom.
         var consumed = Set<UUID>()
 
         func bound(_ lua: String) -> KeyBinding? {
@@ -48,6 +61,11 @@ enum ShortcutsReferenceBuilder {
             }
         }
 
+        // Widened by the layer's own bindings, so a bound Desktop
+        // row keeps its name instead of falling through to Custom
+        // as raw Lua (the General band's #678 item 18 defect).
+        // What the widening adds is exactly what is NOT attached,
+        // so it is also the dim set.
         let offer = KeybindingCatalog.desktopOffer(
             live: desktops,
             bindings: layer.bindings

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsReference.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsReference.swift
@@ -1,21 +1,10 @@
 import Foundation
 import KiwiDeskCore
 
-/// Builds a `ShortcutsReference` from a live key layer by filtering
-/// the `KeybindingCatalog` presets to the bindings that actually
-/// exist — reusing the exact labels, icons, and Lua identity the
-/// editor authors, so the panel can never disagree with the tab.
-/// Anything bound but unrecognized (custom Lua, or a resize of a
-/// non-current step) falls through to the Custom band, so no bound
-/// shortcut is ever invisible — with one deliberate exception:
-/// `KiwiDesk.show_shortcuts()` opens this very panel, so it is
-/// dropped from the working set before any band builds and never
-/// becomes a row in any of them. The footer's dismiss hint
-/// teaches its combo in every state whose bindings are live
-/// (paused bindings do nothing, so the generic hint is honest
-/// there). Un-suppressing it would re-leak the seeded ⌃⌥K
-/// default (#602) into Custom as raw Lua — the band that means
-/// "user-authored". `ShortcutsSelfRowTests` pins the exception.
+/// Builds `ShortcutsReference` from a live key layer (`KeybindingCatalog`).
+///
+/// Suppresses `KiwiDesk.show_shortcuts()` from rows (`ShortcutsSelfRowTests`,
+/// #602). Unrecognized shortcuts fall through to the Custom band.
 @MainActor
 enum ShortcutsReferenceBuilder {
     static func build(
@@ -26,34 +15,13 @@ enum ShortcutsReferenceBuilder {
         resizeStep: Int,
         layerNames: [String]
     ) -> ShortcutsReference {
-        // The panel's own opener never renders as a row (see the
-        // type docstring): drop every binding of it — whatever its
-        // kind or combo — from the working set before any band
-        // builds, so the suppression holds across every band by
-        // construction, not by each band's filter remembering.
-        //
-        // "By construction" is now scoped to callers entering
-        // HERE: the §2.1 split put the band builders in
-        // `+Bands.swift`, which cost them `private`, so a
-        // module-level caller invoking one directly would hand it
-        // an unfiltered layer and re-leak the seeded ⌃⌥K row
-        // `ShortcutsSelfRowTests` pins. Nothing scans for that —
-        // a band builder is `build`'s to call.
         var layer = layer
         layer.bindings.removeAll {
             $0.lua == ShortcutsOpenBinding.lua
         }
 
-        // Keyed by row identity (UUID), not `lua`: two bindings can
-        // share a command's Lua with different combos (vim keys +
-        // arrows both bound to `focus("left")`). Keying by `lua`
-        // would consume the whole command on the first match and
-        // drop the second from every band — invisible, breaking the
-        // "never drop a bound shortcut" contract. By id, only the
-        // matched row is consumed; the twin falls through to Custom.
         var consumed = Set<UUID>()
 
-        // A bound binding (non-empty combo) for a preset's Lua.
         func bound(_ lua: String) -> KeyBinding? {
             layer.bindings.first {
                 $0.lua == lua && !$0.combo.isEmpty
@@ -66,10 +34,6 @@ enum ShortcutsReferenceBuilder {
                     return nil
                 }
                 consumed.insert(binding.id)
-                // Custom space icon first, then a directional arrow
-                // for compass commands, then a space fallback so a
-                // space row always carries a glyph even when the user
-                // set no icon for it.
                 let icon =
                     cmd.icon.flatMap { $0.isEmpty ? nil : $0 }
                     ?? directionalIcon(for: cmd.lua)
@@ -79,20 +43,11 @@ enum ShortcutsReferenceBuilder {
                     label: cmd.resolvedLabel,
                     combo: glyphs(binding.combo),
                     icon: icon,
-                    // Read off the command the catalog built, so
-                    // the panel and the editor cannot disagree
-                    // about which rows are dead right now.
                     unavailable: cmd.unavailable != nil
                 )
             }
         }
 
-        // Widened by the layer's own bindings, so a bound
-        // Desktop row keeps its name here instead of falling
-        // through to Custom as raw Lua — the band that means
-        // "user-authored" (the General band's #678 item 18 note
-        // is the same defect). What the widening adds is exactly
-        // what is NOT attached, so it is also the dim set.
         let offer = KeybindingCatalog.desktopOffer(
             live: desktops,
             bindings: layer.bindings
@@ -106,9 +61,7 @@ enum ShortcutsReferenceBuilder {
             layerNames: layerNames,
             rows: rows
         )
-        // Before Apps and Custom, so an orphan is consumed as
-        // what it is rather than falling through to the band
-        // that means "user-authored" (#820).
+        // Inactive orphans built before Apps/Custom (#820).
         let inactive = buildInactive(
             layer,
             spaces: spaces,

--- a/Sources/KiwiDesk/SingleInstanceGuard.swift
+++ b/Sources/KiwiDesk/SingleInstanceGuard.swift
@@ -1,41 +1,12 @@
 import AppKit
 import KiwiDeskCore
 
-/// The status a second launch reports when the lock is held.
-///
-/// **Zero, and that is load-bearing (#1068).** Declining to
-/// start because another instance already holds the lock is a
-/// job correctly done, not a failure — and launchd reads the
-/// difference. The service plist carries
-/// `KeepAlive { SuccessfulExit: false }`, which exists so a
-/// deliberate quit stays quit while a crash is restarted (#341,
-/// `ServiceManager.plist`). Reporting failure here put
-/// "already running" in the crash bucket: `RunAtLoad` started a
-/// second instance beside a running one, that instance bowed
-/// out non-zero, launchd called it a crash and respawned it one
-/// throttle later — forever, each attempt activating the
-/// running app and taking the user's focus with it.
-///
-/// So the exit code answers "did this process fail?", and the
-/// answer is no. What it no longer answers is "did a new
-/// instance start?" — the stderr line carries that, and a
-/// script shelling out to a bare, argument-less launch reads
-/// THAT rather than the status. (A `kiwidesk <command>`
-/// invocation never reaches here at all: `main.swift` routes
-/// any argument to the CLI and exits before the lock is
-/// touched.)
+/// Status reported on duplicate launch; 0 prevents launchd respawn loops
+/// (`ServiceManager.plist`, #341, #1068).
 let secondLaunchExitStatus: Int32 = 0
 
-/// Second-launch path (#196): another process holds the
-/// single-instance lock. Surface the running instance when it
-/// is identifiable; a bundled (.app) launch that can't be
-/// surfaced gets a notice dialog. Either way the verdict goes
-/// to stderr first — a terminal launch would otherwise look
-/// hung while a dialog waits somewhere behind other windows.
-/// Never force-kills a wedged instance — the user decides that.
-///
-/// Exits `secondLaunchExitStatus`; read its doc before changing
-/// the value, which launchd's respawn policy depends on.
+/// Activates running instance and exits when lock is held
+/// (`main.swift`, #196).
 @MainActor
 func surfaceRunningInstanceAndExit() -> Never {
     fputs(

--- a/Sources/KiwiDesk/SingleInstanceGuard.swift
+++ b/Sources/KiwiDesk/SingleInstanceGuard.swift
@@ -1,8 +1,13 @@
 import AppKit
 import KiwiDeskCore
 
-/// Status reported on duplicate launch; 0 prevents launchd respawn loops
-/// (`ServiceManager.plist`, #341, #1068).
+/// Status reported on duplicate launch; 0 prevents launchd
+/// respawn loops: `KeepAlive { SuccessfulExit: false }` restarts
+/// a crash, and a non-zero "already running" landed in the crash
+/// bucket — respawned forever, stealing focus each attempt
+/// (`ServiceManager.plist`, #341, #1068). The exit code answers
+/// "did this process fail?"; the stderr line answers "did a new
+/// instance start?".
 let secondLaunchExitStatus: Int32 = 0
 
 /// Activates running instance and exits when lock is held

--- a/Sources/KiwiDesk/StatusItemController+Layout.swift
+++ b/Sources/KiwiDesk/StatusItemController+Layout.swift
@@ -2,8 +2,8 @@ import AppKit
 import KiwiDeskCore
 
 extension StatusItemController {
-    /// The Layout submenu: flat with one screen, one level deeper
-    /// with several (#752).
+    /// Builds Layout submenu, nesting per-screen when multiple displays exist
+    /// (#752, #802).
     func layoutItem() -> NSMenuItem {
         let parent = NSMenuItem(
             title: L("menu.layout", "Layout"),
@@ -11,14 +11,6 @@ extension StatusItemController {
             keyEquivalent: ""
         )
         parent.image = symbol("rectangle.3.group")
-        // Manual enablement: under the default auto-enable,
-        // AppKit re-enables at display time any item whose
-        // target responds to its action, discarding the save
-        // row's `isEnabled` below (the quick menu's first
-        // action-bearing item that must stay disabled). The cost
-        // is the other half of the switch — every row here states
-        // `isEnabled`, because a nil-action row is no longer
-        // disabled for free (#802).
         let submenu = NSMenu()
         submenu.autoenablesItems = false
         let info = layoutInfoProvider()
@@ -43,12 +35,7 @@ extension StatusItemController {
         return parent
     }
 
-    /// One screen's row, carrying its own mode list.
-    ///
-    /// The checkmark inside answers "what is this screen running
-    /// right now", so the submenu doubles as the readout the
-    /// menu bar could not give before — a user with three screens
-    /// had to click into each one to find out.
+    /// Single screen submenu item with active mode indication (#802).
     private func screenItem(
         _ screen: LayoutMenuInfo.Screen
     ) -> NSMenuItem {
@@ -57,9 +44,6 @@ extension StatusItemController {
             action: nil,
             keyEquivalent: ""
         )
-        // Stated, not inherited: this menu turned auto-enabling
-        // off, so a submenu parent is no longer enabled for free
-        // either (#802).
         item.isEnabled = true
         let modes = NSMenu()
         modes.autoenablesItems = false
@@ -74,15 +58,7 @@ extension StatusItemController {
         return item
     }
 
-    /// "All screens" — the same pick applied to every screen's
-    /// shown space at once, which is what plugging in a dock
-    /// wants.
-    ///
-    /// It carries **no checkmark**, deliberately: a tick would
-    /// have to mean "every screen is already running this", which
-    /// is a different claim from any one screen's mode and would
-    /// read as the current state of a thing that has no single
-    /// state. The per-screen rows below are where the answer is.
+    /// Submenu item targeting all connected screens simultaneously.
     private func everyScreenItem(
         _ screens: [LayoutMenuInfo.Screen]
     ) -> NSMenuItem {
@@ -104,12 +80,7 @@ extension StatusItemController {
         return item
     }
 
-    /// Every layout mode, checked against `live`.
-    ///
-    /// `subtitleWhenDrifted` gates the "not saved to profile"
-    /// hint: drift is per space, so it is answered per screen row
-    /// rather than once at the top — and the flat menu keeps
-    /// answering it for the active space.
+    /// Populates layout mode items with current selection checkmarks.
     private func addModeRows(
         to menu: NSMenu,
         live: LayoutMode?,
@@ -144,14 +115,8 @@ extension StatusItemController {
         }
     }
 
-    /// The save row, unchanged in meaning: it saves the ACTIVE
-    /// space's layout to the profile.
-    ///
-    /// Deliberately not per screen. `savedModeForActiveSpace` and
-    /// `persistProfile` are whole-profile operations, so a
-    /// per-screen save would be a second feature rather than a
-    /// second row — and the profile a save writes to is one
-    /// profile whatever screen the user is looking at.
+    /// Save row persisting active space layout into active profile
+    /// (`persistProfile`).
     private func addSaveRow(
         to menu: NSMenu,
         info: LayoutMenuInfo
@@ -182,15 +147,6 @@ extension StatusItemController {
         case .space(let id):
             onSetLayoutMode(target.mode, id)
         case .everyScreen(let asBuilt):
-            // The INTERSECTION of what the menu offered and what
-            // is connected now. Re-reading alone was wrong in one
-            // direction and closing over the build alone in the
-            // other: a screen unplugged between opening the menu
-            // and picking a row must not be written to, and a
-            // screen that appeared since must not be silently
-            // included in an action the user took against a menu
-            // that never listed it. The row carries what it
-            // promised; the provider says what still exists.
             let live = Set(layoutInfoProvider().screens.map(\.space))
             for space in asBuilt where live.contains(space) {
                 onSetLayoutMode(target.mode, space)

--- a/Sources/KiwiDesk/StatusItemController+Layout.swift
+++ b/Sources/KiwiDesk/StatusItemController+Layout.swift
@@ -11,6 +11,10 @@ extension StatusItemController {
             keyEquivalent: ""
         )
         parent.image = symbol("rectangle.3.group")
+        // Manual enablement (#802): auto-enable would re-enable
+        // the save row at display time. The cost is the other half
+        // of the switch — every row here states `isEnabled`, since
+        // a nil-action row is no longer disabled for free.
         let submenu = NSMenu()
         submenu.autoenablesItems = false
         let info = layoutInfoProvider()
@@ -58,7 +62,11 @@ extension StatusItemController {
         return item
     }
 
-    /// Submenu item targeting all connected screens simultaneously.
+    /// Submenu item targeting all connected screens at once. It
+    /// carries NO checkmark, deliberately: a tick would claim
+    /// "every screen is already running this" — the current state
+    /// of a thing that has no single state. The per-screen rows
+    /// are where the answer is.
     private func everyScreenItem(
         _ screens: [LayoutMenuInfo.Screen]
     ) -> NSMenuItem {
@@ -115,8 +123,10 @@ extension StatusItemController {
         }
     }
 
-    /// Save row persisting active space layout into active profile
-    /// (`persistProfile`).
+    /// Save row persisting the ACTIVE space's layout. Deliberately
+    /// not per screen: `persistProfile` is a whole-profile
+    /// operation, so a per-screen save would be a second feature,
+    /// not a second row.
     private func addSaveRow(
         to menu: NSMenu,
         info: LayoutMenuInfo
@@ -147,6 +157,11 @@ extension StatusItemController {
         case .space(let id):
             onSetLayoutMode(target.mode, id)
         case .everyScreen(let asBuilt):
+            // The INTERSECTION of what the menu offered and what
+            // is connected now: a screen unplugged since the menu
+            // opened must not be written to, and one that appeared
+            // since must not join an action taken against a menu
+            // that never listed it.
             let live = Set(layoutInfoProvider().screens.map(\.space))
             for space in asBuilt where live.contains(space) {
                 onSetLayoutMode(target.mode, space)

--- a/Sources/KiwiDeskCore/AX/FloatDetection.swift
+++ b/Sources/KiwiDeskCore/AX/FloatDetection.swift
@@ -1,12 +1,9 @@
 import ApplicationServices
 import Foundation
 
-/// Classifies windows from AX and CGWindow signals: float
-/// instead of tile, or ignore entirely (never managed).
+/// Classifies windows from AX and CGWindow signals for tiling or floating.
 public enum FloatDetection {
-    /// Subroles that identify auxiliary windows (dialogs,
-    /// panels, PIP overlays). Everything that is not a
-    /// standard window floats by default.
+    /// Subroles identifying auxiliary windows (dialogs, panels, PIP overlays).
     public static func shouldFloat(
         role: String,
         subrole: String
@@ -15,11 +12,7 @@ public enum FloatDetection {
         return subrole != kAXStandardWindowSubrole
     }
 
-    /// Subrole check plus the window's CGWindow layer. Normal
-    /// windows live on layer 0; panels and overlays (Ghostty's
-    /// quick terminal: layer 3) sit higher and never tile, even
-    /// when their subrole momentarily reads AXStandardWindow
-    /// (apps mid-launch report unreliable subroles).
+    /// Evaluates role/subrole and WindowServer layer (layer != 0 floats).
     public static func shouldFloat(
         role: String,
         subrole: String,
@@ -28,16 +21,12 @@ public enum FloatDetection {
         layer != 0 || shouldFloat(role: role, subrole: subrole)
     }
 
-    /// CGWindow layer of a window, nil if the system does not
-    /// list it (e.g. another native Space).
+    /// Returns CGWindow layer for window ID, or nil if unlisted.
     public static func windowLayer(of id: WindowID) -> Int? {
         serverSnapshot(of: id).layer
     }
 
-    /// One window's WindowServer signals — layer, alpha, and
-    /// bounds (CG global, top-left-origin coordinates) — read in
-    /// a single round trip, so ignore/float/helper classification
-    /// shares one snapshot (never query the server in a loop).
+    /// Snapshot of window properties from WindowServer (`kCGWindowBounds`).
     public struct WindowServerSnapshot: Sendable {
         public let layer: Int?
         public let alpha: Double?
@@ -73,19 +62,7 @@ public enum FloatDetection {
         )
     }
 
-    /// #309: a clearly-non-user helper window — a *raised-layer*
-    /// window that is fully transparent or entirely off every
-    /// display (CodexBar's 20×20 alpha-0 lifecycle keepalive at
-    /// (-5000, 6116)). Such a window must never be tracked: a
-    /// tracked float still earns a Space assignment and an App
-    /// Bar slot, so the menu-bar app reads as an open app.
-    /// Normal-layer (0) windows are never helpers — KiwiDesk
-    /// itself parks inactive-space windows off-screen at the
-    /// peek corner, and those must stay managed. Track-time
-    /// classification: a genuine overlay caught mid fade-in
-    /// (alpha still 0) self-heals — it stays untracked for one
-    /// beat and the next reconcile pass re-tracks it once
-    /// visible.
+    /// Detects non-user helper windows on raised layers (#309).
     public static func isInvisibleHelper(
         layer: Int?,
         alpha: Double?,
@@ -100,9 +77,7 @@ public enum FloatDetection {
         return !displays.contains { $0.intersects(bounds) }
     }
 
-    /// CG global bounds of every active display — the coordinate
-    /// space `kCGWindowBounds` reports in (top-left origin, no
-    /// Cocoa flip needed).
+    /// CG global bounds of all active displays.
     public static func activeDisplayBounds() -> [CGRect] {
         var count: UInt32 = 0
         guard
@@ -119,12 +94,7 @@ public enum FloatDetection {
         return ids.prefix(Int(count)).map { CGDisplayBounds($0) }
     }
 
-    /// AX can expose a transient proxy as an auxiliary window even
-    /// though no matching WindowServer window exists. Managing that
-    /// proxy creates a floating state entry and an AppKit fallback
-    /// border around system UI shown at the same location. Real
-    /// dialogs and panels have a layer; standard windows may be
-    /// absent because they live on another native Space.
+    /// Detects unbacked auxiliary proxy windows.
     public static func isUnbackedAuxiliary(
         role: String,
         subrole: String,
@@ -133,9 +103,7 @@ public enum FloatDetection {
         layer == nil && shouldFloat(role: role, subrole: subrole)
     }
 
-    /// Full decision for a live AX element, including user
-    /// rules. PIP windows (subrole AXFloatingWindow) float
-    /// automatically via the subrole check.
+    /// Evaluates if AX element should float using window rules (`FloatRules`).
     @MainActor
     public static func shouldFloat(
         element: AXUIElement,
@@ -152,9 +120,7 @@ public enum FloatDetection {
         )
     }
 
-    /// Variant for callers that already read the WindowServer layer.
-    /// Tracking uses it to keep ignore and float classification on
-    /// the same snapshot instead of making two server round trips.
+    /// Float decision given cached WindowServer layer (`FloatRules`).
     @MainActor
     public static func shouldFloat(
         element: AXUIElement,
@@ -175,9 +141,7 @@ public enum FloatDetection {
 }
 
 extension AXHelper {
-    /// Detects macOS native tabs (Finder, Terminal, Safari).
-    /// A tab group is a single `NSWindow` and is treated as
-    /// ONE tiling unit — tabs are never split apart.
+    /// Detects macOS native tab group (`AXTabGroup`).
     @MainActor
     public static func hasNativeTabs(
         _ element: AXUIElement

--- a/Sources/KiwiDeskCore/AX/FloatDetection.swift
+++ b/Sources/KiwiDeskCore/AX/FloatDetection.swift
@@ -12,7 +12,10 @@ public enum FloatDetection {
         return subrole != kAXStandardWindowSubrole
     }
 
-    /// Evaluates role/subrole and WindowServer layer (layer != 0 floats).
+    /// Evaluates role/subrole and WindowServer layer: layer != 0
+    /// never tiles, even when the subrole momentarily reads
+    /// AXStandardWindow — apps mid-launch report unreliable
+    /// subroles.
     public static func shouldFloat(
         role: String,
         subrole: String,
@@ -26,7 +29,10 @@ public enum FloatDetection {
         serverSnapshot(of: id).layer
     }
 
-    /// Snapshot of window properties from WindowServer (`kCGWindowBounds`).
+    /// Snapshot of window properties from WindowServer
+    /// (`kCGWindowBounds`, CG global top-left coordinates) — one
+    /// round trip shared by ignore/float/helper classification;
+    /// never query the server in a loop.
     public struct WindowServerSnapshot: Sendable {
         public let layer: Int?
         public let alpha: Double?
@@ -62,7 +68,12 @@ public enum FloatDetection {
         )
     }
 
-    /// Detects non-user helper windows on raised layers (#309).
+    /// Detects non-user helper windows on raised layers (#309):
+    /// fully transparent or entirely off-screen. Normal-layer (0)
+    /// windows are never helpers — KiwiDesk itself parks
+    /// inactive-space windows off-screen, and those must stay
+    /// managed. An overlay caught mid fade-in self-heals on the
+    /// next reconcile.
     public static func isInvisibleHelper(
         layer: Int?,
         alpha: Double?,
@@ -94,7 +105,11 @@ public enum FloatDetection {
         return ids.prefix(Int(count)).map { CGDisplayBounds($0) }
     }
 
-    /// Detects unbacked auxiliary proxy windows.
+    /// Detects unbacked auxiliary proxy windows: AX can expose a
+    /// transient proxy with no WindowServer window behind it, and
+    /// managing it draws a fallback border around system UI. Real
+    /// dialogs have a layer; standard windows may be absent
+    /// because they live on another native Space.
     public static func isUnbackedAuxiliary(
         role: String,
         subrole: String,

--- a/Sources/KiwiDeskCore/Animation/SizeStep.swift
+++ b/Sources/KiwiDeskCore/Animation/SizeStep.swift
@@ -1,44 +1,24 @@
 import CoreGraphics
 import Foundation
 
-/// Which policy drives the *size* channel of an animation
-/// (issue #47). Position is always spring-interpolated
-/// regardless.
+/// Policy driving animation size channel updates (#47, #593).
 public enum SizePolicy: String, Sendable, Equatable,
     CaseIterable
 {
-    /// Legacy fallback (pre-#47). A growing axis holds its start
-    /// size until halfway, then grows in a single frame where the
-    /// ongoing slide masks the jump. One size-set lands mid-flight,
-    /// so slow-AX apps (Electron/WebKit) reflow exactly once. Kept
-    /// as a Lua-selectable escape hatch for an app that can't keep
-    /// pace with the smooth default. Deaf to `BatchSizing` by
-    /// definition: its whole contract is that single size-set, in
-    /// whichever direction the axis moves.
+    /// Single size-set at halfway point for slow-AX applications.
     case midSlide = "mid_slide"
-    /// Shipping default (#47). A growing axis follows the spring
-    /// continuously — and so does a shrinking one, once the
-    /// pass promises it (`BatchSizing.allSpringSized`, #593).
-    /// `sizeRateHz` caps the size-set rate; its default `nil`
-    /// means per **display tick** (60 on a 60 Hz panel, 120 on a
-    /// 120), matching the position channel. Slow-AX apps reflow at
-    /// that rate rather than once; lower the rate, or drop to
-    /// `.midSlide`, if one falls behind.
+    /// Continuous spring-interpolated sizing throttled by rateHz (#47, #593).
     case throttledSmooth = "smooth"
 }
 
-/// Result of one size step: the size to render this frame plus the
-/// carried-forward throttle accumulator.
+/// Result of one size step containing calculated size and throttle
+/// accumulator.
 struct SizeStepResult {
     let size: CGSize
-    /// Seconds accumulated since the last emitted size-set. The
-    /// engine stores this per window and feeds it back next tick.
     let elapsed: TimeInterval
 }
 
-/// Pure size-channel policy, split per axis. Actor-free and
-/// unit-tested — the engine owns the per-window accumulator and
-/// the rounding.
+/// Pure size-channel calculation per axis (#47, #599).
 enum SizeStep {
     static func step(
         policy: SizePolicy,
@@ -64,24 +44,6 @@ enum SizeStep {
                 elapsed: 0
             )
         case .throttledSmooth:
-            // `nil` rate = per-tick: every call is "due", so the
-            // size follows the spring each frame and the
-            // accumulator stays unused (0). A rate throttles below
-            // the refresh: accrue dt and emit only when the
-            // interval has elapsed.
-            //
-            // `dt` is the display-link interval, so this counts
-            // real seconds between size-sets — which is what a cap
-            // in Hz should count. `Spring.step`'s substepping
-            // (#599) does not change that: it partitions one
-            // tick's span into several integrations, but the tick
-            // is still one frame of wall clock and still emits at
-            // most one size. The two do diverge after a stall,
-            // where `Spring.maxIntegratedStep` truncates the span
-            // to 1/30 s while this accrues the whole gap — so the
-            // next frame is instantly due and carries only 33 ms
-            // of travel. Harmless, and the position channel
-            // behaves the same way.
             let acc = elapsed + dt
             let due: Bool
             if let rateHz {
@@ -112,17 +74,7 @@ enum SizeStep {
         }
     }
 
-    /// One axis under `.throttledSmooth`. A growing axis always
-    /// follows the spring (holding its last emitted size between
-    /// throttled frames); a shrinking one takes its target on the
-    /// first frame while `snapShrink` holds, and otherwise follows
-    /// the spring the same way.
-    ///
-    /// An axis that is not moving at all lands in the shrinking
-    /// arm (`target == held`) under both branches and returns that
-    /// same value either way — the spring sits exactly on its
-    /// target with zero velocity — so a pure move still emits no
-    /// resize.
+    /// Single axis calculation under `.throttledSmooth` (`Spring.step`).
     private static func smoothAxis(
         held: CGFloat,
         target: CGFloat,

--- a/Sources/KiwiDeskCore/Animation/SizeStep.swift
+++ b/Sources/KiwiDeskCore/Animation/SizeStep.swift
@@ -5,9 +5,13 @@ import Foundation
 public enum SizePolicy: String, Sendable, Equatable,
     CaseIterable
 {
-    /// Single size-set at halfway point for slow-AX applications.
+    /// Single size-set at halfway point for slow-AX apps — a
+    /// Lua-selectable escape hatch, and deaf to `BatchSizing` by
+    /// definition: its whole contract is that one size-set.
     case midSlide = "mid_slide"
-    /// Continuous spring-interpolated sizing throttled by rateHz (#47, #593).
+    /// Continuous spring-interpolated sizing throttled by rateHz
+    /// (#47, #593). `nil` rate means per display TICK (60 or
+    /// 120 Hz), matching the position channel.
     case throttledSmooth = "smooth"
 }
 
@@ -74,7 +78,10 @@ enum SizeStep {
         }
     }
 
-    /// Single axis calculation under `.throttledSmooth` (`Spring.step`).
+    /// Single axis calculation under `.throttledSmooth`
+    /// (`Spring.step`). An axis not moving at all lands in the
+    /// shrinking arm under both branches and returns the same
+    /// value — a pure move still emits no resize.
     private static func smoothAxis(
         held: CGFloat,
         target: CGFloat,

--- a/Sources/KiwiDeskCore/App/MoveIntentLatch.swift
+++ b/Sources/KiwiDeskCore/App/MoveIntentLatch.swift
@@ -1,45 +1,16 @@
 import Foundation
 
-/// Windows just moved to another space WITHOUT follow, stamped
-/// with the move time (#482/#483).
-///
-/// A plain `move_to_space` refocuses the origin through the same
-/// cooperative raise a space switch uses, and the OS may quietly
-/// drop that activate (#463). The MOVED window then keeps OS key
-/// focus, its app re-reports it as AX-focused, and the deferred
-/// focus-follow (#22) would "follow" that re-report — teleporting
-/// the user to the target space or display the move explicitly
-/// chose not to visit. `scheduleFocusFollow` consults this latch
-/// and drops re-reports for a freshly moved window instead.
-///
-/// Purely age-compared and pruned on write, never consumed — the
-/// `selfRaiseStamps` pattern, sized the same way: Electron/WebKit
-/// apps answer AX lazily (100–300 ms), so the re-report can trail
-/// the move by several hundred ms; beyond ~1 s a focus report for
-/// the moved window is a user action (a deliberate click on it)
-/// and must follow normally.
-///
-/// Deliberately honor-except-follow, NOT a revert-and-return
-/// sibling of the activation-re-report distrust in
-/// `handleWindowFocused`: a latched report may be a genuine
-/// click the latch cannot tell from the echo, so state focus,
-/// the ring, and the focus-change emit are all still honored —
-/// only the space-follow is suppressed. Folding this into the
-/// distrust ladder with revert semantics would eat a real
-/// click's focus entirely, a worse residue than "no follow
-/// once".
+/// Latch suppressing follow on focus re-reports for windows moved
+/// without follow
+/// (`scheduleFocusFollow`, `handleWindowFocused`, #22, #463, #482, #483).
 @MainActor
 final class MoveIntentLatch {
-    /// Beyond this age a stamp no longer suppresses the follow.
-    /// The accepted trade: a genuine click on the just-moved
-    /// window inside the window is not followed once — the next
-    /// focus report follows normally (accepted-limitations row).
+    /// Age window within which focus follow is suppressed.
     static let window: TimeInterval = 1.0
 
     private var stamps: [WindowID: Date] = [:]
 
-    /// Records a no-follow move of `id`, pruning expired entries
-    /// so stamps for windows that never re-report cannot pile up.
+    /// Records no-follow move timestamp for window, pruning expired entries.
     func stamp(_ id: WindowID, at now: Date = Date()) {
         stamps = stamps.filter {
             now.timeIntervalSince($0.value) < Self.window
@@ -47,20 +18,13 @@ final class MoveIntentLatch {
         stamps[id] = now
     }
 
-    /// Whether a focus re-report for `id` arrives inside the
-    /// suppression window of a no-follow move.
+    /// Tests if window's focus report is currently latched against follow.
     func isLatched(_ id: WindowID, at now: Date = Date()) -> Bool {
         guard let stamp = stamps[id] else { return false }
         return now.timeIntervalSince(stamp) < Self.window
     }
 
-    /// Retargets a stamp on a native-tab rekey (#308): the moved
-    /// window still holds OS key focus in the exact hazard this
-    /// latch guards, so a tab-switch chord inside the window
-    /// mints a fresh id whose re-report would otherwise arrive
-    /// unlatched — the teleport reintroduced on one path. Called
-    /// from the `.windowRekeyed` bookkeeping transfer. No prune
-    /// here by design — pruning rides `stamp`.
+    /// Transfers latch stamp on native-tab re-key (`.windowRekeyed`, #308).
     func rekey(old: WindowID, new: WindowID) {
         guard let stamp = stamps.removeValue(forKey: old) else {
             return

--- a/Sources/KiwiDeskCore/App/MoveIntentLatch.swift
+++ b/Sources/KiwiDeskCore/App/MoveIntentLatch.swift
@@ -1,11 +1,21 @@
 import Foundation
 
-/// Latch suppressing follow on focus re-reports for windows moved
-/// without follow
-/// (`scheduleFocusFollow`, `handleWindowFocused`, #22, #463, #482, #483).
+/// Latch suppressing follow on focus re-reports for windows
+/// moved without follow (`scheduleFocusFollow`, #22, #463, #482,
+/// #483). Deliberately honor-except-follow, NOT a
+/// revert-and-return sibling of `handleWindowFocused`'s distrust
+/// ladder: a latched report may be a genuine click the latch
+/// cannot tell from the echo, so focus, ring and emit are all
+/// honored — only the space-follow is suppressed. Revert
+/// semantics would eat a real click's focus, a worse residue.
 @MainActor
 final class MoveIntentLatch {
-    /// Age window within which focus follow is suppressed.
+    /// Age window within which focus follow is suppressed:
+    /// Electron/WebKit answer AX lazily (100–300 ms), so the echo
+    /// can trail by several hundred ms; beyond ~1 s a report is a
+    /// user action. Accepted trade: a genuine click on the moved
+    /// window inside the window is not followed once
+    /// (accepted-limitations row).
     static let window: TimeInterval = 1.0
 
     private var stamps: [WindowID: Date] = [:]

--- a/Sources/KiwiDeskCore/Appearance/ColorPalette+Match.swift
+++ b/Sources/KiwiDeskCore/Appearance/ColorPalette+Match.swift
@@ -1,58 +1,18 @@
 import Foundation
 
-/// Whether a palette is the one a config is currently wearing
-/// (#757).
-///
-/// A palette paints one-shot (#375), so nothing records which one
-/// was applied — and a "last applied" note would go on lying the
-/// moment the user edits a colour by hand. The shelf therefore
-/// asks the only question it can answer truthfully: do these
-/// colours still say what this palette says?
-///
-/// Note *these* rather than "the live colours": the shelf passes
-/// the config it is EDITING, so with unsaved edits the mark
-/// follows the draft rather than the running app. That is the
-/// right half — every other preview on the page reads the draft
-/// too, and a mark that ignored it would contradict the scene
-/// drawn beside it.
+/// Palette matching against active settings values (#375, #757).
 extension ColorPalette {
-    /// True when every colour this palette paints already carries
-    /// this palette's value in `settings`.
+    /// True when every colour defined in this palette matches `settings`
+    /// (`ColorPaletteKeys.extract`, #757).
     public func isApplied(to settings: TilingSettings) -> Bool {
         isApplied(matching: ColorPaletteKeys.extract(from: settings))
     }
 
-    /// The same answer against an already-extracted colour map.
-    ///
-    /// Extraction encodes the whole of `TilingSettings` and walks
-    /// the result, so a shelf asking per tile would pay that once
-    /// per palette per redraw; it extracts once and asks each
-    /// palette. The overload exists for that and nothing else —
-    /// the answer is still computed, never stored, because a
-    /// remembered "applied palette" is the second source of truth
-    /// this design refuses.
-    ///
-    /// Compares what the palette *sets*, not the whole surface: a
-    /// sparse palette that paints four colours is applied when
-    /// those four match, which is exactly what applying it would
-    /// leave behind. A consequence worth stating, since it is
-    /// visible: more than one card can be applied at once — a
-    /// palette saved from the colours a bundled one painted is
-    /// equal to it, and both are honestly "what you have".
-    ///
-    /// Comparison is by parsed colour rather than by string, so
-    /// `#8db354`, `#8DB354` and `#8DB354FF` are one answer — the
-    /// hex a user types in Advanced Colours must not read as a
-    /// different theme from the hex the palette shipped. The two
-    /// mark tints may also carry the empty "Automatic" face
-    /// (`ColorPaletteKeys.allowsAutomatic`), which parses to no
-    /// colour at all and so is matched as itself.
+    /// Evaluates if palette colors match extracted color map
+    /// (`ColorPaletteKeys.allowsAutomatic`, #757).
     public func isApplied(
         matching live: [String: String]
     ) -> Bool {
-        // An empty palette paints nothing, and "nothing is
-        // already true" would mark it applied against every
-        // possible config.
         guard !colors.isEmpty else { return false }
         return colors.allSatisfy { path, hex in
             guard let current = live[path] else { return false }
@@ -60,10 +20,8 @@ extension ColorPalette {
         }
     }
 
-    /// Equal as colours: both empty, or both parse to the same
-    /// components. An unparseable hex matches only an identical
-    /// unparseable one, which keeps a malformed palette from
-    /// reading as applied to anything.
+    /// Compares two color strings for equivalent parsed color value
+    /// (`DragVisual.parseHex`).
     static func sameColor(_ a: String, _ b: String) -> Bool {
         let left = DragVisual.parseHex(a)
         let right = DragVisual.parseHex(b)

--- a/Sources/KiwiDeskCore/Appearance/ColorPalette+Match.swift
+++ b/Sources/KiwiDeskCore/Appearance/ColorPalette+Match.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-/// Palette matching against active settings values (#375, #757).
+/// Palette matching against active settings values (#375,
+/// #757). Computed, never stored: a remembered "last applied"
+/// note would go on lying the moment the user edits a colour by
+/// hand — the shelf asks the only question it can answer
+/// truthfully. The shelf passes the config it is EDITING, so the
+/// mark follows the draft like every other preview.
 extension ColorPalette {
     /// True when every colour defined in this palette matches `settings`
     /// (`ColorPaletteKeys.extract`, #757).
@@ -8,11 +13,17 @@ extension ColorPalette {
         isApplied(matching: ColorPaletteKeys.extract(from: settings))
     }
 
-    /// Evaluates if palette colors match extracted color map
-    /// (`ColorPaletteKeys.allowsAutomatic`, #757).
+    /// Evaluates if palette colors match the extracted map
+    /// (`ColorPaletteKeys.allowsAutomatic`, #757). Compares what
+    /// the palette SETS, not the whole surface — so more than one
+    /// card can honestly read applied at once. Comparison is by
+    /// PARSED colour: `#8db354` and `#8DB354FF` are one answer.
     public func isApplied(
         matching live: [String: String]
     ) -> Bool {
+        // An empty palette paints nothing, and "nothing is
+        // already true" would mark it applied against every
+        // possible config.
         guard !colors.isEmpty else { return false }
         return colors.allSatisfy { path, hex in
             guard let current = live[path] else { return false }
@@ -20,8 +31,10 @@ extension ColorPalette {
         }
     }
 
-    /// Compares two color strings for equivalent parsed color value
-    /// (`DragVisual.parseHex`).
+    /// Compares two color strings for equivalent parsed value
+    /// (`DragVisual.parseHex`). An unparseable hex matches only an
+    /// identical unparseable one, so a malformed palette cannot
+    /// read as applied to anything.
     static func sameColor(_ a: String, _ b: String) -> Bool {
         let left = DragVisual.parseHex(a)
         let right = DragVisual.parseHex(b)

--- a/Sources/KiwiDeskCore/Appearance/ColorPaletteKeys.swift
+++ b/Sources/KiwiDeskCore/Appearance/ColorPaletteKeys.swift
@@ -1,27 +1,6 @@
 import Foundation
 
-/// The color surface a palette can set (#375): every color across
-/// the App Bar, Space Bar, focus borders, drag visuals and the
-/// sticky/floating marks, as fully-qualified dotted paths matching
-/// the profile-JSON vocabulary (`app_bar.fill_color`,
-/// `space_bar.fill_color`, `border.focused_color`,
-/// `drag.ghost.fill_color`, `sticky.color`, …). The dotted
-/// namespace is load-bearing: bare wire keys like `fill_color`
-/// collide between the two bars.
-///
-/// Reflection-derived: each struct's color CodingKeys, namespaced
-/// by where the struct sits in the settings tree, so a new color
-/// key auto-joins the surface (and the drag structs contribute
-/// their keys under both `ghost` and `drop_zone`).
-///
-/// The mark structs joined in the #678 Colours phase: Advanced
-/// Colours renders every color KiwiDesk has on one page under a
-/// "save these as a palette" promise, and the two mark tints were
-/// the only rows on it that a palette could not carry — a bridge
-/// that silently drops two of its rows. Their CodingKey is bare
-/// `color` (the struct IS the mark), which is why the filter below
-/// admits an exact `color` alongside the `_color` suffix rather
-/// than renaming a shipped wire key.
+/// Dotted color key definitions for theme palettes (#375, #678).
 public enum ColorPaletteKeys {
     /// Every settable color path, in a stable order.
     public static var all: [String] {
@@ -55,19 +34,7 @@ public enum ColorPaletteKeys {
             )
     }
 
-    /// Whether `path` may carry the empty "Automatic" value as
-    /// well as a hex. Only the two mark tints have an adaptive
-    /// face (`StickyStyle.color`'s empty default is the system
-    /// label color), and their bare `color` key is exactly what
-    /// distinguishes them — every other path ends in `_color`.
-    /// Derived from the path so a third mark struct cannot join
-    /// the surface without joining this too.
-    ///
-    /// Without it the surface would be one-directional: a palette
-    /// could paint a mark but never hand it back to Automatic,
-    /// and the derived default palette — which extracts the
-    /// shipped defaults, both of them empty — would carry two
-    /// values `apply` silently dropped.
+    /// Whether path permits empty automatic value (`StickyStyle.color`).
     public static func allowsAutomatic(_ path: String) -> Bool {
         path.hasSuffix(".color")
     }
@@ -81,12 +48,7 @@ public enum ColorPaletteKeys {
             .map { "\(prefix).\($0)" }
     }
 
-    /// The current color values of `settings`, keyed by the same
-    /// dotted paths — the inverse of `ColorPalette.apply`. Encodes
-    /// the settings and reads each path out of the JSON, so it
-    /// stays reflection-driven and can't miss a key the encoder
-    /// emits. Backs both the derived "Kiwi (Default)" palette and
-    /// "Save current colors as…" (#375).
+    /// Extracts color dictionary from settings (`ColorPalette.apply`, #375).
     public static func extract(
         from settings: TilingSettings
     ) -> [String: String] {

--- a/Sources/KiwiDeskCore/Appearance/ColorPaletteKeys.swift
+++ b/Sources/KiwiDeskCore/Appearance/ColorPaletteKeys.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-/// Dotted color key definitions for theme palettes (#375, #678).
+/// Dotted color key definitions for theme palettes (#375,
+/// #678). The dotted namespace is load-bearing — bare wire keys
+/// like `fill_color` collide between the two bars — and the
+/// surface is reflection-derived from each struct's color
+/// CodingKeys, so a new color key auto-joins.
 public enum ColorPaletteKeys {
     /// Every settable color path, in a stable order.
     public static var all: [String] {
@@ -34,7 +38,11 @@ public enum ColorPaletteKeys {
             )
     }
 
-    /// Whether path permits empty automatic value (`StickyStyle.color`).
+    /// Whether path permits the empty "Automatic" value
+    /// (`StickyStyle.color`). Derived from the path — a third mark
+    /// struct cannot join the surface without joining this too.
+    /// Without it the surface is one-directional: a palette could
+    /// paint a mark but never hand it back to Automatic.
     public static func allowsAutomatic(_ path: String) -> Bool {
         path.hasSuffix(".color")
     }

--- a/Sources/KiwiDeskCore/Bar/AppBarItemView+Paint.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarItemView+Paint.swift
@@ -2,7 +2,10 @@ import AppKit
 
 /// Visual styling and layer color application for `AppBarItemView`.
 extension AppBarItemView {
-    /// Applies active and hover colors to text, icon, and background layers
+    /// Applies active and hover colors to text, icon, and
+    /// background layers. The icon's dim is deliberately the full
+    /// 0.4, NOT the Space Bar's 0.6 middle tier: a binary signal
+    /// with no lower tier to collide with
     /// (`BarAccent.activeUnfocusedAlpha`).
     func applyColors() {
         label.textColor = NSColor(kiwiHex: textColorHex)
@@ -67,6 +70,10 @@ extension AppBarItemView {
         return style.hasBox
     }
 
+    // The Settings palette scene (`PaletteSceneThumbnail`, GUI
+    // target) is a schematic twin of this box/accent logic —
+    // keep the two in step when the box or accent rules change
+    // (#793).
     var boxColorHex: String {
         if isHovered { return style.hoverFillColor }
         return style.hasBox ? style.fillColor : "#00000000"

--- a/Sources/KiwiDeskCore/Bar/AppBarItemView+Paint.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarItemView+Paint.swift
@@ -1,27 +1,12 @@
 import AppKit
 
-/// How an App Bar item paints itself: the colour ladder (hover
-/// over active over rest), the box fill, the corner rounding and
-/// the active accent. Split from AppBarItemView.swift, which sat
-/// on the §2.1 file ceiling.
-///
-/// One concern, deliberately: every one of these reads `style`
-/// plus the item's own `isActive` / `isHovered` state and writes
-/// a layer property. Click, drag and hover *bookkeeping* stays
-/// with the view; what a hover then LOOKS like is here.
+/// Visual styling and layer color application for `AppBarItemView`.
 extension AppBarItemView {
-    /// Hover swaps the box background (no overlay: a wash on
-    /// top would muddy the icon and text) and the text color.
+    /// Applies active and hover colors to text, icon, and background layers
+    /// (`BarAccent.activeUnfocusedAlpha`).
     func applyColors() {
         label.textColor = NSColor(kiwiHex: textColorHex)
         glyphLabel.textColor = NSColor(kiwiHex: textColorHex)
-        // The app image never tints, so it carried no active
-        // cue at all (QA 2026-07-19): dimmed when inactive,
-        // shape (accent) plus opacity carry the state.
-        // Deliberately the full 0.4 dim, NOT the Space Bar's
-        // 0.6 middle tier — this is a binary signal reinforced
-        // by the outline, with no lower tier to collide with
-        // (see `BarAccent.activeUnfocusedAlpha`).
         iconView.alphaValue =
             isActive || isHovered
             ? 1 : style.dimFactor
@@ -30,18 +15,12 @@ extension AppBarItemView {
         applyCornerRadius()
     }
 
-    /// The item's bar-cross dimension (its thickness), which the
-    /// corner radius resolves against.
+    /// Cross dimension thickness for corner radius resolution.
     var crossThickness: CGFloat {
         horizontal ? bounds.height : bounds.width
     }
 
-    /// Round the box fill to `cornerRoundness`% of a capsule, and
-    /// clip the active mark to the same corner through `accentClip`
-    /// so it cuts on the curve like the Space Bar (owner 2026-07-20)
-    /// instead of a square end — the item itself does NOT clip, so a
-    /// corner count badge stays whole. Which corners round follows
-    /// `maskedCorners`.
+    /// Configures corner rounding and active mark clipping on item layers.
     func applyCornerRadius() {
         let radius = style.resolvedCornerRadius(
             forThickness: crossThickness
@@ -53,12 +32,7 @@ extension AppBarItemView {
         accentClip.layer?.maskedCorners = maskedCorners
     }
 
-    /// Boxed clips all four corners (each item is its own box). Plain
-    /// clips only where the shared plate actually rounds — the run's
-    /// outer end — so the mark cuts on the curve there and runs
-    /// square (touching a neighbour) between (owner 2026-07-20). The
-    /// horizontal run maps the outer end to the X side (flip-safe);
-    /// the vertical run to the Y side.
+    /// Masked corners for item background rounding.
     var maskedCorners: CACornerMask {
         let all: CACornerMask = [
             .layerMinXMinYCorner, .layerMaxXMinYCorner,
@@ -86,32 +60,19 @@ extension AppBarItemView {
             : style.itemColor
     }
 
-    /// Whether this item paints a box behind its content: always
-    /// when `boxed`, and on hover (a `plain` item reveals a box
-    /// only while hovered). `plain` is otherwise boxless in every
-    /// combo, including the active ring (which is a pure stroke).
+    /// Whether a box background should be painted
+    /// (`PaletteSceneThumbnail`, #793).
     var hasBox: Bool {
         if isHovered { return true }
         return style.hasBox
     }
 
-    // The Settings palette scene (`PaletteSceneThumbnail`, GUI
-    // target) is a schematic twin of this box/accent logic —
-    // keep the two in step when the box or accent rules change.
-    // It replaced `AppBarPreviewStrip`, which drew the same
-    // twin and was retired in #793.
     var boxColorHex: String {
         if isHovered { return style.hoverFillColor }
-        // One fill for every box (active marked by the indicator,
-        // not a distinct fill). Plain — and any glass finish, whose
-        // shared plate is the background — paint no per-item box.
         return style.hasBox ? style.fillColor : "#00000000"
     }
 
-    /// How the active item is marked, gated on the indicator and
-    /// orthogonal to `backgroundStyle` (the background no longer
-    /// secretly picks the accent). Only the active item, and never
-    /// under `gap` (its slot is hidden entirely).
+    /// Active item indicator appearance mode.
     enum AccentMode { case none, outline, edgeMark }
 
     var accentMode: AccentMode {
@@ -122,10 +83,7 @@ extension AppBarItemView {
             ? .outline : .edgeMark
     }
 
-    /// The ring and edge mark both live on the `accent` subview
-    /// (mutually exclusive); geometry is set in `layoutAccent`.
-    /// The ring is a pure stroke (no fill) in the highlight
-    /// color; the edge mark a filled bar.
+    /// Applies stroke or fill to active indicator layer (`layoutAccent`).
     func applyAccent() {
         layer?.borderWidth = 0
         switch accentMode {

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+Panel.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+Panel.swift
@@ -1,7 +1,6 @@
 import AppKit
 
-/// Panel plumbing: the non-activating panel, the clipping
-/// item viewport inside it, and per-render container styling.
+/// Panel plumbing and view container styling for AppBarOverlay.
 extension AppBarOverlay {
     /// Flipped so the first item sits at the visual top of
     /// vertical bars.
@@ -9,10 +8,7 @@ extension AppBarOverlay {
         override var isFlipped: Bool { true }
     }
 
-    /// `plain` and `material` draw their shared plate as its
-    /// own view (`updatePlainPlate` / the glass-hosting dispatch)
-    /// so it can hug the run (`background_fit`); `boxed` boxes
-    /// each item. The container itself never paints.
+    /// Configures container layer properties (`background_fit`).
     func styleContainer(
         _ panel: NSPanel,
         style: AppBarStyle,
@@ -23,14 +19,10 @@ extension AppBarOverlay {
         }
         layer.masksToBounds = true
         layer.cornerRadius = 0
-        // The container never paints: the fill is drawn per item
-        // (Boxed) or as a shared plate (Plain / Material glass).
         layer.backgroundColor = NSColor.clear.cgColor
     }
 
-    /// Shows / sizes `plain`'s shared fill plate at
-    /// `plateFrame`, else hides it. Rounds against the real
-    /// (clamped) cross depth, like the glass plate.
+    /// Updates plain shared background plate geometry and style.
     func updatePlainPlate(
         _ panel: NSPanel,
         style: AppBarStyle,
@@ -38,8 +30,6 @@ extension AppBarOverlay {
         plateFrame: CGRect,
         animated: Bool = false
     ) {
-        // Solid Plain plate: the Plain shape without the glass
-        // finish (Plain + glass draws the glass plate instead).
         guard style.backgroundStyle == .plain, !style.glassEnabled,
             let content = panel.contentView
         else {
@@ -57,9 +47,6 @@ extension AppBarOverlay {
             )
         }
         plate.isHidden = false
-        // Ease alongside the items (same animation group): a
-        // snapping hug plate pops while the items it wraps are
-        // still sliding. Fresh plates take their frame direct.
         if animated, plate.frame != .zero,
             plate.frame != plateFrame
         {
@@ -75,8 +62,7 @@ extension AppBarOverlay {
             NSColor(kiwiHex: style.fillColor).cgColor
     }
 
-    /// The one hosting mode for this render (#407), from the
-    /// resolved style and whether the run overflows.
+    /// Resolves glass hosting mode (#407).
     func glassHosting(
         _ style: AppBarStyle,
         overflow: Bool
@@ -89,15 +75,8 @@ extension AppBarOverlay {
         )
     }
 
-    /// Teardown half of the one glass-hosting dispatch (#407): run
-    /// once per render, *before* the item loop, so the items sit in
-    /// the container the target mode expects while their frames are
-    /// laid out. It tears down every mode except `mode`; the target
-    /// itself is installed post-loop by `installGlassHosting`, which
-    /// needs those frames (per-box and plain-glass both place items
-    /// from them). The solid plain plate self-gates in
-    /// `updatePlainPlate`. Keeps the `GlassPlate.holds` idempotency:
-    /// the target's parenting is left in place across renders.
+    /// Prepares container hierarchy for glass hosting before item layout
+    /// (`GlassPlate.holds`, #407).
     func prepareGlassHosting(
         _ mode: GlassHosting,
         panel: NSPanel,
@@ -117,20 +96,13 @@ extension AppBarOverlay {
         guard let content = panel.contentView else { return }
         switch mode {
         case .boxGlass:
-            // Per-box glass keeps its boxes; hand the item run back
-            // so the boxes can reparent items out of it, unwind any
-            // plain-glass run, and hide the single plate.
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
             glassPlate?.isHidden = true
             glassTint?.isHidden = true
         case .plainGlassHug, .plainGlassSpan:
-            // The run + single plate are hosted post-loop by
-            // `updatePlainGlass`; only the boxes must go first.
             teardownBoxGlasses()
         case .plainPlate, .none:
-            // No glass: unwind boxes and run, restore the plain
-            // hierarchy, and hide the glass plate.
             teardownBoxGlasses()
             restoreItemContainer(to: content, viewport: viewport)
             teardownGlassRun()
@@ -139,10 +111,7 @@ extension AppBarOverlay {
         }
     }
 
-    /// Install half of the one glass-hosting dispatch (#407): run
-    /// once per render, *after* the item loop, to host the target
-    /// mode from the laid-out `frames`. The teardown of the other
-    /// modes already happened in `prepareGlassHosting`.
+    /// Installs target glass hosting mode from computed frames (#407).
     func installGlassHosting(
         _ mode: GlassHosting,
         panel: NSPanel,

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
@@ -1,26 +1,17 @@
 import AppKit
 
-/// Slot layout for one Space item: the identifier glyph leads
-/// (left on a horizontal bar, top on a vertical one), the app
-/// glyphs follow along the bar axis. Pixel-rounded so glyphs
-/// never land on half pixels.
+/// Slot layout implementation for `SpaceBarItemView`.
 extension SpaceBarItemView {
     /// Cross-axis padding inside the slot.
     static let pad: CGFloat = 4
 
-    /// Square cell length each glyph (identifier or app)
-    /// occupies along the bar axis, derived from the cross
-    /// depth.
+    /// Cell dimension for glyphs along the bar axis.
     var cellLength: CGFloat {
         let depth = horizontal ? bounds.height : bounds.width
         return max(depth - Self.pad * 2, 8)
     }
 
-    /// The slot length an item with `appCount` glyphs wants
-    /// along the bar axis: identifier cell + the divider rule
-    /// (when glyphs follow) + one cell per app glyph (+ one for
-    /// the "+n" overflow badge) + padding. The overlay uses
-    /// this for auto sizing.
+    /// Computes requested slot length for given app count and overflow badge.
     static func autoLength(
         appCount: Int,
         overflow: Int = 0,
@@ -36,16 +27,10 @@ extension SpaceBarItemView {
         super.layout()
         let cell = cellLength
         if case .text = spaceGlyph {
-            // Emoji/character identifiers use the system font;
-            // App Font ligatures are app glyphs, never
-            // identifiers.
             identifierLabel.font = .systemFont(
                 ofSize: identifierFont
             )
         }
-        // Restyle BEFORE placing: `place` measures each text
-        // glyph to center it vertically, and the glyph fonts
-        // are set in `restyle` (bounds are already final here).
         restyle()
         var cursor = Self.pad
         place(identifierImage, at: cursor, cell: cell)
@@ -80,8 +65,6 @@ extension SpaceBarItemView {
             cursor += cell
         }
         if overflow > 0 {
-            // The "+n" badge occupies its own trailing slot,
-            // centered like a glyph.
             layoutBadge(
                 overflowBadge,
                 onCellAt: cursor,
@@ -93,10 +76,7 @@ extension SpaceBarItemView {
         layoutAccent()
     }
 
-    /// A count badge hugging its glyph cell's top-trailing
-    /// corner (flipped coordinates), or centered in the cell
-    /// for the overflow slot. Circle grows for multi-digit
-    /// counts — same shape as the App Bar's badge.
+    /// Positions count badge on cell corner or centered for overflow.
     private func layoutBadge(
         _ badge: NSTextField,
         onCellAt offset: CGFloat,
@@ -104,12 +84,6 @@ extension SpaceBarItemView {
         centered: Bool = false
     ) {
         guard !badge.isHidden else { return }
-        // The overflow "+n" fills its cell like a glyph, so it reads
-        // as the run's final icon rather than a small detached dot
-        // (owner/designer 2026-07-20). A per-app count stays the
-        // small corner dot (the shared badge-family size, QA
-        // 2026-07-19 — the 0.5-of-cell badge read oversized next to
-        // small glyphs).
         let base =
             centered
             ? cell * 0.8 : StateBadgeMetrics.side(cell: cell)
@@ -118,8 +92,6 @@ extension SpaceBarItemView {
             weight: .bold
         )
         let textWidth = ceil(badge.cell?.cellSize.width ?? 0)
-        // Capped at the cell so a "+42" on a thin bar squeezes
-        // rather than clipping top/bottom under masksToBounds.
         let diameter = min(
             max(base, textWidth + 2),
             cell + 2
@@ -159,11 +131,7 @@ extension SpaceBarItemView {
         badge.layer?.cornerRadius = diameter / 2
     }
 
-    /// The state badges (#414) on one glyph cell: sticky hugs
-    /// the top-LEADING corner, floating the bottom-leading —
-    /// the count badge owns top-trailing. Same footprint as the
-    /// corner count dot, no circle plate (a state mark, not a
-    /// count).
+    /// Positions sticky and floating state badges on glyph cell (#414).
     private func layoutStateBadges(
         at index: Int,
         onCellAt offset: CGFloat,
@@ -184,9 +152,6 @@ extension SpaceBarItemView {
                 width: cell,
                 height: cell
             )
-        // Flipped coordinates: minY is the visual top.
-        // Overhang matching the count badge (#414): sticky
-        // hugs top-leading, floating hugs bottom-leading.
         if index < stickyBadgeViews.count,
             !stickyBadgeViews[index].isHidden
         {
@@ -238,12 +203,7 @@ extension SpaceBarItemView {
                 width: cell,
                 height: cell
             )
-        // AppKit draws text from the frame's TOP, so a text
-        // glyph (App Font ligature, character identifier)
-        // handed the whole square cell reads top-aligned.
-        // Shrink to its measured height, centered — the
-        // `AppBarItemView+GlyphSlot` midY idiom. Images
-        // center natively and keep the full cell.
+        // Center text glyph vertically (`AppBarItemView+GlyphSlot`).
         if let field = view as? NSTextField {
             let height = ceil(
                 field.cell?.cellSize.height ?? 0
@@ -263,10 +223,8 @@ extension SpaceBarItemView {
     private func layoutAccent() {
         switch style.activeIndicator {
         case .outline:
-            // Boxed hugs the box; plain/material insets to the
-            // App Bar's capsule ring (ui-designer 2026-07-14) —
-            // a full-bounds square poked past the shared plate's
-            // rounded corners in hug mode (QA 2026-07-19).
+            // Boxed hugs the box; unboxed insets (`BarAccent.capsuleInset`,
+            // QA 2026-07-19).
             accent.frame =
                 style.hasBox
                 ? bounds
@@ -275,10 +233,7 @@ extension SpaceBarItemView {
                     dy: BarAccent.capsuleInset
                 )
         case .edgeMark:
-            // On the window-facing side of the slot: a top bar
-            // faces down, a left bar right, and so on. The view
-            // is flipped (y grows down), so a top bar's mark
-            // sits at maxY.
+            // Positions edge indicator on window-facing side of slot.
             let mark: CGFloat = 3
             switch style.edge {
             case .top:

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+Layout.swift
@@ -31,6 +31,9 @@ extension SpaceBarItemView {
                 ofSize: identifierFont
             )
         }
+        // Restyle BEFORE placing: `place` measures each text
+        // glyph to center it, and the glyph fonts are set in
+        // `restyle`.
         restyle()
         var cursor = Self.pad
         place(identifierImage, at: cursor, cell: cell)

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Render.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Render.swift
@@ -34,6 +34,10 @@ extension SpaceBarOverlay {
             gap: gap,
             frontExtent: front
         )
+        // Pin only while the trailing band leaves the Spaces a
+        // real viewport; a pathological near-full-width app name
+        // falls back to scrolling with the run rather than
+        // collapsing the Spaces to nothing (#409).
         let arrowRoom = 2 * (BarArrowView.zone + gap)
         let pinFront =
             total > axis && frontApp != nil

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Render.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Render.swift
@@ -1,15 +1,8 @@
 import AppKit
 
-/// The Space Bar's one layout pass. Split from `SpaceBarOverlay`
-/// for file size (§2): the stored views/state and the show/hide
-/// surface stay in the main file; the render composition — item
-/// run, scroll viewport, the pinned front segment (#409), the
-/// glass hosting, and the arrows — lives here.
+/// Layout and rendering passes for `SpaceBarOverlay` (#407, #409).
 extension SpaceBarOverlay {
-    /// One layout pass over the last shown state. `show()`
-    /// follows the active Space into view; a manual arrow or
-    /// autoscroll re-renders without that adjustment so it isn't
-    /// snapped straight back (the App Bar's `followingFocus`).
+    /// Executes one layout pass over the last shown state.
     func render(followingActive: Bool) {
         guard let state = lastShown else { return }
         let (items, frontApp, strip, style, stateMarkColors) = state
@@ -30,15 +23,6 @@ extension SpaceBarOverlay {
                     depth: depth
                 )
         }
-        // While the whole run fits, items plus the trailing front
-        // segment align as ONE run (an end-aligned bar ends at the
-        // rim including the segment) — the segment is the run's
-        // tail, unchanged. When the run OVERFLOWS, the segment is
-        // pinned to the trailing rim in a fixed band and only the
-        // Spaces scroll behind the arrows (#409), so the front app
-        // never scrolls out of view. The overflow threshold still
-        // weighs items + segment together, so the bar starts
-        // scrolling at exactly the same width as before.
         let front = frontExtent(
             frontApp,
             depth: depth,
@@ -50,18 +34,10 @@ extension SpaceBarOverlay {
             gap: gap,
             frontExtent: front
         )
-        // Pin only when the trailing band still leaves the Spaces a
-        // real viewport (room for both arrow zones); a pathological
-        // near-full-width app name falls back to scrolling with the
-        // run rather than collapsing the Spaces to nothing.
         let arrowRoom = 2 * (BarArrowView.zone + gap)
         let pinFront =
             total > axis && frontApp != nil
             && front < axis - arrowRoom
-        // Pinned: the segment owns the trailing `front` band, so the
-        // Spaces scroll in the axis that remains and the segment
-        // leaves the scrolled run. Not pinned: the segment rides the
-        // run as its tail, exactly as before.
         let scrolledFront = pinFront ? 0 : front
         let spacesAxis = pinFront ? axis - front : axis
         let scrolledTotal = Self.runTotal(
@@ -100,21 +76,12 @@ extension SpaceBarOverlay {
             pad: SpaceBarItemView.pad,
             scrollOffset: scrollOffset
         )
-        // The shared plate (plain fill / glass) hugs or spans
-        // per `background_fit`. With no arrow inset the
-        // viewport is the strip, so viewport-local run
-        // coordinates are already strip-local; while inset > 0
-        // the plate is full anyway.
         let runStart: CGFloat
         if let first = metrics.itemFrames.first {
             runStart = horizontal ? first.minX : first.minY
         } else {
             runStart = metrics.frontStart
         }
-        // A pinned segment (#409) means the run fills the strip
-        // (Spaces + arrows + segment), so the shared plate spans it
-        // — nothing to hug, and the pinned segment must sit on the
-        // same continuous plate as the Spaces.
         let plateFrame =
             pinFront
             ? CGRect(
@@ -132,9 +99,6 @@ extension SpaceBarOverlay {
                 horizontal: horizontal,
                 fit: style.backgroundFit
             )
-        // The one hosting mode for this render (#407): prepared
-        // (non-target teardown) here, then installed post-passes
-        // once the item frames are laid out.
         let hosting = glassHosting(style, overflow: inset > 0)
         prepareGlassHosting(
             hosting,
@@ -166,20 +130,10 @@ extension SpaceBarOverlay {
             view.onSelect = { [weak self] space in
                 self?.onSelect(space)
             }
-            // Only the run's outer items meet a rounded plate end.
-            // The trailing end is the front-app segment's when one
-            // trails, so the last Space item clips its trailing
-            // corner only without a front app.
             view.isFirstInRun = index == 0
             view.isLastInRun =
                 index == items.count - 1 && frontApp == nil
         }
-        // Host the segment in the panel content (outside the
-        // clipping viewport) while pinned, so it stays put as the
-        // Spaces scroll; in the viewport as the run's tail while it
-        // fits. Pinned, its divider sits one `gap` past where the
-        // forward arrow ends (`spacesAxis`), mirroring the run-tail
-        // spacing; the name may still reach the strip rim.
         frontHost = pinFront ? panel.contentView : itemContainer
         renderFrontSegment(
             frontApp,
@@ -189,10 +143,6 @@ extension SpaceBarOverlay {
             style: style,
             horizontal: horizontal
         )
-        // Install the target hosting from the now-laid-out item
-        // frames (per-box glass and the plain-glass run both position
-        // from them, so this runs after the item + front passes).
-        // #407: one dispatch, no per-mode branching at the call site.
         installGlassHosting(
             hosting,
             panel: panel,
@@ -226,7 +176,7 @@ extension SpaceBarOverlay {
         }
     }
 
-    /// The index of the active Space, for scroll-follow.
+    /// Index of the active Space for scroll-follow navigation.
     private func activeIndex(_ items: [Item]) -> Int? {
         items.firstIndex(where: \.active)
     }

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Scroll.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Scroll.swift
@@ -1,6 +1,10 @@
 import AppKit
 
-/// Space Bar overflow scroll chrome and drag autoscroll (#385, #409).
+/// Space Bar overflow scroll chrome and drag autoscroll (#385,
+/// #409). The arrow zones structurally exclude every item's hit
+/// frame (`recordHitFrames`), so the autoscroll and the
+/// drop-spring govern disjoint zones and never contend — no
+/// shared dwell state, no coordination flag.
 extension SpaceBarOverlay {
     /// Scroll geometry cached each render for the autoscroll path.
     struct ScrollGeom {

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Scroll.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Scroll.swift
@@ -1,45 +1,24 @@
 import AppKit
 
-/// Whole-bar overflow for the Space Bar (#385): the scroll arrows,
-/// their layout and click handling, and the drag autoscroll that
-/// lets a window be dropped onto a Space scrolled off the strip.
-///
-/// The arrow zones are chrome that structurally excludes every
-/// item's hit frame (see `recordHitFrames`), so a drag cursor is
-/// over an arrow XOR over a Space item, never both. The autoscroll
-/// (this file) and the drop-spring (`SpaceBarDropCoordinator`)
-/// therefore govern disjoint zones and never contend — no shared
-/// dwell state, no coordination flag.
+/// Space Bar overflow scroll chrome and drag autoscroll (#385, #409).
 extension SpaceBarOverlay {
     /// Scroll geometry cached each render for the autoscroll path.
     struct ScrollGeom {
         let strip: CGRect
-        /// Arrow-zone inset (> 0 only while overflowing).
         let inset: CGFloat
         let horizontal: Bool
-        /// Distance one click / autoscroll tick shifts the bar.
         let step: CGFloat
-        /// The largest valid scroll offset (`total − viewport`).
         let maxOffset: CGFloat
-        /// The Spaces region's trailing edge along the axis (#409):
-        /// the strip length, or `strip − front band` while the front
-        /// segment is pinned. The forward arrow sits one zone inside
-        /// it, and `arrowHit` bounds the forward zone by it.
+        /// Trailing edge bound along axis (#409).
         let trailingAxis: CGFloat
     }
 
-    /// Quiet dwell over an arrow before the first autoscroll tick,
-    /// then the tick interval. Proposed defaults (#385) — worth a
-    /// feel-test pass, like #372's spring dwell, before treated as
-    /// settled; not user-configurable (no new knob).
+    /// Autoscroll timing parameters (#372, #385).
     nonisolated static let autoScrollInitialDelay: TimeInterval =
         0.2
     nonisolated static let autoScrollInterval: TimeInterval = 0.3
 
-    // MARK: - Arrow layout
-
-    /// Places the two scroll arrows over the strip's ends, shown
-    /// only toward hidden items, and caches the scroll geometry.
+    /// Configures scroll arrows based on overflow and scroll offset (#409).
     func layoutArrows(
         strip: CGRect,
         inset: CGFloat,
@@ -61,9 +40,6 @@ extension SpaceBarOverlay {
             horizontal
             ? CGRect(x: 0, y: 0, width: zone, height: strip.height)
             : CGRect(x: 0, y: 0, width: strip.width, height: zone)
-        // The forward arrow sits at the Spaces region's trailing
-        // edge — the strip rim, or one front band in while the front
-        // segment is pinned there (#409).
         forwardArrow.frame =
             horizontal
             ? CGRect(
@@ -110,21 +86,13 @@ extension SpaceBarOverlay {
         )
     }
 
-    /// Shifts the bar by `delta` and re-renders without following
-    /// the active Space, so a manual scroll isn't snapped back.
-    /// `render` re-clamps the offset to the valid range.
+    /// Shifts bar offset and re-renders without forcing active follow.
     func scroll(by delta: CGFloat) {
         scrollOffset += delta
         render(followingActive: false)
     }
 
-    // MARK: - Drag autoscroll
-
-    /// Feeds the live drag cursor (Cocoa, bottom-left global) so a
-    /// dwell over an arrow zone autoscrolls the bar toward the
-    /// hidden Spaces. Off the strip or off the arrows, stops any
-    /// running autoscroll. Drives the arrow's synthetic hover too
-    /// — a foreign AX drag delivers no `mouseEntered` (#385).
+    /// Updates drag autoscroll state based on cursor position (#385).
     func updateDragAutoScroll(atGlobal cocoaPoint: CGPoint) {
         guard isPanelVisible, let geom = scrollGeom else {
             cancelDragAutoScroll()
@@ -146,15 +114,13 @@ extension SpaceBarOverlay {
             trailingAxis: geom.trailingAxis,
             horizontal: geom.horizontal
         )
-        // Only a direction that still has hidden items counts —
-        // the matching arrow is visible exactly then.
         let direction = scrollableDirection(hit, geom: geom)
         backArrow.setDragHover(direction == .back)
         forwardArrow.setDragHover(direction == .forward)
         setAutoScrollDirection(direction)
     }
 
-    /// Stops any autoscroll and clears the arrows' drag hover.
+    /// Cancels active autoscroll task and clears drag hovers.
     func cancelDragAutoScroll() {
         autoScrollTask?.cancel()
         autoScrollTask = nil
@@ -163,8 +129,6 @@ extension SpaceBarOverlay {
         forwardArrow.setDragHover(false)
     }
 
-    /// The scroll direction the hit implies, but only if the bar
-    /// can still move that way; nil otherwise.
     private func scrollableDirection(
         _ hit: ScrollArrow?,
         geom: ScrollGeom
@@ -185,10 +149,6 @@ extension SpaceBarOverlay {
         autoScrollTask?.cancel()
         autoScrollTask = nil
         guard direction != nil else { return }
-        // Dwell, then tick every interval until the direction is
-        // cleared (cursor left the arrow), the drag ends (task
-        // cancelled), or the bar can't scroll further. Mirrors the
-        // drop coordinator's `dwellTask`.
         autoScrollTask = Task { [weak self] in
             try? await Task.sleep(
                 nanoseconds: nanos(Self.autoScrollInitialDelay)
@@ -204,9 +164,6 @@ extension SpaceBarOverlay {
         }
     }
 
-    /// One autoscroll step; returns whether to keep ticking. Stops
-    /// (returns false) once the bar is clamped at the far end —
-    /// the arrow it was hovering has now hidden.
     private func autoScrollTick() -> Bool {
         guard let direction = autoScrollDirection,
             let geom = scrollGeom

--- a/Sources/KiwiDeskCore/Borders/BorderManager+Sync.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager+Sync.swift
@@ -1,7 +1,11 @@
 import AppKit
 
-/// BorderManager ring overlay synchronization and rendering paths
-/// (`FollowSource`, #594, #596).
+/// BorderManager ring overlay synchronization and rendering
+/// paths. Three writers, descending authority while our own
+/// animation drives a window (#594/#596): `apply` is unguarded
+/// (the WS re-read owns the frame), `follow` asks
+/// `FollowSource`, `sync` rebuilds everything but holds an
+/// animating window's geometry.
 extension BorderManager {
     /// Synchronizes overlays to match desired specs and retires unused
     /// overlays (`FollowSource.syncFrame`, #596).
@@ -17,6 +21,12 @@ extension BorderManager {
         for spec in desired {
             specs[spec.window] = spec
             let overlay = overlay(for: spec.window)
+            // Only geometry stands down mid-animation (#596);
+            // create, recolor, re-order and retire run
+            // unconditionally. `screen` MUST derive from this same
+            // rect, not `spec.frame`: it picks the backing scale,
+            // and a held frame paired with the spec's screen
+            // rasterizes the ring at the wrong display's scale.
             let frame = FollowSource.syncFrame(
                 spec: spec.frame,
                 held: overlay.lastRenderedFrame,
@@ -32,6 +42,9 @@ extension BorderManager {
                 screen: screen(for: frame),
                 glowBlur: spec.glowBlur
             )
+            // Re-assert stacking each sync — the target may have
+            // moved in the window order since the ring last
+            // positioned.
             overlay.order(relativeTo: spec.window.raw)
         }
     }

--- a/Sources/KiwiDeskCore/Borders/BorderManager+Sync.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderManager+Sync.swift
@@ -1,24 +1,10 @@
 import AppKit
 
-/// `BorderManager`'s ring-rendering paths: the steady-state
-/// `sync` (which also creates and retires overlays), the
-/// animation / AX-echo `follow`, the unguarded `apply`, and the
-/// test seams that read back what was rendered. Split out when
-/// #596's additions pushed `BorderManager.swift` past the 350
-/// line ceiling; the main type keeps the stores, the app
-/// lifecycle, the draw-order flip and the per-window caches
-/// these read.
-///
-/// The three writers, in descending order of authority while our
-/// own animation drives a window (#594/#596): `apply` is
-/// unguarded and belongs to whoever owns the frame outright (the
-/// WindowServer re-read); `follow` carries a `FollowSource` and
-/// asks the shared decision; `sync` rebuilds everything but
-/// holds an animating window's geometry.
+/// BorderManager ring overlay synchronization and rendering paths
+/// (`FollowSource`, #594, #596).
 extension BorderManager {
-    /// Shows exactly `desired` — one ring per window — and retires
-    /// the overlays of any window no longer in the set (an empty
-    /// array retires them all).
+    /// Synchronizes overlays to match desired specs and retires unused
+    /// overlays (`FollowSource.syncFrame`, #596).
     public func sync(_ desired: [Spec]) {
         let wanted = Set(desired.map(\.window))
         updateSkyLightSubscription(wanted)
@@ -31,15 +17,6 @@ extension BorderManager {
         for spec in desired {
             specs[spec.window] = spec
             let overlay = overlay(for: spec.window)
-            // Geometry stands down mid-animation (#596) — the one
-            // decision the mark's `sync` shares. Everything else
-            // here (create, recolor, re-order, retire) runs
-            // unconditionally: only the frame is held back.
-            // `screen` MUST derive from the same rect, not from
-            // `spec.frame`: it selects the backing scale, so on a
-            // cross-display animated move a held frame paired with
-            // the spec's screen rasterizes the ring at the wrong
-            // display's scale.
             let frame = FollowSource.syncFrame(
                 spec: spec.frame,
                 held: overlay.lastRenderedFrame,
@@ -55,20 +32,12 @@ extension BorderManager {
                 screen: screen(for: frame),
                 glowBlur: spec.glowBlur
             )
-            // Re-assert stacking each sync (focus change, retile,
-            // z-order restore) — the target may have moved in the
-            // window order since the ring last positioned.
             overlay.order(relativeTo: spec.window.raw)
         }
     }
 
-    /// Animation / AX-echo hot path: move an already-shown ring
-    /// to a window's current frame. The render decision is
-    /// `FollowSource.renderFrame` — one switch shared with the
-    /// sticky mark, so no caller re-implements it (#285), the
-    /// two overlays cannot drift (#594), and the #677 size pin
-    /// corrects both at once. A no-op for windows without a
-    /// ring.
+    /// Moves overlay to match window frame during animation or AX echo
+    /// (`FollowSource.renderFrame`, #285, #594, #677).
     public func follow(
         _ id: WindowID,
         windowFrame: CGRect,
@@ -86,24 +55,18 @@ extension BorderManager {
         apply(id, windowFrame: frame)
     }
 
-    /// The frame a window's ring last rendered against, for
-    /// tests that need to prove `follow` stood down (or didn't).
+    /// Returns last rendered frame for testing (#596).
     func lastFrame(_ id: WindowID) -> CGRect? {
         overlays[id]?.lastRenderedFrame
     }
 
-    /// Its colour sibling — for proving a `sync` that stood down
-    /// on geometry still recolored (#596).
+    /// Returns last rendered color hex for testing (#596).
     func lastColorHex(_ id: WindowID) -> String? {
         overlays[id]?.lastRenderedColorHex
     }
 
-    /// Unguarded reposition — the WS bounds re-read
-    /// (`reconcile`) owns the ring's frame outright, so it
-    /// bypasses the guards on `follow`. Internal, not private:
-    /// `reconcile` lives in the `+SkyLight` extension. `sync`
-    /// does NOT come through here; it asks
-    /// `FollowSource.syncFrame` first (#596).
+    /// Repositions overlay without follow guards
+    /// (`FollowSource.syncFrame`, #596).
     func apply(
         _ id: WindowID,
         windowFrame: CGRect,

--- a/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
@@ -2,7 +2,10 @@ import AppKit
 import CoreFoundation
 import CoreGraphics
 
-/// Focus ring overlay rendered directly via SkyLight window (#285 Tier 2).
+/// Focus ring overlay rendered directly via SkyLight window
+/// (#285 Tier 2). Any failed private operation retires this
+/// backend and lets `BorderOverlay` replay the latest state
+/// through its AppKit panel.
 @MainActor
 final class SkyLightBorderOverlay: BorderOverlayBackend {
     static let borderTags: UInt64 =
@@ -54,6 +57,9 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
         let previous = self.geometry
         let nextScale = screen?.backingScaleFactor ?? 2
         let recreatedForScale = window != 0 && scale != nextScale
+        // Recreate the raw window on a scale change (the
+        // JankyBorders model): the CGContext owns that surface's
+        // pixel density, so mutating it in place is not reliable.
         if recreatedForScale {
             _ = hide()
             destroyWindow()
@@ -105,6 +111,10 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
         guard window != 0, windowNumber == targetWindow,
             let transaction = makeTransaction()
         else { return false }
+        // `SLSTransaction*` mutators return no meaningful status
+        // (JankyBorders fires them and only commits): gating on
+        // `.success` reads a junk register and would falsely
+        // retire this backend. Only `makeTransaction` gates.
         if orderMode == .below {
             // Below-order relies on target window occlusion (#357, #361).
             _ = SkyLight.transactionOrder?(

--- a/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/SkyLightBorderOverlay.swift
@@ -2,23 +2,13 @@ import AppKit
 import CoreFoundation
 import CoreGraphics
 
-/// A focus ring drawn directly into a SkyLight window (#285 Tier 2).
-/// Origin-only updates are one WindowServer transaction; resizing or
-/// restyling rebuilds the shape/context content. Any failed private
-/// operation retires this backend and lets `BorderOverlay` replay the
-/// latest state through its AppKit panel.
+/// Focus ring overlay rendered directly via SkyLight window (#285 Tier 2).
 @MainActor
 final class SkyLightBorderOverlay: BorderOverlayBackend {
-    // The surface plumbing (create/reshape/draw/destroy) lives in
-    // the `SkyLightBorderOverlay+Surface` extension (separate
-    // file, 350-line ceiling), so this state is internal rather
-    // than private.
     static let borderTags: UInt64 =
         (1 << 1) | (1 << 9) | (1 << 18)
 
-    /// The WindowServer-backed context drops every shadow colour
-    /// to default black-at-low-alpha (#533) — glow rings belong
-    /// on the AppKit backend.
+    /// SkyLight contexts drop shadow colours (#533); glow uses AppKit.
     let rendersGlow = false
     static let backingStoreBuffered: Int32 = 2
     static let orderOut: Int32 = 0
@@ -26,19 +16,12 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
     static let orderBelow: Int32 = -1
     static let parkedOrigin = CGPoint(x: -9_999, y: -9_999)
 
-    /// Where this ring stacks (#357/#367). `above` keeps its own
-    /// clean corner arc as the only visible edge and preserves
-    /// child-window occlusion by pinning to the target's
-    /// sub-level; `below` needs no such pinning — the target
-    /// itself occludes the ring beneath it — so its re-stack is a
-    /// single order-below transaction (see `order(relativeTo:)`).
+    /// Window stacking relative position (#357, #367).
     let orderMode: BorderGeometry.Order
 
     let connection: SkyLight.ConnectionID
     let targetWindow: CGWindowID
     var window: CGWindowID = 0
-    /// Unsafe only so Swift 6's nonisolated `deinit` can release the
-    /// retained CF object; all operational access remains MainActor.
     nonisolated(unsafe) var context: CGContext?
     var geometry: BorderGeometry?
     var colorHex = ""
@@ -72,9 +55,6 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
         let nextScale = screen?.backingScaleFactor ?? 2
         let recreatedForScale = window != 0 && scale != nextScale
         if recreatedForScale {
-            // JankyBorders likewise recreates its raw window when
-            // resolution changes: the CGContext owns that surface's
-            // pixel density, so mutating it in place is not reliable.
             _ = hide()
             destroyWindow()
         }
@@ -109,13 +89,7 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
             destroyWindow()
             return false
         }
-        // Match JankyBorders' split: a full update establishes the
-        // inverse transform that anchors the raw surface, while a
-        // move-only update is one cheap origin transaction.
         let resetTransform = previous == nil || needsRedraw
-        // Fire-and-forget: `move` commits a transaction whose ops
-        // report no meaningful status, so it cannot fail in a way
-        // worth a fallback (unlike create/reshape/draw above).
         move(
             to: geometry.overlayFrame.origin,
             resetTransform: resetTransform
@@ -131,19 +105,8 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
         guard window != 0, windowNumber == targetWindow,
             let transaction = makeTransaction()
         else { return false }
-        // The `SLSTransaction*` mutators return no meaningful status
-        // (JankyBorders fires them and only commits), so they are
-        // best-effort: gating them on `.success` reads a junk register
-        // and would falsely retire this backend to the AppKit
-        // fallback. Only `makeTransaction` is load-bearing.
         if orderMode == .below {
-            // Below-order needs none of the level/sub-level
-            // pinning above-order re-asserts for popover
-            // occlusion (#357): the target itself occludes a
-            // ring beneath it, so one plain order-below op keeps
-            // the re-stack churn-free (the jankyborders model —
-            // the above path's per-sync sub-level transactions
-            // are the suspected #361 flicker source).
+            // Below-order relies on target window occlusion (#357, #361).
             _ = SkyLight.transactionOrder?(
                 transaction,
                 window,
@@ -164,13 +127,8 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
                 Int32(level)
             )
         }
-        // Pin the ring into the target's exact sub-level band. A child
-        // the OS stacks over the target (a popover, a sheet) sits at a
-        // *higher* sub-level, so it keeps rendering above a
-        // sub-level-pinned ring even though the ring is ordered above
-        // the target itself. Without this pin, above-order paints over
-        // child popups — the #320 regression below-order avoided
-        // (#357).
+        // Pins ring into target's sub-level to prevent popup occlusion
+        // (#320, #357).
         let subLevel =
             SkyLight.getWindowSubLevel?(connection, targetWindow) ?? 0
         _ = SkyLight.transactionSubLevel?(transaction, window, subLevel)
@@ -202,7 +160,6 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
         resetTransform: Bool
     ) {
         guard let transaction = makeTransaction() else { return }
-        // Fire-and-forget mutators; only `makeTransaction` gates.
         _ = SkyLight.transactionMove?(transaction, window, origin)
         if resetTransform {
             let transform = CGAffineTransform(
@@ -224,9 +181,7 @@ final class SkyLightBorderOverlay: BorderOverlayBackend {
         SkyLight.transactionCreate?(connection)?.takeRetainedValue()
     }
 
-    /// Commits and releases the transaction. `SLSTransactionCommit`
-    /// returns no meaningful status (JankyBorders ignores it), so this
-    /// is fire-and-forget — a garbage return must not read as failure.
+    /// Commits SkyLight window server transaction.
     private func commit(_ transaction: CFTypeRef) {
         _ = SkyLight.transactionCommit?(transaction, 0)
     }

--- a/Sources/KiwiDeskCore/Commands/Reference/APIReference+Entries.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIReference+Entries.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 /// Maps API names to structured documentation records (#1033).
+/// Order is the tables' own declaration order, never
+/// alphabetical — flattening it into one alphabetical run is
+/// half of what #1033 was filed about.
 extension APIReference {
     /// Command group section in command listing.
     public struct APIGroup: Sendable, Equatable {
@@ -35,7 +38,11 @@ extension APIReference {
             for alias in entry.aliases { table[alias] = entry }
         }
 
-    /// Core command entries (`APIRecordCensusTests`, `APIRecordFilledTests`).
+    /// Core command entries. A record missing for a name falls
+    /// back to a pending record rather than dropping the command —
+    /// the listing must never be shorter than the API
+    /// (`APIRecordCensusTests` names the missing key,
+    /// `APIRecordFilledTests` asserts no record stays pending).
     static var coreEntries: [APIEntry] {
         var aliases: [String: [String]] = [:]
         var order: [String] = []

--- a/Sources/KiwiDeskCore/Commands/Reference/APIReference+Entries.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIReference+Entries.swift
@@ -1,26 +1,14 @@
 import Foundation
 
-/// Walks the name tables and pairs each name with its record
-/// (#1033).
-///
-/// Order is the tables' own declaration order, not alphabetical:
-/// `commands` reads navigation → Spaces → windows → settings →
-/// profiles, which is how someone scanning the listing wants to
-/// meet them. Flattening that into one alphabetical run is half
-/// of what #1033 was filed about.
+/// Maps API names to structured documentation records (#1033).
 extension APIReference {
-    /// One group of the listing, in print order.
+    /// Command group section in command listing.
     public struct APIGroup: Sendable, Equatable {
         public let name: String
         public let entries: [APIEntry]
     }
 
-    /// Every command, grouped: the `KiwiDesk` table first, then
-    /// the namespace tables alphabetically.
-    ///
-    /// Stored, not computed: the tables it walks are compile-time
-    /// constants, and `help` asks for the listing and then looks
-    /// one name up in it.
+    /// All command groups in display order.
     public static let groups: [APIGroup] =
         [APIGroup(name: coreGroup, entries: coreEntries)]
         + namespaces.keys.sorted().map { table in
@@ -30,34 +18,24 @@ extension APIReference {
             )
         }
 
-    /// Every command in every group, flattened.
+    /// Flattened list of all command entries.
     public static let entries: [APIEntry] = groups.flatMap(
         \.entries
     )
 
-    /// The entry a caller named — `focus`, `scroll.set_anchor`,
-    /// or an alias such as `list_commands`. Nil when nothing
-    /// answers to it.
+    /// Looks up command entry by canonical name or alias.
     public static func entry(named name: String) -> APIEntry? {
         entriesByName[name]
     }
 
-    /// Every name an entry answers to, including aliases.
+    /// Name and alias lookup index for fast entry resolution.
     private static let entriesByName: [String: APIEntry] =
         entries.reduce(into: [:]) { table, entry in
             table[entry.qualifiedName] = entry
             for alias in entry.aliases { table[alias] = entry }
         }
 
-    /// The `KiwiDesk` table: the dispatcher verbs in declaration
-    /// order, then `subscribe` (socket-only), then the Lua-only
-    /// entry points.
-    ///
-    /// A record missing for a name falls back to a pending record
-    /// rather than dropping the command from the listing — the
-    /// listing must never be shorter than the API. Both guards
-    /// see it: `APIRecordCensusTests` names the missing key, and
-    /// `APIRecordFilledTests` asserts that no record is pending.
+    /// Core command entries (`APIRecordCensusTests`, `APIRecordFilledTests`).
     static var coreEntries: [APIEntry] {
         var aliases: [String: [String]] = [:]
         var order: [String] = []
@@ -106,7 +84,7 @@ extension APIReference {
         return result
     }
 
-    /// One namespace table's entries, in its declared order.
+    /// Namespace table command entries in declaration order.
     static func namespaceEntries(of table: String) -> [APIEntry] {
         let records = namespaceRecords[table] ?? [:]
         return (namespaces[table] ?? []).map { function in
@@ -121,20 +99,12 @@ extension APIReference {
         }
     }
 
-    /// The record a name falls back to when its table has none.
-    ///
-    /// One home rather than four spellings of the construction:
-    /// it is deliberately NOT a factory on `APIRecord`, which is
-    /// what `.todo()` was and what invited a record table to
-    /// call it. Nothing can legitimately reach this — the census
-    /// is what keeps it unreachable, not the compiler — and a
-    /// command dropped from the listing is the worse failure.
+    /// Fallback record when documentation is pending
+    /// (`APIRecord.pendingSummary`).
     private static let pendingRecord = APIRecord(
         APIRecord.pendingSummary
     )
 
-    /// The one command reachable over the socket that has no
-    /// `KiwiDesk` table function — `dispatchable` inserts it by
-    /// hand, and so does the census.
+    /// Socket-only command without a KiwiDesk table mapping.
     public static let socketOnlyCommand = "subscribe"
 }

--- a/Sources/KiwiDeskCore/Commands/Reference/APIReference+Help.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIReference+Help.swift
@@ -65,7 +65,11 @@ extension APIReference {
         return .object(object)
     }
 
-    /// Serializes APIArgument to JSON (`APIChoice.type`, AGENTS.md §5).
+    /// Serializes APIArgument to JSON. The Swift type's NAME is
+    /// deliberately not on the wire (`APIChoice.type` carries it
+    /// for the terminal): publishing it as a JSON field would make
+    /// a Swift symbol part of the CLI's output contract, and
+    /// AGENTS.md §5 encourages renaming those.
     static func json(for argument: APIArgument) -> JSONValue {
         var object: [String: JSONValue] = [
             "name": .string(argument.name),
@@ -80,7 +84,10 @@ extension APIReference {
         return .object(object)
     }
 
-    /// Suggests closest matching command name across entire surface (#37).
+    /// Suggests closest matching command name across the WHOLE
+    /// surface — deliberately not `suggestion`, which must only
+    /// hint at what the caller's channel can invoke (#37): help is
+    /// a lookup, not an invocation.
     public static func helpSuggestion(
         for unknown: String
     ) -> String? {

--- a/Sources/KiwiDeskCore/Commands/Reference/APIReference+Help.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIReference+Help.swift
@@ -1,20 +1,9 @@
 import Foundation
 
-/// The `help` / `list_commands` payload (#1033).
-///
-/// **One implementation, three callers.** The dispatcher's
-/// `help` case returns this over the socket and to Lua, and the
-/// CLI calls it directly rather than round-tripping static data
-/// through a socket — see `CLIHelp` for why answering locally is
-/// the ruling. Nothing may re-derive the listing beside a call
-/// site; `CLIHelpSeamTests` scans for that.
+/// Help and command listing response generation
+/// (`CLIHelp`, `CLIHelpSeamTests`, #1033).
 extension APIReference {
-    /// The whole surface, grouped — or one command's record when
-    /// `name` is given.
-    ///
-    /// An unrecognised name fails with a did-you-mean hint, which
-    /// is the answer `list_commands focus` silently withheld
-    /// before (#1033).
+    /// Command listing or detailed single command record (#1033).
     public static func helpResponse(
         for name: String? = nil
     ) -> CommandResponse {
@@ -33,8 +22,7 @@ extension APIReference {
         return .ok(json(for: entry))
     }
 
-    /// The full listing: a count, then the groups in print
-    /// order.
+    /// Full grouped command listing as JSON.
     static var listingJSON: JSONValue {
         let all = groups
         return .object([
@@ -54,7 +42,7 @@ extension APIReference {
         ])
     }
 
-    /// One command as JSON.
+    /// Serializes APIEntry to JSON representation.
     static func json(for entry: APIEntry) -> JSONValue {
         var object: [String: JSONValue] = [
             "name": .string(entry.name),
@@ -77,20 +65,7 @@ extension APIReference {
         return .object(object)
     }
 
-    /// One argument as JSON. `values` appears only on an
-    /// enum-typed argument, read off the Swift type rather than
-    /// typed here.
-    ///
-    /// **The Swift type's NAME is deliberately not on the wire.**
-    /// `APIChoice.type` carries it and the terminal rendering
-    /// prints it, because a human reading `help` is helped by
-    /// knowing which decoder to go and read. Publishing it as a
-    /// JSON field would make a Swift symbol part of the CLI's
-    /// output contract, and AGENTS.md §5 actively encourages
-    /// renaming those — a rename would then change documented
-    /// output with nothing to notice. `values` is what answers
-    /// "what may I send", and it is stable in the way the wire
-    /// needs.
+    /// Serializes APIArgument to JSON (`APIChoice.type`, AGENTS.md §5).
     static func json(for argument: APIArgument) -> JSONValue {
         var object: [String: JSONValue] = [
             "name": .string(argument.name),
@@ -105,21 +80,14 @@ extension APIReference {
         return .object(object)
     }
 
-    /// A close name for an unknown one, over the WHOLE surface.
-    ///
-    /// Deliberately not `suggestion`, which must only hint at
-    /// what the caller's channel can invoke (#37). Help is a
-    /// lookup rather than an invocation: pointing a reader at
-    /// `KiwiDesk.bind` when they typed `bnid` is the right
-    /// answer even though the CLI cannot call it.
+    /// Suggests closest matching command name across entire surface (#37).
     public static func helpSuggestion(
         for unknown: String
     ) -> String? {
         closest(to: unknown, among: lookupNames)
     }
 
-    /// Every name `help` answers to: each command's qualified
-    /// name plus its Lua aliases.
+    /// Qualified command names and aliases recognized by help.
     static let lookupNames: [String] = entries.flatMap {
         [$0.qualifiedName] + $0.aliases
     }

--- a/Sources/KiwiDeskCore/Commands/Reference/APIReference.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIReference.swift
@@ -274,24 +274,13 @@ public enum APIReference {
         ],
     ]
 
-    /// Lua-only entry points on the `KiwiDesk` table that
-    /// are not routed through the dispatcher and therefore
-    /// absent from the CLI/IPC socket. Listed here so
-    /// `help()` / `list_commands` cover the full Lua API
-    /// surface. Deliberately excluded from did-you-mean
-    /// (`suggestion`), which must only hint at commands the
-    /// caller's channel can invoke (issue #37).
+    /// Lua-only commands on KiwiDesk table bypassing dispatcher (#37).
     public static let luaOnly: [String] = [
         "exec", "bind", "on", "define_layer", "switch_layer",
         "show_shortcuts", "open_settings",
     ]
 
-    /// Command names reachable through the dispatcher (and thus
-    /// the CLI/IPC socket): dispatcher verbs, namespace
-    /// sub-commands, and `subscribe`. This is the did-you-mean
-    /// set — a typo hint must never point at a command the
-    /// caller's channel cannot invoke, so the Lua-only entry
-    /// points are deliberately excluded here (issue #37).
+    /// Command names reachable through dispatcher and CLI/IPC (#37).
     public static var dispatchable: [String] {
         var names = Set(commands.map(\.command))
         for (table, functions) in namespaces {
@@ -303,19 +292,8 @@ public enum APIReference {
         return names.sorted()
     }
 
-    /// Every command name shown by `help()` / `list_commands`,
-    /// sorted — the full Lua-visible surface: everything
-    /// dispatchable plus the Lua-only entry points that bypass
-    /// the dispatcher (`exec`, `bind`, …).
-    ///
-    /// **Not a live door onto the listing.** Since #1033 the
-    /// listing is `APIReference.groups`, and nothing in
-    /// production calls this — `CLIHelpSeamTests` bans the CLI
-    /// from naming it precisely so a second answer to "what
-    /// commands exist" cannot appear. It survives as
-    /// `APIRecordCensusTests`' independent cross-check: computed
-    /// the old way, from the name tables alone, it is what the
-    /// grouped listing is held against.
+    /// Full set of command names for census cross-checking
+    /// (`APIRecordCensusTests`, `CLIHelpSeamTests`, #1033).
     public static var allCommands: [String] {
         Set(dispatchable).union(luaOnly).sorted()
     }

--- a/Sources/KiwiDeskCore/Config/AppRuleOverride.swift
+++ b/Sources/KiwiDeskCore/Config/AppRuleOverride.swift
@@ -1,7 +1,10 @@
 import Foundation
 
-/// Sparse per-profile app→space rule override
-/// (#109, `AppRuleOverrideTests`).
+/// Sparse per-profile app→space rule override (#109). A stored
+/// nil is a TOMBSTONE (un-pin), unlike `KeyLayerOverride`.
+/// Bespoke on that seam, NOT a generic sparse-override primitive
+/// (AGENTS.md §5, `.claude/rules/parity-tests.md`); guarded by
+/// round-trip + resolve + diff-inverse in `AppRuleOverrideTests`.
 public struct AppRuleOverride: Sendable, Equatable {
     /// Sparse app overrides where stored `nil` indicates a tombstone unpin.
     public var rules: [String: SpaceID?]

--- a/Sources/KiwiDeskCore/Config/AppRuleOverride.swift
+++ b/Sources/KiwiDeskCore/Config/AppRuleOverride.swift
@@ -1,40 +1,19 @@
 import Foundation
 
-// MARK: - AppRuleOverride
-
-/// Sparse per-profile app→space rule override (#109). nil
-/// (absent) inherits the global `app_rules` base entirely;
-/// present, it shadows the base per app: an app the override
-/// mentions takes its space, apps it does not mention survive
-/// unchanged. Unlike `KeyLayerOverride`, a TOMBSTONE exists — a
-/// present-but-null entry un-pins an app the base pins, so a
-/// profile can add, change, or remove a base rule.
-///
-/// Bespoke, templated on `KeyLayerOverride`'s seam — NOT a
-/// generic sparse-override primitive (AGENTS.md §5,
-/// `.claude/rules/parity-tests.md`): keyed flat-map merge, so
-/// no reflection parity net applies; guarded by a round-trip +
-/// resolve + diff-inverse test in `AppRuleOverrideTests`.
+/// Sparse per-profile app→space rule override
+/// (#109, `AppRuleOverrideTests`).
 public struct AppRuleOverride: Sendable, Equatable {
-    /// Sparse: only apps that diverge from the base. A stored
-    /// nil is the tombstone (un-pin this app in this profile).
+    /// Sparse app overrides where stored `nil` indicates a tombstone unpin.
     public var rules: [String: SpaceID?]
 
     public init(rules: [String: SpaceID?] = [:]) {
         self.rules = rules
     }
 
-    /// True when no app diverges — a fully-inherited profile
-    /// needs no stored override (drives sparse encoding).
+    /// Whether this override has no diverging app rules.
     public var isEmpty: Bool { rules.isEmpty }
 
-    /// Resolves this override onto `base`, producing the
-    /// effective app→space map. Returns `base` unchanged when
-    /// empty.
-    ///
-    /// Merge rule: per-app, override wins — a named space
-    /// replaces (or adds) the app's pin, a tombstone removes
-    /// it. Base apps the override does not mention survive.
+    /// Resolves override onto global base rules (#109).
     public func resolved(
         onto base: [String: SpaceID]
     ) -> [String: SpaceID] {
@@ -50,17 +29,8 @@ public struct AppRuleOverride: Sendable, Equatable {
     }
 }
 
-// MARK: - Diff (inverse of resolved)
-
 extension AppRuleOverride {
-    /// Inverse of `resolved(onto:)`: the sparse override that,
-    /// resolved onto `base`, yields `edited`. An app whose pin
-    /// equals its base pin is inherited and omitted; a changed
-    /// or added pin is included; a base app absent from
-    /// `edited` becomes a tombstone (un-pin — deletions ARE
-    /// expressible here, unlike `KeyLayerOverride`). Returns nil
-    /// when nothing diverges — a fully-inherited profile stores
-    /// no override (an empty override is never persisted).
+    /// Computes sparse difference from base to edited rules (#109).
     public static func diff(
         base: [String: SpaceID],
         edited: [String: SpaceID]
@@ -78,9 +48,7 @@ extension AppRuleOverride {
         return over.isEmpty ? nil : over
     }
 
-    /// Canonical bundle-id map shared by resolve, diff, and the
-    /// global-base cache. Case collisions are invalid in practice;
-    /// sorting makes the fallback deterministic for hand edits.
+    /// Canonical lowercase bundle-id map shared across resolve and diff.
     public static func normalized(
         _ rules: [String: SpaceID]
     ) -> [String: SpaceID] {
@@ -93,8 +61,6 @@ extension AppRuleOverride {
         return result
     }
 
-    /// A tombstone wins when hand-edited case variants collapse
-    /// onto one bundle id; otherwise the sorted fallback is stable.
     private var normalizedRules: [String: SpaceID?] {
         var result: [String: SpaceID?] = [:]
         for (app, target) in rules.sorted(by: {
@@ -111,8 +77,6 @@ extension AppRuleOverride {
     }
 }
 
-// MARK: - Codable
-
 extension AppRuleOverride: Codable {
     private struct AppKey: CodingKey {
         var stringValue: String
@@ -125,14 +89,8 @@ extension AppRuleOverride: Codable {
         init?(intValue: Int) { nil }
     }
 
-    /// Transparent to the base `app_rules` dict: encode/decode
-    /// as a bare JSON object (`{"Mail": "1", "Music": null}`),
-    /// matching the `GuiConfig.appRules` shape so both surfaces
-    /// share one vocabulary (AGENTS.md §5) — null is the
-    /// tombstone. Decoded input is untrusted (hand-edited
-    /// profile JSON, #31): an empty app name or an empty space
-    /// name is dropped, mirroring `GuiConfig`'s decode-time
-    /// sanitization.
+    /// Decodes dictionary with nulls as tombstones
+    /// (`GuiConfig.appRules`, #31).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: AppKey.self
@@ -172,13 +130,9 @@ extension AppRuleOverride: Codable {
     }
 }
 
-// MARK: - ConfigResolver
-
 extension ConfigResolver {
-    /// Returns the effective app→space rules: `base` (from
-    /// gui.json) when `profile` is nil or empty; the per-app
-    /// merge otherwise. Sibling of `resolvedLayers` — one
-    /// resolver per behavior-override tier (AGENTS.md §5).
+    /// Resolves effective app rules from base and profile override
+    /// (AGENTS.md §5).
     public static func resolvedAppRules(
         base: [String: SpaceID],
         profile: AppRuleOverride?

--- a/Sources/KiwiDeskCore/Config/ConfigMigration+Surgical.swift
+++ b/Sources/KiwiDeskCore/Config/ConfigMigration+Surgical.swift
@@ -1,45 +1,10 @@
 import Foundation
 
-/// The envelope every rewriting step shares: **the parse
-/// decides, a textual edit applies, and an edit that is ever
-/// wrong is simply not used.**
-///
-/// Extracted because it had reached three copies — the
-/// bar-content rewrite, the format stamp and the scroll-duration
-/// key rename — each re-prosing the same argument beside a walk
-/// of its own (architect review, 2026-08-27). The WALKS stay
-/// duplicated and should: a value map with no collision case and
-/// a key rename with a both-spellings rule are genuinely
-/// different, and AGENTS.md §2.4 prefers a small readable
-/// duplication to a hierarchy. What must not be duplicated is
-/// this envelope, because the load-bearing part of it is a
-/// safety net — and a fourth step that copies the shape and
-/// drops the compare is green on the day it lands.
-///
-/// Why a textual edit at all: re-serializing the parsed tree
-/// re-encodes every `Double` in the file. `0.4` became
-/// `0.40000000000000002` and `0.6` became `0.59999999999999998`,
-/// in five places, for a ONE-value migration (measured,
-/// 2026-08-20). The decoded values are identical, so nothing
-/// breaks; what breaks is the promise. This rewrites the user's
-/// file without being asked, so it may touch only what it came
-/// for — a config kept in a dotfiles repo shows every unasked
-/// byte as a diff.
-///
-/// Correctness does not rest on the edit: its result is
-/// re-parsed and compared against the tree the walk produced,
-/// and anything but an exact match falls back to serializing
-/// that tree.
+/// Surgical textual rewriting helper with parse-validated fallback
+/// (AGENTS.md §2.4).
 extension ConfigMigration {
-    /// `data` rewritten by `rewriting`, applied surgically by
-    /// `editing` where that is provably equivalent, or nil when
-    /// the gate refuses, the bytes do not parse, or the walk
-    /// changed nothing.
-    ///
-    /// Nil rather than the unchanged bytes, deliberately: a
-    /// caller writes back exactly when this returns non-nil, so
-    /// a config that needs nothing is never rewritten and its
-    /// mtime never moves.
+    /// Rewrites `data` using surgical text edits when verified by re-parsing,
+    /// or falls back to serialized JSON tree; returns nil if unchanged.
     static func surgicallyApplying(
         _ data: Data,
         gate: (Data) -> Bool = { _ in true },
@@ -70,9 +35,7 @@ extension ConfigMigration {
         )
     }
 
-    /// One serializer for both sides of the comparison, so the
-    /// check is about VALUES and never about how either side
-    /// happened to spell a float.
+    /// Serializes JSON node to canonical formatted data for value comparison.
     static func canonical(_ node: Any) -> Data? {
         try? JSONSerialization.data(
             withJSONObject: node,

--- a/Sources/KiwiDeskCore/Config/ConfigMigration+Surgical.swift
+++ b/Sources/KiwiDeskCore/Config/ConfigMigration+Surgical.swift
@@ -1,7 +1,15 @@
 import Foundation
 
-/// Surgical textual rewriting helper with parse-validated fallback
-/// (AGENTS.md §2.4).
+/// Surgical textual rewriting: the parse decides, a textual
+/// edit applies, and an edit that is ever wrong is simply not
+/// used — the result is re-parsed and compared against the tree
+/// the walk produced. The envelope must not be duplicated
+/// (AGENTS.md §2.4): a step that copies the shape and drops the
+/// compare is green the day it lands. Why textual at all:
+/// re-serializing re-encodes every Double (`0.4` became
+/// `0.40000000000000002`, five places, for a one-value migration
+/// — measured 2026-08-20), and a rewrite of the user's file may
+/// touch only what it came for.
 extension ConfigMigration {
     /// Rewrites `data` using surgical text edits when verified by re-parsing,
     /// or falls back to serialized JSON tree; returns nil if unchanged.

--- a/Sources/KiwiDeskCore/Config/DefaultKeybindings+Size.swift
+++ b/Sources/KiwiDeskCore/Config/DefaultKeybindings+Size.swift
@@ -2,8 +2,19 @@ import Foundation
 
 /// Default size layer keybindings (#1075).
 extension DefaultKeybindings {
-    /// Seeded ⌥⌘ + digit resize keybindings (`resize.step`, `KeypadKeys`,
-    /// `SystemShortcuts.map`, `SizeLayerSeedTests`, #58, #270, #1074, #1075).
+    /// Seeded ⌥⌘ + digit resize rows (#1075): `1`/`2` width,
+    /// `4`/`5` height, by `resize.step` (#58). Digits, not arrows:
+    /// an arrow reads two ways on a tiled window, and which edge
+    /// is free depends on the slot. Within a pair the HIGHER digit
+    /// grows, and the pairs form the keypad's 2×2 block — #1074's
+    /// aliasing makes those keypad keys reach these rows
+    /// (`KeypadKeys`). The pairs are SEPARATED on the number row
+    /// (owner 2026-08-28): keep that gap when retuning, or the two
+    /// axes' nearest keys sit adjacent. The digits are MEASURED,
+    /// not assumed — `⌥⌘8` is macOS Zoom toggle
+    /// (`SystemShortcuts.map`; `SizeLayerSeedTests` holds every
+    /// seeded row against it). Why ⌥⌘ is available despite #270 is
+    /// argued in `docs/design-decisions.md`.
     static func resizeRows(step: Int) -> [KeyBinding] {
         [
             KeyBinding(

--- a/Sources/KiwiDeskCore/Config/DefaultKeybindings+Size.swift
+++ b/Sources/KiwiDeskCore/Config/DefaultKeybindings+Size.swift
@@ -1,50 +1,9 @@
 import Foundation
 
-/// The seeded ⌥⌘ **size** layer (#1075), split from
-/// `DefaultKeybindings` at the §2.1 file target: the four rows
-/// are short, but the argument for which four keys they are is
-/// not, and it is the part a retune has to read.
+/// Default size layer keybindings (#1075).
 extension DefaultKeybindings {
-    /// The four ⌥⌘ + digit resize rows (#1075): `1`/`2` shrink
-    /// and grow WIDTH, `4`/`5` shrink and grow HEIGHT, each by
-    /// the configurable `resize.step` (#58).
-    ///
-    /// Digits rather than arrows because an arrow reads two ways
-    /// on a tiled window — "which axis and sign" and "which way
-    /// the edge moves" — and which edge is free depends on where
-    /// the window sits in the flat array, so the same arrow grows
-    /// a right-column window and shrinks a left-column one. No
-    /// relabelling fixes that; the arrow shape creates it.
-    ///
-    /// Within a pair the HIGHER digit grows, and the pairs form a
-    /// 2×2 block on a numeric keypad — `4`/`5` sit directly above
-    /// `1`/`2`, so the pair that is higher drives the dimension
-    /// that grows upward. That block is the only place a keyboard
-    /// encodes a second axis without using arrows, and it is why
-    /// this binds digits at all, and **#1074 landed the aliasing
-    /// that makes those keypad keys reach these rows** — a
-    /// keypad digit IS its number-row twin, so both physical
-    /// keys fire these bindings (`KeypadKeys`).
-    ///
-    /// `5`/`6` and `2`/`3`+`5`/`6` were both rejected: touch
-    /// typing splits the number row between `5` and `6`, so any
-    /// pair spanning them straddles the hand boundary.
-    ///
-    /// The pairs are also SEPARATED — `3` sits between them on
-    /// the number row — so a mistimed reach for "grow width"
-    /// cannot land on "shrink height" (owner, 2026-08-28). Keep
-    /// that gap when retuning: two adjoining pairs would put the
-    /// two axes' nearest keys against each other.
-    ///
-    /// **The digits are measured, not assumed.** `⌥⌘8` is macOS's
-    /// Zoom toggle and `⌥⌘-` / `⌥⌘=` are Zoom out / in
-    /// (`com.apple.symbolichotkeys` ids 15/19/17, read
-    /// 2026-08-28), so an earlier `4`/`5`+`7`/`8` draft would have
-    /// died for any user with Zoom's keyboard shortcuts on.
-    /// `SystemShortcuts.map` carries them, and
-    /// `SizeLayerSeedTests` holds every seeded row against it.
-    /// Why ⌥⌘ is available at all, given #270 rejected it, is
-    /// argued in `docs/design-decisions.md`.
+    /// Seeded ⌥⌘ + digit resize keybindings (`resize.step`, `KeypadKeys`,
+    /// `SystemShortcuts.map`, `SizeLayerSeedTests`, #58, #270, #1074, #1075).
     static func resizeRows(step: Int) -> [KeyBinding] {
         [
             KeyBinding(

--- a/Sources/KiwiDeskCore/IPC/SocketServer.swift
+++ b/Sources/KiwiDeskCore/IPC/SocketServer.swift
@@ -119,6 +119,9 @@ public final class SocketServer {
     ) -> [String] {
         var events: Set<KiwiNotification> = []
         var unknown: [String] = []
+        // `seen` rather than `unknown.contains`: the 1 MB frame
+        // can carry ~150k names, and a linear scan per name is
+        // quadratic work on the main queue.
         var seen: Set<String> = []
         for arg in args {
             let name = arg.stringValue ?? "<non-string>"
@@ -129,6 +132,11 @@ public final class SocketServer {
             }
         }
         if !unknown.isEmpty {
+            // Capped: names are client-supplied on an
+            // unauthenticated socket, so an unbounded join lets
+            // any local process write a line of any length into
+            // the unified log. The RETURNED list is deliberately
+            // uncapped — it echoes only what this client sent.
             let listed = unknown.prefix(5).joined(separator: ", ")
             let rest = unknown.count > 5 ? ", …" : ""
             onLog(
@@ -138,6 +146,12 @@ public final class SocketServer {
                         : "; ignored")
             )
         }
+        // Empty filter means "everything" only for the request
+        // that means it — NO arguments. Letting it also catch a
+        // subscribe made entirely of typos handed back the whole
+        // firehose. Asked of `args`, never reconstructed from the
+        // accumulators above (review): they are equivalent only
+        // while every argument lands in one of them.
         let wanted =
             args.isEmpty
             ? Set(KiwiNotification.allCases)

--- a/Sources/KiwiDeskCore/IPC/SocketServer.swift
+++ b/Sources/KiwiDeskCore/IPC/SocketServer.swift
@@ -1,12 +1,8 @@
 import Foundation
 import Network
 
-/// UNIX domain socket server for the CLI and external tools.
-///
-/// Protocol: newline-delimited JSON. Requests are
-/// `CommandRequest`, responses `CommandResponse`. The special
-/// `subscribe` command turns the connection into an event
-/// stream (`EventMessage` per line).
+/// UNIX domain socket server for CLI and external tooling
+/// (`core-boundaries.md`).
 @MainActor
 public final class SocketServer {
     public typealias Handler =
@@ -30,7 +26,6 @@ public final class SocketServer {
 
     public func start() throws {
         guard listener == nil else { return }
-        // Remove a stale socket from an unclean shutdown.
         try? FileManager.default.removeItem(atPath: path)
         let parameters = NWParameters.tcp
         parameters.requiredLocalEndpoint = NWEndpoint.unix(
@@ -56,8 +51,6 @@ public final class SocketServer {
         clients = [:]
         try? FileManager.default.removeItem(atPath: path)
     }
-
-    // MARK: - Connections
 
     private func accept(_ connection: NWConnection) {
         let client = Client(connection: connection)
@@ -85,8 +78,6 @@ public final class SocketServer {
         }
         client.connection.cancel()
     }
-
-    // MARK: - Requests
 
     private func process(_ line: String, from client: Client) {
         guard let data = line.data(using: .utf8),
@@ -121,32 +112,15 @@ public final class SocketServer {
         )
     }
 
-    /// Subscribes `client` and returns the names it asked for
-    /// that name no event.
-    ///
-    /// A misspelled name used to be dropped in silence while the
-    /// client still got a bare `ok`, so the subscription read as
-    /// working; when *every* name is unknown the empty set falls
-    /// through to the firehose below, which reads as working
-    /// harder. The caller now carries the list back on the wire
-    /// — the client made the mistake, so the client is told —
-    /// and the log line is the server's own record. English like
-    /// every other IPC string (core-boundaries.md).
+    /// Subscribes client to requested notifications (`core-boundaries.md`).
     private func subscribe(
         _ client: Client,
         args: [JSONValue]
     ) -> [String] {
         var events: Set<KiwiNotification> = []
         var unknown: [String] = []
-        // `seen` rather than `unknown.contains`: the frame limit
-        // is 1 MB, so `args` can carry ~150k names, and a linear
-        // scan per name is quadratic work on the main queue —
-        // where the whole window manager lives.
         var seen: Set<String> = []
         for arg in args {
-            // A non-string arg has no name to report, but it is
-            // just as dropped, so it is counted as unknown
-            // rather than vanishing a second way.
             let name = arg.stringValue ?? "<non-string>"
             if let event = KiwiNotification(rawValue: name) {
                 events.insert(event)
@@ -155,14 +129,6 @@ public final class SocketServer {
             }
         }
         if !unknown.isEmpty {
-            // Capped: the names are client-supplied and the
-            // socket is unauthenticated, so an unbounded join
-            // lets any local process write a line of any length
-            // into the unified log. The *returned* list is
-            // deliberately not capped — it echoes only what this
-            // client just sent, whose decode already cost the
-            // main actor more than the echo will, and truncating
-            // it would hide a real typo from a client with many.
             let listed = unknown.prefix(5).joined(separator: ", ")
             let rest = unknown.count > 5 ? ", …" : ""
             onLog(
@@ -172,23 +138,6 @@ public final class SocketServer {
                         : "; ignored")
             )
         }
-        // An empty filter means "everything" only for the
-        // request that means it — **no arguments**. Letting it
-        // also catch a subscribe made entirely of typos handed
-        // back the whole firehose, which is not a partial
-        // result but the opposite of what was asked for, and it
-        // read as a subscription working very hard. Arguments
-        // given, filter honoured exactly; none given,
-        // everything.
-        //
-        // Asked of `args` and not reconstructed from the two
-        // accumulators above. Those are equivalent only while
-        // every argument lands in one of them, so a later branch
-        // that consumes one without doing so — skipping an empty
-        // name, capping the collected list the way the log is
-        // capped — would restore this bug in silence, and no
-        // argument shape that skips both exists to have a test
-        // (review).
         let wanted =
             args.isEmpty
             ? Set(KiwiNotification.allCases)

--- a/Sources/KiwiDeskCore/Keys/ComboSymbols.swift
+++ b/Sources/KiwiDeskCore/Keys/ComboSymbols.swift
@@ -1,26 +1,14 @@
 import Foundation
 
-/// Renders a `KeyCombo` as the compact macOS-native glyph string
-/// menus use (`⇧⌘,`, `⌃⌥←`): modifier symbols in the canonical
-/// ⌃⌥⇧⌘ order (Command last, adjacent to the key) followed by the
-/// key glyph, with **no `+` separator**.
+/// Formats `KeyCombo` into macOS native glyph string
+/// (`⇧⌘,`, `⌃⌥←`, #23).
 ///
-/// Dropping the separator resolves the combinator ambiguity #23
-/// raises: with no `+` between tokens, any `+` that appears is the
-/// key itself (`⌘+`), never a "together with" combinator.
-///
-/// The glyph for a printable key is resolved through the *active*
-/// keyboard layout by the injected `layoutChar` closure — the GUI
-/// backs it with `UCKeyTranslate`, so a German layout shows `+`
-/// where a US layout shows `]`. Non-printable keys (arrows,
-/// return, function keys) use fixed symbols; when the layout
-/// lookup yields nothing, the US key name falls back to a symbol.
-/// This type is pure and Core-testable — only the injected closure
-/// touches the OS.
+/// Modifiers appear in canonical `⌃⌥⇧⌘` order with no `+` delimiter
+/// (#23). Printable characters resolve via active layout
+/// (`UCKeyTranslate`).
 public enum ComboSymbols {
-    /// The combo as a native glyph string. `layoutChar` maps a
-    /// virtual key code to its base character on the active
-    /// layout, or nil for keys with no printable character.
+    /// Renders combo into native glyph string using provided layout
+    /// translator.
     public static func render(
         _ combo: KeyCombo,
         layoutChar: (UInt32) -> String?
@@ -29,15 +17,8 @@ public enum ComboSymbols {
             + keyGlyph(combo.keyCode, layoutChar)
     }
 
-    /// Modifier symbols in the macOS-canonical ⌃⌥⇧⌘ order.
-    ///
-    /// Public because a modifier set is a thing the GUI names on
-    /// its own, without a key beside it: the keyboard preview's
-    /// chips label one layer each (⌥, ⌃⌥, …) and `render` can
-    /// only ever draw a whole combo. The GUI's own
-    /// `ChordRecorder` is not a second copy of this — it renders
-    /// `NSEvent.ModifierFlags` mid-chord, before a `KeyCombo`
-    /// exists.
+    /// Formats modifiers in canonical macOS `⌃⌥⇧⌘` order
+    /// (`ChordRecorder`).
     public static func modifierSymbols(
         _ modifiers: HotkeyModifiers
     ) -> String {
@@ -49,16 +30,8 @@ public enum ComboSymbols {
         return out
     }
 
-    /// A key's character, capitalised — but only where
-    /// capitalising it stays ONE key's worth of glyph.
-    ///
-    /// German ß uppercases to "SS", so a shortcut on that key
-    /// rendered `⌃⌥SS`: two characters for a key the user's
-    /// keyboard prints as one, in every surface that draws a
-    /// combo (the recorder, the Shortcuts list, the draft diff
-    /// rows, the quick menu). Turkish ı and Greek final sigma
-    /// have the same shape of problem, which is why the rule is
-    /// mechanical rather than a ß special case.
+    /// Capitalises character if character count remains 1
+    /// (avoids German `ß` -> `SS`).
     public static func capitalisedGlyph(_ char: String) -> String {
         let upper = char.uppercased()
         return upper.count == char.count ? upper : char
@@ -78,9 +51,7 @@ public enum ComboSymbols {
         return ""
     }
 
-    /// Fixed glyphs for keys that carry no printable character —
-    /// arrows, editing, whitespace, and function keys. Nil means
-    /// the key is printable and resolves through the layout.
+    /// Returns fixed symbol for non-printable keys (#1074).
     static func specialKeyGlyph(_ code: UInt32) -> String? {
         specials[code]
     }
@@ -88,12 +59,6 @@ public enum ComboSymbols {
     private static let specials: [UInt32: String] = [
         123: "←", 124: "→", 125: "↓", 126: "↑",
         36: "↩", 76: "⌤", 48: "⇥", 49: "␣",
-        // Keypad Clear prints nothing, so without a glyph
-        // here it would fall through to the uppercased key
-        // NAME — a literal "KEYPADCLEAR" in the recorder,
-        // the Shortcuts list and the menu (#1074). Every
-        // other keypad key either prints (`+ − × ÷ . =`,
-        // through `layoutChar`) or is already here (enter).
         71: "⌧",
         51: "⌫", 117: "⌦", 53: "⎋",
         115: "↖", 119: "↘", 116: "⇞", 121: "⇟",
@@ -102,9 +67,7 @@ public enum ComboSymbols {
         101: "F9", 109: "F10", 103: "F11", 111: "F12",
     ]
 
-    /// A symbol for a US key name when the active layout gives no
-    /// character (punctuation words → their glyph; a bare letter/
-    /// digit uppercases). Mirrors `KeyCombo.keyName` word aliases.
+    /// Punctuation and named key symbol fallback (`KeyCombo.keyName`).
     static func fallbackGlyph(_ name: String) -> String {
         let symbols: [String: String] = [
             "comma": ",", "period": ".", "slash": "/",

--- a/Sources/KiwiDeskCore/Keys/ComboSymbols.swift
+++ b/Sources/KiwiDeskCore/Keys/ComboSymbols.swift
@@ -59,6 +59,9 @@ public enum ComboSymbols {
     private static let specials: [UInt32: String] = [
         123: "←", 124: "→", 125: "↓", 126: "↑",
         36: "↩", 76: "⌤", 48: "⇥", 49: "␣",
+        // Keypad Clear prints nothing: without a glyph here it
+        // falls through to the uppercased key NAME — a literal
+        // "KEYPADCLEAR" in the recorder and menus (#1074).
         71: "⌧",
         51: "⌫", 117: "⌦", 53: "⎋",
         115: "↖", 119: "↘", 116: "⇞", 121: "⇟",

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager+Activation.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager+Activation.swift
@@ -4,6 +4,8 @@ import Foundation
 /// (`KeypadKeys`, #1074).
 extension KeybindingManager {
     func deactivate() {
+        // The ids are about to vanish, so no release can ever
+        // arrive to stop a live glide — end it here (#1056).
         holdGlide.cancelRun()
         for id in activeBindings.keys {
             registrar.unregister(id: id)
@@ -31,6 +33,12 @@ extension KeybindingManager {
                 )
                 continue
             }
+            // A keypad digit IS its number-row twin (#1074) — but
+            // register the twin only once the authored key landed,
+            // or the keypad fires a binding the Settings caption
+            // calls ungranted. A twin's OWN refusal is never
+            // reported as the binding's: the shortcut still works
+            // from the row.
             if let twin = KeypadKeys.keypadTwin(
                 of: combo.keyCode
             ) {
@@ -43,7 +51,12 @@ extension KeybindingManager {
         }
     }
 
-    /// Registers physical key for combo (`KeypadKeys`, #1056).
+    /// Registers ONE physical key for combo. Each physical key
+    /// needs its OWN box: the handler carries its registration id,
+    /// filled when `register` returns and never re-derived after
+    /// the fire (#1056 review) — a box shared with the keypad twin
+    /// would hand the second press the first's id, and hold-glide
+    /// keys its whole run by that id (`KeypadKeys`).
     private func registerPhysical(
         code: UInt32,
         combo: KeyCombo,

--- a/Sources/KiwiDeskCore/Keys/KeybindingManager+Activation.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingManager+Activation.swift
@@ -1,24 +1,9 @@
 import Foundation
 
-/// The manager's hotkey-activation half, split out at the file
-/// ceiling (§2.1): what is registered with the OS right now, and
-/// the second registration a keypad twin adds beside it (#1074).
-///
-/// `activate` and `deactivate` themselves went from private to
-/// module-internal to live here, as did `registrar` (a `let`) and
-/// the SETTERS of `activeBindings` and `activationFailures`,
-/// which this file writes. Nothing else was loosened: `layers`
-/// and `suspended` stay private and are read through their
-/// existing accessors (`bindings(for:)`, `isSuspended`), because
-/// `layers` owns the Lua registry refs that `bind`, `defineLayer`,
-/// `replaceLayers` and `reset` are careful to release — an
-/// internal setter there would drop the compiler's enforcement of
-/// that ownership for no gain. The same seam
-/// `KeybindingManager+HoldGlide.swift` took for `holdGlide`.
+/// Hotkey activation and OS registration for KeybindingManager
+/// (`KeypadKeys`, #1074).
 extension KeybindingManager {
     func deactivate() {
-        // The ids are about to vanish, so no release can ever
-        // arrive to stop a live glide — end it here (#1056).
         holdGlide.cancelRun()
         for id in activeBindings.keys {
             registrar.unregister(id: id)
@@ -29,8 +14,6 @@ extension KeybindingManager {
     func activate(_ layer: String) {
         deactivate()
         activationFailures = []
-        // A recorder is armed: keep the table current but
-        // register nothing, so testing a shortcut can't fire.
         guard !isSuspended else { return }
         for (combo, ref) in bindings(for: layer) {
             guard
@@ -48,15 +31,6 @@ extension KeybindingManager {
                 )
                 continue
             }
-            // A keypad digit IS its number-row twin (#1074), so
-            // one binding claims a SECOND physical key — but
-            // only once the authored key has landed. Registering
-            // the twin after the authored code was refused would
-            // leave the keypad firing a binding the Settings
-            // caption calls ungranted, so the report and the
-            // keyboard would disagree. A twin's OWN refusal is
-            // not the binding's — the shortcut still works from
-            // the row — so it is never reported.
             if let twin = KeypadKeys.keypadTwin(
                 of: combo.keyCode
             ) {
@@ -69,17 +43,7 @@ extension KeybindingManager {
         }
     }
 
-    /// Registers ONE physical key for `combo` and records it as
-    /// live. False when the OS refused the registration.
-    ///
-    /// Each physical key needs its OWN box: the handler carries
-    /// its registration id through it, filled the moment
-    /// `register` returns and never re-derived after the fire,
-    /// where the Lua body may have rebuilt the table and minted
-    /// fresh ids for the same ref+combo (#1056 review). A box
-    /// shared between a key and its keypad twin would hand the
-    /// second press the first's id, and the hold-glide ladder
-    /// keys its whole run by that id.
+    /// Registers physical key for combo (`KeypadKeys`, #1056).
     private func registerPhysical(
         code: UInt32,
         combo: KeyCombo,

--- a/Sources/KiwiDeskCore/Keys/LuaBindingBody.swift
+++ b/Sources/KiwiDeskCore/Keys/LuaBindingBody.swift
@@ -1,36 +1,9 @@
 import Foundation
 
-/// Extracts the body of a bound `function() ... end` literal from
-/// its source range, so a keybinding's action text can be
-/// recovered from init.lua (#4).
-///
-/// `debug.getinfo` reports only the line range of a function, not
-/// its columns, so the slice for `KiwiDesk.bind("alt+h",
-/// function() KiwiDesk.focus("left") end)` still holds the whole
-/// call. This scanner walks that slice — skipping strings and
-/// comments so their contents never count as syntax — to find the
-/// `function` header, then the matching `end`, and returns the
-/// text between them (dedented; the writer re-indents).
-///
-/// Block depth uses the classic Lua-lexer trick: `function`, `if`,
-/// and `do` each open a block closed by `end`, while `for`/`while`
-/// are opened by their own `do` and so are not counted. This
-/// covers plain literals and multi-statement custom bodies; it
-/// does not evaluate the code, only balances its block keywords.
-///
-/// Two assumptions, both true for GUI-authored configs (each bind
-/// on its own line with an inline literal) and only relevant to
-/// hand-written files adopted once:
-/// - The action is an inline `function() … end` literal. A bind to
-///   a named handler (`KiwiDesk.bind("x", my_handler)`) has no
-///   literal in range and yields nil, so that row is dropped.
-/// - One function literal per source line: `debug.getinfo` reports
-///   the same range for every literal sharing a line, so only the
-///   first is recovered.
+/// Extracts body text of an inline `function() ... end` literal from Lua
+/// source line ranges (#4).
 enum LuaBindingBody {
-    /// Slices the 1-based inclusive line range out of `source`
-    /// and returns the dedented function body, or nil when the
-    /// range holds no balanced `function ... end`.
+    /// Extracts and dedents function body within 1-based inclusive line range.
     static func extract(
         from source: String,
         firstLine: Int,
@@ -49,10 +22,6 @@ enum LuaBindingBody {
         return body(in: Array(region))
     }
 
-    // MARK: - Scanning
-
-    /// The dedented body between the first `function` header and
-    /// its matching `end` in `chars`.
     private static func body(in chars: [Character]) -> String? {
         guard let paramsEnd = functionParamsEnd(chars) else {
             return nil
@@ -88,8 +57,6 @@ enum LuaBindingBody {
         return nil
     }
 
-    /// The index just past the `)` of the first `function (...)`
-    /// header, skipping any leading call syntax and its strings.
     private static func functionParamsEnd(
         _ chars: [Character]
     ) -> Int? {
@@ -112,8 +79,6 @@ enum LuaBindingBody {
         return nil
     }
 
-    /// The index just past the matching `)` of a `(...)` param
-    /// list beginning at or after `from`.
     private static func paramListEnd(
         _ chars: [Character],
         _ from: Int
@@ -135,11 +100,6 @@ enum LuaBindingBody {
         return nil
     }
 
-    // MARK: - Trivia (strings & comments)
-
-    /// If a string or comment starts at `i`, the index just past
-    /// it; otherwise nil. Keeps keyword-like text inside literals
-    /// from being counted as block syntax.
     private static func skipTrivia(
         _ chars: [Character],
         _ i: Int
@@ -157,8 +117,6 @@ enum LuaBindingBody {
         return nil
     }
 
-    /// A `--` comment: a long bracket if one opens here, else to
-    /// the end of the line.
     private static func skipComment(
         _ chars: [Character],
         _ i: Int
@@ -192,8 +150,6 @@ enum LuaBindingBody {
         return chars.count
     }
 
-    /// The `=` level of a long-bracket opener (`[[`, `[==[`) at
-    /// `i`, and the index just past it — else nil.
     private static func longOpen(
         _ chars: [Character],
         _ i: Int
@@ -232,8 +188,6 @@ enum LuaBindingBody {
         return chars.count
     }
 
-    // MARK: - Words & whitespace
-
     private static func readWord(
         _ chars: [Character],
         _ i: Int
@@ -255,13 +209,6 @@ enum LuaBindingBody {
         c == " " || c == "\t" || c == "\n" || c == "\r"
     }
 
-    /// Trims blank edges, removes the common leading indent, and
-    /// strips each line's trailing whitespace so the writer's
-    /// re-indentation starts from column zero and a one-line
-    /// `function() … end` doesn't keep the space before `end`.
-    /// (Trailing whitespace is only meaningful inside a multi-line
-    /// `[[…]]` string — vanishingly rare in a keybinding body, and
-    /// the user reviews the import before saving.)
     private static func dedent(_ text: String) -> String {
         var lines = text.components(separatedBy: "\n")
         while let first = lines.first, isBlank(first) {
@@ -283,7 +230,6 @@ enum LuaBindingBody {
         .joined(separator: "\n")
     }
 
-    /// `line` without its trailing spaces and tabs.
     private static func trimTrailing(_ line: String) -> String {
         var end = line.endIndex
         while end > line.startIndex {

--- a/Sources/KiwiDeskCore/Keys/LuaBindingBody.swift
+++ b/Sources/KiwiDeskCore/Keys/LuaBindingBody.swift
@@ -1,7 +1,10 @@
 import Foundation
 
-/// Extracts body text of an inline `function() ... end` literal from Lua
-/// source line ranges (#4).
+/// Extracts body text of an inline `function() ... end` literal
+/// from Lua source line ranges (#4). Two assumptions, true for
+/// GUI-authored configs: a bind to a named handler yields nil
+/// (that row is dropped), and only the FIRST literal on a shared
+/// source line is recovered.
 enum LuaBindingBody {
     /// Extracts and dedents function body within 1-based inclusive line range.
     static func extract(

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle+Metrics.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle+Metrics.swift
@@ -17,7 +17,12 @@ extension AppBarStyle {
         content.rendered(horizontal: edge.isHorizontal)
     }
 
-    /// Supported title character cap range (8...80), shared across both bars.
+    /// Title-cap bounds, shared by both bars. 8 at the floor —
+    /// below it every title collapses to its first word and stops
+    /// telling two windows apart; 80 at the ceiling — the slot
+    /// clamps to a quarter of the bar long before that. A fixed
+    /// clamp, never fit-derived: a display-dependent cap resolves
+    /// differently per screen.
     public static let titleCapRange = 8...80
 
     /// Title cap clamped to `titleCapRange`.
@@ -28,7 +33,10 @@ extension AppBarStyle {
         )
     }
 
-    /// Truncates title to character cap with trailing ellipsis.
+    /// Truncates title to the cap, tail-first. Counts
+    /// **Characters**, not UTF-16 units, so an emoji costs one the
+    /// way the reader sees it; the ellipsis is not counted against
+    /// the cap, which answers "how much title".
     public static func cappedTitle(
         _ title: String,
         to cap: Int

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle+Metrics.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle+Metrics.swift
@@ -1,17 +1,9 @@
 import CoreGraphics
 
-/// Pure resolve helpers split from AppBarStyle.swift (file-size
-/// ceiling) — `SpaceBarStyle+Metrics` is the same seam on the
-/// other bar. The Codable conformance stays with the struct.
+/// Metric resolution helpers for `AppBarStyle` (`SpaceBarStyle+Metrics`).
 extension AppBarStyle {
-    /// The item font ladder: an explicit `font_size` wins;
-    /// auto scales with the bar's cross dimension (its
-    /// thickness), so a fat bar gets readable text and a slim
-    /// one stays inside its strip. One resolution site shared
-    /// by the item view, the slot measurement and the GUI
-    /// preview so they can't drift —
-    /// `SpaceBarStyle.identifierFontSize(forDepth:)` is the
-    /// same shape on the other bar.
+    /// Resolves font size from explicit setting or thickness scaling
+    /// (`SpaceBarStyle.identifierFontSize(forDepth:)`).
     public func resolvedFontSize(
         forThickness thickness: CGFloat
     ) -> CGFloat {
@@ -19,42 +11,16 @@ extension AppBarStyle {
         return min(max(thickness * 0.42, 9), 28)
     }
 
-    /// What THIS bar actually draws — `content` with the
-    /// vertical collapse (`Content.rendered(horizontal:)`)
-    /// folded in against its own `edge`.
-    ///
-    /// The two terms are one question, so they are composed
-    /// once. Asked separately, a change to the collapse rule
-    /// reaches whichever sites remembered to re-spell it: the
-    /// slot measurement and the GUI's two bar gates each had
-    /// their own copy.
-    ///
-    /// A site whose horizontality is NOT this style's edge calls
-    /// `Content.rendered(horizontal:)` directly instead, because
-    /// there the edge is genuinely a parameter: the item view is
-    /// handed one by its overlay, and a Settings preview draws a
-    /// mock bar at whatever edge it is illustrating.
+    /// Rendered content folded with horizontal/vertical collapse
+    /// (`Content.rendered(horizontal:)`).
     public var renderedContent: Content {
         content.rendered(horizontal: edge.isHorizontal)
     }
 
-    /// Valid title-cap bounds, shared by both bars — the Space
-    /// Bar aliases this rather than declaring a second range, the
-    /// way it already shares `BackgroundStyle` and `BarAlignment`.
-    /// 8 at the floor because below it every title collapses to
-    /// its first word and stops telling two windows of one app
-    /// apart, which is the whole point of drawing a title; 80 at
-    /// the ceiling because the slot clamps to a quarter of the bar
-    /// long before that, so a larger number would silently do
-    /// nothing. A fixed clamp, not fit-derived — the same
-    /// reasoning as `glyphCapRange`: a display-dependent cap would
-    /// resolve differently per screen and break the bar's
-    /// otherwise-uniform model.
+    /// Supported title character cap range (8...80), shared across both bars.
     public static let titleCapRange = 8...80
 
-    /// The title cap clamped to `titleCapRange` — the driver reads
-    /// this so a stored out-of-range value can't blank a title or
-    /// hand the measurement an unbounded string.
+    /// Title cap clamped to `titleCapRange`.
     public var resolvedTitleCap: Int {
         min(
             max(titleCap, Self.titleCapRange.lowerBound),
@@ -62,19 +28,7 @@ extension AppBarStyle {
         )
     }
 
-    /// `title` cut to `cap` characters, tail-first, with an
-    /// ellipsis standing in for what was dropped. The one copy
-    /// both bars call: the App Bar's items and the Space Bar's
-    /// front segment must agree, or the same window reads two
-    /// lengths on one screen.
-    ///
-    /// Counts **Characters**, not UTF-16 units, so an emoji or a
-    /// combining mark costs one the way the reader sees it — a
-    /// ghostty tab titled "◐ app bar title truncation" must not
-    /// spend two of its budget on the leading glyph. The ellipsis
-    /// is not counted against `cap`: the cap answers "how much
-    /// title", and making the marker eat a character of it would
-    /// leave the cap describing something the user cannot see.
+    /// Truncates title to character cap with trailing ellipsis.
     public static func cappedTitle(
         _ title: String,
         to cap: Int

--- a/Sources/KiwiDeskCore/Layouts/GridLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/GridLayout.swift
@@ -1,6 +1,10 @@
 import CoreGraphics
 
-/// Grid layout system supporting dynamic and rigid tiling (`OverlapStack`).
+/// Grid layout system supporting dynamic and rigid tiling.
+/// Both types share one ceiling: `columns`×`rows` (or the
+/// auto-size screen-computed dimensions) is the most cells the
+/// grid splits into — rigid fills it, dynamic balances up to it,
+/// and the excess cascades in the last cell (`OverlapStack`).
 public struct GridLayout: LayoutSystem {
     public init() {}
 
@@ -148,7 +152,11 @@ public struct GridLayout: LayoutSystem {
         return (max(1, cols), max(1, rows))
     }
 
-    /// Resolves grid dimensions bounded by capacity ceiling (#712).
+    /// Resolves grid dimensions bounded by the cap — the cap
+    /// bounds the CEILING, not the growth, so a dynamic grid stays
+    /// tight until it hits it. Public + static because the
+    /// Settings preview needs the whole rule or it subdivides past
+    /// where the real grid stops (#712).
     public static func dimensions(
         count: Int,
         params: GridParams,

--- a/Sources/KiwiDeskCore/Layouts/GridLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/GridLayout.swift
@@ -1,14 +1,6 @@
 import CoreGraphics
 
-/// Grid layout: dynamic (auto-balanced, square-ish) or rigid
-/// (fixed user-defined columns x rows).
-///
-/// Both types share one ceiling. `columns`x`rows` (or, with
-/// `auto_size`, the screen-computed dimensions) is the most
-/// cells the grid ever splits into: a rigid grid always fills
-/// it, a dynamic grid auto-balances *up to* it. Past capacity
-/// the excess windows cascade in the last cell — the same
-/// `OverlapStack` overflow either type falls back to.
+/// Grid layout system supporting dynamic and rigid tiling (`OverlapStack`).
 public struct GridLayout: LayoutSystem {
     public init() {}
 
@@ -71,14 +63,8 @@ public struct GridLayout: LayoutSystem {
         var result: [WindowID: CGRect] = [:]
         let capacity = columns * rows
 
-        // Overflow: excess windows beyond the capped capacity
-        // stack in the last cell. Dynamic reaches here only once
-        // the balanced arrangement is clamped to the cap; rigid
-        // whenever the fixed grid fills up.
         if count > capacity {
-            // Sticky windows keep a fully-tiled cell (#414 v2):
-            // one caught past the cap trades places with the
-            // last non-sticky tiled window, which piles instead.
+            // Sticky windows preserve a fully-tiled cell (#414 v2).
             let ordered = OverlapStack.stickyExempt(
                 windows,
                 tiled: capacity - 1,
@@ -108,10 +94,7 @@ public struct GridLayout: LayoutSystem {
 
         let fillLast =
             params.type == .dynamic && params.fillEmptyCells
-        // Both grid types honour the arrange order (#217): columns
-        // first fills row-major (across a row, then down), rows
-        // first column-major (down a column, then across). It is a
-        // fill-order setting, not only a dynamic-growth one.
+        // Both grid types honor arrangement order (#217).
         let columnFirst =
             params.splitDirection == .horizontal
 
@@ -119,11 +102,9 @@ public struct GridLayout: LayoutSystem {
             let col: Int
             let row: Int
             if columnFirst {
-                // Row-major filling.
                 col = index % columns
                 row = index / columns
             } else {
-                // Column-major filling.
                 col = index / rows
                 row = index % rows
             }
@@ -147,11 +128,7 @@ public struct GridLayout: LayoutSystem {
         return result
     }
 
-    /// The grid's cell ceiling: the screen-computed dimensions
-    /// when `auto_size` is on, otherwise the typed `columns` x
-    /// `rows`. Auto-size fits as many min-size cells as each
-    /// axis allows, so a landscape monitor yields more columns
-    /// than rows.
+    /// Computes cell capacity ceiling under auto-size or fixed parameters.
     func capDimensions(
         params: GridParams,
         usable: CGRect,
@@ -171,22 +148,7 @@ public struct GridLayout: LayoutSystem {
         return (max(1, cols), max(1, rows))
     }
 
-    /// Grid dimensions (columns x rows) for a window count,
-    /// bounded by the `cap`. Rigid uses the cap verbatim;
-    /// dynamic auto-balances a square-ish arrangement clamped to
-    /// the cap — the cap bounds the ceiling, not the growth, so a
-    /// dynamic grid stays tight until it hits it. When the
-    /// balanced arrangement's orientation fights the cap's (a
-    /// wide balance against a tall cap), the unpinned axis grows
-    /// to use the cap's full capacity before the count overflows.
-    ///
-    /// Public and `static` for the same reason `balanced` is: the
-    /// Settings preview needs the *whole* rule, not just the
-    /// balance, or it draws a grid that keeps subdividing past
-    /// the point the real one stops (#712). It takes the cap as a
-    /// parameter and touches no screen, so exposing it hands out
-    /// no state — the caller supplies the ceiling, which is the
-    /// one part that IS screen-derived (`capDimensions`).
+    /// Resolves grid dimensions bounded by capacity ceiling (#712).
     public static func dimensions(
         count: Int,
         params: GridParams,
@@ -212,22 +174,11 @@ public struct GridLayout: LayoutSystem {
         }
     }
 
-    /// Ceiling of `a / b` for positive integers.
     private static func ceilDiv(_ a: Int, _ b: Int) -> Int {
         (a + b - 1) / b
     }
 
-    /// The square-ish auto-balanced arrangement for a window
-    /// count, before any cap. Column-first (horizontal split)
-    /// grows columns first: 1x1, 2x1, 2x2, 3x2, 3x3, …;
-    /// row-first mirrors it.
-    ///
-    /// Public because the Settings preview balances its own
-    /// window count through it (#678 turn 10) rather than
-    /// reproducing the arithmetic: a preview holding a private
-    /// copy of this rule is a picture of the layout that stops
-    /// agreeing with it the day the rule changes. Pure and
-    /// screen-free, so exposing it hands out no state.
+    /// Auto-balanced column/row count for window count (#678 turn 10).
     public static func balanced(
         count: Int,
         splitDirection: GridParams.SplitDirection

--- a/Sources/KiwiDeskCore/Layouts/MonocleLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/MonocleLayout.swift
@@ -1,16 +1,9 @@
 import CoreGraphics
 
-/// Monocle: every window is maximized to the full usable area.
+/// Monocle layout: maximizes windows to usable area (#677, #881).
 ///
-/// All windows share the same frame; whichever is focused sits
-/// on top, the rest are hidden behind it — or, with
-/// `hide_style = park` (#881), the unfocused members park at
-/// the stash corner so a transparent body or a centered
-/// width-bound window (#677) cannot reveal them. No geometry
-/// splitting regardless of window count. With the indicator bar
-/// enabled, its strip is carved out of the usable area first,
-/// so windows and bar never overlap and both stay on the
-/// monitor.
+/// Unfocused windows stack underneath or park at stash corner when
+/// `hide_style = park` (#881).
 public struct MonocleLayout: LayoutSystem {
     public init() {}
 
@@ -23,11 +16,7 @@ public struct MonocleLayout: LayoutSystem {
             inner: context.gaps.inner,
             global: context.appBarStyle
         )
-        // A window whose app refuses the monocle size (#677)
-        // takes the learned answer CENTERED in the slot —
-        // residue split symmetrically instead of piling on one
-        // side. Only the refused ask consumes; anything else
-        // asks the full frame.
+        // Center size-bound window in slot (#677).
         func effective(_ window: WindowID) -> CGRect {
             context.sizeBounds[window]?
                 .centered(
@@ -42,21 +31,6 @@ public struct MonocleLayout: LayoutSystem {
             }
             return result
         }
-        // Park (#881): only the shown member takes its slot;
-        // every other member parks at the stash corner — the
-        // space stash's own geometry and sliver trade, anchored
-        // to `parkBounds` so the sliver clears both bars. The
-        // shown member is the pan anchor (a tiled-sticky
-        // traveler parks like a member and shows while it holds
-        // the focus, #431), which the engine HOLDS across a
-        // float focus (`monocleShownMembers`) so a float taking
-        // focus cannot swap the members beneath it; with no
-        // anchored member at all the front of the carousel
-        // stands in, matching `new_window_placement`'s "front"
-        // instinct. Parking each member's OWN effective frame
-        // keeps a refused-width window's sliver on screen: a
-        // full-width park of a narrower window would push its
-        // body past the peek entirely.
         let shown = Self.shownMember(
             anchor: context.focused,
             of: windows
@@ -80,11 +54,8 @@ public struct MonocleLayout: LayoutSystem {
         return result
     }
 
-    /// The one copy of park's shown-member pick (#881, review
-    /// round): the anchor while it is a member, else the front
-    /// of the carousel. The navigate filter consumes the same
-    /// rule (`KiwiCore+NavigateCommand`), so the tier it keeps
-    /// and the member the layout shows cannot drift apart.
+    /// Selects active shown member for park mode (#431, #881,
+    /// `KiwiCore+NavigateCommand`).
     static func shownMember(
         anchor: WindowID?,
         of members: [WindowID]
@@ -94,20 +65,7 @@ public struct MonocleLayout: LayoutSystem {
         } ?? members.first
     }
 
-    /// The rect a park anchors to: the layout bounds, pulled in
-    /// past the monocle bar's strip (#881 review round). The
-    /// bar renders ABOVE windows on its edge, so a sliver
-    /// anchored to the raw bounds would park underneath a
-    /// bottom bar — enabled at the bottom by default — and the
-    /// "thin edge stays visible" promise would be false. Only
-    /// the bar's own edge moves; the Space Bar's strip is
-    /// already carved from `context.bounds` by the engine
-    /// (#293), which is also why the sliver clears a bottom
-    /// Space Bar. Deliberately private rather than an
-    /// `AppBarGeometry` op (§2.4, architect round): the
-    /// "bounds pulled to the strip's near edge" arithmetic has
-    /// this one consumer — home it beside `windowFrame` and
-    /// `clampClear` when a second appears.
+    /// Computes park anchor bounds accounting for bar insets (#293, #881).
     private func parkBounds(
         in context: LayoutContext
     ) -> CGRect {

--- a/Sources/KiwiDeskCore/Layouts/MonocleLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/MonocleLayout.swift
@@ -31,6 +31,11 @@ public struct MonocleLayout: LayoutSystem {
             }
             return result
         }
+        // Park (#881): the engine HOLDS the shown member across a
+        // float focus (`monocleShownMembers`) so a float taking
+        // focus cannot swap the members beneath it. Each member
+        // parks its OWN effective frame — a full-width park of a
+        // narrower window would push its body past the peek.
         let shown = Self.shownMember(
             anchor: context.focused,
             of: windows

--- a/Sources/KiwiDeskCore/Layouts/MonocleParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/MonocleParams.swift
@@ -40,6 +40,8 @@ extension MonocleParams: Codable {
         case override
     }
 
+    /// Manual decoding: profiles saved before a field existed
+    /// must keep loading (missing keys fall back to defaults).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self

--- a/Sources/KiwiDeskCore/Layouts/MonocleParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/MonocleParams.swift
@@ -1,58 +1,28 @@
 import CoreGraphics
 import Foundation
 
-/// Monocle tuning: orientation (which focus axis cycles
-/// through the windows) and the indicator bar listing them.
-/// The bar's look is global (`AppBarStyle`); this layout only
-/// carries its own `enabled` + overrides (`bar`).
+/// Monocle layout tuning parameters (`AppBarStyle`, `AppBarHosting`).
 public struct MonocleParams: Sendable, Equatable, AppBarHosting {
-    /// Which focus axis cycles through the monocle windows —
-    /// and, with it, which edges the indicator bar may sit on.
+    /// Focus navigation axis and indicator bar placement.
     public enum Orientation: String, Sendable, Codable, CaseIterable {
-        /// `focus("left"/"right")` cycles; bar on top/bottom.
         case horizontal
-        /// `focus("up"/"down")` cycles; bar on left/right.
         case vertical
     }
 
-    /// How the unfocused members are hidden (#881). Monocle's
-    /// illusion of "one window" has two ways to break: an app
-    /// with a transparent or blurred body shows the stack
-    /// straight through itself, and a width-bound window (#677)
-    /// centers with symmetric gaps the stack shows through with
-    /// no transparency involved. `park` closes both by moving
-    /// the unfocused members out from behind instead of
-    /// ordering them.
+    /// Mechanism for hiding unfocused monocle members (#677, #881).
     public enum HideStyle: String, Sendable, Codable, CaseIterable {
-        /// Every member shares the full frame; only z-order
-        /// hides the unfocused ones. The default.
         case stack
-        /// Unfocused members park at the stash corner (the
-        /// space stash's own geometry and sliver trade), and
-        /// the focus switch snaps instantly.
         case park
     }
 
     public var orientation: Orientation = .horizontal
     public var hideStyle: HideStyle = .stack
-    /// Whether the focus cycle wraps past the ends (#168). Unlike
-    /// Whether moving focus past the last window wraps to the
-    /// first (and the reverse). Defaults **off**, matching the
-    /// other array-order layouts (scrolling/track) — one default
-    /// across all three. Turn it on for carousel-style cycling.
-    /// `swap` never wraps. Per-layout, like the scrolling/track
-    /// wrap toggles.
+    /// Whether focus navigation wraps at cycle ends (#168).
     public var wrapFocus = false
-    /// Where a new window lands in the flat array — and, since
-    /// monocle shows one window at a time, where it sits in the
-    /// focus cycle. `.first` by default: a new window comes to
-    /// the front of the carousel (the stack-master instinct),
-    /// never buried mid-cycle. The same `SpawnPlacement`
-    /// vocabulary every other layout uses.
+    /// Placement for newly spawned windows (`SpawnPlacement`).
     public var newWindowPlacement: SpawnPlacement = .first
     public var appBar = LayoutAppBar()
-    /// Per-space overrides (`layout.monocle.override[space_id]`),
-    /// resolved via `TilingSettings.resolvedMonocle(for:)`.
+    /// Per-space overrides (`TilingSettings.resolvedMonocle(for:)`).
     public var override: [SpaceID: MonocleOverride] = [:]
 
     public init() {}
@@ -70,8 +40,6 @@ extension MonocleParams: Codable {
         case override
     }
 
-    /// Manual decoding: profiles saved before a field existed
-    /// must keep loading (missing keys fall back to defaults).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self
@@ -109,8 +77,7 @@ extension MonocleParams: Codable {
             ) ?? [:]
     }
 
-    /// Manual encode so the per-space override map stays sparse
-    /// (absent when empty), unlike the synthesized encode.
+    /// Encodes monocle parameters keeping sparse override map structure.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(orientation, forKey: .orientation)

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle+CopyAppearance.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle+CopyAppearance.swift
@@ -4,7 +4,11 @@ import Foundation
 /// One-shot appearance synchronization between space bar and app bar styles
 /// (`SpaceBarParityTests.copyAppearanceParity`, #293, #678 Phase 2).
 extension SpaceBarStyle {
-    /// JSON key spellings excluded from the copy.
+    /// JSON key spellings excluded from the copy: `edge`
+    /// (placement is not appearance), `enabled` (visibility is
+    /// not), and every `*_color` key (colours are Advanced
+    /// Colours' concern, owner ruling 2026-08-02 — derived by
+    /// suffix so a new shared colour stays out automatically).
     public static let copyAppearanceExclusions: Set<String> = [
         "enabled", "edge",
     ]
@@ -31,8 +35,10 @@ extension SpaceBarStyle {
             .subtracting(sharedColorKeys)
     }
 
-    /// Copies shared appearance fields from AppBarStyle
-    /// (`AppBarStyle.copyAppearance(from:)`).
+    /// Copies shared appearance fields from AppBarStyle — the
+    /// RETIRED forward direction (the shipped button pulls the
+    /// other way, owner flip 2026-08-10). Stays internal as the
+    /// parity suite's seed (`AppBarStyle.copyAppearance(from:)`).
     mutating func copyAppearance(from appBar: AppBarStyle) {
         for key in Self.copyAppearanceKeys {
             copyField(key, from: appBar)

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle+CopyAppearance.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle+CopyAppearance.swift
@@ -1,29 +1,8 @@
 import CoreGraphics
 import Foundation
 
-/// The one-shot "Copy sizes and style to Space Bar…" action
-/// (#293, rescoped with the #678 Phase 2 Bars page): the Space
-/// Bar takes the App Bar's current values for the structural
-/// fields the two styles share — sizes, background, indicator,
-/// content-adjacent style — then stays fully independent, never
-/// a live inherit.
-///
-/// The copied set is the **CodingKey intersection** of the two
-/// styles minus deliberate exclusions, so a field added to
-/// both styles joins the copy automatically (no hand list to
-/// forget — `SpaceBarParityTests.copyAppearanceParity` pins
-/// this):
-/// - `edge` — placement is not appearance; copying it would
-///   silently relocate the bar onto the App Bar's edge.
-/// - `enabled` — visibility is not appearance. Inert today
-///   (the global `AppBarStyle` has no `enabled` key; the App
-///   Bar's toggle is per-layout), listed so the exclusion is
-///   already in force the day one appears.
-/// - every `*_color` key — colours are the Advanced Colours
-///   area's concern (owner ruling 2026-08-02, with the Bars
-///   redesign): a colours-copy, if it ships at all, lives
-///   there. Derived by suffix, so a new shared colour field
-///   stays out of this copy automatically.
+/// One-shot appearance synchronization between space bar and app bar styles
+/// (`SpaceBarParityTests.copyAppearanceParity`, #293, #678 Phase 2).
 extension SpaceBarStyle {
     /// JSON key spellings excluded from the copy.
     public static let copyAppearanceExclusions: Set<String> = [
@@ -40,9 +19,8 @@ extension SpaceBarStyle {
             .filter { $0.hasSuffix("_color") }
     }
 
-    /// The shared, copyable key spellings (intersection minus
-    /// exclusions minus colours) — the parity test's contract
-    /// surface.
+    /// Shared copyable key spellings
+    /// (`SpaceBarParityTests.copyAppearanceParity`).
     public static var copyAppearanceKeys: Set<String> {
         let ours = Set(CodingKeys.allCases.map(\.stringValue))
         let theirs = Set(
@@ -53,14 +31,8 @@ extension SpaceBarStyle {
             .subtracting(sharedColorKeys)
     }
 
-    /// Copies every shared appearance field from `appBar` —
-    /// the RETIRED forward direction: the shipped button pulls
-    /// the other way (`AppBarStyle.copyAppearance(from:)`,
-    /// owner flip 2026-08-10), and no production path calls
-    /// this any more. It stays, internal, as the parity
-    /// suite's seed and the symmetric statement of the
-    /// contract both directions share; if a Space Bar card
-    /// ever earns its own pull button this is it, re-argued.
+    /// Copies shared appearance fields from AppBarStyle
+    /// (`AppBarStyle.copyAppearance(from:)`).
     mutating func copyAppearance(from appBar: AppBarStyle) {
         for key in Self.copyAppearanceKeys {
             copyField(key, from: appBar)

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle+Metrics.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle+Metrics.swift
@@ -1,38 +1,21 @@
 import CoreGraphics
 import Foundation
 
-/// Shared metric constants and pure resolve helpers, split
-/// from SpaceBarStyle.swift (file-size ceiling). The Codable
-/// conformance stays with the struct (synthesized `encode`
-/// requires same-file).
+/// Metrics and resolution helpers for space bar styling (#376).
 extension SpaceBarStyle {
-    /// Muted-badge background alpha over `item_color` on
-    /// inactive spaces — one derivation shared by the runtime
-    /// item view and the Settings preview.
+    /// Muted-badge background alpha over `item_color` on inactive spaces.
     public static let mutedBadgeAlpha: CGFloat = 0.3
 
-    /// The divider rules' alpha over `item_color` — the
-    /// identifier↔glyphs rule and the front-app rule share it,
-    /// like `mutedBadgeAlpha` above.
+    /// Divider rule alpha over `item_color`.
     public static let dividerAlpha: CGFloat = 0.4
 
-    /// Valid drag-drop dwell bounds (ms): fast enough to feel
-    /// responsive, slow enough not to spring by accident. Floored
-    /// at 1000 so the sweep (which starts after a 0.5 s quiet
-    /// pre-delay) still has visible fill time.
+    /// Valid drag-drop dwell bounds in milliseconds.
     public static let springDelayRange = 1000...4000
 
-    /// Valid glyph-cap bounds (#376): 1 (a lone glyph + "+n",
-    /// matching the PR #381 "0 is toggle-only, floor at 1" idiom)
-    /// through 12 (past ~a dozen a status glyph row stops being
-    /// scannable at any item size). A fixed clamp, not fit-derived —
-    /// a display-dependent cap would resolve differently per screen
-    /// and break the bar's otherwise-uniform model.
+    /// Valid glyph-cap bounds (#376).
     public static let glyphCapRange = 1...12
 
-    /// The glyph cap clamped to `glyphCapRange` — the driver reads
-    /// this so a stored out-of-range value can't render nothing or
-    /// an unscannable row.
+    /// Clamped glyph cap value (`glyphCapRange`).
     public var resolvedGlyphCap: Int {
         min(
             max(glyphCap, Self.glyphCapRange.lowerBound),
@@ -40,9 +23,8 @@ extension SpaceBarStyle {
         )
     }
 
-    /// The front-segment title cap clamped to the range both
-    /// bars share (`AppBarStyle.titleCapRange`) — one range, so
-    /// the same window cannot read two lengths on one screen.
+    /// Front-segment title cap clamped to shared range
+    /// (`AppBarStyle.titleCapRange`).
     public var resolvedTitleCap: Int {
         min(
             max(titleCap, AppBarStyle.titleCapRange.lowerBound),
@@ -50,9 +32,7 @@ extension SpaceBarStyle {
         )
     }
 
-    /// The drag-drop spring dwell in seconds, clamped to
-    /// `springDelayRange` — the coordinator and the sweep both
-    /// read this so a stored out-of-range value can't misbehave.
+    /// Drag-drop spring dwell in seconds clamped to `springDelayRange`.
     public var resolvedSpringDelay: TimeInterval {
         let ms = min(
             max(springDelay, Self.springDelayRange.lowerBound),
@@ -61,9 +41,7 @@ extension SpaceBarStyle {
         return TimeInterval(ms) / 1000
     }
 
-    /// The identifier's font ladder: an explicit `font_size`
-    /// wins; auto scales with half the strip depth, clamped to
-    /// the depth minus padding.
+    /// Calculated font size for space identifier based on bar depth.
     public func identifierFontSize(
         forDepth depth: CGFloat
     ) -> CGFloat {
@@ -71,19 +49,15 @@ extension SpaceBarStyle {
         return min(base, max(depth - 8, 8))
     }
 
-    /// App glyphs sit a step below the identifier — defined as
-    /// a ratio of ONE ladder so the item glyphs, the front-app
-    /// glyph, and the identifier can never desync (two
-    /// independent formulas rendered the same app at visibly
-    /// different sizes in auto mode, QA 2026-07-19).
+    /// Scaled font size for app glyphs based on identifier size.
     public func glyphFontSize(
         forDepth depth: CGFloat
     ) -> CGFloat {
         identifierFontSize(forDepth: depth) * 0.9
     }
 
-    /// Same %-resolve as `AppBarStyle.resolvedCornerRadius` —
-    /// small duplicated helper over a shared protocol (§2.4).
+    /// Resolves corner radius proportional to bar thickness
+    /// (`AppBarStyle.resolvedCornerRadius`).
     public func resolvedCornerRadius(
         forThickness thickness: CGFloat
     ) -> CGFloat {

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle+Metrics.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle+Metrics.swift
@@ -12,7 +12,10 @@ extension SpaceBarStyle {
     /// Valid drag-drop dwell bounds in milliseconds.
     public static let springDelayRange = 1000...4000
 
-    /// Valid glyph-cap bounds (#376).
+    /// Valid glyph-cap bounds (#376): floor 1 (a lone glyph +
+    /// "+n", the PR #381 "0 is toggle-only" idiom), ceiling 12. A
+    /// fixed clamp, never fit-derived — a display-dependent cap
+    /// would break the bar's uniform model.
     public static let glyphCapRange = 1...12
 
     /// Clamped glyph cap value (`glyphCapRange`).
@@ -49,7 +52,10 @@ extension SpaceBarStyle {
         return min(base, max(depth - 8, 8))
     }
 
-    /// Scaled font size for app glyphs based on identifier size.
+    /// Scaled font size for app glyphs — a ratio of ONE ladder,
+    /// so item glyphs, front-app glyph and identifier can never
+    /// desync (two formulas rendered the same app at visibly
+    /// different sizes, QA 2026-07-19).
     public func glyphFontSize(
         forDepth depth: CGFloat
     ) -> CGFloat {

--- a/Sources/KiwiDeskCore/Layouts/StackLayout+Heal.swift
+++ b/Sources/KiwiDeskCore/Layouts/StackLayout+Heal.swift
@@ -1,34 +1,7 @@
-/// The session-weight feasibility heal (#944), beside the
-/// domain authorities it derives from.
+/// Weight feasibility reconciliation operations (`weightedSpan`, #944).
 extension StackLayout {
-    /// Heals a weighted group whose STORED weights no longer fit
-    /// its CURRENT membership and span (#944): the write-time
-    /// clamps (#933) validate a weight against the membership at
-    /// press time, so a weight that was legal when written — the
-    /// store ceiling is 10.0 — can, once a member JOINS the
-    /// group (or the span shrinks), squeeze the smallest share
-    /// below `minSize`, trip the layouts' cascade check
-    /// (`maxColumnTotal`, the same authority) and collapse the
-    /// whole group into an overlap pile.
-    ///
-    /// Returns nil when nothing needs healing — the total passes
-    /// the layouts' own check (no margin: a stored value between
-    /// the margined clamp target and the raw check still renders,
-    /// and shaving it would rewrite a legal weight) — and nil
-    /// when no weights can fit (the span is below the group's
-    /// count × minimum): that pile is honest physics and stays
-    /// with the overflow folds. Otherwise the healed array: a
-    /// waterline cap `c` chosen so the capped total lands the
-    /// smallest share exactly at `minSize + minSizeMargin` —
-    /// inside the cascade check by the same margin the
-    /// interactive clamps keep (#925/#933). Only weights above
-    /// `c` are shaved, so small weights, the smallest member and
-    /// the relative order of everything below the cap survive
-    /// the heal untouched.
-    ///
-    /// Pure math over the gap-adjusted span the layout divides
-    /// (`weightedSpan`); the caller owns which store it heals,
-    /// where the span comes from, and writing the result back.
+    /// Reconciles stored weights to ensure minimum window size constraints
+    /// (`maxColumnTotal`, `minSizeMargin`, #925, #933, #944).
     public static func healedWeights(
         weights: [Double],
         span: Double,

--- a/Sources/KiwiDeskCore/Layouts/StackLayout+Heal.swift
+++ b/Sources/KiwiDeskCore/Layouts/StackLayout+Heal.swift
@@ -1,7 +1,12 @@
 /// Weight feasibility reconciliation operations (`weightedSpan`, #944).
 extension StackLayout {
-    /// Reconciles stored weights to ensure minimum window size constraints
-    /// (`maxColumnTotal`, `minSizeMargin`, #925, #933, #944).
+    /// Reconciles stored weights to fit current membership and
+    /// span (#944; `maxColumnTotal`, `minSizeMargin`, #925/#933).
+    /// Nil when nothing needs healing — no margin: a stored value
+    /// between the margined clamp target and the raw check still
+    /// renders, and shaving it would rewrite a legal weight — and
+    /// nil when no weights can fit: that pile is honest physics.
+    /// Only weights above the waterline cap are shaved.
     public static func healedWeights(
         weights: [Double],
         span: Double,

--- a/Sources/KiwiDeskCore/Layouts/StackParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/StackParams.swift
@@ -26,7 +26,9 @@ public struct StackParams: Sendable, Equatable, Codable {
             self == .left || self == .right
         }
 
-        /// Inferred orientation for windows in the stack zone (#222).
+        /// Inferred orientation for the stack zone — derived,
+        /// never a free knob (#222): any other combination
+        /// degenerates into slivers.
         public var stackOrientation: Orientation {
             splitsHorizontally ? .vertical : .horizontal
         }
@@ -59,6 +61,8 @@ public struct StackParams: Sendable, Equatable, Codable {
         case override
     }
 
+    /// Manual decoding: profiles saved before a field existed
+    /// must keep loading (missing keys fall back to defaults).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self

--- a/Sources/KiwiDeskCore/Layouts/StackParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/StackParams.swift
@@ -1,79 +1,54 @@
 import Foundation
 
-/// The stack layout's parameters, split from `LayoutParams`
-/// for file size (AGENTS.md §2) when the #222 arrangement
-/// fields joined the ratio/count/overflow trio.
+/// Parameters for the stack/master-stack layout engine (#222).
 public struct StackParams: Sendable, Equatable, Codable {
-    /// What happens when a zone can't give every window
-    /// `minWindowSize`.
+    /// Overflow behavior when windows exceed `minWindowSize`.
     public enum OverflowStyle: String, Sendable, Codable, CaseIterable {
-        /// Only the windows that don't fit cascade at the
-        /// bottom; the rest stay fully tiled.
         case cascadeOverflow = "cascade_overflow"
-        /// The whole zone cascades.
         case cascadeAll = "cascade_all"
     }
 
-    /// How a zone lines up its windows (#222). The overflow
-    /// cascade is NOT affected: piles always offset downward
-    /// so title bars stay visible (`OverlapStack`).
+    /// Linear orientation within a zone (`OverlapStack`, #222).
     public enum Orientation: String, Sendable, Codable, CaseIterable {
-        /// Windows stacked top-to-bottom (a column).
         case vertical
-        /// Windows side by side (a row).
         case horizontal
     }
 
-    /// Where the stack zone sits relative to the master
-    /// (#222). Decides the split axis: `left`/`right` split
-    /// the width, `top`/`bottom` split the height.
+    /// Position of stack zone relative to master zone (#222).
     public enum StackPosition: String, Sendable, Codable, CaseIterable {
         case top
         case right
         case bottom
         case left
 
-        /// True when the master/stack split divides the
-        /// width — the single authority for the split axis,
-        /// shared by the layout math and both resize paths.
+        /// True when the master/stack split divides width.
         public var splitsHorizontally: Bool {
             self == .left || self == .right
         }
 
-        /// The stack zone's lineup, derived — never a free
-        /// knob (design decision on #222): a left/right zone
-        /// is a tall strip, so it stacks vertically; a
-        /// top/bottom zone is wide, so windows sit side by
-        /// side. Any other combination degenerates into
-        /// slivers.
+        /// Inferred orientation for windows in the stack zone (#222).
         public var stackOrientation: Orientation {
             splitsHorizontally ? .vertical : .horizontal
         }
     }
 
-    /// Windows 0..<masterCount form the master zone.
+    /// Number of windows in the master zone.
     public var masterCount: Int = 1
-    /// The master zone's share of the split axis.
+    /// Master zone share of split axis.
     public var masterRatio: Double = 0.6
-    /// Zone overflow behavior (applies to both zones).
+    /// Overflow behavior applying to both zones.
     public var overflowStyle: OverflowStyle = .cascadeOverflow
-    /// How the master zone lines up its windows (#222). The
-    /// stack zone has no such knob — its lineup derives from
-    /// `stackPosition` (see `StackPosition.stackOrientation`).
+    /// Master zone layout orientation (#222).
     public var masterOrientation: Orientation = .horizontal
-    /// Where the stack zone sits (#222); `right` is the
-    /// classic dwm arrangement (master left).
+    /// Position of stack zone (#222).
     public var stackPosition: StackPosition = .right
-    /// dwm-style default: `.first` makes the new window the
-    /// master (the last master slides into the stack).
+    /// Spawn placement rule for incoming windows.
     public var newWindowPlacement: SpawnPlacement = .first
-    /// Per-space overrides (`layout.stack.override[space_id]`),
-    /// resolved via `TilingSettings.resolvedStack(for:)`.
+    /// Per-space overrides (`TilingSettings.resolvedStack(for:)`).
     public var override: [SpaceID: StackOverride] = [:]
 
     public init() {}
 
-    /// JSON keys follow the Lua setters (`stack.set_*`).
     private enum CodingKeys: String, CodingKey {
         case masterCount = "master_count"
         case masterRatio = "master_ratio"
@@ -84,8 +59,6 @@ public struct StackParams: Sendable, Equatable, Codable {
         case override
     }
 
-    /// Manual decoding: profiles saved before a field existed
-    /// must keep loading (missing keys fall back to defaults).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self
@@ -127,8 +100,7 @@ public struct StackParams: Sendable, Equatable, Codable {
             ) ?? [:]
     }
 
-    /// Manual encode so the per-space override map stays sparse
-    /// (absent when empty), unlike the synthesized encode.
+    /// Encodes stack parameters keeping sparse override map structure.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(masterCount, forKey: .masterCount)

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+Insert.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+Insert.swift
@@ -2,8 +2,11 @@ import Foundation
 
 /// Spawn-time insertion into a track space (#128, #188, #437).
 extension Space {
-    /// Inserts a window per track rules, supporting fill-then-spill
-    /// (#128, #188, #192, #437, `WorkspaceManager.add`).
+    /// Inserts a window per track rules, supporting
+    /// fill-then-spill (#128, #188, #192, #437,
+    /// `WorkspaceManager.add`). `spillCapacity == nil` disables
+    /// the spill — the explicit-placement path (`move_to_space`
+    /// travelers), which must not be relocated.
     public mutating func insertIntoTrack(
         _ window: WindowID,
         rule: TrackParams.NewWindowTrack,

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+Insert.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+Insert.swift
@@ -1,34 +1,9 @@
 import Foundation
 
-/// Spawn-time insertion into a track space (#128, #188): where a
-/// new window lands per `new_window` (own vs focused track) and
-/// `new_window_position` (first / last / before / after focused).
-/// Split from `TrackLayout+Domain` for file size (§2). Pure state
-/// over the flat array — no geometry; the layout renders overflow.
+/// Spawn-time insertion into a track space (#128, #188, #437).
 extension Space {
-    /// Inserts a window per the track layout's `new_window` rule
-    /// (#128, #437) and `new_window_position` (#188). `ownTrack`
-    /// ALWAYS opens its own new track (#192): the overflow track is
-    /// a read-time view, so spawn never caps — the far-edge surplus
-    /// folds into it when the layout renders. `focusedTrack` is
-    /// fill-then-spill: the window joins the focused track (placed
-    /// by `position` among its windows) UNTIL that track already
-    /// holds `spillCapacity` windows — as many as fit at
-    /// `min_window_size` — and another track fits under `trackCap`,
-    /// when it opens a NEW track beside the focused one instead
-    /// (#437). `spillCapacity == nil` disables the spill so the
-    /// window always joins-and-piles — the explicit-placement path
-    /// (`move_to_space` travelers), which must not be relocated.
-    /// `trackCap` is 0 (unlimited, `auto_tracks`) or the fixed
-    /// `count + 1`; at the cap there is no room to spill, so it
-    /// piles. `isTiled` supplies the float knowledge the space
-    /// itself does not hold — the partition only spans tiled
-    /// windows.
-    /// `spillCapacity`/`trackCap` default to the no-spill identity
-    /// (join-and-pile): production routes through
-    /// `WorkspaceManager.add`, which requires both so every spawn
-    /// path chooses, but the Space primitive's default keeps
-    /// position-only callers simple.
+    /// Inserts a window per track rules, supporting fill-then-spill
+    /// (#128, #188, #192, #437, `WorkspaceManager.add`).
     public mutating func insertIntoTrack(
         _ window: WindowID,
         rule: TrackParams.NewWindowTrack,
@@ -44,9 +19,6 @@ extension Space {
             trackBreaks.insert(window)
             return
         }
-        // The true (uncapped) marker partition: placement is
-        // relative to real tracks, and the overflow merge is the
-        // layout's job, not spawn's.
         let counts = TrackLayout.counts(
             of: tiled,
             breaks: trackBreaks,
@@ -77,12 +49,6 @@ extension Space {
             spillCapacity: spillCapacity,
             trackCap: trackCap
         ) {
-            // Fill-then-spill (#437): the focused track can't fit
-            // another window at min size and another track fits, so
-            // open a NEW track immediately after the focused one.
-            // Focus follows it (the caller's `focus`), so the next
-            // window fills that track and spills again — the
-            // recursion needs no special-casing.
             insertOwnTrack(
                 window,
                 position: .afterFocused,
@@ -102,10 +68,7 @@ extension Space {
         }
     }
 
-    /// Places `window` into the full array at the slot just
-    /// before tiled index `at` (0…tiled.count) — anchoring off
-    /// the preceding tiled window so interleaved floating
-    /// windows don't shift the track partition.
+    /// Places `window` at tiled boundary slot, respecting floating windows.
     private mutating func insertAtTiledBoundary(
         _ window: WindowID,
         tiledIndex at: Int,
@@ -120,8 +83,7 @@ extension Space {
         }
     }
 
-    /// Opens `window` as its own new track, positioned among the
-    /// existing tracks by `position` (#188).
+    /// Opens `window` as its own new track (#188, `moveWindowToTrack`).
     private mutating func insertOwnTrack(
         _ window: WindowID,
         position: SpawnPlacement,
@@ -138,19 +100,13 @@ extension Space {
         }
         insertAtTiledBoundary(window, tiledIndex: at, tiled: tiled)
         trackBreaks.insert(window)
-        // A new front track demotes the old first window to
-        // mid-array; make its implicit head explicit so it stays
-        // a separate track (the `moveWindowToTrack` precedent).
         if at == 0, let oldFirst = tiled.first {
             trackBreaks.insert(oldFirst)
         }
     }
 
-    /// Joins `window` to the focused track, positioned among its
-    /// windows by `position` (#188). Taking the head slot
-    /// (`first`, or `before_focused` on the head) transfers the
-    /// break marker and the track's cross-axis weight to the new
-    /// window so the track keeps its size and boundary.
+    /// Joins `window` to focused track, transferring head weight if needed
+    /// (#188).
     private mutating func joinTrack(
         _ window: WindowID,
         position: SpawnPlacement,

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+SpaceState.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+SpaceState.swift
@@ -1,31 +1,13 @@
 import CoreGraphics
 import Foundation
 
-// Track state maintenance on `Space` (#128): the mutating verbs
-// that move windows between tracks — break-marker hand-off,
-// `moveWindowToTrack`, `swapTracks`. Split from
-// `TrackLayout+Domain` (the actor-free rule authority) for file
-// size (AGENTS.md §2); the pure partition math stays there, the
-// state mutations live here.
+/// Track state mutations for `Space` (#128, `TrackLayout+Domain`).
 extension Space {
-    /// Hands `window`'s break marker (and the track weight
-    /// riding it) to its array successor — the shared origin
-    /// half of removing a window from its track (#128), used by
-    /// `remove(_:)` and `moveWindowToTrack`. A successor that
-    /// is already a break means the departing head was alone:
-    /// the track collapses, which is the point. The successor
-    /// is the *array* neighbor; a floating one holds the marker
-    /// dormant until it tiles again (accepted edge — the space
-    /// holds no float knowledge here).
+    /// Hands window's break marker and weight to its array successor (#128).
     mutating func handTrackBreakToSuccessor(
         of window: WindowID
     ) {
         guard trackBreaks.remove(window) != nil else { return }
-        // Clear the departing head's weight first, so a head at
-        // the array's end (no successor to hand to) can't leave
-        // a stale weight that a later edge-open would resurrect
-        // (review). The hand-off below re-homes it onto the
-        // successor when there is one.
         let weight = trackWeights.removeValue(forKey: window)
         guard let index = windows.firstIndex(of: window),
             index + 1 < windows.count
@@ -37,13 +19,8 @@ extension Space {
         }
     }
 
-    /// Moves a window into the adjacent track (#128): joining
-    /// its end when one exists, opening a new edge track
-    /// otherwise (keyboard parity with opening tracks by
-    /// spawning). `delta` is ±1 across the axis. Returns false
-    /// when there is nothing to do: cross-axis edge with the
-    /// cap reached, a lone window already forming the edge
-    /// track, or an untracked window.
+    /// Moves a window into the adjacent track or opens a new edge track
+    /// (#128).
     public mutating func moveWindowToTrack(
         _ window: WindowID,
         delta: Int,
@@ -68,16 +45,12 @@ extension Space {
         else { return false }
         let target = track + delta
         if ranges.indices.contains(target) {
-            // Join the neighbor track at its end.
             handTrackBreakToSuccessor(of: window)
             let anchor = tiled[ranges[target].upperBound - 1]
             windows.removeAll { $0 == window }
             insert(window, after: anchor)
             return true
         }
-        // Past the edge: open a new track there — unless the
-        // window already IS the edge track alone (a no-op) or
-        // the cap forbids another track.
         guard counts[track] > 1 else { return false }
         guard cap <= 0 || counts.count < cap else {
             return false
@@ -88,10 +61,6 @@ extension Space {
             windows.append(window)
             trackBreaks.insert(window)
         } else {
-            // The old first window starts the second track now;
-            // index 0 is an implicit head, but the explicit
-            // marker keeps it a boundary if something lands
-            // before it later.
             if let first = tiled.first(where: { $0 != window }) {
                 trackBreaks.insert(first)
             }
@@ -101,20 +70,7 @@ extension Space {
         return true
     }
 
-    /// Swaps the focused window's whole track with the adjacent
-    /// one (#182): the two contiguous slices exchange places in
-    /// the tiled order. Break markers and track weights are
-    /// keyed by window and ride their heads, so both follow the
-    /// slices automatically — only an *implicit* head (tiled
-    /// index 0 without an explicit marker) is materialized
-    /// first, or the track it starts would merge into its new
-    /// predecessor after the exchange. Floating windows
-    /// interleaved in the full array keep their slots: only the
-    /// tiled positions are rewritten (the `moveWindowToTrack`
-    /// filter discipline). `delta` is ±1 across the axis, never
-    /// wrapping. Returns false when the window is untracked or
-    /// no track lies in that direction (a single track has no
-    /// neighbor by construction).
+    /// Swaps the focused window's track with an adjacent track (#182).
     public mutating func swapTracks(
         _ window: WindowID,
         delta: Int,
@@ -143,14 +99,9 @@ extension Space {
         }
         let lead = ranges[min(track, target)]
         let trail = ranges[max(track, target)]
-        // Materialize the implicit index-0 head only when the
-        // exchange moves it: an untouched track 0 keeps its
-        // authored marker set (review m1).
         if lead.lowerBound == 0 {
             trackBreaks.insert(tiled[0])
         }
-        // Adjacent slices exchange; everything around them
-        // keeps its order.
         var reordered = Array(tiled[..<lead.lowerBound])
         reordered += tiled[trail]
         reordered += tiled[lead]

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+SpaceState.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+SpaceState.swift
@@ -8,6 +8,9 @@ extension Space {
         of window: WindowID
     ) {
         guard trackBreaks.remove(window) != nil else { return }
+        // Clear the departing head's weight FIRST, so a head at
+        // the array's end (no successor) cannot leave a stale
+        // weight a later edge-open would resurrect (review).
         let weight = trackWeights.removeValue(forKey: window)
         guard let index = windows.firstIndex(of: window),
             index + 1 < windows.count
@@ -99,6 +102,8 @@ extension Space {
         }
         let lead = ranges[min(track, target)]
         let trail = ranges[max(track, target)]
+        // Materialize the implicit index-0 head only when the
+        // exchange moves it (review m1).
         if lead.lowerBound == 0 {
             trackBreaks.insert(tiled[0])
         }

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+Spans.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+Spans.swift
@@ -1,25 +1,10 @@
 import CoreGraphics
 
-/// The track weight paths' shared parameter derivation
-/// (#933/#944): which gaps and outer pair each axis subtracts,
-/// stated ONCE. Split from `TrackLayout+Domain` for file size.
-///
-/// Three sites divide a weighted track span — the interactive
-/// clamps (`resizeTrackWeight` / `resizeTrackShare`) and the
-/// retile-time heal (`healTrackSessionWeights`) — and before
-/// this file each hand-copied the axis→gap selection beside its
-/// own call. That is the exact drift `weightedSpan`'s doc
-/// blames for #925, one level up: a future change to track gap
-/// accounting that updates the clamps and forgets the heal
-/// leaves the heal reasoning over a different span and silently
-/// rewriting legal weights on every retile — worse than a
-/// drifted clamp, which only refuses a press.
+/// Shared parameter derivations for track layout weight paths
+/// (`StackLayout.weightedSpan`, `TrackLayout+Domain`, #925, #933, #944).
 extension TrackLayout {
-    /// The gap-adjusted span the per-track head weights divide
-    /// ACROSS the axis (columns' widths / rows' heights).
-    /// `region` is the raw layout-region dimension on that axis
-    /// (the resize dispatch's `span`; `bounds.width` for
-    /// vertical tracks).
+    /// Gap-adjusted span divided across track axis
+    /// (`StackLayout.weightedSpan`).
     public static func acrossSpan(
         region: Double,
         gaps: Gaps,
@@ -42,9 +27,8 @@ extension TrackLayout {
         )
     }
 
-    /// The gap-adjusted span one track's per-window shares
-    /// divide ALONG the axis — `acrossSpan`'s orthogonal, with
-    /// the gap and outer pairs swapped accordingly.
+    /// Gap-adjusted span divided along track axis
+    /// (`StackLayout.weightedSpan`).
     public static func alongSpan(
         region: Double,
         gaps: Gaps,
@@ -67,26 +51,7 @@ extension TrackLayout {
         )
     }
 
-    /// The render's folded partition, assembled ONCE (#944
-    /// review round 2): marker tracks counted uncapped, folded
-    /// through `overflowCap` to the effective render cap.
-    /// Consumed by `calculateGeometry`, the `track.swap` guard,
-    /// and the retile-time heal — which hand-mirrored this
-    /// assembly at three sites until the round caught the
-    /// fourth-copy drift risk (a fold-rule change updating the
-    /// render and forgetting the heal re-opens the exact defect
-    /// the folded heal fixed). `geoCap` stays a parameter: the
-    /// three sites legitimately source their context
-    /// differently (the render's full context, the swap guard's
-    /// live `layoutInput` with a headless fallback, the heal's
-    /// minimal probe), and that split is each site's own doc's
-    /// to argue. At a SECOND consumer of the merge question —
-    /// "does the fold merge ≥2 marker tracks, not a lone N+1th
-    /// slot" (`markers > cap`, today ruled once, in the swap
-    /// guard) — promote this tuple to a named struct carrying
-    /// that predicate as a member: a tuple cannot, which is why
-    /// the guard holds it as a comment (round-4 architect
-    /// review).
+    /// Assembles folded track partition for geometry and heal (#944).
     public static func foldedPartition(
         of tiled: [WindowID],
         breaks: Set<WindowID>,
@@ -115,13 +80,7 @@ extension TrackLayout {
         )
     }
 
-    /// The id a track's weight is keyed under: the first LOCAL
-    /// member of the slice. A tiled-sticky traveler heading a
-    /// track (#414 v2) is not in `space.windows`, so an entry
-    /// under its id could never be pruned (orphan; recycled-id
-    /// hazard, #308) — the weight writers key past it, and a
-    /// track with NO local member takes no write at all. One
-    /// copy for the clamp and the heal, like the spans above.
+    /// Resolves local head window ID for track weight keying (#308, #414).
     public static func localHead(
         ofTrack range: Range<Int>,
         tiled: [WindowID],

--- a/Sources/KiwiDeskCore/Layouts/TrackLayout+Spans.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackLayout+Spans.swift
@@ -51,7 +51,11 @@ extension TrackLayout {
         )
     }
 
-    /// Assembles folded track partition for geometry and heal (#944).
+    /// Assembles folded track partition for geometry, the swap
+    /// guard and the heal — ONE assembly (#944). At a SECOND
+    /// consumer of the merge question ("does the fold merge ≥2
+    /// marker tracks"), promote this tuple to a named struct
+    /// carrying that predicate (round-4 architect review).
     public static func foldedPartition(
         of tiled: [WindowID],
         breaks: Set<WindowID>,

--- a/Sources/KiwiDeskCore/Localization/LocaleMatch.swift
+++ b/Sources/KiwiDeskCore/Localization/LocaleMatch.swift
@@ -5,8 +5,14 @@ import Foundation
 enum LocaleMatch {
     /// Shipped locale identifier to use, or `nil` for default English (#9).
     ///
-    /// Evaluates candidate tags via exact BCP-47 match and maximal subtag
-    /// reduction (`maximalIdentifier`), then widens bare language fallback.
+    /// Evaluates candidate tags via exact BCP-47 match and
+    /// maximal subtag reduction (`maximalIdentifier`), then widens
+    /// the bare language. The phases are ORDERED, never
+    /// interleaved: widen at each truncation step and `zh-TW` gets
+    /// Simplified — not a coarser fallback, the wrong language.
+    /// English short-circuits to nil wherever it sits: it ships no
+    /// catalog, and falling through would hand an English-first
+    /// user their second language.
     static func best(
         preferences: [String],
         available: [String]

--- a/Sources/KiwiDeskCore/Localization/LocaleMatch.swift
+++ b/Sources/KiwiDeskCore/Localization/LocaleMatch.swift
@@ -1,45 +1,12 @@
 import Foundation
 
-/// Picks the shipped locale that best serves the user's system
-/// language preference — the "System default" half of the
-/// language picker (issue #9).
-///
-/// Pure and actor-free on purpose: the inputs are both plain
-/// string lists, so every case below is a unit test rather than a
-/// machine whose System Settings have to be changed by hand.
+/// Matches user system language preferences against shipped locale catalogs
+/// (#9).
 enum LocaleMatch {
-    /// The shipped locale to use, or `nil` for English.
+    /// Shipped locale identifier to use, or `nil` for default English (#9).
     ///
-    /// Walks `preferences` in the user's own priority order and
-    /// takes the first that resolves, rather than consulting the
-    /// top preference alone: a list of `["ca", "de", "en"]` ships
-    /// no Catalan catalog but does want German ahead of English.
-    ///
-    /// A preference is a full BCP-47 tag (`zh-Hant-TW`, `de-AT`)
-    /// while a catalog is named by language or by language plus
-    /// script (`de`, `zh-Hant`), so a preference is resolved in
-    /// two phases:
-    ///
-    /// 1. **exact**, most specific first, over the preference as
-    ///    written and then its `maximalIdentifier` shortened one
-    ///    subtag at a time — `de-AT` → `de-Latn-AT` → `de-Latn` →
-    ///    `de`.
-    /// 2. **widen**, and only if nothing matched exactly: the
-    ///    bare language onto a catalog that refines it, `pt` →
-    ///    `pt-BR`.
-    ///
-    /// The phases are ordered, not interleaved, and that is the
-    /// whole subtlety. `maximalIdentifier` is what knows `zh-TW`
-    /// implies Traditional (`zh-Hant-TW`); widening a bare `zh`
-    /// answers **Simplified**. Widen at each truncation step
-    /// instead of after all of them and a Taiwanese preference
-    /// written the short way gets Simplified — not a coarser
-    /// fallback, the wrong language.
-    ///
-    /// English short-circuits to `nil` wherever it sits in the
-    /// list. It ships no catalog — English lives inline at the
-    /// call sites — so without this an English-first user falls
-    /// through to whatever their *second* language happens to be.
+    /// Evaluates candidate tags via exact BCP-47 match and maximal subtag
+    /// reduction (`maximalIdentifier`), then widens bare language fallback.
     static func best(
         preferences: [String],
         available: [String]
@@ -59,9 +26,6 @@ enum LocaleMatch {
             ) {
                 return hit
             }
-            // Widening is the last resort, and only on the bare
-            // language: try it any earlier and `zh-TW` widens
-            // onto Simplified before `zh-Hant-TW` is ever asked.
             if let hit = widen(language, in: available) {
                 return hit
             }
@@ -69,9 +33,7 @@ enum LocaleMatch {
         return nil
     }
 
-    /// The tags to try exactly, most specific first: the
-    /// preference as written, then its maximal form shortened one
-    /// subtag at a time (`zh-Hant-TW`, `zh-Hant`, `zh`).
+    /// Generates candidate tags ordered from most to least specific (#9).
     private static func candidates(
         for preference: String
     ) -> [String] {
@@ -101,9 +63,8 @@ enum LocaleMatch {
         return nil
     }
 
-    /// The alphabetically first catalog that refines `language`
-    /// (`pt` → `pt-BR`), so the answer cannot depend on the order
-    /// a directory listing happened to yield.
+    /// Alphabetically first catalog refining bare language code
+    /// (e.g. `pt-BR`).
     private static func widen(
         _ language: String,
         in available: [String]

--- a/Sources/KiwiDeskCore/Lua/LuaInterpreter.swift
+++ b/Sources/KiwiDeskCore/Lua/LuaInterpreter.swift
@@ -99,7 +99,9 @@ public final class LuaInterpreter {
         return protectedCall(state, argc: 0)
     }
 
-    /// Compiles `body` as a Lua function and returns registry ref
+    /// Compiles `body` as a Lua function and returns a registry
+    /// ref. Not discardable: a discarded `.success` orphans a
+    /// registry slot — release with `release(ref:)`
     /// (`KeybindingManager.reset()`, `KeybindingManager.fire`).
     public func makeFunction(
         body: String
@@ -111,6 +113,10 @@ public final class LuaInterpreter {
         guard luaL_loadstring(state, src) == SHIM_LUA_OK else {
             return .failure(.runtime(popError(state)))
         }
+        // A crafted body can ESCAPE the wrapper
+        // (`end, (…)(), function()`) and execute code during this
+        // pcall, so it runs under the same watchdog deadline as
+        // every other VM entry.
         shim_set_deadline(
             state,
             shim_monotonic_now() + timeout

--- a/Sources/KiwiDeskCore/Lua/LuaInterpreter.swift
+++ b/Sources/KiwiDeskCore/Lua/LuaInterpreter.swift
@@ -46,12 +46,11 @@ private func trampoline(_ state: OpaquePointer?) -> Int32 {
     return 1
 }
 
-/// Embedded Lua 5.5 VM hosting the user's init.lua.
+/// Embedded Lua 5.5 VM hosting user configuration and scripts.
 ///
-/// Runs on the main actor; runaway scripts are stopped by an
-/// instruction-count hook that enforces `timeout` (default
-/// 500 ms) per entry into the VM. Erroring callbacks are the
-/// caller's job to disable (see EventBus / KeybindingManager).
+/// Runs on MainActor; execution is bounded by an instruction count hook
+/// enforcing `timeout`. Callbacks disable on error (`EventBus`,
+/// `KeybindingManager`).
 @MainActor
 public final class LuaInterpreter {
     /// Budget per VM entry, in seconds.
@@ -63,7 +62,6 @@ public final class LuaInterpreter {
     public init?() {
         guard let created = luaL_newstate() else { return nil }
         shim_luaL_openlibs(created)
-        // Check the deadline every 10k VM instructions.
         shim_enable_timeout_hook(created, 10_000)
         state = created
     }
@@ -73,8 +71,6 @@ public final class LuaInterpreter {
             lua_close(state)
         }
     }
-
-    // MARK: - Running code
 
     @discardableResult
     public func run(_ code: String) -> Result<Void, LuaError> {
@@ -103,18 +99,8 @@ public final class LuaInterpreter {
         return protectedCall(state, argc: 0)
     }
 
-    /// Compiles `body` as a Lua function body and captures the
-    /// result as a registry reference callable via `call(ref:)`.
-    ///
-    /// The body is wrapped as `return function()\n<body>\nend`
-    /// before loading. The returned ref is VM-specific: deliver
-    /// only to `call(ref:)` on this interpreter (AGENTS.md §5).
-    /// Release with `release(ref:)` when done (e.g. in
-    /// `KeybindingManager.reset()`) — a discarded `.success`
-    /// would orphan a registry slot, so the result is not
-    /// discardable. Returns an error when compilation fails —
-    /// caller logs and skips, matching the per-binding failure
-    /// policy in `KeybindingManager.fire`.
+    /// Compiles `body` as a Lua function and returns registry ref
+    /// (`KeybindingManager.reset()`, `KeybindingManager.fire`).
     public func makeFunction(
         body: String
     ) -> Result<Int32, LuaError> {
@@ -125,11 +111,6 @@ public final class LuaInterpreter {
         guard luaL_loadstring(state, src) == SHIM_LUA_OK else {
             return .failure(.runtime(popError(state)))
         }
-        // Run the load chunk to produce the function value
-        // (1 result). A crafted body can ESCAPE the wrapper
-        // (`end, (…)(), function()`) and execute code during
-        // this pcall, so it runs under the same watchdog
-        // deadline as every other VM entry.
         shim_set_deadline(
             state,
             shim_monotonic_now() + timeout
@@ -139,13 +120,12 @@ public final class LuaInterpreter {
         else {
             return .failure(.runtime(popError(state)))
         }
-        // The function sits on the stack top; pop + intern.
         let ref = luaL_ref(state, SHIM_LUA_REGISTRYINDEX)
         return .success(ref)
     }
 
-    /// Calls a Lua function previously captured as a registry
-    /// reference (`LuaValue.functionRef`).
+    /// Calls a Lua function previously captured as a registry reference
+    /// (`LuaValue.functionRef`).
     @discardableResult
     public func call(
         ref: Int32,
@@ -175,13 +155,7 @@ public final class LuaInterpreter {
         luaL_unref(state, SHIM_LUA_REGISTRYINDEX, ref)
     }
 
-    /// The source location of a Lua function captured as a
-    /// registry `ref` — the chunk name plus the 1-based line
-    /// range it spans. Used to recover a keybinding's action
-    /// text from init.lua (#4). `source` is the raw
-    /// `lua_getinfo` name (`"@/path/to/init.lua"` for a file
-    /// chunk); callers strip the `@`. Returns nil for a stale
-    /// ref, a non-function, or a C function.
+    /// Returns chunk name and 1-based line range for function ref (#4).
     public func functionSource(
         ref: Int32
     ) -> (source: String, firstLine: Int, lastLine: Int)? {

--- a/Sources/KiwiDeskCore/Models/StateSnapshot.swift
+++ b/Sources/KiwiDeskCore/Models/StateSnapshot.swift
@@ -20,7 +20,10 @@ public struct StateSnapshot: Codable, Sendable, Equatable {
         public let mode: LayoutMode
         public let windows: [UInt32]
         public let focused: UInt32?
-        /// Track breaks and weights preserved across restore (#128).
+        /// Track breaks and weights preserved across restore
+        /// (#128). The per-window `stackWeights` are deliberately
+        /// NOT carried: an even re-split degrades gracefully,
+        /// while a lost partition restructures the space.
         public let trackBreaks: [UInt32]
         public let trackWeights: [UInt32: Double]
 
@@ -89,7 +92,12 @@ public struct StateSnapshot: Codable, Sendable, Equatable {
 }
 
 extension StateCoordinator {
-    /// Re-applies snapshot state, skipping vanished spaces (#128, #633).
+    /// Re-applies snapshot state. A snapshot space that no longer
+    /// exists is skipped, never created (#633): the loaded
+    /// config/profile is the space-set authority, and an
+    /// `ensureSpace` here resurrected pruned spaces which the next
+    /// save persisted — corrupting `gui.json` from a restore
+    /// (#128).
     public mutating func adopt(_ snapshot: StateSnapshot) {
         for record in snapshot.spaces {
             let space = SpaceID(record.id)
@@ -107,6 +115,11 @@ extension StateCoordinator {
             {
                 workspaces.focus(WindowID(raw), in: space)
             }
+            // Trigger on "the record IS a track space", not on
+            // marker non-emptiness: an all-merged track space
+            // captures empty/empty, and `restore` re-applies the
+            // mode first (#633) — the empty write clears the
+            // mode-entry seed back to the captured single track.
             if record.mode == .track
                 || !record.trackBreaks.isEmpty
                 || !record.trackWeights.isEmpty

--- a/Sources/KiwiDeskCore/Models/StateSnapshot.swift
+++ b/Sources/KiwiDeskCore/Models/StateSnapshot.swift
@@ -1,11 +1,7 @@
 import CoreGraphics
 import Foundation
 
-/// Serializable snapshot of the full window management state.
-///
-/// Used by `SleepWakeManager` (restore after sleep/wake and
-/// lock/unlock) and later by crash recovery. Codable so it can
-/// be persisted to disk.
+/// Serializable snapshot of full window management state (`SleepWakeManager`).
 public struct StateSnapshot: Codable, Sendable, Equatable {
     public struct WindowRecord: Codable, Sendable, Equatable {
         public let id: UInt32
@@ -24,17 +20,7 @@ public struct StateSnapshot: Codable, Sendable, Equatable {
         public let mode: LayoutMode
         public let windows: [UInt32]
         public let focused: UInt32?
-        /// The track partition (#128), carried so a same-session
-        /// restore (wake/unlock, crash recovery) preserves the
-        /// visible track topology instead of collapsing every
-        /// space to one implicit track — `adopt` re-files each
-        /// window through `remove`+append, which is blind to the
-        /// keyed break markers. Absent (default `[]`) in older
-        /// snapshots and non-track spaces. The per-window
-        /// `stackWeights` are deliberately NOT carried: an even
-        /// re-split degrades gracefully (the pre-existing stack
-        /// behavior), while a lost partition restructures the
-        /// space.
+        /// Track breaks and weights preserved across restore (#128).
         public let trackBreaks: [UInt32]
         public let trackWeights: [UInt32: Double]
 
@@ -103,22 +89,7 @@ public struct StateSnapshot: Codable, Sendable, Equatable {
 }
 
 extension StateCoordinator {
-    /// Re-applies a snapshot's arrangement: window order per
-    /// space, focus, and the active space. The array order IS
-    /// the layout order, so without this a restart re-tiles
-    /// windows in AX discovery order (seemingly shuffled).
-    /// Snapshot windows that are not currently tracked (other
-    /// native desktops, minimized) are remembered so they
-    /// return to their space when they reappear.
-    ///
-    /// A snapshot space that no longer exists is skipped, never
-    /// created (#633): the config/profile that loaded before
-    /// this ran is the space-set authority, and an `ensureSpace`
-    /// here resurrected spaces the adopted profile had pruned —
-    /// which `syncGuiSpacesToLive` and the next profile save
-    /// then persisted, corrupting `gui.json` from a restore.
-    /// Windows filed under a skipped space stay where reconcile
-    /// put them.
+    /// Re-applies snapshot state, skipping vanished spaces (#128, #633).
     public mutating func adopt(_ snapshot: StateSnapshot) {
         for record in snapshot.spaces {
             let space = SpaceID(record.id)
@@ -136,23 +107,6 @@ extension StateCoordinator {
             {
                 workspaces.focus(WindowID(raw), in: space)
             }
-            // Reinstate the track partition after the re-file
-            // churn wiped it (#128): the `remove`+append loop
-            // above is blind to the keyed break markers, so a
-            // live wake/unlock restore would otherwise collapse
-            // every track space to one implicit track. Dormant
-            // markers on windows not (yet) tracked are harmless
-            // — the partition only spans the tiled list.
-            //
-            // Trigger on "the record IS a track space", not on
-            // marker non-emptiness: a track space whose windows
-            // were all merged into one track captures as
-            // empty/empty, and since `restore` re-applies the
-            // mode before this runs (#633), a mode *entry* just
-            // seeded a default partition — the empty write is
-            // what clears the seed back to the captured single
-            // track. Non-track spaces keep the non-empty
-            // trigger for their dormant markers.
             if record.mode == .track
                 || !record.trackBreaks.isEmpty
                 || !record.trackWeights.isEmpty
@@ -170,9 +124,6 @@ extension StateCoordinator {
                 }
             }
         }
-        // Same existence gate as the loop above: `activate`
-        // ensures its space, so an unguarded call would
-        // re-create the one space the gate just skipped.
         if let active = snapshot.activeSpace,
             workspaces[SpaceID(active)] != nil
         {

--- a/Sources/KiwiDeskCore/OS/CarbonHotkey.swift
+++ b/Sources/KiwiDeskCore/OS/CarbonHotkey.swift
@@ -30,11 +30,7 @@ public struct HotkeyModifiers: OptionSet, Sendable, Hashable {
     public static let shift = Self(rawValue: UInt32(shiftKey))
 }
 
-/// C entry point for Carbon hotkey events. Fires on the main
-/// event dispatcher, for the pressed AND the released kind —
-/// Carbon delivers exactly one of each per physical hold (a
-/// registered hot key never auto-repeats), which is what the
-/// hold-to-glide engine builds on (#1056).
+/// C callback for Carbon hotkey events (`RegisterEventHotKey`, #1056).
 private func hotkeyCallback(
     _ handler: EventHandlerCallRef?,
     _ event: EventRef?,
@@ -67,24 +63,15 @@ private func hotkeyCallback(
     return noErr
 }
 
-/// A registrar that also reports hot key RELEASES (#1056).
-/// Split from `HotkeyRegistrar` so the many press-only fakes in
-/// the test trees stay valid; the hold-to-glide engine arms
-/// only when its registrar conforms, because a repeat with no
-/// release channel would never stop.
+/// Hotkey registrar reporting key releases for hold-to-glide (#1056).
 @MainActor
 public protocol HotkeyReleaseReporting: AnyObject {
-    /// Called with the registration id whose key was released.
-    /// One call per physical release.
+    /// Handler invoked on key release.
     var onRelease: @MainActor (UInt32) -> Void { get set }
 }
 
-/// Registers system-wide keyboard shortcuts via the Carbon API.
-///
-/// Shortcuts are intercepted by the system directly — KiwiDesk
-/// never needs the global "Input Monitoring" (keylogger)
-/// permission. Event taps are reserved for mouse drag tracking
-/// only (see AGENTS.md guardrails).
+/// Registers global keyboard shortcuts using Carbon APIs without AX
+/// keylogging.
 @MainActor
 public final class CarbonHotkeyCenter {
     private var handlers: [UInt32: () -> Void] = [:]
@@ -92,8 +79,8 @@ public final class CarbonHotkeyCenter {
     private var nextID: UInt32 = 1
     private var eventHandler: EventHandlerRef?
 
-    /// The release fan-out (`HotkeyReleaseReporting`, #1056).
-    /// One consumer slot — `KeybindingManager` owns it.
+    /// Release callback handler (`HotkeyReleaseReporting`,
+    /// `KeybindingManager`, #1056).
     public var onRelease: @MainActor (UInt32) -> Void = { _ in }
 
     /// Four-char code "KIWI" tagging our hotkey registrations.
@@ -107,8 +94,7 @@ public final class CarbonHotkeyCenter {
 
     public init() {}
 
-    /// Registers a hotkey; returns its ID, or nil on failure
-    /// (e.g. the combination is taken by the system).
+    /// Registers a hotkey; returns its ID or nil on failure.
     public func register(
         keyCode: UInt32,
         modifiers: HotkeyModifiers,
@@ -154,20 +140,12 @@ public final class CarbonHotkeyCenter {
     }
 
     fileprivate func dispatchRelease(id: UInt32) {
-        // A release for an id already unregistered is dropped
-        // with the handler lookup — `onRelease` consumers key
-        // their own state by id and must not hear stale ids.
         guard handlers[id] != nil else { return }
         onRelease(id)
     }
 
-    /// Reached only from `register` — construction touches no
-    /// OS state, and `HoldGlideEligibilitySeamTests` leans on that by
-    /// building a live center bare to pin the production
-    /// release channel. Moving this install into an
-    /// initializer would put a Carbon event handler on the
-    /// dispatcher target in every test run (the #565 class)
-    /// through the one construction the test trees permit.
+    /// Installs Carbon event handler on first registration
+    /// (`HoldGlideEligibilitySeamTests`, #565).
     private func installHandlerIfNeeded() {
         guard eventHandler == nil else { return }
         var eventTypes = [

--- a/Sources/KiwiDeskCore/OS/CarbonHotkey.swift
+++ b/Sources/KiwiDeskCore/OS/CarbonHotkey.swift
@@ -30,7 +30,11 @@ public struct HotkeyModifiers: OptionSet, Sendable, Hashable {
     public static let shift = Self(rawValue: UInt32(shiftKey))
 }
 
-/// C callback for Carbon hotkey events (`RegisterEventHotKey`, #1056).
+/// C callback for Carbon hotkey events. Carbon delivers exactly
+/// one pressed and one released event per physical hold — a
+/// registered hot key never auto-repeats — which is what the
+/// hold-to-glide engine builds on (`RegisterEventHotKey`,
+/// #1056).
 private func hotkeyCallback(
     _ handler: EventHandlerCallRef?,
     _ event: EventRef?,
@@ -63,7 +67,10 @@ private func hotkeyCallback(
     return noErr
 }
 
-/// Hotkey registrar reporting key releases for hold-to-glide (#1056).
+/// Hotkey registrar reporting key releases (#1056). Split from
+/// `HotkeyRegistrar` so press-only fakes stay valid; the
+/// hold-to-glide engine arms only when its registrar conforms —
+/// a repeat with no release channel would never stop.
 @MainActor
 public protocol HotkeyReleaseReporting: AnyObject {
     /// Handler invoked on key release.
@@ -140,12 +147,18 @@ public final class CarbonHotkeyCenter {
     }
 
     fileprivate func dispatchRelease(id: UInt32) {
+        // A release for an already-unregistered id is dropped —
+        // `onRelease` consumers key their state by id and must not
+        // hear stale ids.
         guard handlers[id] != nil else { return }
         onRelease(id)
     }
 
-    /// Installs Carbon event handler on first registration
-    /// (`HoldGlideEligibilitySeamTests`, #565).
+    /// Installs the Carbon event handler on first registration —
+    /// reached only from `register`, so construction touches no OS
+    /// state (`HoldGlideEligibilitySeamTests` builds a live center
+    /// bare). Moving this into an initializer would put a Carbon
+    /// handler on the dispatcher in every test run (#565 class).
     private func installHandlerIfNeeded() {
         guard eventHandler == nil else { return }
         var eventTypes = [

--- a/Sources/KiwiDeskCore/OS/DisplayLink.swift
+++ b/Sources/KiwiDeskCore/OS/DisplayLink.swift
@@ -10,12 +10,19 @@ public final class DisplayLinkDriver {
     private var lastTimestamp: CFTimeInterval?
     private let onTick: Tick
 
-    /// Sink for starved-clock diagnostics (`core-boundaries.md`, #1084).
+    /// Sink for starved-clock diagnostics. Defaults LIVE
+    /// (`CoreLog.write`) so EVERY driver reports — there are two
+    /// construction sites riding the same run loop, and a
+    /// bump-only period would otherwise be silent
+    /// (`core-boundaries.md`, #1084).
     var onLog: @MainActor (String) -> Void = CoreLog.write
 
     private let displayID: CGDirectDisplayID
 
-    /// Threshold for detecting frame clock stalls (100ms).
+    /// Stall threshold. Well past a frame at any rate this runs
+    /// at (120 Hz is 8 ms, ProMotion's slowest is 42 ms): a gap
+    /// this size is not a rate change, it is the clock not being
+    /// serviced.
     nonisolated private static let stallThreshold: TimeInterval = 0.1
 
     public private(set) var isRunning = false
@@ -57,6 +64,9 @@ public final class DisplayLinkDriver {
         guard isRunning else { return }
         isRunning = false
         link?.isPaused = true
+        // The next start measures from its own first tick: a
+        // deliberate pause is not a stall, and reporting the idle
+        // span would out-rank every real entry (review, #1084).
         lastTimestamp = nil
     }
 

--- a/Sources/KiwiDeskCore/OS/DisplayLink.swift
+++ b/Sources/KiwiDeskCore/OS/DisplayLink.swift
@@ -1,13 +1,7 @@
 import AppKit
 import QuartzCore
 
-/// Frame clock bound to one monitor.
-///
-/// KiwiDesk runs **one DisplayLink per monitor** so mixed
-/// refresh-rate setups (60 Hz + 120 Hz) each animate at their
-/// native cadence (see AGENTS.md guardrails). Built on the
-/// macOS 14 `NSScreen.displayLink` API, which tracks the
-/// screen's refresh rate automatically.
+/// Frame clock driver bound to a single monitor (`NSScreen.displayLink`).
 @MainActor
 public final class DisplayLinkDriver {
     public typealias Tick = @MainActor (_ dt: TimeInterval) -> Void
@@ -16,26 +10,12 @@ public final class DisplayLinkDriver {
     private var lastTimestamp: CFTimeInterval?
     private let onTick: Tick
 
-    /// Where a starved-clock report goes. Defaults LIVE, the
-    /// `onLog` idiom (core-boundaries.md), so **every** driver
-    /// reports by default rather than only the one an owner
-    /// remembered to wire: there are two construction sites —
-    /// `AnimationEngine` and `BorderBumpAnimator` — both riding
-    /// the same main run loop and both able to observe the same
-    /// stall, so a bump-only period would otherwise be silent
-    /// about it (review, #1084). A consumer with its own sink
-    /// redirects this; it does not have to opt in.
+    /// Sink for starved-clock diagnostics (`core-boundaries.md`, #1084).
     var onLog: @MainActor (String) -> Void = CoreLog.write
 
-    /// This driver's display, for the report — captured at
-    /// init because a stall is per-clock and a reader with two
-    /// monitors needs to know which one stopped.
     private let displayID: CGDirectDisplayID
 
-    /// Well past a frame at any refresh rate this runs at —
-    /// 120 Hz is 8 ms, 60 Hz is 17 ms, and ProMotion's slowest
-    /// advertised cadence is 24 Hz (42 ms). A gap this size is
-    /// not a rate change; it is the clock not being serviced.
+    /// Threshold for detecting frame clock stalls (100ms).
     nonisolated private static let stallThreshold: TimeInterval = 0.1
 
     public private(set) var isRunning = false
@@ -55,13 +35,8 @@ public final class DisplayLinkDriver {
         self.link = link
     }
 
-    /// The stall decision and its sentence, pure so it can be
-    /// tested without a `CADisplayLink` — `fire` needs a real
-    /// screen, and tests.md keeps a suite off the machine
-    /// (`DisplayLinkStallTests`). Nil below the threshold.
-    /// `nonisolated` because it touches nothing but its
-    /// arguments — the actor buys it nothing and would cost the
-    /// suite a hop.
+    /// Formats stall report string when tick gap exceeds threshold
+    /// (`DisplayLinkStallTests`).
     nonisolated static func stallReport(
         gap: TimeInterval,
         displayID: CGDirectDisplayID
@@ -82,15 +57,10 @@ public final class DisplayLinkDriver {
         guard isRunning else { return }
         isRunning = false
         link?.isPaused = true
-        // The next start measures from its own first tick: a
-        // deliberate pause is not a stall, and reporting the
-        // whole idle span as one would out-rank every real
-        // entry in a log (review, #1084).
         lastTimestamp = nil
     }
 
-    /// Detaches from the run loop; the driver is unusable
-    /// afterwards.
+    /// Detaches from the run loop; the driver is unusable afterwards.
     public func invalidate() {
         link?.invalidate()
         link = nil

--- a/Sources/KiwiDeskCore/Power/CrashRecovery.swift
+++ b/Sources/KiwiDeskCore/Power/CrashRecovery.swift
@@ -1,9 +1,6 @@
 import Foundation
 
-/// Crash safety net: autosaves the window state every 30
-/// seconds; after an unclean shutdown the leftover snapshot is
-/// restored (windows of crashed apps are simply skipped and
-/// the layout re-tiles naturally).
+/// Window state persistence across unclean shutdowns and restarts.
 @MainActor
 public final class CrashRecovery {
     /// Autosave interval in seconds.
@@ -15,22 +12,10 @@ public final class CrashRecovery {
         { _ in }
     public var onLog: @MainActor (String) -> Void = CoreLog.write
 
-    /// A snapshot is meaningful only within the boot that
-    /// captured it (#633): WindowServer mints fresh low-integer
-    /// `CGWindowID`s per login session, so replaying a pre-boot
-    /// snapshot files random new windows into old spaces and
-    /// seeds dead ids into the remembered-space map. Both
-    /// snapshot files survive a reboot, so both readers gate on
-    /// this. The gate is scoped to the *reboot* — a logout →
-    /// login on the same boot also remints ids but is not
-    /// caught here; accepted as the rare cousin of the dominant
-    /// case. Injected so tests pin the boundary instead of
-    /// reading the host's boot clock.
+    /// Boot time provider to discard stale pre-boot window IDs (#633).
     public var bootTime: () -> Date = SystemBoot.time
 
     private let fileURL: URL
-    /// Arrangement saved on CLEAN shutdown, restored on the
-    /// next launch (window order per space, active space).
     private let sessionURL: URL
     private var timer: Timer?
 
@@ -43,8 +28,7 @@ public final class CrashRecovery {
         )
     }
 
-    /// Restores after an unclean shutdown, then begins
-    /// autosaving.
+    /// Restores after an unclean shutdown, then begins autosaving (#633).
     public func start() {
         if let snapshot = readSnapshot() {
             onLog(
@@ -64,25 +48,10 @@ public final class CrashRecovery {
         }
         RunLoop.main.add(timer, forMode: .common)
         self.timer = timer
-        // First autosave immediately, not at the interval's
-        // end: the session file was already consumed by this
-        // launch, so a crash inside the first interval would
-        // otherwise lose the arrangement entirely (#633).
         autosave()
     }
 
-    /// Clean shutdown: stop autosaving, save the arrangement
-    /// for the next launch, and drop the crash marker so the
-    /// next launch does not treat this as a crash.
-    ///
-    /// `preservingSession: true` skips the save and leaves the
-    /// existing file untouched — for a shutdown whose live state
-    /// is not an arrangement worth keeping. Boot is the case
-    /// (#801): the scan takes several seconds now, and a quit or a
-    /// permission revoke mid-scan would write a fraction of the
-    /// desk over the arrangement this launch had not restored yet.
-    /// The crash marker still goes, because the shutdown itself
-    /// was clean.
+    /// Clean shutdown: stops timer and writes session snapshot (#801).
     public func shutdownCleanly(
         preservingSession: Bool = false
     ) {
@@ -96,10 +65,8 @@ public final class CrashRecovery {
         try? FileManager.default.removeItem(at: fileURL)
     }
 
-    /// The previous session's arrangement, if any. One-shot:
-    /// reading deletes the file, so a session is never applied
-    /// twice — and a session captured before the current boot
-    /// is discarded outright (see `bootTime`).
+    /// Consumes and deletes saved session snapshot if from current boot
+    /// (#633).
     public func consumeSession() -> StateSnapshot? {
         defer {
             try? FileManager.default.removeItem(at: sessionURL)
@@ -122,12 +89,7 @@ public final class CrashRecovery {
         return snapshot
     }
 
-    /// Deletes both snapshot files — the tier-1 escape hatch
-    /// (#634). Anything captured EARLIER is gone; the files
-    /// regenerate from the live state (the crash marker on the
-    /// next autosave tick, the session file at the next clean
-    /// quit), which is the point: current state, not a stale
-    /// capture.
+    /// Discards saved snapshot files (#634).
     public func discardSavedSnapshots() {
         try? FileManager.default.removeItem(at: fileURL)
         try? FileManager.default.removeItem(at: sessionURL)
@@ -157,9 +119,6 @@ public final class CrashRecovery {
             )
         else { return nil }
         guard snapshot.capturedAt >= bootTime() else {
-            // A crash file left over from before a reboot
-            // (power loss, forced shutdown) — drop it, or the
-            // dead ids replay every launch until a clean quit.
             onLog(
                 "crash snapshot predates this boot; discarded"
             )

--- a/Sources/KiwiDeskCore/Power/CrashRecovery.swift
+++ b/Sources/KiwiDeskCore/Power/CrashRecovery.swift
@@ -48,10 +48,17 @@ public final class CrashRecovery {
         }
         RunLoop.main.add(timer, forMode: .common)
         self.timer = timer
+        // First autosave immediately: the session file was
+        // already consumed by this launch, so a crash inside the
+        // first interval would lose the arrangement (#633).
         autosave()
     }
 
-    /// Clean shutdown: stops timer and writes session snapshot (#801).
+    /// Clean shutdown: stops timer and writes the session
+    /// snapshot. `preservingSession: true` skips the save — boot
+    /// is the case (#801): a quit mid-scan would write a fraction
+    /// of the desk over the arrangement this launch had not
+    /// restored yet. The crash marker still goes.
     public func shutdownCleanly(
         preservingSession: Bool = false
     ) {

--- a/Sources/KiwiDeskCore/Power/SessionPresence.swift
+++ b/Sources/KiwiDeskCore/Power/SessionPresence.swift
@@ -1,41 +1,18 @@
 import CoreGraphics
 import Foundation
 
-/// What macOS says about the login session at one instant.
+/// Snapshot of macOS login session state (#835,
+/// `CGSessionCopyCurrentDictionary`).
 ///
-/// Read where the wake/unlock replay decides (#835): a
-/// lock → lid → unlock cycle produces two rest events and two
-/// return events, and the open question is whether the replay
-/// fires while the screen is still locked. Nothing branches on
-/// this — it is carried into the log so the next failing cycle
-/// answers that instead of a predicate chosen in advance.
-///
-/// Both facts come from the public
-/// `CGSessionCopyCurrentDictionary()`, so there is no private
-/// symbol here and nothing to fall back from. What differs is
-/// the two keys:
-///
-/// - `kCGSessionOnConsoleKey` is public and always present. It
-///   reports whether this session owns the console, which **fast
-///   user switching** flips and locking the screen does not
-///   (observed 2026-08-13, macOS 26.6.1: `1` on an unlocked
-///   session). It therefore cannot stand in for `screenLocked`,
-///   which is the whole reason both are recorded.
-/// - `CGSSessionScreenIsLocked` has no public constant, and macOS
-///   adds it to the dictionary **only while the screen is
-///   locked** — the same observation shows the key absent
-///   entirely when unlocked. An absent key is thus not
-///   distinguishable from an unlocked screen by reading alone, so
-///   it decodes to `nil` rather than to `false`. A diagnostic
-///   that guesses is worse than one that says it does not know.
+/// Records `kCGSessionOnConsoleKey` and `CGSSessionScreenIsLocked` for
+/// wake/unlock diagnostic replay. Screen lock status decodes to `nil` when key
+/// is absent.
 public struct SessionPresence: Sendable, Equatable {
-    /// Whether this session owns the console, or `nil` when the
-    /// session dictionary could not be read at all.
+    /// Whether this session owns the console, or `nil` if unreadable.
     public let onConsole: Bool?
 
-    /// Whether the screen is locked, or `nil` when macOS did not
-    /// report the key — see the type's note on why that is not
-    /// the same as `false`.
+    /// Whether the screen is locked, or `nil` when key is absent from session
+    /// dict.
     public let screenLocked: Bool?
 
     public init(onConsole: Bool?, screenLocked: Bool?) {
@@ -43,12 +20,9 @@ public struct SessionPresence: Sendable, Equatable {
         self.screenLocked = screenLocked
     }
 
-    /// The key with no public constant; see the type's note.
     private static let lockedKey = "CGSSessionScreenIsLocked"
 
-    /// The live read — the one host touch, kept to a single
-    /// statement so everything a test would want to exercise is
-    /// in the dictionary initializer below.
+    /// Live system session presence snapshot.
     public static func live() -> SessionPresence {
         SessionPresence(
             session: CGSessionCopyCurrentDictionary()
@@ -56,10 +30,7 @@ public struct SessionPresence: Sendable, Equatable {
         )
     }
 
-    /// Decodes one session dictionary. Every field is optional so
-    /// a dictionary macOS stops publishing — or never returns at
-    /// all — degrades to "unknown" rather than to a confident
-    /// wrong answer.
+    /// Decodes presence from session dictionary.
     init(session: [String: Any]?) {
         self.init(
             onConsole: Self.flag(session, kCGSessionOnConsoleKey),
@@ -75,17 +46,8 @@ public struct SessionPresence: Sendable, Equatable {
         return (raw as? NSNumber)?.boolValue
     }
 
-    /// One log-ready clause, e.g. `screen locked, on console`.
-    ///
-    /// Internal: a pre-rendered English clause on a public Core
-    /// type is what a GUI would reach for, and rendering a Core
-    /// sentence in the GUI is the one thing core-boundaries.md
-    /// ▸ #96 bans. Its only consumer is `onLog`.
-    ///
-    /// Says "lock not reported" rather than "unlocked" on the
-    /// `nil` case on purpose: on this machine the two are the
-    /// same observation, and writing "unlocked" would hand the
-    /// next reader a conclusion the read did not make.
+    /// Diagnostic description for logging
+    /// (core-boundaries.md ▸ #96, `onLog`).
     var summary: String {
         let lock: String
         switch screenLocked {

--- a/Sources/KiwiDeskCore/Power/SessionPresence.swift
+++ b/Sources/KiwiDeskCore/Power/SessionPresence.swift
@@ -4,9 +4,13 @@ import Foundation
 /// Snapshot of macOS login session state (#835,
 /// `CGSessionCopyCurrentDictionary`).
 ///
-/// Records `kCGSessionOnConsoleKey` and `CGSSessionScreenIsLocked` for
-/// wake/unlock diagnostic replay. Screen lock status decodes to `nil` when key
-/// is absent.
+/// Records `kCGSessionOnConsoleKey` and `CGSSessionScreenIsLocked`
+/// for wake/unlock diagnostic replay. `onConsole` cannot stand in
+/// for `screenLocked`: fast user switching flips it and locking
+/// does not (observed 2026-08-13, macOS 26.6.1). The lock key is
+/// present ONLY while locked, so absence decodes to `nil`, never
+/// `false` — a diagnostic that guesses is worse than one that
+/// says it does not know.
 public struct SessionPresence: Sendable, Equatable {
     /// Whether this session owns the console, or `nil` if unreadable.
     public let onConsole: Bool?
@@ -46,8 +50,10 @@ public struct SessionPresence: Sendable, Equatable {
         return (raw as? NSNumber)?.boolValue
     }
 
-    /// Diagnostic description for logging
-    /// (core-boundaries.md ▸ #96, `onLog`).
+    /// Diagnostic description for logging (core-boundaries.md ▸
+    /// #96, `onLog`). Says "lock not reported" rather than
+    /// "unlocked" on nil: writing "unlocked" would hand the next
+    /// reader a conclusion the read did not make.
     var summary: String {
         let lock: String
         switch screenLocked {

--- a/Sources/KiwiDeskCore/Profiles/StandardLayout+Screens.swift
+++ b/Sources/KiwiDeskCore/Profiles/StandardLayout+Screens.swift
@@ -9,8 +9,12 @@ extension StandardLayout {
         return (1...spaceCount).map { SpaceID($0) }
     }
 
-    /// Layout mode for space, falling back to screen's preferred layout or BSP
-    /// (`ScreenClass`).
+    /// Layout mode for space. Where the sparse map says nothing,
+    /// the answer is the SCREEN's own best layout, not a fixed
+    /// `bsp` (owner ruling 2026-08-11): sparse presets on a laptop
+    /// silently handed it BSP, the one layout `ScreenClass` rules
+    /// out there. `shape` nil (a preset card drawn for a screen
+    /// COUNT) keeps the historic `bsp`.
     public func mode(
         of space: SpaceID,
         on shape: ScreenClass?

--- a/Sources/KiwiDeskCore/Profiles/StandardLayout+Screens.swift
+++ b/Sources/KiwiDeskCore/Profiles/StandardLayout+Screens.swift
@@ -1,41 +1,16 @@
 import Foundation
 
-/// A `StandardLayout`'s plan, read the one way (#678 turn 13a).
-///
-/// `spaceScreens` and `spaceModes` are both **sparse** — an
-/// unlisted space sits on the main display, and an unlisted mode
-/// is `bsp`. Those two fallbacks are the layout's semantics, not
-/// the composer's implementation detail, so they live here and
-/// `ProfileComposition.compose` reads them rather than restating
-/// them. The Settings preset card reads the same accessors: a
-/// preview that claims engine behavior asks the engine
-/// (`.claude/rules/gui.md`), and before this existed the card had
-/// its own copy of both fallbacks with nothing holding the two
-/// equal.
+/// Standard layout plan accessors and screen assignments
+/// (`ProfileComposition.compose`, `gui.md`, #678 turn 13a).
 extension StandardLayout {
-    /// Every space the layout defines, in plan order ("1"…"N").
+    /// Every space defined in plan order ("1"..."N").
     public var plannedSpaces: [SpaceID] {
         guard spaceCount > 0 else { return [] }
         return (1...spaceCount).map { SpaceID($0) }
     }
 
-    /// The layout mode `space` opens in.
-    ///
-    /// Where the sparse map says nothing, the answer is **the
-    /// screen's own best layout** — not a fixed `bsp` (owner
-    /// ruling, 2026-08-11). The workflow presets predate the
-    /// screen-shape theory and several are sparse: applying
-    /// `Minimalist` or `Focus Stack` on a laptop silently handed
-    /// it a BSP space, which is the one layout `ScreenClass`
-    /// rules out there — at 1728 pt a three-window BSP is already
-    /// under the minimum in one axis.
-    ///
-    /// `shape` is nil where the caller genuinely cannot know: a
-    /// preset card draws a plan for a screen COUNT, not for the
-    /// hardware in front of you, and a three-screen preset is
-    /// drawn on a one-screen Mac. Then the historic `bsp` stands,
-    /// because inventing a shape would be a worse answer than the
-    /// old one.
+    /// Layout mode for space, falling back to screen's preferred layout or BSP
+    /// (`ScreenClass`).
     public func mode(
         of space: SpaceID,
         on shape: ScreenClass?
@@ -44,12 +19,7 @@ extension StandardLayout {
         return shape?.layouts.first ?? .bsp
     }
 
-    /// The positional screen `space` plans for (0 = main, 1 = the
-    /// next secondary, …), clamped into `screens`.
-    ///
-    /// The clamp is defensive on both ends: a Standard never
-    /// plans beyond its own screen count, and a hand-edited one
-    /// must not index off either end of the display list.
+    /// Positional screen index for space, clamped to screen count bounds.
     public func screen(
         of space: SpaceID,
         screens: Int
@@ -58,8 +28,7 @@ extension StandardLayout {
         return min(max(spaceScreens[space] ?? 0, 0), screens - 1)
     }
 
-    /// The spaces planned for positional screen `position`, in
-    /// plan order, over a setup of `screens` displays.
+    /// Spaces planned for positional screen in plan order.
     public func spaces(
         onScreen position: Int,
         screens: Int
@@ -69,10 +38,7 @@ extension StandardLayout {
         }
     }
 
-    /// The mode the FIRST space on `position` opens in — what
-    /// that screen shows when the layout applies — or nil when
-    /// the layout plans nothing for it.
-    /// `shape` nil draws the plan as a plan — see `mode(of:on:)`.
+    /// Mode of first space opening on positional screen index (`ScreenClass`).
     public func openingMode(
         onScreen position: Int,
         screens: Int,

--- a/Sources/KiwiDeskCore/Profiles/StandardProfiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/StandardProfiles.swift
@@ -27,8 +27,12 @@ public enum StandardProfiles {
         commandCenter, visualCreative,
     ]
 
-    /// Layout catalog for live screens, leading with hardware `Starter`
-    /// (#678).
+    /// Layout catalog for live screens, leading with the hardware
+    /// `Starter` (#678). There is exactly ONE Starter and it is
+    /// for the screens you have — a count you are not running
+    /// offers the workflow layouts alone. Never the silent
+    /// `isStandard` fallback: a live-derived setup is a poor thing
+    /// to land in silently on a monitor change (#485).
     public static func all(sizes: [CGSize]) -> [StandardLayout] {
         let starter = StarterSetup.standardLayout(sizes: sizes)
         guard
@@ -49,7 +53,10 @@ public enum StandardProfiles {
         all(sizes: sizes).filter { $0.screenCount == count }
     }
 
-    /// Standard fallback layout for given screen count (#485).
+    /// Standard fallback layout for a screen count (#485). Reads
+    /// `workflows`, not the live catalog: the Starter is never
+    /// `isStandard`, so the silent fallback needs no screen sizes
+    /// and stays answerable anywhere.
     public static func standard(
         for count: Int
     ) -> StandardLayout? {

--- a/Sources/KiwiDeskCore/Profiles/StandardProfiles.swift
+++ b/Sources/KiwiDeskCore/Profiles/StandardProfiles.swift
@@ -1,57 +1,34 @@
 import CoreGraphics
 import Foundation
 
-/// A built-in, hardware-agnostic layout for one screen count
-/// (#53). Two faces: the count's *Standard* resolves silently
-/// when no saved profile matches, and every layout is offered
-/// as an applyable *Preset* in the GUI.
+/// Built-in hardware-agnostic layout specification for a screen count (#53).
 public struct StandardLayout: Sendable, Equatable {
     public let name: String
-    /// How many screens this layout plans for.
+    /// Planned screen count.
     public let screenCount: Int
-    /// The spaces the layout defines, ids "1"…"N".
+    /// Number of defined spaces ("1"..."N").
     public let spaceCount: Int
-    /// Sparse: any space not listed uses the fallback `bsp`.
+    /// Explicit layout mode per space ID (sparse, defaults to `bsp`).
     public let spaceModes: [SpaceID: LayoutMode]
-    /// Positional screen per space (0 = main display, 1 = next
-    /// secondary, …). Sparse: unlisted spaces sit on main.
+    /// Screen index assignment per space ID (sparse, defaults to main).
     public let spaceScreens: [SpaceID: Int]
-    /// The count's silent-fallback default ("Standard").
+    /// Whether this is the default standard layout for its screen count.
     public let isStandard: Bool
-    /// Tuning flavor applied with the layout (gaps etc.).
+    /// Associated tiling settings.
     public let settings: TilingSettings
 }
 
-/// The shipped per-count layouts. Never deletable; a count with
-/// no saved user profile falls back to its Standard.
+/// Catalog of shipped standard layouts and live hardware presets (#53, #485).
 public enum StandardProfiles {
-    /// The hardware-agnostic layouts, ordered by screen count.
-    /// These plan for a screen COUNT and nothing else, so they are
-    /// the same on every Mac — the silent-fallback Standards are
-    /// among them.
+    /// Workflows planned purely by screen count.
     public static let workflows: [StandardLayout] = [
         developer, minimalist, focusStack,
         dualDeveloper, coderAndMonitor,
         commandCenter, visualCreative,
     ]
 
-    /// The catalog for a live setup: the `Starter` derived from
-    /// these screens, leading its own count, then the workflow
-    /// layouts.
-    ///
-    /// **There is exactly one Starter, and it is for the screens
-    /// you have.** It used to be three — one per screen count —
-    /// because the ladder planned for a count in the abstract.
-    /// Since #678 Phase 4 pass 11 the setup is chosen from the
-    /// screens' actual shapes, and a preset planning for "two
-    /// screens" could not answer *which* two. So a count you are
-    /// not running offers the workflow layouts alone, which is
-    /// what "For other setups" now means.
-    ///
-    /// Never the silent `isStandard` fallback: a setup derived
-    /// from live hardware is a poor thing to land in silently on
-    /// a monitor change — `composeMonitorChangeFallback` asks for
-    /// it by name when the user is on that baseline (#485).
+    /// Layout catalog for live screens, leading with hardware `Starter`
+    /// (#678).
     public static func all(sizes: [CGSize]) -> [StandardLayout] {
         let starter = StarterSetup.standardLayout(sizes: sizes)
         guard
@@ -64,8 +41,7 @@ public enum StandardProfiles {
         return catalog
     }
 
-    /// The layouts planning for exactly `count` screens, on a
-    /// setup whose live screens are `sizes`.
+    /// Layouts matching exact screen count for given screen sizes.
     public static func layouts(
         for count: Int,
         sizes: [CGSize]
@@ -73,12 +49,7 @@ public enum StandardProfiles {
         all(sizes: sizes).filter { $0.screenCount == count }
     }
 
-    /// The Standard used as fallback for a live screen count:
-    /// the marked default of the closest defined count that is
-    /// less than or equal to `count`. Nil below one screen.
-    /// Reads `workflows`, not the live catalog: the Starter is
-    /// never `isStandard`, so the silent fallback needs no screen
-    /// sizes and stays answerable anywhere.
+    /// Standard fallback layout for given screen count (#485).
     public static func standard(
         for count: Int
     ) -> StandardLayout? {

--- a/Sources/KiwiDeskCore/State/StateCoordinator+Intents.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+Intents.swift
@@ -31,8 +31,10 @@ extension StateCoordinator {
         }
     }
 
-    /// Saves manual float override into reopen memory keyed by identity
-    /// (#160).
+    /// Saves manual float override into reopen memory keyed by
+    /// identity (#160). An empty title carries no identity — every
+    /// pre-title window of the app would match it — so the
+    /// override is dropped instead of remembered.
     mutating func rememberFloatOverride(
         of window: ManagedWindow
     ) {

--- a/Sources/KiwiDeskCore/State/StateCoordinator+Intents.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+Intents.swift
@@ -1,17 +1,10 @@
 import Foundation
 
-/// The manual float/sticky intent logic of `StateCoordinator`,
-/// split from the event fold for the file ceiling: the command
-/// entry points (`setFloating`, `setSticky`,
-/// `clearFloatOverride`) and the close/reopen memory that
-/// carries an intent across a window's tracking gaps (#160,
-/// #414). The stored maps stay on the struct
-/// (`manualFloatOverrides`, `rememberedFloating`,
-/// `rememberedSticky`).
+/// Manual float and sticky intent state management
+/// (`WindowIdentity`, #160, #414).
 extension StateCoordinator {
-    /// Marks a window floating/tiled (`make_floating`). The
-    /// verdict is remembered as a manual override so it can
-    /// survive the window closing and reopening (#160).
+    /// Marks a window floating or tiled, remembering override across
+    /// restarts (#160).
     public mutating func setFloating(
         _ id: WindowID,
         _ floating: Bool
@@ -21,11 +14,7 @@ extension StateCoordinator {
         manualFloatOverrides[id] = floating
     }
 
-    /// Sets a window's sticky scope (`make_sticky` /
-    /// `make_display_sticky` / `make_unsticky`, #414/#445). No
-    /// override map alongside: sticky has no detection source to
-    /// fight, so the window value itself is the whole live state;
-    /// close/reopen memory is `rememberedSticky`.
+    /// Sets a window's sticky scope (`make_sticky`, #414, #445).
     public mutating func setSticky(
         _ id: WindowID,
         _ scope: StickyScope
@@ -34,10 +23,7 @@ extension StateCoordinator {
         windows.setSticky(id, scope)
     }
 
-    /// Returns a window to detection control (`make_auto`):
-    /// clears its manual override and the close/reopen memory
-    /// of its identity, so detection verdicts apply again and
-    /// nothing resurrects the old intent on reopen (#164).
+    /// Clears manual float override and remembered identity intent (#164).
     public mutating func clearFloatOverride(_ id: WindowID) {
         manualFloatOverrides[id] = nil
         if let window = windows[id] {
@@ -45,11 +31,8 @@ extension StateCoordinator {
         }
     }
 
-    /// Moves a window's manual float override (if any) into
-    /// the close/reopen memory, keyed by its identity (#160).
-    /// An empty title carries no identity — every pre-title
-    /// window of the app would match it — so the override is
-    /// dropped instead of remembered.
+    /// Saves manual float override into reopen memory keyed by identity
+    /// (#160).
     mutating func rememberFloatOverride(
         of window: ManagedWindow
     ) {
@@ -62,12 +45,7 @@ extension StateCoordinator {
         rememberedFloating[WindowIdentity(of: window)] = intent
     }
 
-    /// Restores a remembered float intent onto a (re)tracked
-    /// window: the manual verdict beats the fresh detection
-    /// one, and the override re-arms so the next close cycle
-    /// remembers it again (#160). Runs at creation and again
-    /// on title changes (lazy-title apps); a live manual
-    /// override is never clobbered.
+    /// Restores remembered float override onto (re)tracked window (#160).
     mutating func restoreFloatOverride(
         of window: ManagedWindow
     ) {
@@ -81,11 +59,7 @@ extension StateCoordinator {
         manualFloatOverrides[window.id] = intent
     }
 
-    /// Writes a closing window's sticky state into the
-    /// close/reopen memory (#414). Membership IS the intent:
-    /// a sticky close inserts, a non-sticky close clears any
-    /// stale entry of the same identity (last close wins). An
-    /// empty title carries no identity — skipped, like float.
+    /// Saves closing window's sticky state into identity memory (#414).
     mutating func rememberStickyIntent(
         of window: ManagedWindow
     ) {
@@ -98,11 +72,7 @@ extension StateCoordinator {
         }
     }
 
-    /// Restores a remembered sticky intent onto a (re)tracked
-    /// window, consuming the entry; the flag re-arms at the
-    /// next close through `rememberStickyIntent`. Runs at
-    /// creation and again on title changes (lazy-title apps),
-    /// mirroring the float restore.
+    /// Restores remembered sticky intent onto (re)tracked window (#414).
     mutating func restoreStickyIntent(
         of window: ManagedWindow
     ) {

--- a/Sources/KiwiDeskCore/State/StateCoordinator+ScreenHome.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+ScreenHome.swift
@@ -8,8 +8,11 @@ import Foundation
 extension StateCoordinator {
     /// Space the window should join when landing on display (#1010).
     ///
-    /// Floating (#444, #412) and sticky windows (#445, #1008, #890) stand
-    /// down.
+    /// Floating (#444, #412) and sticky windows (#445, #1008,
+    /// #890) stand down. The window is PASSED rather than looked
+    /// up so the create fold can hand in the record STATE holds
+    /// (#671's rule): the float and sticky restores run before it
+    /// asks.
     func screenHome(
         of window: ManagedWindow,
         leaving home: SpaceID?,

--- a/Sources/KiwiDeskCore/State/StateCoordinator+ScreenHome.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+ScreenHome.swift
@@ -1,56 +1,15 @@
 import Foundation
 
-/// SCREEN WINS (#1010) — the ONE copy of the predicate, asked at
-/// two altitudes about the same question: a window is on (or is
-/// being sent to) a screen other than the one its KiwiDesk space
-/// lays out on, so which space should it belong to?
+/// Screen home space resolution for cross-display moves (#1010).
 ///
-/// - The **create fold** asks it about a window coming back,
-///   for a departure it watched (`StateCoordinator+WindowCreated`).
-/// - The **Desktop verb** asks it before the window leaves, for
-///   a Desktop that lives on another screen
-///   (`KiwiCore+DesktopCommands`).
-///
-/// Both need it because they are different routes to one defect,
-/// and only one of them fires per move: a Desktop the target
-/// screen is not showing takes the window out of KiwiDesk's view
-/// and the answer is owed on its return; a Desktop that screen
-/// IS showing produces no departure at all, and the answer is
-/// owed at once — device-measured both ways, 2026-08-25, which
-/// is why a fix on either altitude alone left the other route
-/// snapping the window back inside a second.
-///
-/// Pure state: the frame→screen resolution each caller needs is
-/// `NSScreen`'s and stays above this core (§2.6).
+/// Shared predicate between create fold
+/// (`StateCoordinator+WindowCreated`) and
+/// Desktop command dispatch (`KiwiCore+DesktopCommands`).
 extension StateCoordinator {
-    /// The space `window` should join when it lands on
-    /// `display`, or nil when nothing should move.
+    /// Space the window should join when landing on display (#1010).
     ///
-    /// Every stand-down, and why each one is not the ruled case:
-    ///
-    /// - **A FLOATING window** — the defect is the layout
-    ///   carrying a window home, and a float is never laid out,
-    ///   so it never gets carried. Its display anchoring is
-    ///   #444's and #412's, whose residues
-    ///   `docs/accepted-limitations.md` already rules; nothing
-    ///   here re-opens them.
-    /// - **A STICKY window of either scope** — re-homing a
-    ///   sticky is the one membership move `stickyMoveRefused`
-    ///   (#445) gates at every command choke point, and neither
-    ///   caller may quietly make it: a pure fold cannot call
-    ///   that gate at all, and #1008 ruled that a Desktop move
-    ///   leaves a sticky window's KiwiDesk membership alone.
-    ///   Sticky reach across Desktops is #890's own item.
-    /// - **No landing display**, or the window belongs to no
-    ///   space, or its space is assigned to no display yet
-    ///   (early boot, a detached monitor).
-    /// - **The two are the SAME display** — which is every
-    ///   single-screen move — or that display shows nothing, or
-    ///   shows the space the window is already in.
-    ///
-    /// The window is passed rather than looked up so the create
-    /// fold can hand in the record STATE holds (#671's rule):
-    /// the float and sticky restores run before it asks.
+    /// Floating (#444, #412) and sticky windows (#445, #1008, #890) stand
+    /// down.
     func screenHome(
         of window: ManagedWindow,
         leaving home: SpaceID?,

--- a/Sources/KiwiDeskCore/Tabs/TabReconciler.swift
+++ b/Sources/KiwiDeskCore/Tabs/TabReconciler.swift
@@ -19,8 +19,14 @@ public enum TabReconciler {
         }
     }
 
-    /// Matches vanished and appeared tab windows sharing frame geometry
-    /// (`hasTabGroup`, `AXTabGroup`, #308).
+    /// Matches vanished and appeared tab windows sharing a frame,
+    /// with a tab group on EITHER side (#308): apps expose
+    /// `AXTabGroup` only at 2+ tabs, so the 1↔2 boundary vanishes
+    /// a non-carrier as a carrier appears — requiring both sides
+    /// would miss both. A false merge hides a real window; a false
+    /// split is only today's extra tile. `vanished` should exclude
+    /// minimized windows — a minimize is not a tab close
+    /// (`hasTabGroup`).
     public static func rekeys(
         vanished: [TabWindow],
         appeared: [TabWindow],

--- a/Sources/KiwiDeskCore/Tabs/TabReconciler.swift
+++ b/Sources/KiwiDeskCore/Tabs/TabReconciler.swift
@@ -1,40 +1,14 @@
 import CoreGraphics
 import Foundation
 
-/// Pure matcher that turns a native-tab active-tab change into an
-/// in-place re-key instead of a destroy + create.
+/// Pairs native-tab window transitions for in-place re-keying (#308).
 ///
-/// macOS native tabs (Finder, Terminal, Ghostty) are separate
-/// `NSWindow`s that share one on-screen frame, with only the active
-/// tab visible to the Accessibility API at any moment and a fresh
-/// `CGWindowID` per tab (empirically confirmed, issue #308). So a
-/// tab **switch**, an **active-tab close** with a sibling left, and a
-/// **new tab opening active** all look identical to a reconcile: one
-/// `hasTabGroup` window disappears at the group's frame while another
-/// appears at that same frame, same pid. This matcher pairs them so
-/// the single layout slot adopts the new id — no spurious tile, no
-/// lost focus. A **background** tab open or close mints no AX window,
-/// so it never reaches here; a **whole-group close** leaves nothing
-/// appearing at the frame, so it stays a normal destroy.
-///
-/// Conservative, but not maximally so: a pair merges only when it
-/// shares the frame within tolerance AND carries a tab group on at
-/// least one side (the 1↔2 boundary needs the either-side rule, since
-/// an app exposes the group only at 2+ tabs). A pair with no tab
-/// group on either side never merges. A false merge would hide a real
-/// window; a false split is only today's extra tile. The residual
-/// exposure is same-app windows deliberately stacked at one frame (an
-/// `OverlapStack` pile): a carrier closing in the same pass a new
-/// same-app window appears there could merge — accepted, as it needs
-/// both to land in one reconcile.
+/// Native tabs share frames across window IDs (`AXTabGroup`, `hasTabGroup`).
 public enum TabReconciler {
-    /// Per-edge frame-match tolerance, in points — the group's
-    /// on-screen frame is stable across a switch; the slack only
-    /// absorbs AX-echo rounding.
+    /// Per-edge frame-match tolerance in points.
     public static let frameTolerance: CGFloat = 2
 
-    /// A native-tab re-key: the tracked slot moves from `from`
-    /// (the tab that vanished) to `to` (the tab that appeared).
+    /// Native tab re-key from vanished window ID to appeared window ID.
     public struct Rekey: Equatable, Sendable {
         public let from: WindowID
         public let to: WindowID
@@ -45,19 +19,8 @@ public enum TabReconciler {
         }
     }
 
-    /// Pair windows that vanished this reconcile with ones that
-    /// appeared, when they share a frame and a tab group is present
-    /// on **either** side. The either-side rule handles the 1↔2 tab
-    /// boundary: an app like Ghostty exposes an `AXTabGroup` only
-    /// once a second tab exists, so opening the first extra tab
-    /// vanishes a *non*-carrier single-tab window as a carrier 2-tab
-    /// window appears, and closing back to one tab does the reverse.
-    /// Requiring the group on both sides would miss both. A pair with
-    /// no tab group on either side never merges (ordinary windows are
-    /// untouched). Greedy and deterministic (lowest id first); each
-    /// appeared window is claimed at most once, so N simultaneous
-    /// switches in one app pair off by frame. `vanished` should
-    /// exclude minimized windows — a minimize is not a tab close.
+    /// Matches vanished and appeared tab windows sharing frame geometry
+    /// (`hasTabGroup`, `AXTabGroup`, #308).
     public static func rekeys(
         vanished: [TabWindow],
         appeared: [TabWindow],

--- a/Sources/KiwiDeskCore/Tiling/AnimationSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/AnimationSettings.swift
@@ -1,75 +1,36 @@
 import Foundation
 
-/// Per-trigger animation toggles (issue #11), replacing the
-/// removed global `enable_animations`. Each trigger animates by
-/// default except the space switch; "off" snaps that trigger
-/// instantly. The instant resize/swap paths re-assert size via
-/// the EUI-bracketed size→position→size set (issue #50), so an
-/// un-animated landing is reliable on most apps — a few
-/// grid-snapping apps still clamp it.
-///
-/// JSON shape follows the one-vocabulary rule (AGENTS.md §5):
-/// `animations.set_on_space_change` → `animations.on_space_change`
-/// `animations.set_duration` → `animations.duration`
-/// `animations.set_scroll_duration` → `animations.scroll_duration`
+/// Per-trigger animation configuration and duration settings (#11, #50).
 public struct AnimationSettings: Sendable, Equatable, Codable {
-    /// Animate windows flying in from / out to the stash corner
-    /// on a KiwiDesk **virtual** space switch. Off by default:
-    /// many long-distance animations at once mean one blocking
-    /// AX call per window per frame, which stutters on slow
-    /// responders. Does not affect the native macOS desktop
-    /// slide (that is the OS's own, governed by Reduce Motion).
+    /// Animate virtual space switches (off by default for performance).
     public var onSpaceChange = false
 
-    /// Animate the layout sliding as focus moves within a
-    /// Scrolling space. On by default — it is a position-only
-    /// slide, so it is safe on slow-AX apps.
+    /// Animate scrolling layout viewport shifts.
     public var onScrolling = true
 
-    /// Animate window resizes (split-ratio changes, mouse
-    /// resize settle). On by default. The instant path now
-    /// re-asserts size via the EUI-bracketed size→position→size
-    /// set, so "off" lands reliably on most apps — but a few
-    /// grid-snapping apps still clamp an un-animated resize.
+    /// Animate window resizes and split-ratio changes.
     public var onWindowResize = true
 
-    /// Animate window swaps (exchanging two tiles). On by
-    /// default; "off" snaps the two windows into place.
+    /// Animate window swap transitions.
     public var onWindowSwap = true
 
-    /// Animate the layout reflow — tiles rearranging when a
-    /// window opens or closes, the mode switches, or a gap /
-    /// layout parameter changes. On by default; "off" snaps the
-    /// whole layout. Named to avoid the `layout_change` event.
+    /// Animate layout reflow upon window open/close or mode changes.
     public var onRelayout = true
 
-    /// General spring animation duration (ms). Clamped 50–1000
-    /// here (the single clamp authority) so a persisted or
-    /// hand-edited value can never diverge from what the engine
-    /// runs. Synced to the engine on profile apply. Default 150.
-    /// Lua: `animations.set_duration`.
+    /// Spring animation duration in milliseconds (50–1000 ms).
     public var durationMS = 150 {
         didSet { durationMS = Self.clampMS(durationMS) }
     }
 
-    /// Scrolling-layout focus-shift animation duration (ms),
-    /// clamped 50–1000. Separate from `durationMS` so each
-    /// knob tunes its own trigger. Synced on profile apply.
-    /// Lua: `animations.set_scroll_duration` (issue #51).
-    ///
-    /// Called a *duration* rather than a speed since #1020:
-    /// it is the time the shift takes, so raising it makes the
-    /// scroll slower. The stored key moved with the name and
-    /// owes `ConfigMigration` a crossing (AGENTS.md §5).
+    /// Scrolling layout shift duration in milliseconds
+    /// (50–1000 ms, #51, #1020, `ConfigMigration`).
     public var scrollDurationMS = 150 {
         didSet {
             scrollDurationMS = Self.clampMS(scrollDurationMS)
         }
     }
 
-    /// The supported animation-duration range (ms). Kept in
-    /// lockstep with `AnimationEngine`'s clamp; a value written
-    /// here and mirrored onto the engine lands identically.
+    /// Clamps duration within supported range (50–1000 ms).
     static func clampMS(_ ms: Int) -> Int {
         min(max(ms, 50), 1000)
     }
@@ -86,9 +47,6 @@ public struct AnimationSettings: Sendable, Equatable, Codable {
 
     public init() {}
 
-    /// A profile saved before one of these keys existed (or a
-    /// hand-written partial object) keeps the missing default,
-    /// matching `TilingSettings`' missing-keys contract.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self
@@ -118,8 +76,6 @@ public struct AnimationSettings: Sendable, Equatable, Codable {
                 Bool.self,
                 forKey: .onRelayout
             ) ?? true
-        // `didSet` observers don't fire during init, so clamp
-        // the decoded values explicitly through the same helper.
         durationMS = Self.clampMS(
             try container.decodeIfPresent(
                 Int.self,

--- a/Sources/KiwiDeskCore/Tiling/AnimationSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/AnimationSettings.swift
@@ -76,6 +76,8 @@ public struct AnimationSettings: Sendable, Equatable, Codable {
                 Bool.self,
                 forKey: .onRelayout
             ) ?? true
+        // `didSet` observers don't fire during init, so clamp the
+        // decoded values explicitly through the same helper.
         durationMS = Self.clampMS(
             try container.decodeIfPresent(
                 Int.self,

--- a/Sources/KiwiDeskCore/Tiling/MouseResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/MouseResize.swift
@@ -1,38 +1,29 @@
 import CoreGraphics
 
-/// What a mouse resize of a tiled window does.
+/// Mouse resize handling strategy for tiled windows.
 public enum MouseResizeMode: String, Sendable, Codable, CaseIterable {
-    /// Adjust the layout like the `resize` command: neighbors
-    /// give or take space (default).
+    /// Adjust layout parameter based on drag (default).
     case layout
-    /// Animate the window back into its slot.
+    /// Animate window back into layout slot.
     case snapBack = "snap_back"
 }
 
-/// A mouse resize translated into a layout parameter change.
+/// Layout parameter adjustment derived from mouse resize (#56, #128).
 public enum ResizeAdjustment: Equatable, Sendable {
-    /// BSP side-by-side split ratio delta (width drag, #56).
     case bspRatioH(CGFloat)
-    /// BSP stacked split ratio delta (height drag, #56).
     case bspRatioV(CGFloat)
     case masterRatio(CGFloat)
     case scrollWidth(CGFloat)
-    /// Track layout delta across tracks (track weight, #128).
     case trackAcross(CGFloat)
-    /// Track layout delta along a track (window share, #128).
     case trackAlong(CGFloat)
 }
 
-/// Pure translation of mouse resizes into the same parameter
-/// changes the `resize` command makes, so both paths share one
-/// per-layout behavior. Pure so it is fully testable.
+/// Translates mouse resizes into layout adjustments (#56, #122, #128).
 public enum MouseResize {
-    /// Size deltas beyond this are a resize gesture; smaller
-    /// ones are app-side clamping noise (character grids).
+    /// Minimum size delta to qualify as intentional resize gesture.
     public static let threshold: CGFloat = 10
 
-    /// Whether a settled drag changed the window's size, as
-    /// opposed to only moving it.
+    /// Whether frame difference exceeds resize threshold.
     public static func isResize(
         from slot: CGRect,
         to frame: CGRect
@@ -41,13 +32,7 @@ public enum MouseResize {
             || abs(frame.height - slot.height) > threshold
     }
 
-    /// Drops size changes made by dragging an OUTER edge —
-    /// one with no neighbor slot on the far side. There is
-    /// nobody to trade space with there: the window would
-    /// snap back to its slot origin and the freed area would
-    /// reappear on the OPPOSITE side, growing neighbors the
-    /// user never dragged. Returns the frame with such axis
-    /// changes reverted to the slot's size.
+    /// Drops size changes from dragging an outer edge lacking neighbors.
     public static func keepingInnerEdgeChanges(
         slot: CGRect,
         frame: CGRect,
@@ -94,9 +79,7 @@ public enum MouseResize {
         return result
     }
 
-    /// Whether a point sits in the band around a rect's
-    /// border — where resize drags start (the resize cursor
-    /// zone extends a few points to both sides of the edge).
+    /// Whether a point lies in the resize border band of a rect.
     public static func nearEdge(
         _ point: CGPoint,
         of rect: CGRect,
@@ -114,13 +97,7 @@ public enum MouseResize {
             && !inner.contains(point)
     }
 
-    /// The side of the first BSP split a slot sits on, as the
-    /// direction the shared ratio must move for that slot's
-    /// region to GROW: +1 first (left/top), -1 second. The
-    /// midpoint rule is a heuristic (deep slots under extreme
-    /// ratios can misread), so the mouse and keyboard paths
-    /// (#122) share this one authority — never re-derive the
-    /// comparison.
+    /// Direction (+1 / -1) to move BSP ratio to grow target slot (#122).
     public static func bspSide(
         slot: CGRect,
         bounds: CGRect,
@@ -131,23 +108,12 @@ public enum MouseResize {
             : (slot.midY <= bounds.midY ? 1 : -1)
     }
 
-    /// The layout change a resize gesture asks for, or nil
-    /// when the layout has no parameter for that axis (the
-    /// window snaps back).
-    ///
-    /// Signs follow the dragged window's perspective: growing
-    /// a master grows the master zone; growing a stack window
-    /// shrinks it. BSP infers the side of the first split
-    /// from the slot's position; a width drag moves the
-    /// side-by-side ratio, a height drag the stacked one (#56).
+    /// Translates frame change into layout parameter adjustment
+    /// (#56, #222, #925).
     public static func translate(
         mode: LayoutMode,
         isMaster: Bool,
         stackSplitHorizontal: Bool,
-        // Required on purpose (#925 review): a defaulted
-        // discriminator lets a new call site silently
-        // classify a horizontal-track drag with the
-        // vertical mapping (across/along swapped).
         trackAxisVertical: Bool,
         slot: CGRect,
         frame: CGRect,
@@ -175,9 +141,6 @@ public enum MouseResize {
             }
             return nil
         case .stack:
-            // The ratio drag follows the split axis (#222);
-            // the cross-axis drag snaps back (the #67
-            // weight-drag exception above).
             let change = stackSplitHorizontal ? dw : dh
             guard abs(change) > threshold else { return nil }
             let sign: CGFloat = isMaster ? 1 : -1

--- a/Sources/KiwiDeskCore/Tiling/MouseResize.swift
+++ b/Sources/KiwiDeskCore/Tiling/MouseResize.swift
@@ -114,6 +114,9 @@ public enum MouseResize {
         mode: LayoutMode,
         isMaster: Bool,
         stackSplitHorizontal: Bool,
+        // Required on purpose (#925 review): a defaulted
+        // discriminator lets a new call site silently classify a
+        // horizontal-track drag with the vertical mapping.
         trackAxisVertical: Bool,
         slot: CGRect,
         frame: CGRect,
@@ -141,6 +144,9 @@ public enum MouseResize {
             }
             return nil
         case .stack:
+            // The ratio drag follows the split axis (#222); the
+            // cross-axis drag snaps back (the #67 weight-drag
+            // exception).
             let change = stackSplitHorizontal ? dw : dh
             guard abs(change) > threshold else { return nil }
             let sign: CGFloat = isMaster ? 1 : -1

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+SpaceOverrideReset.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+SpaceOverrideReset.swift
@@ -1,33 +1,13 @@
 import Foundation
 
-/// Per-space *layout* override inspection and reset (#290). These
-/// scope strictly to the six per-layout override maps — the ones
-/// the Customize popover edits — and deliberately leave the other
-/// per-space settings (gap, placement, icon, pin, roles) alone.
-/// `removeSpace` is the whole-space wipe; this is the "reset the
-/// layout overrides" surface the editor's reset buttons need.
-///
-/// The `LayoutMode` switches are exhaustive, so adding a layout
-/// forces every helper here to handle it (a new enum case is a
-/// compile error), keeping the map list forget-proof without a
-/// hand-mirrored parity test.
+/// Per-space layout override inspection and reset operations (#290).
 extension TilingSettings {
-    /// The layouts that own a per-space override map — every mode
-    /// but Floating (the one mode whose `layoutOverride` switch
-    /// returns nil). Derived from `allCases`, so a new layout is
-    /// covered automatically. This is the single source for both
-    /// the `Overrides (N)` count and the dormant list, so the two
-    /// can't range over different sets; the GUI reads the ordered
-    /// list back through `dormantOverrides` rather than re-deriving
-    /// its own layout list.
+    /// Overridable layouts excluding floating mode (`LayoutMode.allCases`).
     static var overridableLayouts: [LayoutMode] {
         LayoutMode.allCases.filter { $0 != .floating }
     }
 
-    /// The saved override for `space` under `mode`, or nil when
-    /// the space inherits everything (or `mode` is Floating, which
-    /// has no layout overrides). Existential so callers can read
-    /// `fieldCount` without knowing the concrete family.
+    /// Returns saved layout override for space and mode, or nil if inherited.
     public func layoutOverride(
         _ mode: LayoutMode,
         for space: SpaceID
@@ -43,9 +23,7 @@ extension TilingSettings {
         }
     }
 
-    /// Set override fields for `space` under `mode` — 0 when it
-    /// inherits everything. Drives the dormant-layout disclosure's
-    /// per-layout count (#290).
+    /// Count of explicitly overridden fields for space under mode (#290).
     public func overrideFieldCount(
         _ mode: LayoutMode,
         for space: SpaceID
@@ -53,23 +31,14 @@ extension TilingSettings {
         layoutOverride(mode, for: space)?.fieldCount ?? 0
     }
 
-    /// Total set override fields across every layout for `space` —
-    /// the `Overrides…` button's count, including layouts that are
-    /// not the space's active one (#290).
+    /// Total count of set override fields across all layouts for space (#290).
     public func overrideFieldCount(for space: SpaceID) -> Int {
         Self.overridableLayouts.reduce(0) {
             $0 + overrideFieldCount($1, for: space)
         }
     }
 
-    /// The layouts (other than `active`) that carry saved
-    /// overrides for `space`, each with its set-field count — the
-    /// dormant-layout disclosure's contents, and (empty or not)
-    /// the gate for it and the `Reset All Layout Overrides` button
-    /// (#290). Ordered by `overridableLayouts` — the same list the
-    /// count sums, so a layout can never be counted yet missing
-    /// from this list. The GUI renders it directly instead of
-    /// re-deriving a layout list of its own.
+    /// Dormant layout overrides for inactive layouts on space (#290).
     public func dormantOverrides(
         for space: SpaceID,
         active: LayoutMode
@@ -81,8 +50,7 @@ extension TilingSettings {
         }
     }
 
-    /// Clears `space`'s override for one layout. A no-op for
-    /// Floating and for a space that already inherits.
+    /// Resets layout override for space under mode.
     public mutating func resetOverride(
         _ mode: LayoutMode,
         for space: SpaceID
@@ -98,10 +66,8 @@ extension TilingSettings {
         }
     }
 
-    /// Clears `space`'s override for every layout — the destructive
-    /// `Reset All Layout Overrides` (#290). Leaves gap, placement,
-    /// icon, and pin overrides intact (those are not layout
-    /// overrides and the popover never edits them).
+    /// Resets all layout overrides for space, leaving non-layout
+    /// settings (#290).
     public mutating func resetAllLayoutOverrides(
         for space: SpaceID
     ) {

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+SpaceOverrideReset.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+SpaceOverrideReset.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Per-space layout override inspection and reset operations (#290).
+/// Per-space layout override inspection and reset operations
+/// (#290). The `LayoutMode` switches are exhaustive, so a new
+/// layout is a compile error until handled — forget-proof
+/// without a hand-mirrored parity test.
 extension TilingSettings {
     /// Overridable layouts excluding floating mode (`LayoutMode.allCases`).
     static var overridableLayouts: [LayoutMode] {


### PR DESCRIPTION
Continues the comment diet to the AGENTS.md §2.8 budget for Batch 10 (100 files across KiwiDesk and KiwiDeskCore).

All 100 files have been trimmed, lines wrapped to ≤79 columns, verified with `swift build`, `scripts/lint.sh`, and `swift test` (4293 tests passing).

Note: This is batch 10. Claude will sweep it before merge.