### PR TITLE
chore(comments): trim core and gui to §2.8 budget (batch 12)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Common/Color+KiwiHex.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/Color+KiwiHex.swift
@@ -2,32 +2,13 @@ import KiwiDeskCore
 import SwiftUI
 
 extension Color {
-    /// SwiftUI twin of the runtime bar's `NSColor(kiwiHex:)`,
-    /// for the settings previews (#125): both parse a user hex
-    /// string through the same `DragVisual.parseHex`, so a
-    /// *valid* preview color always matches the rendered one.
-    /// The failure paths differ on purpose — this falls back to
-    /// clear (an invalid color reads as "nothing" in a preview),
-    /// while the runtime bar substitutes the accent color; only
-    /// a hand-broken hex reaches either.
-    /// A colour whose EMPTY value means "Automatic" rather than
-    /// "unset" — the two mark tints (#429), which
-    /// `ColorPaletteKeys.allowsAutomatic` identifies by their
-    /// bare `.color` key.
-    ///
-    /// `Color(kiwiHex:)` maps an unparseable hex to `.clear`,
-    /// which is right for an invalid colour and wrong for this
-    /// one: Automatic is the adaptive label colour that flips
-    /// with light and dark, so falling through to clear draws a
-    /// mark that IS configured as an empty hole in the preview.
-    /// A palette scene shipped exactly that for the sticky and
-    /// floating marks at their shipped defaults (#793 review),
-    /// which is a preview claiming the app draws nothing where
-    /// it draws a mark.
+    /// Resolves mark tint from hex or primary for automatic (#429, #793).
     static func kiwiMark(_ hex: String) -> Color {
         hex.isEmpty ? .primary : Color(kiwiHex: hex)
     }
 
+    /// Initializes SwiftUI Color from Kiwi hex string
+    /// (`DragVisual.parseHex`, #125).
     init(kiwiHex hex: String) {
         guard let c = DragVisual.parseHex(hex) else {
             self = .clear

--- a/Sources/KiwiDesk/Settings/Components/Common/Color+KiwiHex.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/Color+KiwiHex.swift
@@ -2,7 +2,10 @@ import KiwiDeskCore
 import SwiftUI
 
 extension Color {
-    /// Resolves mark tint from hex or primary for automatic (#429, #793).
+    /// Resolves mark tint from hex, or `.primary` for the empty
+    /// "Automatic" sentinel (#429): `Color(kiwiHex:)` maps empty to
+    /// `.clear`, which would preview a configured mark as a hole
+    /// (#793).
     static func kiwiMark(_ hex: String) -> Color {
         hex.isEmpty ? .primary : Color(kiwiHex: hex)
     }

--- a/Sources/KiwiDesk/Settings/Components/Common/ColorField+AutomaticMenu.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ColorField+AutomaticMenu.swift
@@ -1,23 +1,11 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The adaptive well's right-click "Automatic" path, split from
-/// `ColorField` at the §2.1 ceiling.
+/// Context menu modifier offering "Automatic" reset for adaptive color
+/// wells (#429, #845).
 extension View {
-    /// The right-click clear path for an adaptive well (#429): one
-    /// "Automatic" item, checked while the well already is, that
-    /// resets the color to the empty sentinel. A no-op wrapper on a
-    /// well that has no Automatic concept. This is the discoverable
-    /// way back — the swatch click opens the picker (a concrete
-    /// pick), and typing an empty value is the other path.
-    ///
-    /// The same item is also a named VoiceOver action (#678 Phase
-    /// 4 pass 10, turn 20a rule 1) and keyboard shortcut (#845).
-    /// The typed-empty path meant this was never *unreachable*
-    /// without a pointer, unlike the palette and space menus — but
-    /// it required knowing that an empty field means automatic,
-    /// which is precisely the thing a menu item exists to stop you
-    /// having to know.
+    /// Context menu and accessibility action resetting color to empty
+    /// sentinel (#429).
     @ViewBuilder
     func automaticMenu(
         automatic: Bool,

--- a/Sources/KiwiDesk/Settings/Components/Common/ColorField+AutomaticMenu.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ColorField+AutomaticMenu.swift
@@ -4,8 +4,10 @@ import SwiftUI
 /// Context menu modifier offering "Automatic" reset for adaptive color
 /// wells (#429, #845).
 extension View {
-    /// Context menu and accessibility action resetting color to empty
-    /// sentinel (#429).
+    /// Context menu and accessibility action resetting color to the
+    /// empty "Automatic" sentinel (#429); a no-op wrapper on wells
+    /// with no Automatic concept. Also a named VoiceOver action
+    /// (#678) and keyboard shortcut (#845).
     @ViewBuilder
     func automaticMenu(
         automatic: Bool,

--- a/Sources/KiwiDesk/Settings/Components/Common/ColorPanelController.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ColorPanelController.swift
@@ -1,19 +1,13 @@
 import AppKit
 import KiwiDeskCore
 
-/// Drives the one shared `NSColorPanel` for every `ColorSwatch`.
-/// The last swatch to open the panel owns it: `present`
-/// retargets the panel and re-points the change callback,
-/// mirroring how a native color well hands the panel between
-/// wells. Split from `ColorField.swift` for the file ceiling.
+/// Controller for shared `NSColorPanel` presented by `ColorSwatch`.
 @MainActor
 final class ColorPanelController: NSObject {
     static let shared = ColorPanelController()
 
     private var onChange: ((NSColor) -> Void)?
     private lazy var doneAccessory: NSView = makeDoneAccessory()
-    /// Bumped per `present`; identifies the current owner so a
-    /// swatch only resigns the panel while it still owns it.
     private var activeToken = 0
 
     @discardableResult
@@ -26,8 +20,6 @@ final class ColorPanelController: NSObject {
         let panel = NSColorPanel.shared
         panel.showsAlpha = true
         panel.accessoryView = doneAccessory
-        // Open on the colour wheel (preferred over the sliders
-        // pane, even though hex entry lives there).
         panel.mode = .wheel
         panel.color = current
         panel.setTarget(self)
@@ -36,26 +28,16 @@ final class ColorPanelController: NSObject {
         return activeToken
     }
 
-    /// Detach when the owning swatch disappears — only if it is
-    /// still the owner (a later swatch may have taken over).
+    /// Resigns panel if matching token still owns it.
     func resign(_ token: Int) {
         guard token == activeToken else { return }
         dismiss()
     }
 
-    /// Unconditional teardown, e.g. on window close: stop
-    /// routing and put the panel away so it can't write into a
-    /// reloaded config after the window is gone. `activeToken`
-    /// is intentionally NOT reset — `present` always advances
-    /// it, so a later `resign(oldToken)` still no-ops; resetting
-    /// to 0 would collide with a never-clicked swatch's initial
-    /// token.
+    /// Dismisses shared NSColorPanel and clears accessories and callbacks.
     func dismiss() {
         onChange = nil
         let panel = NSColorPanel.shared
-        // Detach our Done bar so it can't linger on the shared
-        // panel for the process lifetime and bleed into any other
-        // future `NSColorPanel.shared` user.
         panel.accessoryView = nil
         panel.orderOut(nil)
     }

--- a/Sources/KiwiDesk/Settings/Components/Common/ColorPanelController.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ColorPanelController.swift
@@ -1,13 +1,16 @@
 import AppKit
 import KiwiDeskCore
 
-/// Controller for shared `NSColorPanel` presented by `ColorSwatch`.
+/// Controller for the one shared `NSColorPanel`: the last swatch to
+/// `present` owns it, like native color wells handing the panel over.
 @MainActor
 final class ColorPanelController: NSObject {
     static let shared = ColorPanelController()
 
     private var onChange: ((NSColor) -> Void)?
     private lazy var doneAccessory: NSView = makeDoneAccessory()
+    /// Bumped per `present`; a swatch resigns the panel only while
+    /// it still owns it.
     private var activeToken = 0
 
     @discardableResult
@@ -34,10 +37,14 @@ final class ColorPanelController: NSObject {
         dismiss()
     }
 
-    /// Dismisses shared NSColorPanel and clears accessories and callbacks.
+    /// Unconditional teardown so the panel can't write into a
+    /// reloaded config. `activeToken` deliberately NOT reset:
+    /// `present` always advances it, so stale `resign` still no-ops.
     func dismiss() {
         onChange = nil
         let panel = NSColorPanel.shared
+        // Detach our Done bar — the shared panel outlives us and
+        // would show it to any future NSColorPanel user.
         panel.accessoryView = nil
         panel.orderOut(nil)
     }

--- a/Sources/KiwiDesk/Settings/Components/Common/DropdownRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/DropdownRow.swift
@@ -1,25 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// A dropdown row on the shared label axis: the visible label
-/// sits in the label column and the menu button starts on the
-/// control line, like every slider and segmented picker.
-///
-/// The row NAMES the control and gives its choice back as the
-/// VALUE: `labelsHidden` drops a `.menu` picker's AX title (the
-/// observation is `docs/design-decisions.md` ▸ a name replaces
-/// the announcement), and a label alone would take the choice
-/// away. So `spokenValue` is required — the selected option's
-/// title, as the site knows it — and `nil` is for a control
-/// whose state IS its value and survives a label — the login
-/// row's `Toggle` — and nothing else, held by
-/// `AnnouncedValueTests`' `nilSpokenValue` map.
+/// Standard settings dropdown row with label and accessibility value
+/// (`AnnouncedValueTests`).
 struct DropdownRow<P: View>: View {
     let label: String
-    /// The selected option's title, spoken as the control's
-    /// value; `nil` only for a `Toggle`, whose on/off is kept.
+    /// Selected option title spoken as accessibility value.
     let spokenValue: String?
-    /// Optional `?` popover (#94), label-adjacent.
+    /// Optional help popover text (#94).
     var help: String? = nil
     @ViewBuilder let picker: P
 

--- a/Sources/KiwiDesk/Settings/Components/Common/DropdownRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/DropdownRow.swift
@@ -1,11 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Standard settings dropdown row with label and accessibility value
-/// (`AnnouncedValueTests`).
+/// Standard settings dropdown row: `labelsHidden` drops a `.menu`
+/// picker's AX title, so the row NAMES the control and `spokenValue`
+/// gives the choice back as the VALUE (`AnnouncedValueTests`).
 struct DropdownRow<P: View>: View {
     let label: String
-    /// Selected option title spoken as accessibility value.
+    /// Selected option's title, spoken as the value; `nil` only for
+    /// a `Toggle`, whose on/off state survives a label.
     let spokenValue: String?
     /// Optional help popover text (#94).
     var help: String? = nil

--- a/Sources/KiwiDesk/Settings/Components/Common/ScrollAnchorLabel.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ScrollAnchorLabel.swift
@@ -2,7 +2,10 @@ import KiwiDeskCore
 import SwiftUI
 
 /// Localized label mapping for scrolling focus anchor options
-/// (#96, #239, #753).
+/// (#96, #239, #753). Both pickers map
+/// `ScrollingParams.Anchor.allCases` through this, so the on-screen
+/// order IS the enum's declaration order; the label names the
+/// concrete edge for the current orientation — presentation only.
 @MainActor
 enum ScrollAnchorLabel {
     static func text(

--- a/Sources/KiwiDesk/Settings/Components/Common/ScrollAnchorLabel.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ScrollAnchorLabel.swift
@@ -1,31 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// What the Focus-anchor picker calls each `ScrollingParams.Anchor`
-/// (#239, #753).
-///
-/// Two pickers offer the anchor — the Layout Defaults card and the
-/// per-space override row — and both build their options by
-/// mapping `ScrollingParams.Anchor.allCases` through this, so a
-/// fifth anchor reaches the user without either of them being
-/// edited. Hand-listing the four in each picker is what made the
-/// enum's `CaseIterable` an assertion-only affordance: three test
-/// sweeps would have covered a new case while the two places a
-/// user actually picks one silently omitted it.
-///
-/// **The picker's on-screen order is therefore the enum's
-/// declaration order**, which is what a reader of either call site
-/// sees; reordering the cases reorders the segments.
-///
-/// `start` / `end` are axis-relative and the label names the
-/// concrete edge for the current orientation (Top/Bottom vertical,
-/// Left/Right horizontal) — presentation only, the stored value
-/// staying orientation-neutral. That branch is the reason this is
-/// a function of the orientation rather than a table on the enum,
-/// and the reason it lives in `Common/`: Core names the anchor,
-/// the GUI narrates the edge (#96).
-/// `@MainActor` because `L()` is: the labels resolve through the
-/// live catalog, exactly as they did inline in each picker.
+/// Localized label mapping for scrolling focus anchor options
+/// (#96, #239, #753).
 @MainActor
 enum ScrollAnchorLabel {
     static func text(

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGateHelp.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGateHelp.swift
@@ -1,7 +1,8 @@
 import KiwiDeskCore
 
-/// Help explanations for disabled Gaps & Borders controls
-/// (`GapsAndBordersGateWiringTests`, #678).
+/// Help explanations for disabled Gaps & Borders controls: a
+/// sentence is authored once, HERE, never beside a row —
+/// `GapsAndBordersGateWiringTests` reds on a second copy (#678).
 @MainActor
 enum GapsBordersGateHelp {
     static func sentence(

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGateHelp.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/GapsBordersGateHelp.swift
@@ -1,16 +1,7 @@
 import KiwiDeskCore
 
-/// The inline sentence each `GapsBordersGates.InertReason`
-/// renders — the "why you can't edit this" a greyed row or block
-/// shows on hover. Split from the resolver so the resolver stays
-/// assertable off the main actor; the reason and its sentence are
-/// one decision, never two that can disagree (#678, gui.md).
-///
-/// A sentence is authored once, here, and never beside a row —
-/// `GapsAndBordersGateWiringTests` reds on a second copy. When a
-/// sentence's MEANING moves, its key is dropped in the same
-/// change set (localization.md) rather than left to render a
-/// fluent translation of what the row no longer does.
+/// Help explanations for disabled Gaps & Borders controls
+/// (`GapsAndBordersGateWiringTests`, #678).
 @MainActor
 enum GapsBordersGateHelp {
     static func sentence(

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/StickyMarkEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/StickyMarkEditor.swift
@@ -1,7 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Sticky window mark settings editor (`StickyMarkUngatedTests`, #414).
+/// Sticky window mark settings editor (#414). Deliberately ungated
+/// on the Space Bar — the mark survives the bar going off;
+/// `StickyMarkUngatedTests` keeps it ungated.
 struct StickyMarkEditor: View {
     @ObservedObject var model: SettingsModel
 

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/StickyMarkEditor.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/StickyMarkEditor.swift
@@ -1,20 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// This Profile ▸ Gaps & Borders ▸ Sticky windows (#414): the
-/// on-window mark's toggle. Sits below the focus border — the
-/// mark is its overlay sibling.
-///
-/// The toggle stands alone: it carries no gate on the Space Bar.
-/// The greying it used to carry asserted a dependency that runs
-/// the wrong way — the mark paints on the window, so it is
-/// exactly what SURVIVES the bar going off. What the greying was
-/// reaching for is timeless rather than live, so it belongs in
-/// the row's `?` help (`docs/ui-patterns.md` ▸ Help &
-/// cross-references, "A concept goes in the `?`"). Why the gate
-/// went, and why no softer warning replaced it, is argued in
-/// `docs/design-decisions.md` under "Sticky has no native cue".
-/// `StickyMarkUngatedTests` is what keeps it ungated.
+/// Sticky window mark settings editor (`StickyMarkUngatedTests`, #414).
 struct StickyMarkEditor: View {
     @ObservedObject var model: SettingsModel
 

--- a/Sources/KiwiDesk/Settings/Components/Icons/IconCatalog.swift
+++ b/Sources/KiwiDesk/Settings/Components/Icons/IconCatalog.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-/// One pickable glyph: an SF Symbol name or an emoji, with
-/// keyword tags so search matches meaning, not just the
-/// symbol's literal name (#68 §6.4).
+/// Curated glyph and search tag pair for icon picker (#68 §6.4).
 struct IconChoice: Identifiable, Hashable {
     let glyph: String
     /// Space-separated search tags.
@@ -20,12 +18,7 @@ struct IconChoice: Identifiable, Hashable {
     }
 }
 
-/// The curated icon catalog shared by mode icons and space
-/// icons — one vocabulary, one component (§6.4/§6.5). SF
-/// Symbols render from macOS itself (nothing is bundled); the
-/// system catalog isn't enumerable at runtime, but any valid
-/// symbol name typed into the search appears as a result (the
-/// exact-name escape hatch).
+/// Curated SF Symbol and emoji catalog for modes and spaces (#68 §6.4).
 enum IconCatalog {
     static let symbols: [IconChoice] = [
         // Web / communication

--- a/Sources/KiwiDesk/Settings/Components/Icons/IconGlyphLabel.swift
+++ b/Sources/KiwiDesk/Settings/Components/Icons/IconGlyphLabel.swift
@@ -1,9 +1,8 @@
 import AppKit
 import SwiftUI
 
-/// Renders an icon string: an SF Symbol if the string names
-/// one, otherwise the literal character(s); a placeholder
-/// symbol when empty.
+/// Renders SF Symbol or text glyph for an icon string with placeholder
+/// fallback.
 struct IconGlyphLabel: View {
     let icon: String
     var placeholder: String?

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup+AddRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup+AddRow.swift
@@ -1,12 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Open applications add-row: pick an app, then commit it —
-/// mirroring App Rules, so a new binding always lands with an app
-/// identity (its shortcut is recorded afterward in the row). Apps
-/// that already carry every launch behavior are dropped from the
-/// picker and the Add button greys, so re-adding can only ever
-/// produce a *distinct* behavior, never a duplicate (#334).
+/// Add-row view and application binding creation for ApplicationsGroup (#334).
 extension ApplicationsGroup {
     var addRow: some View {
         HStack {
@@ -26,8 +21,6 @@ extension ApplicationsGroup {
                         newApp = app
                     }
                 },
-                // Drop apps that already carry every launch
-                // behavior — re-adding could only duplicate (#334).
                 exclude: fullyBoundBundleIDs()
             )
             // Hug the content, like the per-row picker.
@@ -70,20 +63,13 @@ extension ApplicationsGroup {
         newApp = nil
     }
 
-    /// The picked add-row app already has every launch behavior
-    /// bound — adding it again would only duplicate. Greys the Add
-    /// button (grey-don't-hide) instead of silently no-opping. A
-    /// backstop for the "Other…" panel, which can still reach a
-    /// fully-bound bundle the picker list already omits.
+    /// True if selected application has all launch behaviors already bound.
     private var newAppFullyBound: Bool {
         guard let app = newApp else { return false }
         return firstAvailableBehavior(for: app.bundleID) == nil
     }
 
-    /// Bundle ids that already carry every launch behavior, hidden
-    /// from the app pickers (#334). The add-row passes no exclusion;
-    /// a per-row re-pick excludes its own row, so an app fully bound
-    /// only *because of that row* stays pickable.
+    /// Bundle IDs that already carry every launch behavior (#334).
     func fullyBoundBundleIDs(
         excluding id: UUID? = nil
     ) -> Set<String> {

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup+AddRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup+AddRow.swift
@@ -63,13 +63,17 @@ extension ApplicationsGroup {
         newApp = nil
     }
 
-    /// True if selected application has all launch behaviors already bound.
+    /// Greys the Add button (grey-don't-hide) — a backstop for the
+    /// "Other…" panel, which can still reach a fully-bound bundle
+    /// the picker list already omits.
     private var newAppFullyBound: Bool {
         guard let app = newApp else { return false }
         return firstAvailableBehavior(for: app.bundleID) == nil
     }
 
     /// Bundle IDs that already carry every launch behavior (#334).
+    /// A per-row re-pick excludes its own row, so an app fully
+    /// bound only BECAUSE of that row stays pickable.
     func fullyBoundBundleIDs(
         excluding id: UUID? = nil
     ) -> Set<String> {

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+DisplayName.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+DisplayName.swift
@@ -1,30 +1,9 @@
 import KiwiDeskCore
 
-/// The stored-label → localized-name mapping the conflict
-/// banner narrates through (#96: `KeyBinding.label` is the
-/// stable ENGLISH canonical the classifier matches on, and a
-/// banner interpolating it verbatim shipped "Focus window to
-/// the left" inside a German sentence — owner, 2026-08-10).
+/// Localized display name resolution for stored keybinding labels (#96).
 extension KeybindingCatalog {
-    /// The localized display name for a persisted binding
-    /// label. The roster is the classifier's own, piece by
-    /// piece: the navigation groups, the per-layer switches,
-    /// the current-step resize rows (their labels are
-    /// step-independent — "Grow width" — so retired-step rows
-    /// resolve too), `stepFreeCommands`, the one shared copy of
-    /// the float/sticky bracket, and the Desktop rows.
-    ///
-    /// The Desktop half is read off the BINDINGS rather than
-    /// the config, which records no Desktops — and never off a
-    /// live list, because the banner must still name a row
-    /// whose screen is unplugged. Whatever the classifier can
-    /// assign, this roster must translate back (the invariant
-    /// `KeybindingImportClassifier.navigationLabels` states),
-    /// and the classifier assigns Desktop rows by shape, which
-    /// no live list bounds. A label outside it —
-    /// an app name, a custom row, a deleted space's or layer's
-    /// row — returns unchanged: an app name needs no
-    /// translation and a custom label is the user's own text.
+    /// Resolves localized display name for persisted label
+    /// (`KeybindingImportClassifier.navigationLabels`, #96).
     @MainActor static func localizedLabel(
         for label: String,
         config: GuiConfig

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+DisplayName.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+DisplayName.swift
@@ -4,6 +4,9 @@ import KiwiDeskCore
 extension KeybindingCatalog {
     /// Resolves localized display name for persisted label
     /// (`KeybindingImportClassifier.navigationLabels`, #96).
+    /// The Desktop half reads the BINDINGS, never a live list —
+    /// the banner must still name a row whose screen is unplugged.
+    /// A label outside the roster returns unchanged.
     @MainActor static func localizedLabel(
         for label: String,
         config: GuiConfig

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Layers.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Layers.swift
@@ -1,21 +1,10 @@
 import AppKit
 import KiwiDeskCore
 
-/// The layer-switching half of the catalog: the row that
-/// switches to a named layer, and the pure rename that
-/// rewrites those rows across a config.
-///
-/// Split from `KeybindingCatalog.swift` on §2's file-size
-/// limit, on the seam the file already marked. Both halves
-/// stay the single authority for the Lua they author, which
-/// is what keeps the writer and the import classifier
-/// matching byte-for-byte (#4).
+/// Layer switching command generation and rename refactoring (#4).
 extension KeybindingCatalog {
 
-    /// The Change-Layers row that switches to `name`. The one
-    /// authority for this Lua so the writer (`SwitchLayersGroup`)
-    /// and the import classifier match byte-for-byte — a drift
-    /// here would silently demote imports to Custom (#4).
+    /// Authors layer switch command matching import classifier syntax (#4).
     static func switchLayerCommand(_ name: String) -> NavCommand {
         NavCommand(
             label: "Switch to \(name)",
@@ -30,11 +19,7 @@ extension KeybindingCatalog {
         )
     }
 
-    /// Renames a layer across `layers`: the layer itself plus
-    /// every switch-layer row targeting it, rewritten through
-    /// `switchLayerCommand` so writer and import classifier
-    /// keep matching byte-for-byte (#4). Pure — the tested
-    /// core of the Shortcuts header's rename.
+    /// Renames a layer across all configuration bindings (#4).
     static func renameLayer(
         in layers: [KeyLayer],
         from old: String,

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Layers.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingCatalog+Layers.swift
@@ -19,7 +19,9 @@ extension KeybindingCatalog {
         )
     }
 
-    /// Renames a layer across all configuration bindings (#4).
+    /// Renames a layer across all configuration bindings, rewritten
+    /// through `switchLayerCommand` so writer and import classifier
+    /// stay matched byte-for-byte (#4).
     static func renameLayer(
         in layers: [KeyLayer],
         from old: String,

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingNavRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingNavRow.swift
@@ -1,13 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// A single catalog row: label plus a recorder that upserts a
-/// `.navigation` binding keyed by the command's Lua. The
-/// preflight hard-blocks combos already held by another row
-/// (#34); the row id feeds "Go to" (#68 §3.6.2).
-///
-/// Extracted from `KeybindingGroups` (the shared row every
-/// section composes) to keep that file under the size ceiling.
+/// Single navigation shortcut row with label and recorder field
+/// (#34, #68 §3.6.2).
 struct NavRow: View {
     @ObservedObject var model: SettingsModel
     @Binding var bindings: [KeyBinding]

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/OrphanedShortcutsGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/OrphanedShortcutsGroup.swift
@@ -2,6 +2,9 @@ import KiwiDeskCore
 import SwiftUI
 
 /// Display and editing group for orphaned space shortcuts (#92).
+/// Surfaced, never pruned: the binding revives when its space
+/// returns, so dropping it on save would lose config across a
+/// routine profile/monitor swap.
 struct OrphanedShortcutsGroup: View {
     @ObservedObject var model: SettingsModel
     @Binding var bindings: [KeyBinding]

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/OrphanedShortcutsGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/OrphanedShortcutsGroup.swift
@@ -1,22 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Inactive / orphaned shortcuts (#92): a space-targeting
-/// `.navigation` binding whose space is no longer in the
-/// current space list — e.g. `option+6 → Go to Space 6` after
-/// switching from an 8-space to a 4-space profile. The per-
-/// space catalog sections render one row per *live* space, so
-/// without this section such a binding was invisible while
-/// still Carbon-registered (pressing it silently recreates the
-/// space) and still holding its combo (hard-blocking the
-/// recorder with a holder the user could not see or reach).
-///
-/// Surfaced, never pruned: the binding is only orphaned
-/// relative to the current space set and comes back to life
-/// when its space returns, so dropping it on save would lose
-/// config across a routine profile/monitor swap. Rows here are
-/// ordinary `NavRow`s — rebind, clear, and the recorder's
-/// "Go to" (which scrolls to the row's Lua id) all work.
+/// Display and editing group for orphaned space shortcuts (#92).
 struct OrphanedShortcutsGroup: View {
     @ObservedObject var model: SettingsModel
     @Binding var bindings: [KeyBinding]

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutCard+Rows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutCard+Rows.swift
@@ -47,6 +47,7 @@ extension LayoutCard {
                 placement: monocle.newWindowPlacement
             )
         case .gridColumns, .gridRows, .trackLimit:
+            // Drawn by their Auto toggles' `AutoGatedGroup` above.
             EmptyView()
         case .bspOverrideStrategy, .bspOverrideSplitRatioH,
             .bspOverrideSplitRatioV, .stackOverrideMasterCount,

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutCard+Rows.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutCard+Rows.swift
@@ -1,16 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Layout Defaults row builders — one per census row, keyed
-/// by the census case, so a row moves between layouts by moving
-/// its placement. Split across files for the ceiling; this one
-/// holds the dispatch plus BSP, Stack and Monocle.
-///
-/// The Auto pairs (Grid's auto-size, Track's auto limit) render
-/// at the AUTO key as one `AutoGatedGroup`, with the value key
-/// an `EmptyView` arm: the census keeps them as two gated rows
-/// and the GUI composes the pair, the same shape the Bars area
-/// uses for its Auto sliders.
+/// Layout Defaults row builders for BSP, Stack, and Monocle settings
+/// (`LayoutCard`).
 extension LayoutCard {
     @ViewBuilder func layoutRow(_ key: LayoutKey) -> some View {
         switch key {
@@ -55,9 +47,6 @@ extension LayoutCard {
                 placement: monocle.newWindowPlacement
             )
         case .gridColumns, .gridRows, .trackLimit:
-            // Drawn by their Auto toggles' `AutoGatedGroup`
-            // above — the census keeps them as their own gated
-            // rows, the GUI composes the pair.
             EmptyView()
         case .bspOverrideStrategy, .bspOverrideSplitRatioH,
             .bspOverrideSplitRatioV, .stackOverrideMasterCount,
@@ -73,19 +62,12 @@ extension LayoutCard {
             .monocleOverrideOrientation, .trackOverrideAxis,
             .trackOverrideLimit, .trackOverrideOverflowStyle,
             .trackOverrideAutoTracks:
-            // Per-space overrides (Spaces & Layouts) and the two
-            // Lua-only ones. If a census move brings one here,
-            // the render-parity guard forces it into an order
-            // list and it lands on this arm — fail loud in debug
-            // rather than draw nothing.
             let _ = assertionFailure(
                 "unrendered Layout Defaults row: \(key.rawValue)"
             )
             EmptyView()
         }
     }
-
-    // MARK: - Bindings
 
     var bsp: Binding<BspParams> { $model.config.settings.bsp }
     var stack: Binding<StackParams> {
@@ -101,8 +83,6 @@ extension LayoutCard {
     var track: Binding<TrackParams> {
         $model.config.settings.track
     }
-
-    // MARK: - BSP
 
     var bspStrategyRow: some View {
         SegmentedPicker(
@@ -215,9 +195,7 @@ extension LayoutCard {
         )
     }
 
-    /// Shared by Stack and Track — the far-edge overflow track
-    /// piles the same two ways a stack zone does, which is why
-    /// the labels are one pair rather than two.
+    /// Shared overflow options for Stack and Track layouts.
     var overflowOptions: [(String, StackParams.OverflowStyle)] {
         [
             (
@@ -232,8 +210,6 @@ extension LayoutCard {
             ),
         ]
     }
-
-    // MARK: - Monocle
 
     var monocleOrientationRow: some View {
         SegmentedPicker(

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutUsage.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutUsage.swift
@@ -1,20 +1,9 @@
 import KiwiDeskCore
 
-/// Which spaces run which layout — the one answer three
-/// surfaces on this page need: the strip's per-tile count, the
-/// spaces-using card's list, and the landing layout the page
-/// opens on.
-///
-/// It is one function because the three disagreed while it was
-/// three: two read `config.spaces` and defaulted an unrecorded
-/// space to `.bsp` (the reading every other surface in the app
-/// uses), while the landing counted `spaceModes.values` alone —
-/// so a profile of untouched spaces plus one Grid space landed
-/// the reader on Grid while the strip beside them said BSP had
-/// the spaces.
+/// Layout usage queries across configured spaces.
 enum LayoutUsage {
-    /// The profile's spaces on `mode`, in the user's own order.
-    /// A space with no recorded mode runs the default.
+    /// Returns profile spaces using mode, defaulting unrecorded spaces
+    /// to .bsp.
     static func spaces(
         on mode: LayoutMode,
         in config: GuiConfig

--- a/Sources/KiwiDesk/Settings/Components/Layouts/LayoutUsage.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/LayoutUsage.swift
@@ -1,6 +1,9 @@
 import KiwiDeskCore
 
-/// Layout usage queries across configured spaces.
+/// Layout usage queries across configured spaces — ONE answer for
+/// the page's three surfaces (strip counts, spaces-using card,
+/// landing layout), which disagreed on the unrecorded-space
+/// default while they were three copies.
 enum LayoutUsage {
     /// Returns profile spaces using mode, defaulting unrecorded spaces
     /// to .bsp.

--- a/Sources/KiwiDesk/Settings/Components/Layouts/StackSchematic+Slots.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/StackSchematic+Slots.swift
@@ -1,26 +1,12 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The stack zone's slot math, split from `StackSchematic` when
-/// the #222 arrangement branches grew it past the line ceiling
-/// (AGENTS.md §2). Pure geometry over the mini canvas; the view
-/// side stays in `StackSchematic.swift`.
+/// Stack zone schematic slot geometry calculations (#222).
 extension StackSchematic {
-    /// `cascade_all` piles every window (always downward, like
-    /// the engine's `OverlapStack`); `cascade_overflow` tiles
-    /// the run along the staged stack orientation and piles the
-    /// surplus at the zone's trailing end. Piled tiles keep
-    /// their extent but overlap by `cascadeOffset`, so only
-    /// their top edge shows above the next.
+    /// Computes stack slot frames for cascade and overflow styles
+    /// (`OverlapStack`).
     func stackSlots(in size: CGSize) -> [Slot] {
         let n = stackWins.count
-        // `order` always carries the incoming window, so the
-        // stack zone is never actually empty and this guard does
-        // not fire today. It stays because the divisions below
-        // are live arithmetic since turn 10 made the count an
-        // input: at n == 0 the overflow branch would build a
-        // reversed `Range` and trap, which is a worse way to
-        // learn that the partition changed.
         guard n > 0 else { return [] }
         let w = size.width
         let h = size.height

--- a/Sources/KiwiDesk/Settings/Components/Layouts/StackSchematic+Slots.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/StackSchematic+Slots.swift
@@ -7,6 +7,9 @@ extension StackSchematic {
     /// (`OverlapStack`).
     func stackSlots(in size: CGSize) -> [Slot] {
         let n = stackWins.count
+        // Unreachable today (`order` carries the incoming window),
+        // but at n == 0 the overflow branch would build a reversed
+        // `Range` and trap — keep the guard.
         guard n > 0 else { return [] }
         let w = size.width
         let h = size.height

--- a/Sources/KiwiDesk/Settings/Components/Layouts/TrackSchematic+Overflow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/TrackSchematic+Overflow.swift
@@ -1,14 +1,9 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// `TrackSchematic`'s far-edge overflow track, split out to keep
-/// the schematic itself under the file ceiling — the pile's
-/// geometry is self-contained and nothing else in the strip reads
-/// it.
+/// Overflow track layout and slot geometry for TrackSchematic.
 extension TrackSchematic {
-    /// The far-edge overflow track: an always-vertical title-bar
-    /// pile. `cascade_all` piles every window; `cascade_overflow`
-    /// keeps the first tiled and piles the rest.
+    /// Renders cascade or overflow pile in far-edge track.
     var overflowTrack: some View {
         GeometryReader { geo in
             let slots = overflowSlots(geo.size)

--- a/Sources/KiwiDesk/Settings/Components/Lua/AdvancedLuaGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Lua/AdvancedLuaGroup.swift
@@ -1,10 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Lua bindings (#68 §3.6.1) — the old "Custom
-/// Bindings", renamed and collapsed by its host. Raw Lua stays
-/// monospaced on purpose: arbitrary Lua *is* the capability
-/// here, not a serialization leak.
+/// Custom arbitrary Lua keybinding management group (#68 §3.6.1).
 struct AdvancedLuaGroup: View {
     @ObservedObject var model: SettingsModel
     @Binding var bindings: [KeyBinding]

--- a/Sources/KiwiDesk/Settings/Components/Lua/AdvancedLuaGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Lua/AdvancedLuaGroup.swift
@@ -2,6 +2,8 @@ import KiwiDeskCore
 import SwiftUI
 
 /// Custom arbitrary Lua keybinding management group (#68 §3.6.1).
+/// Raw Lua stays monospaced on purpose: arbitrary Lua IS the
+/// capability, not a serialization leak.
 struct AdvancedLuaGroup: View {
     @ObservedObject var model: SettingsModel
     @Binding var bindings: [KeyBinding]

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorArrangement+Tray.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorArrangement+Tray.swift
@@ -3,7 +3,11 @@ import KiwiDeskCore
 
 /// Dynamic height calculation for follows-main monitor arrangement tray.
 extension MonitorArrangement {
-    /// Computes tray height dynamically for chip count and layout width.
+    /// Computes tray height for the chip count: a constant clipped
+    /// the heading once chips wrapped (owner 2026-08-04). Rows
+    /// derive from the same `minChipWidth` the flow layout wraps
+    /// on — a deliberate UPPER bound: too tall is empty space,
+    /// too short clips.
     static func trayHeight(
         chips: Int,
         width: CGFloat

--- a/Sources/KiwiDesk/Settings/Components/Monitors/MonitorArrangement+Tray.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/MonitorArrangement+Tray.swift
@@ -1,25 +1,9 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// How tall the follows-main tray has to be for what it holds.
-/// Split from `MonitorArrangement` when the derivation took
-/// that file past the §2.1 ceiling — it is the one piece of
-/// that arithmetic which reasons about CHIPS rather than about
-/// displays.
+/// Dynamic height calculation for follows-main monitor arrangement tray.
 extension MonitorArrangement {
-    /// The tray's height for `chips` spaces at `width`.
-    ///
-    /// A CONSTANT 52 was wrong the moment a fourth space followed
-    /// main: the chips wrap, and the box did not grow, so the
-    /// second row pushed the tray's own heading out of the top of
-    /// it (owner, 2026-08-04). Rows are derived from the same
-    /// `minChipWidth` the flow layout wraps on, so the box and its
-    /// contents agree by construction rather than by a guess.
-    ///
-    /// The row count is an UPPER bound, deliberately: real chips
-    /// are usually wider than the minimum, so this can reserve a
-    /// row that ends up unused. A tray one row too tall is a
-    /// little empty space; one row too short clips a heading.
+    /// Computes tray height dynamically for chip count and layout width.
     static func trayHeight(
         chips: Int,
         width: CGFloat

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideCellState.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideCellState.swift
@@ -1,22 +1,7 @@
 import Foundation
 
-/// What a space row's override cell reads, resolved purely from
-/// the space's total saved-override count and whether its mode is
-/// Floating (owner ruling 2026-08-04, #678 8a).
-///
-/// The count is the SUM across every layout
-/// (`overrideFieldCount(for:)`) — the scannable "how much custom
-/// config does this Space carry" signal, which the pushed editor
-/// then splits into active-layout rows and a dormant drawer.
-///
-/// Floating carries no *active* overrides, but a Floating space
-/// may still hold overrides saved for OTHER layouts. Hiding that
-/// count would reproduce the "haunted tiler" (#458): a Floating
-/// space silently carrying tiling overrides the user cannot see,
-/// which reactivate the moment the space switches back. So the
-/// count stays visible and the cell stays a way into the editor —
-/// "grey, don't hide" (§2.7). Only a Floating space with nothing
-/// parked is genuinely inert.
+/// Override badge and trigger cell display state for space rows
+/// (#458, #678 8a).
 enum OverrideCellState: Equatable {
     /// Tiled space, no overrides: the offer to add. "Customize…"
     case customize

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideCellState.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideCellState.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// Override badge and trigger cell display state for space rows
-/// (#458, #678 8a).
+/// (#678 8a). A Floating space may still hold overrides saved for
+/// OTHER layouts; hiding that count would reproduce the haunted
+/// tiler (#458), so it stays visible — grey, don't hide.
 enum OverrideCellState: Equatable {
     /// Tiled space, no overrides: the offer to add. "Customize…"
     case customize

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideSlotSizeRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideSlotSizeRow.swift
@@ -1,25 +1,11 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The one per-space override that is a *pair* of rows, not one
-/// (#290): the scrolling slot size is a unit picker plus its value
-/// control, but a single `ScrollSize?` — so one inherit checkbox
-/// owns both. `OverrideChrome(alignment: .top)` wraps the two-row
-/// `VStack` as its content, so the accent bar and dim state span
-/// the pair and the checkbox lines up with the first row. The rows
-/// themselves are the shared `SlotSizeRows` bound through
-/// `overrideValue`, so inherit shows the resolved global value and
-/// checking seeds it (no jump) — the same seam every other
-/// override row uses, no hand-rolled copy to drift (§5).
+/// Override row pair for scrolling slot size settings (#239, #290, #291).
 struct OverrideSlotSizeRow: View {
     @ObservedObject var model: SettingsModel
-    /// Effective scroll orientation for the space, so the value
-    /// row reads "Column width" horizontally / "Row height"
-    /// vertically off the resolved orientation (#239 pattern).
     let isVertical: Bool
     @Binding var value: ScrollSize?
-    /// The inherited value shown while unchecked and seeded on
-    /// check — the space's resolved (effective) slot size.
     let global: ScrollSize
 
     var body: some View {

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideSlotSizeRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/OverrideSlotSizeRow.swift
@@ -4,8 +4,12 @@ import SwiftUI
 /// Override row pair for scrolling slot size settings (#239, #290, #291).
 struct OverrideSlotSizeRow: View {
     @ObservedObject var model: SettingsModel
+    /// Resolved scroll orientation, so the value row reads
+    /// "Column width" / "Row height" off the effective axis (#239).
     let isVertical: Bool
     @Binding var value: ScrollSize?
+    /// Resolved value shown while unchecked and seeded on check,
+    /// so checking never jumps.
     let global: ScrollSize
 
     var body: some View {

--- a/Sources/KiwiDesk/Settings/DeletionFocus.swift
+++ b/Sources/KiwiDesk/Settings/DeletionFocus.swift
@@ -1,7 +1,9 @@
 /// Focus return target calculation following row deletion (#816).
 enum DeletionFocus {
-    /// Determines next focus target in list before deletion (next, else
-    /// previous).
+    /// Determines next focus target (next, else previous), read
+    /// from the list BEFORE the mutation — read after, the
+    /// end-of-list case names a row that no longer exists and
+    /// focus falls off (#816).
     static func neighbour<Item: Equatable>(
         after item: Item,
         in list: [Item]

--- a/Sources/KiwiDesk/Settings/DeletionFocus.swift
+++ b/Sources/KiwiDesk/Settings/DeletionFocus.swift
@@ -1,28 +1,7 @@
-/// Where the keyboard lands after a deletion (#816).
-///
-/// The rule is one sentence — **the next row, else the previous,
-/// else nowhere, read from the list BEFORE the mutation** — and
-/// it was written six times in six comments across five lists
-/// before this existed. Each copy was correct; none of them
-/// owned the rule, so a seventh list would have restated it, and
-/// the parity guard cannot tell a neighbour read before the
-/// delete from one read after (both spell
-/// `returningRow = neighbour`).
-///
-/// Reading it AFTER the mutation is the failure worth naming:
-/// the list then reports whichever row slid into the gap, which
-/// is right by accident everywhere except at the end of a list,
-/// where the deleted row's index no longer exists and focus
-/// falls off it.
-///
-/// Deliberately a free function over the DISPLAY order rather
-/// than a protocol: what varies between the lists is which order
-/// is on screen (sorted by display name in App Rules, profile
-/// order in Profiles, the drag order in Spaces), and that is the
-/// argument, not the stepping.
+/// Focus return target calculation following row deletion (#816).
 enum DeletionFocus {
-    /// The neighbour of `item` in `list`: the next one, else the
-    /// previous, else nil when it was the only row.
+    /// Determines next focus target in list before deletion (next, else
+    /// previous).
     static func neighbour<Item: Equatable>(
         after item: Item,
         in list: [Item]

--- a/Sources/KiwiDesk/Settings/HomeCardOrder.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardOrder.swift
@@ -1,5 +1,7 @@
 /// Home dashboard card offer and display order
-/// (`HomeCardOrderTests`, #678 turn 9).
+/// (`HomeCardOrderTests`, #678 turn 9). The order is STABLE across
+/// mode flips: Power User inserts its cards at their slots rather
+/// than appending, so a card never moves on a segment toggle.
 enum HomeCardOrder {
     /// THIS PROFILE, full (Power User) order.
     static let thisProfile: [SettingsDestination] = [
@@ -12,7 +14,10 @@ enum HomeCardOrder {
         .shortcuts, .profiles, .appRules, .general,
     ]
 
-    /// Single offer predicate for home dashboard cards (#18, #678 turn 9).
+    /// Single offer predicate for home dashboard cards (#18) — no
+    /// hand-negated copies. The `displayCount` axis deliberately
+    /// has NO selection repair: unplugging a display must not yank
+    /// the screen mid-edit; the next Home visit re-derives.
     static func isOffered(
         _ destination: SettingsDestination,
         mode: SettingsMode,

--- a/Sources/KiwiDesk/Settings/HomeCardOrder.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardOrder.swift
@@ -1,12 +1,5 @@
-/// Which cards Home offers, in which order (#678 turn 9).
-///
-/// The order is the turn-9 frame's and is STABLE across mode
-/// flips: Power User inserts its cards at their slots rather than
-/// appending, so a card never moves when the segment is toggled
-/// — Monitors auto-promoted into Simple sits exactly where Power User
-/// shows it. `HomeCardOrderTests` pins both lists to the
-/// destination groups so a thirteenth destination cannot miss
-/// the grid.
+/// Home dashboard card offer and display order
+/// (`HomeCardOrderTests`, #678 turn 9).
 enum HomeCardOrder {
     /// THIS PROFILE, full (Power User) order.
     static let thisProfile: [SettingsDestination] = [
@@ -19,19 +12,7 @@ enum HomeCardOrder {
         .shortcuts, .profiles, .appRules, .general,
     ]
 
-    /// One offer predicate for every surface that shows or
-    /// lands on a card (the grid, the selection repair, the
-    /// `settingsNavigate` guard, search) — the #18 rule with
-    /// the mode as its second axis. No hand-negated copies.
-    ///
-    /// The `displayCount` axis deliberately has NO selection
-    /// repair: unplugging the second display while standing in
-    /// an auto-promoted Monitors area leaves the user there —
-    /// the area still exists and still edits (its own gates
-    /// handle the missing geometry); only the next Home visit
-    /// re-derives the card offer. Repairing here would yank the
-    /// screen out from under a user mid-edit for a change they
-    /// did not make in Settings.
+    /// Single offer predicate for home dashboard cards (#18, #678 turn 9).
     static func isOffered(
         _ destination: SettingsDestination,
         mode: SettingsMode,
@@ -47,7 +28,7 @@ enum HomeCardOrder {
                 ) == .simple)
     }
 
-    /// The grid's two groups under the current state.
+    /// Filters destination group to currently offered cards.
     static func offered(
         _ group: [SettingsDestination],
         mode: SettingsMode,

--- a/Sources/KiwiDesk/Settings/HoverCursor.swift
+++ b/Sources/KiwiDesk/Settings/HoverCursor.swift
@@ -1,16 +1,6 @@
 import SwiftUI
 
-/// Link-like hover affordance for controls that don't look
-/// like buttons (the make-default link, the rename pencil):
-/// the pointing-hand cursor plus a secondary→primary color
-/// lift while the mouse is over the view. Cursor changes use
-/// `set()`, never push/pop: both call sites can remove
-/// themselves from the hierarchy mid-hover (make-default
-/// drops its own link, rename rebuilds the row identity) and
-/// a removed view never delivers the balancing
-/// `onHover(false)` — the imbalance the spaces drag handle
-/// fixed the same way. `onDisappear` restores the arrow when
-/// the view vanishes under the pointer.
+/// Hover affordance applying pointing-hand cursor and color lift.
 private struct LinkHover: ViewModifier {
     @State private var hovering = false
     @Environment(\.accessibilityReduceMotion)
@@ -23,8 +13,7 @@ private struct LinkHover: ViewModifier {
                     ? AnyShapeStyle(.primary)
                     : AnyShapeStyle(.secondary)
             )
-            // The colour lift IS the affordance and stays; only
-            // the cross-fade to it stands down (#1069).
+            // Color lift is preserved; fade respects reduceMotion (#1069).
             .animation(
                 reduceMotion ? nil : .easeOut(duration: 0.12),
                 value: hovering
@@ -40,10 +29,7 @@ private struct LinkHover: ViewModifier {
     }
 }
 
-/// Pointing-hand cursor on hover *without* the link color
-/// lift — for clickable controls that aren't text (the color
-/// swatch). Same `set()` + `onDisappear` discipline as
-/// `LinkHover`, so a view removed mid-hover restores the arrow.
+/// Pointing-hand cursor on hover without color lift.
 private struct PointingHandCursor: ViewModifier {
     @State private var hovering = false
 

--- a/Sources/KiwiDesk/Settings/HoverCursor.swift
+++ b/Sources/KiwiDesk/Settings/HoverCursor.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 /// Hover affordance applying pointing-hand cursor and color lift.
+/// Cursor via `set()`, never push/pop: both call sites can leave
+/// the hierarchy mid-hover and a removed view never delivers the
+/// balancing `onHover(false)`; `onDisappear` restores the arrow.
 private struct LinkHover: ViewModifier {
     @State private var hovering = false
     @Environment(\.accessibilityReduceMotion)
@@ -29,7 +32,8 @@ private struct LinkHover: ViewModifier {
     }
 }
 
-/// Pointing-hand cursor on hover without color lift.
+/// Pointing-hand cursor on hover without color lift — same `set()`
+/// + `onDisappear` discipline as `LinkHover`.
 private struct PointingHandCursor: ViewModifier {
     @State private var hovering = false
 

--- a/Sources/KiwiDesk/Settings/LocaleNativeName.swift
+++ b/Sources/KiwiDesk/Settings/LocaleNativeName.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-/// Formats capitalized native endonym for a locale code (e.g. "Deutsch").
+/// Formats a locale's native endonym (never the English exonym),
+/// capitalized FOR THAT LOCALE: `localizedString(forIdentifier:)`
+/// returns running-text casing ("español"), which reads as a bug
+/// in a list; uppercasing with the entry's own locale keeps its
+/// rules in charge and leaves caseless scripts untouched.
 enum LocaleNativeName {
     static func name(for code: String) -> String {
         let locale = Locale(identifier: code)

--- a/Sources/KiwiDesk/Settings/LocaleNativeName.swift
+++ b/Sources/KiwiDesk/Settings/LocaleNativeName.swift
@@ -1,22 +1,6 @@
 import Foundation
 
-/// One shipped locale's endonym (e.g. "Deutsch" for `de`) with
-/// its first character capitalized *for that locale* — never
-/// the English exonym. ONE owner for the General picker and the
-/// Home card's language line, hoisted because the casing detail
-/// is subtle and a second copy had already grown (review
-/// 2026-08-04).
-///
-/// `localizedString(forIdentifier:)` returns the running-text
-/// form, and Spanish, French, Italian and Russian do not
-/// capitalize a language name mid-sentence — so the raw values
-/// read "English, Deutsch, español, français…", capitalized only
-/// where the language's own orthography happens to do it. In a
-/// LIST that reads as a bug: macOS System Settings capitalizes
-/// every entry, and matching it is the Apple-native call (§2.7).
-/// Uppercasing with the entry's own locale keeps its casing
-/// rules in charge; caseless scripts (日本語, 한국어, 中文) come
-/// back untouched.
+/// Formats capitalized native endonym for a locale code (e.g. "Deutsch").
 enum LocaleNativeName {
     static func name(for code: String) -> String {
         let locale = Locale(identifier: code)

--- a/Sources/KiwiDesk/Settings/ProfileHeader.swift
+++ b/Sources/KiwiDesk/Settings/ProfileHeader.swift
@@ -1,20 +1,11 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The profile edit-target dropdown (#18): pick the live config
-/// or a saved profile to edit in place — editing a non-loaded
-/// profile never switches the running layout. A borderless menu
-/// (title + chevron, no pill). Saving lives in the footer.
+/// Profile edit-target dropdown menu (#18, #94, #251, #259).
 struct ProfileEditTargetMenu: View {
     @ObservedObject var model: SettingsModel
 
     var body: some View {
-        // The menu isn't an icon-only control, so its "why"
-        // rides a label-adjacent `?` popover (#94/#259), not a
-        // hover-only `.help()` a user finds by accident. One `?`
-        // in this shared header → subject omitted (#251). The
-        // live `statusText` caption still carries the dynamic
-        // per-target state beneath.
         HStack(spacing: 4) {
             menu
             HelpButton(
@@ -56,10 +47,6 @@ struct ProfileEditTargetMenu: View {
         .menuStyle(.borderlessButton)
         .neutralMenuLabel()
         .fixedSize()
-        // The closed menu shows only its VALUE (the profile's
-        // name), so VoiceOver heard a name with no noun; the
-        // pair below names the control and keeps the value
-        // (#812, the App Rules facet shape).
         .accessibilityLabel(
             L("profile_header.menu.ax", "Profile to edit")
         )
@@ -67,14 +54,9 @@ struct ProfileEditTargetMenu: View {
     }
 
     private func requestSelect(_ name: String?) {
-        // A `nil` name is Live (`editingProfile == nil`); any
-        // name — the loaded profile included (#209) — is that
-        // stored target. Re-picking the open one is a no-op, so
-        // it never pops a pointless discard dialog.
         guard name != model.editingProfile else { return }
-        // This menu was the original discard-confirm site; it
-        // now shares the dashboard-wide gate (#515) so the six
-        // other discard paths cannot drift from it.
+        // Confirms discarding pending edits before switching profile
+        // (#209, #515).
         model.discardingEdits(
             message: L(
                 "discard.switch_profile.message",
@@ -126,11 +108,8 @@ struct ProfileEditTargetMenu: View {
     }
 
     private var title: String {
-        // Override mode gets a distinct closed-menu form, so
-        // "MyProfile — overrides" can't be mistaken for Live
-        // with MyProfile loaded — which shows the bare name and
-        // would otherwise collide when editing the loaded
-        // profile (#209).
+        // Override form distinguishes editing stored copy from loaded live
+        // layout (#209).
         if let editing = model.editingProfile {
             return L(
                 "profile_header.title.overrides",

--- a/Sources/KiwiDesk/Settings/ProfileHeader.swift
+++ b/Sources/KiwiDesk/Settings/ProfileHeader.swift
@@ -47,6 +47,9 @@ struct ProfileEditTargetMenu: View {
         .menuStyle(.borderlessButton)
         .neutralMenuLabel()
         .fixedSize()
+        // Closed, the menu shows only its VALUE, so VoiceOver
+        // heard a name with no noun — name the control, keep the
+        // value (#812, the App Rules facet shape).
         .accessibilityLabel(
             L("profile_header.menu.ax", "Profile to edit")
         )
@@ -54,6 +57,8 @@ struct ProfileEditTargetMenu: View {
     }
 
     private func requestSelect(_ name: String?) {
+        // Re-picking the open target is a no-op, so it never pops
+        // a pointless discard dialog.
         guard name != model.editingProfile else { return }
         // Confirms discarding pending edits before switching profile
         // (#209, #515).

--- a/Sources/KiwiDesk/Settings/Sections/AppRuleTitledEditor.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRuleTitledEditor.swift
@@ -1,12 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The "Windows titled…" pattern editor of an app-rule row
-/// (#68 §3.11): the chip list, the open-window picker, and the
-/// free-text escape. Split from `AppRuleRow` to stay under the
-/// file-size ceiling. `editingTitles` stays owned by the row
-/// (it also gates this editor's visibility) and is bound here
-/// so adding the first pattern keeps the editor open.
+/// Editor for window title matching patterns within an app rule (#68 §3.11).
 struct AppRuleTitledEditor: View {
     @ObservedObject var model: SettingsModel
     let app: String

--- a/Sources/KiwiDesk/Settings/Sections/AppRuleTitledEditor.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRuleTitledEditor.swift
@@ -1,7 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Editor for window title matching patterns within an app rule (#68 §3.11).
+/// Editor for window title matching patterns within an app rule
+/// (#68 §3.11). `editingTitles` stays owned by the row — it also
+/// gates this editor's visibility — and is bound here so adding
+/// the first pattern keeps the editor open.
 struct AppRuleTitledEditor: View {
     @ObservedObject var model: SettingsModel
     let app: String

--- a/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
@@ -1,24 +1,8 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// This Profile ▸ Bars, the first area rendered from the
-/// settings census (#678 Phase 2, turn 7a): one page — the
-/// Space Bar card and the App Bar card with its "Show it in"
-/// switches. The #293 App Bar / Space Bar switch is gone: both
-/// cards fit one scroll now that the per-layout override
-/// sub-editors left the GUI (GUI_REMOVED_2026-08; per-layout
-/// styling stays fully available in Lua).
-///
-/// Space Bar leads, matching everywhere else it does
-/// (ui-designer 2026-07-19): it is omnipresent across every
-/// layout, while the App Bar renders only where a layout shows
-/// one.
-///
-/// No colours here. The interim colour cards retired in #678
-/// Phase 3, when Advanced Colours started rendering every bar
-/// tint from the same census rows — a colour that renders in two
-/// areas has two answers to "what is this set to", and
-/// `SettingsColorSurfaceTests` now pins that it renders in one.
+/// Profile Bars settings section with Space Bar and App Bar cards
+/// (#293, #678).
 struct BarsSection: View {
     @ObservedObject var model: SettingsModel
 

--- a/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BarsSection.swift
@@ -2,7 +2,8 @@ import KiwiDeskCore
 import SwiftUI
 
 /// Profile Bars settings section with Space Bar and App Bar cards
-/// (#293, #678).
+/// (#293, #678). No colours here: a colour renders in ONE area —
+/// Advanced Colours — which `SettingsColorSurfaceTests` pins.
 struct BarsSection: View {
     @ObservedObject var model: SettingsModel
 

--- a/Sources/KiwiDesk/Settings/Sections/GapsAndBordersSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/GapsAndBordersSection.swift
@@ -1,34 +1,14 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// This Profile ▸ Gaps & Borders (#68 §3.2, renamed in #678
-/// Phase 3): the STRUCTURE of what KiwiDesk draws around windows
-/// — spacing, the drag visuals' shape, the focus ring's width and
-/// glow, the sticky mark's presence. Every colour on it moved to
-/// the two Colours areas.
-///
-/// The name is the census's own for this area
-/// (`SettingsArea.gapsAndBorders`), so the interim sidebar
-/// teaches the name that survives into the Home card rather than
-/// one that dies with the sidebar. Why the rename was owed at
-/// all — a destination title is a search key, so a page must not
-/// keep a name for content it no longer has — is argued in
-/// `docs/design-decisions.md` under "Colour is its own
-/// destination".
+/// Settings view for Gaps & Borders (#68 §3.2, #678 Phase 3).
 struct GapsAndBordersSection: View {
     @ObservedObject var model: SettingsModel
 
     var body: some View {
         ScrollView {
-            // Focus border leads the drag visuals since #754:
-            // the ring is the stroke seen all day, and it is the
-            // one the other two match. `BordersCard` sits above
-            // all three because it holds what they share — and
-            // `GapsAndBordersGateWiringTests` pins that every
-            // one of these five is mounted here, each line
-            // included: each editor declares its own card, so a
-            // deleted mount takes a whole surface off screen
-            // with every other guard still green.
+            // Mounted card composition pinned by
+            // `GapsAndBordersGateWiringTests` (#754).
             VStack(alignment: .leading, spacing: 20) {
                 GapsEditor(model: model)
                 BordersCard(model: model)

--- a/Sources/KiwiDesk/Settings/Sections/SpacePinBadge.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacePinBadge.swift
@@ -1,7 +1,10 @@
 import KiwiDeskCore
 
-/// Display pin badge resolution for space rows
-/// (`SpacePlacement`, #678 Phase 3).
+/// Display pin badge resolution for space rows (#678 Phase 3).
+/// The connected/offline split is the GUI face of
+/// `SpacePlacement.Resolution.pinned` vs `.pinnedAbsent` — it
+/// asks the placement resolver's own question, so the two cannot
+/// disagree about whether a pin is live.
 enum SpacePinBadge: Equatable {
     case none
     case pinned(displayName: String)

--- a/Sources/KiwiDesk/Settings/Sections/SpacePinBadge.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacePinBadge.swift
@@ -1,31 +1,13 @@
 import KiwiDeskCore
 
-/// Which display-pin badge a space row shows (#678 Phase 3, turn
-/// 8a). A space can be pinned to a specific display for the
-/// profile; the row surfaces that as a badge so the pin is visible
-/// without opening Monitors — and, when the pinned display is not
-/// currently attached, says so rather than looking unpinned.
-///
-/// Pure over its inputs (no `SettingsModel`, no `L()`), so the
-/// decision is unit-testable off the main actor and the row view
-/// only maps the case to a `BadgeChip` and its localized string.
-/// The connected/offline split is the GUI face of Core's
-/// `SpacePlacement.Resolution.pinned` vs `.pinnedAbsent` — the row
-/// asks the same question (is this pin's fingerprint among the
-/// attached displays?) the placement resolver does, so the two
-/// cannot disagree about whether a pin is live.
+/// Display pin badge resolution for space rows
+/// (`SpacePlacement`, #678 Phase 3).
 enum SpacePinBadge: Equatable {
-    /// No display pin for this space — no badge.
     case none
-    /// Pinned to an attached display, named for the badge.
     case pinned(displayName: String)
-    /// Pinned to a display that is not currently attached.
     case offline
 
-    /// `pin` is the space's stored display fingerprint (nil / empty
-    /// when unpinned). `connectedFingerprints` is the set of
-    /// attached displays' fingerprints; `name` resolves a
-    /// fingerprint to its human display name for the badge.
+    /// Resolves display pin status against connected display fingerprints.
     static func resolve(
         pin: String?,
         connectedFingerprints: Set<String>,

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+Remove.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+Remove.swift
@@ -17,6 +17,9 @@ extension SpacesSection {
     private func neighbourAfterDeleting(
         _ space: SpaceID
     ) -> SpaceID? {
+        // `displayedSpaces`, not `model.config.spaces`: mid-drag
+        // the rows render from `dragOrder`, and the neighbour must
+        // be the one the user can SEE (review 2026-08-11).
         let spaces = displayedSpaces
         guard let index = spaces.firstIndex(of: space) else {
             return nil

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+Remove.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+Remove.swift
@@ -1,22 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Removing a space, and where the keyboard lands afterwards.
-/// Split from `SpacesSection` at the §2.1 ceiling — the focus
-/// destination is what made this more than a one-line mutation
-/// (#678 Phase 4 pass 10).
+/// Space removal and keyboard focus return target handling (#678 Phase 4).
 extension SpacesSection {
     func removeSpace(_ space: SpaceID) {
-        // Where focus goes AFTER the row it was on stops existing
-        // (#678 Phase 4 pass 10, turn 20a rule 4: deleting moves
-        // focus to the next row, never to the top). Read BEFORE
-        // the mutation — the neighbour is defined by the list the
-        // deletion is about to change, and reading it afterwards
-        // names whichever row slid into the gap only by accident.
-        //
-        // Falls BACKWARD when the deleted row was last, which is
-        // the only direction left, and to nil on the last row of
-        // all, where there is genuinely nowhere to be.
+        // Compute focus neighbor before mutation (#678 Phase 4 pass 10).
         let neighbour = neighbourAfterDeleting(space)
         model.config.removeSpace(space)
         if model.nav.spaceOverridesFocus == space {
@@ -25,19 +13,10 @@ extension SpacesSection {
         returningRow = neighbour
     }
 
-    /// The row a deletion should leave focus on: the next one
-    /// down, else the previous, else nothing.
+    /// Focus target following space deletion: next row, else previous.
     private func neighbourAfterDeleting(
         _ space: SpaceID
     ) -> SpaceID? {
-        // `displayedSpaces`, not `model.config.spaces`: while a
-        // drag is in flight the rows render from the local
-        // `dragOrder`, and the neighbour has to be the one the
-        // user can SEE below the row they deleted. Practically
-        // unreachable today (the delete goes through a
-        // confirmation dialog, which no drag survives) — read
-        // this way so the claim in the comment above is true
-        // rather than nearly true (code review, 2026-08-11).
         let spaces = displayedSpaces
         guard let index = spaces.firstIndex(of: space) else {
             return nil

--- a/Sources/KiwiDesk/Settings/SettingsDiffRow.swift
+++ b/Sources/KiwiDesk/Settings/SettingsDiffRow.swift
@@ -8,7 +8,8 @@ struct SettingsDiffRow: Identifiable, Hashable {
     var key: SettingKey
     /// Localized label ("Outer gap", "Monocle · thickness").
     var label: String
-    /// Display strings for scalar before/after values.
+    /// Display strings; nil when the change has no scalar to
+    /// state — the row then renders its `changeNote` alone.
     var oldValue: String?
     var newValue: String?
     /// Localized change description for structural modifications.

--- a/Sources/KiwiDesk/Settings/SettingsDiffRow.swift
+++ b/Sources/KiwiDesk/Settings/SettingsDiffRow.swift
@@ -1,30 +1,17 @@
 import KiwiDeskCore
 
-/// One display-ready row of the draft diff (#678 turn 9, digest
-/// §1.1): the label the census names the setting by, and the
-/// old → new values where the readout can state them. Three
-/// surfaces render these rows — the detail panel's "CHANGED IN
-/// THIS DRAFT" list, Home's unsaved-changes popover, and (pass
-/// 6) nothing else claims them — all through
-/// `SettingsDiffRowsView`, so the draft has one row vocabulary.
+/// Display-ready row of the draft diff (`SettingsDiffRowsView`, #678 turn 9).
 struct SettingsDiffRow: Identifiable, Hashable {
-    /// Stable identity: the census id, plus an instance
-    /// discriminator where one key draws several rows (a
-    /// per-space override books one row per touched space).
+    /// Stable identity: census id plus instance discriminator.
     var id: String
-    /// The census key the row belongs to — the jump target's
-    /// anchor and the popover's area grouping both read it.
+    /// Census key the row belongs to.
     var key: SettingKey
-    /// Composed, localized ("Outer gap", "Monocle · thickness").
+    /// Localized label ("Outer gap", "Monocle · thickness").
     var label: String
-    /// Display strings. Nil when the change has no scalar to
-    /// state (an added space, an edited binding list) — the row
-    /// then renders its `changeNote` alone.
+    /// Display strings for scalar before/after values.
     var oldValue: String?
     var newValue: String?
-    /// The valueless rows' one-word narration ("Added",
-    /// "Removed", "Edited"), localized. Nil when the value pair
-    /// carries the story.
+    /// Localized change description for structural modifications.
     var changeNote: String?
 
     /// A plain value-pair row.

--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar+Identity.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar+Identity.swift
@@ -3,10 +3,15 @@ import SwiftUI
 
 /// Header bar identity component and titlebar clearance.
 extension SettingsHeaderBar {
-    /// Inset clearing macOS window control traffic lights.
+    /// 100 − the bar's own 16 pt gutter: the third light ends near
+    /// 78 pt (observed macOS 26) and starting there touched the
+    /// green button. No API publishes this — a look constant that
+    /// breaks silently if Apple moves the buttons.
     static let trafficLightInset: CGFloat = 84
 
-    /// Home identity view with app mark and localized title.
+    /// Home identity view; the 26 pt mark (over the inventory's
+    /// 22) read undersized against the taller bar (owner
+    /// 2026-08-04).
     var identity: some View {
         HStack(spacing: 8) {
             if let mark = BrandAssets.appMark {

--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar+Identity.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar+Identity.swift
@@ -1,27 +1,12 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The header bar's Home identity and titlebar clearance — its
-/// own file for the §2.1 ceiling, not for reuse.
+/// Header bar identity component and titlebar clearance.
 extension SettingsHeaderBar {
-    /// 100 − the bar's own 16 pt gutter.
-    ///
-    /// The third light's trailing edge falls at about 78 pt on a
-    /// standard macOS titlebar (observed 2026-08-04, macOS 26),
-    /// and starting the row THERE is what the first cut did: the
-    /// app mark ended up 4 pt from the green button, touching it.
-    /// 100 buys the mark the same air the prototype gives it.
-    /// Neither number is published by any API, so this is a look
-    /// constant like the top padding beside it and breaks the
-    /// same silent way if Apple moves the buttons.
+    /// Inset clearing macOS window control traffic lights.
     static let trafficLightInset: CGFloat = 84
 
-    /// Home's identity: the mark beside "Settings" — decorative
-    /// pair, one accessibility element.
-    ///
-    /// 26 pt, over the §3 inventory's 22: the mark is the app's
-    /// one piece of identity on this screen and read as
-    /// undersized against the taller bar (owner, 2026-08-04).
+    /// Home identity view with app mark and localized title.
     var identity: some View {
         HStack(spacing: 8) {
             if let mark = BrandAssets.appMark {

--- a/Sources/KiwiDesk/Settings/SettingsModel+Derived.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Derived.swift
@@ -1,7 +1,10 @@
 import Foundation
 import KiwiDeskCore
 
-/// Core engine forwarding derivations for SettingsModel.
+/// Core engine forwarding derivations for SettingsModel. Small on
+/// purpose: a derivation belongs beside the value it derives FROM
+/// (edit-target reads sit with their state machine); a value
+/// lands here only when it has no subsystem.
 extension SettingsModel {
     var configURL: URL { core.configURL }
     var displays: [Display] { core.state.workspaces.allDisplays }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Derived.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Derived.swift
@@ -1,24 +1,7 @@
 import Foundation
 import KiwiDeskCore
 
-/// The dashboard model's reads derived from `core` — values it
-/// holds no state for and forwards from the engine.
-///
-/// Split from `SettingsModel.swift` on the §2.1 file ceiling,
-/// which that file reached with its stored properties alone: a
-/// `@Published` stored property cannot live in an extension, so
-/// what could move was exactly what computes.
-///
-/// **Small on purpose, and not a home for "everything derived".**
-/// A derivation belongs beside the value it derives FROM, which
-/// is why the two edit-target reads (`editingProfile`,
-/// `editingStoredProfile`) sit in
-/// `SettingsModel+EditTarget.swift` with the state machine that
-/// owns `target`, and the layout-drift and profile reads sit in
-/// their own files. What is left here is what derives from
-/// `core` itself and belongs to no subsystem — so a new
-/// computed property joins its subsystem's file, and lands here
-/// only when it genuinely has none.
+/// Core engine forwarding derivations for SettingsModel.
 extension SettingsModel {
     var configURL: URL { core.configURL }
     var displays: [Display] { core.state.workspaces.allDisplays }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Palette.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Palette.swift
@@ -2,8 +2,10 @@ import KiwiDeskCore
 
 /// Color palette application extension for SettingsModel (#375).
 extension SettingsModel {
-    /// Applies palette colors onto staged settings
-    /// (`ColorPaletteKeys`, #375, #578).
+    /// Applies palette colors onto staged settings — a sparse
+    /// paint of `ColorPaletteKeys`, colors-only (#375): no
+    /// name-check may toggle a non-color flag (the retracted Neon
+    /// glow write, #578; design-decisions "colors-only").
     func applyPalette(_ palette: ColorPalette) {
         palette.apply(to: &config.settings)
     }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Palette.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Palette.swift
@@ -1,25 +1,10 @@
 import KiwiDeskCore
 
-/// Palette apply (#375): kept out of `SettingsModel` for the file
-/// ceiling. The palette *library* lives on the model as
-/// `paletteStore`; this is just the one-shot paint.
+/// Color palette application extension for SettingsModel (#375).
 extension SettingsModel {
-    /// Applies a palette's colors onto the staged config — a
-    /// one-shot paint, identical in lifecycle to a color-field edit
-    /// or the Copy-appearance button (dirty now, persisted by the
-    /// footer Save), never a live link.
+    /// Applies palette colors onto staged settings
+    /// (`ColorPaletteKeys`, #375, #578).
     func applyPalette(_ palette: ColorPalette) {
-        // A palette is a colors-only shelf (#375): a sparse paint of
-        // `ColorPaletteKeys` onto the staged config, nothing else.
-        // No name-check side-effect turns a non-color flag on —
-        // Kiwi Neon used to force `border.glow = true` here, but that
-        // was one-directional (a later sober palette couldn't clear
-        // it, so glow stuck on) and a category error: a color pick
-        // silently mutating an unrelated Focus-border toggle the user
-        // may have set on purpose. Neon's identity is its own vivid
-        // colors; the glow pairing is surfaced as a discoverable
-        // link under its swatch (#578), not a hidden write. See the
-        // #375 "colors-only" entry in docs/design-decisions.md.
         palette.apply(to: &config.settings)
     }
 }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Persistence.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Persistence.swift
@@ -11,16 +11,23 @@ extension SettingsModel {
                 atomically: true,
                 encoding: .utf8
             )
+            // The reload replaces every hotkey; the recorder
+            // snapshot must not roll the fresh Lua table back.
             liveKeySession = nil
             core.loadConfig()
             reload()
+            // Free-form Lua isn't checked at input time, so set or
+            // clear the conflict banner from the reloaded config.
             warnIfAnyConflict()
         } catch {
             core.onLog("settings save failed: \(error)")
         }
     }
 
-    /// Reverts staged edits and reapplies profile if layout drifted (#123).
+    /// Reverts staged edits and reapplies profile if layout
+    /// drifted (#123). Drift is computed fresh, not from the
+    /// published snapshot, so a switch the UI hasn't caught up
+    /// with still reverts.
     func revert() {
         if computeLayoutDrift() != nil,
             let activeProfileName = activeProfile

--- a/Sources/KiwiDesk/Settings/SettingsModel+Persistence.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Persistence.swift
@@ -1,12 +1,9 @@
 import KiwiDeskCore
 
-/// Writing the edited config back out: the raw Lua editor's save,
-/// the staged-edit revert, and adopting a hand-written file into
-/// GUI management. Split out of `SettingsModel` for the 350-line
-/// ceiling — the published state stays in the main file, because
-/// `@Published` cannot live in an extension.
+/// Configuration persistence, revert, and GUI adoption actions
+/// for SettingsModel.
 extension SettingsModel {
-    /// Writes the raw Lua editor's buffer to disk and reloads.
+    /// Writes raw Lua editor buffer to disk and reloads runtime state.
     func saveLuaSource() {
         do {
             try luaSource.write(
@@ -14,28 +11,17 @@ extension SettingsModel {
                 atomically: true,
                 encoding: .utf8
             )
-            // The raw file is now authoritative. Its reload
-            // replaces every hotkey, so the recorder snapshot
-            // must not roll the freshly loaded Lua table back.
             liveKeySession = nil
             core.loadConfig()
             reload()
-            // Free-form Lua isn't checked at input time (no
-            // recorder was involved), so set or clear the
-            // banner here from the reloaded config.
             warnIfAnyConflict()
         } catch {
             core.onLog("settings save failed: \(error)")
         }
     }
 
+    /// Reverts staged edits and reapplies profile if layout drifted (#123).
     func revert() {
-        // Re-applying the profile (restores the saved layout,
-        // prunes stale spaces, force-retiles) is gated on
-        // actual drift — a plain staged-edit revert stays
-        // model-only, as before #123. Computed fresh, not from
-        // the published snapshot, so a switch the UI hasn't
-        // caught up with still reverts.
         if computeLayoutDrift() != nil,
             let activeProfileName = activeProfile
         {
@@ -44,9 +30,8 @@ extension SettingsModel {
         reload()
     }
 
-    /// Migrates a hand-written config into GUI management (the
-    /// old file is kept as a commented backup) and switches to
-    /// the visual editor. See `KiwiCore.adoptConfigIntoGui`.
+    /// Adopts hand-written config into GUI management
+    /// (`KiwiCore.adoptConfigIntoGui`).
     func adoptIntoGui() {
         do {
             try core.adoptConfigIntoGui()

--- a/Sources/KiwiDesk/Settings/SettingsPreviewForm.swift
+++ b/Sources/KiwiDesk/Settings/SettingsPreviewForm.swift
@@ -1,27 +1,14 @@
-/// Which form an offering area's live preview takes at the
-/// measured width (#678 turn 17a), as ONE total derivation
-/// rather than three predicates a site can get half right.
-///
-/// The point of stating it as an enum is what the enum makes
-/// impossible: an area that offers a preview always lands on
-/// exactly one of these three, so no width and no answer can
-/// leave the preview unreachable. 17a drops the preview's
-/// COLUMN as the window narrows — never the preview, and never
-/// the way to it (`SettingsResponsiveOrderTests` proves the
-/// totality over every band and every answer).
+/// Responsive display form for live previews
+/// (`SettingsResponsiveOrderTests`, #678 17a).
 enum SettingsPreviewForm: String, CaseIterable, Sendable {
-    /// A column of its own beside the content — the only form
-    /// that takes layout space, and so the only one the save
-    /// pill's centring offset answers to.
+    /// Dedicated side column.
     case docked
-    /// A card over the content: draggable, closable, and the
-    /// same object in both narrow bands.
+    /// Floating card overlay.
     case floating
-    /// No card, and the "Show preview" offer in its place.
+    /// Collapsed state showing button offer.
     case offer
 
-    /// `shown` is the user's answer this mount, `nil` while the
-    /// band's own default stands.
+    /// Resolves preview form for width class and visibility state.
     static func at(
         _ width: SettingsWidthClass,
         shown: Bool?

--- a/Sources/KiwiDesk/Settings/SettingsPreviewForm.swift
+++ b/Sources/KiwiDesk/Settings/SettingsPreviewForm.swift
@@ -1,14 +1,16 @@
 /// Responsive display form for live previews
 /// (`SettingsResponsiveOrderTests`, #678 17a).
 enum SettingsPreviewForm: String, CaseIterable, Sendable {
-    /// Dedicated side column.
+    /// Dedicated side column — the only form taking layout space,
+    /// so the only one the save pill's centring offset answers to.
     case docked
     /// Floating card overlay.
     case floating
     /// Collapsed state showing button offer.
     case offer
 
-    /// Resolves preview form for width class and visibility state.
+    /// Resolves preview form; `shown` is the user's answer this
+    /// mount, nil while the band's own default stands.
     static func at(
         _ width: SettingsWidthClass,
         shown: Bool?

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+AppRules.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+AppRules.swift
@@ -1,10 +1,6 @@
 import KiwiDeskCore
 
-/// App Rules rows. The app→space map narrates per app as
-/// "— → Mail"-style value pairs of space names; the two rule
-/// lists (float, ignore) narrate membership as structural
-/// notes per entry, the instance being the entry exactly as
-/// stored.
+/// App Rules settings diff readout rows for SettingsValueReadout.
 extension SettingsValueReadout {
     static func appRulesRows(
         _ key: AppRulesKey,
@@ -27,12 +23,6 @@ extension SettingsValueReadout {
                 new: new.floatRules
             )
         case .floatRulesPattern:
-            // The pattern facet edits entries of
-            // `config.floatRules` — a `[String]` has no
-            // `.pattern` leaf for the walk to book, so changes
-            // land on the list key above. Narrating the same
-            // membership diff keeps this key total; the rows
-            // carry the list key's label as their base.
             return appRulesListNotes(
                 census,
                 base: label(
@@ -52,14 +42,11 @@ extension SettingsValueReadout {
                 new: new.ignoreRules
             )
         case .appRulesAdd, .appRulesDelete:
-            // no model path — never booked by the diff
             return []
         }
     }
 
-    /// One value-pair row per re-ruled app: the space it opens
-    /// in, with the unset dash where the rule appeared or was
-    /// removed.
+    /// Diff rows for application space routing map changes.
     private static func appRulesSpaceRows(
         _ census: SettingKey,
         old: [String: SpaceID],

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+AppRules.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+AppRules.swift
@@ -23,6 +23,9 @@ extension SettingsValueReadout {
                 new: new.floatRules
             )
         case .floatRulesPattern:
+            // A `[String]` has no `.pattern` leaf for the walk to
+            // book — changes land on the list key; narrating the
+            // same membership diff keeps this key total.
             return appRulesListNotes(
                 census,
                 base: label(
@@ -42,6 +45,7 @@ extension SettingsValueReadout {
                 new: new.ignoreRules
             )
         case .appRulesAdd, .appRulesDelete:
+            // No model path — never booked by the diff.
             return []
         }
     }

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+BordersValues.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+BordersValues.swift
@@ -1,12 +1,7 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// The Borders rows' value formatters and row shape, split
-/// from `SettingsValueReadout+Borders.swift` so neither file
-/// crosses the size ceiling (the `SettingKey+BordersText`
-/// shape). Internal rather than private because the switch
-/// consuming them lives in that sibling file; the `borders`
-/// prefix keeps them scoped to this key slice.
+/// Borders section value formatters for SettingsValueReadout.
 extension SettingsValueReadout {
     static func bordersRow(
         _ census: SettingKey,
@@ -47,8 +42,7 @@ extension SettingsValueReadout {
         bordersRow(census, hexDisplay(old), hexDisplay(new))
     }
 
-    /// Empty is the mark tints' stored "Automatic" sentinel —
-    /// shown the way the colour well's own hex field prints it.
+    /// Mark tint diff row formatting automatic sentinel.
     static func bordersAutoHexRow(
         _ census: SettingKey,
         _ old: String,
@@ -78,8 +72,7 @@ extension SettingsValueReadout {
         }
     }
 
-    /// Lua-only (#367): no GUI option list to reuse, so the
-    /// labels are the diff's own.
+    /// Border draw order label (#367).
     static func bordersDrawOrderLabel(
         _ order: BorderStyle.DrawOrder
     ) -> String {
@@ -91,7 +84,7 @@ extension SettingsValueReadout {
         }
     }
 
-    /// Lua-only (#754): no GUI option list to reuse either.
+    /// Border alignment label (#754).
     static func bordersAlignmentLabel(
         _ alignment: BorderAlignment
     ) -> String {
@@ -109,9 +102,7 @@ extension SettingsValueReadout {
         }
     }
 
-    /// The width master's display value: the shared width while
-    /// the three strokes agree, "mixed" once a Lua edit split
-    /// them — matching the acknowledgement the card's `?` makes.
+    /// Shared border width or mixed if strokes differ.
     static func bordersUnifiedWidth(
         _ settings: TilingSettings
     ) -> String {
@@ -128,11 +119,7 @@ extension SettingsValueReadout {
         return points(first)
     }
 
-    /// The corner shape all three strokes agree on — read from
-    /// `GapsBordersGates.agreedCornerStyle`, the one copy of
-    /// that comparison — or "mixed" while the ring's style and
-    /// the drag pair's radius disagree (the card's picker shows
-    /// no segment there).
+    /// Unified corner shape across strokes (`GapsBordersGates`).
     static func bordersAgreedCorner(
         _ settings: TilingSettings
     ) -> String {

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Layout4.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Layout4.swift
@@ -1,14 +1,8 @@
 import KiwiDeskCore
 
-/// The Layout override expansion machinery (`+Layout3` is the
-/// per-key dispatch): the touched-space filter, the generic
-/// field expander, and the two scrolling rows whose words are
-/// axis-relative and so need the space's resolved orientation.
+/// Layout override readout expansion helpers for SettingsValueReadout.
 extension SettingsValueReadout {
-    /// The spaces whose value for one override FIELD differs —
-    /// an entry whose other fields changed books no row here, so
-    /// each override key narrates only its own edits. Sorted by
-    /// name for a stable row order.
+    /// Returns sorted spaces where the specific override field changed.
     static func layoutTouched<O, V: Equatable>(
         _ old: [SpaceID: O],
         _ new: [SpaceID: O],
@@ -21,10 +15,7 @@ extension SettingsValueReadout {
             .sorted { $0.raw < $1.raw }
     }
 
-    /// One row per touched space: "Master ratio · Work", the
-    /// missing side reading as unset. `base` overrides the
-    /// census label for the two Lua-only keys whose census text
-    /// is `.none`.
+    /// Builds one diff row per touched space for an override field.
     static func layoutOvr<O, V: Equatable>(
         _ census: SettingKey,
         _ old: [SpaceID: O],
@@ -47,10 +38,7 @@ extension SettingsValueReadout {
         }
     }
 
-    // MARK: - Scrolling's axis-relative override rows
-
-    /// The anchor's words are axis-relative (Top/Left), so each
-    /// side reads its own resolved orientation for the space.
+    /// Axis-relative anchor override diff rows for scrolling layout.
     static func layoutAnchorOvrRows(
         _ census: SettingKey,
         old: TilingSettings,
@@ -87,10 +75,7 @@ extension SettingsValueReadout {
         }
     }
 
-    /// Slot-size overrides: the value AND the base label are
-    /// axis-relative, so the label follows the DRAFT's resolved
-    /// orientation for the space and each side's value reads in
-    /// that side's own unit.
+    /// Axis-relative slot size override diff rows for scrolling layout.
     static func layoutSlotOvrRows(
         _ census: SettingKey,
         old: TilingSettings,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Layout4.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Layout4.swift
@@ -15,7 +15,9 @@ extension SettingsValueReadout {
             .sorted { $0.raw < $1.raw }
     }
 
-    /// Builds one diff row per touched space for an override field.
+    /// Builds one diff row per touched space; `base` overrides the
+    /// census label for the Lua-only keys whose census text is
+    /// `.none`.
     static func layoutOvr<O, V: Equatable>(
         _ census: SettingKey,
         _ old: [SpaceID: O],

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+ShortcutsGlyphs.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+ShortcutsGlyphs.swift
@@ -1,20 +1,9 @@
 import KiwiDeskCore
 
-/// The Shortcuts readout's naming half, split from
-/// `SettingsValueReadout+Shortcuts.swift` for the file-size
-/// target (AGENTS.md §2.1): a binding's row label resolved the
-/// way the area's own rows resolve it — the `KeybindingCatalog`
-/// command for its Lua, the app display name for an app row —
-/// and its combo rendered through the recorder's own
-/// `ComboSymbols` + `LayoutKeyGlyph` pipeline (#23), never a
-/// second combo renderer.
+/// Shortcut action label resolution and glyph rendering for settings readout
+/// (#23).
 extension SettingsValueReadout {
-    /// Lua action → localized row label, built from the same
-    /// catalog builders the editor and the ⌃⌥K panel render
-    /// from. Space-targeting commands come from the union of
-    /// both sides' space lists and resize commands from both
-    /// sides' steps, so a row keeps its name even when the
-    /// draft also renamed the thing it targets.
+    /// Builds localized action label mapping from catalog definitions.
     static func shortcutsActionLabels(
         old: GuiConfig,
         new: GuiConfig
@@ -61,10 +50,7 @@ extension SettingsValueReadout {
         return labels
     }
 
-    /// Every Desktop row either side of the diff names, built
-    /// from the BINDINGS rather than from a live Desktop list:
-    /// a config records no Desktops, and a diff must name a row
-    /// whatever is plugged in while it is read.
+    /// Desktop navigation commands extracted from diff config layers.
     private static func desktopCommands(
         old: GuiConfig,
         new: GuiConfig
@@ -80,10 +66,7 @@ extension SettingsValueReadout {
             + KeybindingCatalog.moveToDesktop(desktops.desktops)
     }
 
-    /// The binding's row label as the Shortcuts area shows it:
-    /// catalog command label, else the app's display name, else
-    /// the stored editor label, else the raw Lua — the same
-    /// ladder the ⌃⌥K panel's bands fall through.
+    /// Resolves display label for keybinding.
     static func shortcutsBindingLabel(
         _ binding: KeyBinding,
         labels: [String: String]
@@ -102,10 +85,7 @@ extension SettingsValueReadout {
         return binding.lua
     }
 
-    /// The recorder's own combo rendering (#23): native glyphs
-    /// mapped through the active keyboard layout, the raw
-    /// string on a parse failure, the unset dash while
-    /// unrecorded.
+    /// Formats shortcut combo string into native glyphs (#23).
     static func shortcutsCombo(_ combo: String) -> String {
         guard !combo.isEmpty else { return unset }
         guard let parsed = KeyCombo.parse(combo) else {

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+ShortcutsGlyphs.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+ShortcutsGlyphs.swift
@@ -3,7 +3,9 @@ import KiwiDeskCore
 /// Shortcut action label resolution and glyph rendering for settings readout
 /// (#23).
 extension SettingsValueReadout {
-    /// Builds localized action label mapping from catalog definitions.
+    /// Builds localized action labels from the union of BOTH
+    /// sides' space lists and resize steps, so a row keeps its
+    /// name even when the draft also renamed the thing it targets.
     static func shortcutsActionLabels(
         old: GuiConfig,
         new: GuiConfig
@@ -50,7 +52,9 @@ extension SettingsValueReadout {
         return labels
     }
 
-    /// Desktop navigation commands extracted from diff config layers.
+    /// Desktop rows read from the BINDINGS, never a live Desktop
+    /// list: a config records no Desktops, and the diff must name
+    /// a row whatever is plugged in while it is read.
     private static func desktopCommands(
         old: GuiConfig,
         new: GuiConfig

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+SpaceBar.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+SpaceBar.swift
@@ -1,14 +1,7 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// Space Bar rows: every key narrates the one `SpaceBarStyle`
-/// field its census id names. Enum-valued rows reuse the option
-/// labels the Bars editor renders (`AppBarOptions` — the Space
-/// Bar's own pickers already read those lists), the
-/// auto-sentinel size sliders read "Automatic" at 0 the way the
-/// GUI's slider readout does, and a colour shows its stored hex
-/// verbatim. The copy-appearance action stores nothing, so it
-/// draws no row.
+/// Diff row readout generators for SpaceBarStyle census keys.
 extension SettingsValueReadout {
     static func spaceBarRows(
         _ key: SpaceBarKey,
@@ -164,8 +157,6 @@ extension SettingsValueReadout {
     }
 }
 
-// MARK: - Space Bar row shapes
-
 extension SettingsValueReadout {
     private static func spaceBarRow(
         _ census: SettingKey,
@@ -198,8 +189,7 @@ extension SettingsValueReadout {
         spaceBarRow(census, points(old), points(new))
     }
 
-    /// `0` is the stored auto sentinel on the size sliders —
-    /// the shared `autoPoints` reads "Automatic" there.
+    /// Readout for size sliders with 0 as Automatic sentinel.
     private static func spaceBarAutoPointsRow(
         _ census: SettingKey,
         _ old: CGFloat,
@@ -221,9 +211,7 @@ extension SettingsValueReadout {
         )
     }
 
-    /// The label the Bars editor's own option list renders for
-    /// this value; the fallback is unreachable while those lists
-    /// stay exhaustive (their own docs hold them to it).
+    /// Resolves display label from options list.
     private static func spaceBarChoice<T: Equatable>(
         _ value: T,
         _ options: [(T, String)]
@@ -232,8 +220,7 @@ extension SettingsValueReadout {
             ?? String(describing: value)
     }
 
-    /// "1.5 s" — the spring-delay readout unit (`SecondsRow`
-    /// prints seconds at one decimal, so this matches it).
+    /// Formats seconds with one decimal place.
     private static func spaceBarSeconds(_ ms: Int) -> String {
         L(
             "diff.value.seconds",

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Spaces.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Spaces.swift
@@ -1,9 +1,6 @@
 import KiwiDeskCore
 
-/// Spaces rows: the space list itself, the per-space
-/// assignments (mode, icon), the fallback designation, and the
-/// three action keys — which name no model path, so the draft
-/// diff never attributes a change to them.
+/// Spaces settings diff readout rows for SettingsValueReadout.
 extension SettingsValueReadout {
     static func spacesRows(
         _ key: SpacesKey,
@@ -34,17 +31,11 @@ extension SettingsValueReadout {
             ]
         case .spaceOverrideResetActive, .spaceOverrideResetAll,
             .spacesDelete:
-            // Actions: "(action)" ids are skipped by
-            // `SettingsDraftDiff.censusBases()`, so no change
-            // ever resolves to them — nothing to narrate.
             return []
         }
     }
 
-    /// The list's own story is structural: one Added/Removed
-    /// note per space that joined or left, and one Edited note
-    /// for a pure reorder (same members, new order) — a scalar
-    /// pair cannot state a permutation.
+    /// Structural diff rows for spaces list changes.
     private static func spacesListRows(
         _ census: SettingKey,
         old: GuiConfig,
@@ -82,11 +73,7 @@ extension SettingsValueReadout {
         return rows
     }
 
-    /// A rename keeps the count and the position
-    /// (`GuiConfig.renameSpace` maps in place), so the pairs
-    /// read positionally: old name → new name. Adds and removes
-    /// are `spaceList`'s story, so a count change leaves nothing
-    /// for this key to say.
+    /// Diff rows for space renames (`GuiConfig.renameSpace`).
     private static func spacesRenameRows(
         _ census: SettingKey,
         old: GuiConfig,
@@ -109,10 +96,8 @@ extension SettingsValueReadout {
             }
     }
 
-    /// Absent means the default `bsp` (the writer strips it —
-    /// `SpacesSection.modeBinding`), so both sides resolve
-    /// before comparing and a row always narrates two mode
-    /// names, never a bare unset.
+    /// Diff rows for space layout mode assignments
+    /// (`SpacesSection.modeBinding`).
     private static func spacesModeRows(
         _ census: SettingKey,
         old: GuiConfig,
@@ -137,9 +122,7 @@ extension SettingsValueReadout {
         }
     }
 
-    /// The icon is its own display (an SF Symbol name, an emoji
-    /// or a single character — #68's grammar), so the value is
-    /// shown verbatim; a cleared entry reads as unset.
+    /// Diff rows for space icon assignments (#68).
     private static func spacesIconRows(
         _ census: SettingKey,
         old: GuiConfig,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Spaces.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Spaces.swift
@@ -31,6 +31,8 @@ extension SettingsValueReadout {
             ]
         case .spaceOverrideResetActive, .spaceOverrideResetAll,
             .spacesDelete:
+            // "(action)" ids are skipped by `censusBases()` — no
+            // change ever resolves to them.
             return []
         }
     }

--- a/Sources/KiwiDesk/Settings/SidebarTile.swift
+++ b/Sources/KiwiDesk/Settings/SidebarTile.swift
@@ -1,11 +1,9 @@
 import SwiftUI
 
-/// A System-Settings-style icon tile: white glyph on a flat
-/// rounded-rect color (§6.1).
+/// System-Settings-style icon tile with optional badge dot.
 struct SidebarTile: View {
     let destination: SettingsDestination
-    /// Accent dot on the tile's top-trailing corner — the
-    /// native "something to look at in this section" cue.
+    /// Accent dot on tile corner for notifications.
     var badged = false
 
     var body: some View {

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsOpenBinding.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsOpenBinding.swift
@@ -1,23 +1,11 @@
 import KiwiDeskCore
 
-/// The bindable "open the shortcuts panel" action (#330). One
-/// place owns its Lua body so the catalog row, the quick-menu combo
-/// display, and the panel's footer hint all speak of the same
-/// binding — and a rename can't drift them apart.
+/// Binding definitions and glyph rendering for opening shortcuts panel (#330).
 enum ShortcutsOpenBinding {
-    /// The Lua the catalog binds and the classifier recognizes.
+    /// Lua statement for opening shortcuts panel.
     static let lua = "KiwiDesk.show_shortcuts()"
 
-    /// The combo currently bound to open the panel, rendered as
-    /// native glyphs (`⌃⌥K`) via the same `ComboSymbols` + layout
-    /// path the editor and reference panel use — so it reads
-    /// identically everywhere. Nil when nothing is bound, or when
-    /// the live snapshot is unavailable (paused / init.lua-owned):
-    /// there is no live combo to advertise then.
-    ///
-    /// Read from the RESOLVED active layer (post profile-override),
-    /// not raw `gui.json` — the displayed combo must match what
-    /// Carbon actually has installed.
+    /// Formatted glyphs for shortcuts panel hotkey (`ComboSymbols`, #330).
     @MainActor static func comboGlyphs(core: KiwiCore) -> String? {
         guard let parsed = combo(core: core) else { return nil }
         return ComboSymbols.render(

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsOpenBinding.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsOpenBinding.swift
@@ -1,11 +1,16 @@
 import KiwiDeskCore
 
-/// Binding definitions and glyph rendering for opening shortcuts panel (#330).
+/// Binding definitions and glyph rendering for opening shortcuts
+/// panel (#330): one place owns the Lua body so the catalog row,
+/// quick-menu display and footer hint cannot drift apart.
 enum ShortcutsOpenBinding {
     /// Lua statement for opening shortcuts panel.
     static let lua = "KiwiDesk.show_shortcuts()"
 
-    /// Formatted glyphs for shortcuts panel hotkey (`ComboSymbols`, #330).
+    /// Formatted glyphs for the panel hotkey (`ComboSymbols`,
+    /// #330), read from the RESOLVED active layer, never raw
+    /// `gui.json` — the displayed combo must match what Carbon
+    /// actually has installed.
     @MainActor static func comboGlyphs(core: KiwiCore) -> String? {
         guard let parsed = combo(core: core) else { return nil }
         return ComboSymbols.render(

--- a/Sources/KiwiDesk/StatusItemHandle.swift
+++ b/Sources/KiwiDesk/StatusItemHandle.swift
@@ -1,6 +1,11 @@
 import AppKit
 
-/// Menu bar status item injection seam (`StatusItemSeamGuardTests`, #565).
+/// Menu bar status item injection seam (#565 shape): production
+/// default stays the live system item, tests inject a fake and
+/// never touch `NSStatusBar.system` — never test-detection in
+/// production code. The live wrapper stays file-private (sealed
+/// by construction); `StatusItemSeamGuardTests` scans the other
+/// routes. Widen this protocol rather than reaching around it.
 @MainActor
 protocol StatusItemHandle: AnyObject {
     var button: NSStatusBarButton? { get }

--- a/Sources/KiwiDesk/StatusItemHandle.swift
+++ b/Sources/KiwiDesk/StatusItemHandle.swift
@@ -1,31 +1,6 @@
 import AppKit
 
-/// The menu-bar slot behind `StatusItemController`, as a seam:
-/// the production default is the real system item; tests inject
-/// a per-file fake and never touch `NSStatusBar.system`.
-///
-/// Same defect class as the hotkey registrar (#565). The
-/// controller's init used to create its `NSStatusItem` directly,
-/// so every suite that exercised the quick-menu logic also
-/// registered live menu-bar items nothing ever removed — a full
-/// GUI run parked up to 15 blank slots in the real menu bar and
-/// held WindowServer at sustained 40%+ CPU (observed
-/// 2026-07-29). The fix is the #565 shape: an injection seam
-/// whose production default stays live — never test-detection
-/// inside production code.
-///
-/// Enforcement is split by route. The live wrapper
-/// (`SystemStatusItem`) lives file-scoped `private` beside the
-/// controller, so a test cannot name it even under
-/// `@testable import` — sealed by construction. The remaining
-/// routes — a bare construction taking the live default, a
-/// hand-rolled handle naming `NSStatusBar` — are scanned by
-/// `StatusItemSeamGuardTests`, which also pins the wrapper's
-/// access level so the seal cannot be raised unnoticed.
-///
-/// The surface is only what the controller uses: the button
-/// (icon rendering) and the menu assignment.
-/// Widen the protocol here rather than reaching around it.
+/// Menu bar status item injection seam (`StatusItemSeamGuardTests`, #565).
 @MainActor
 protocol StatusItemHandle: AnyObject {
     var button: NSStatusBarButton? { get }

--- a/Sources/KiwiDesk/ToolTipDelay.swift
+++ b/Sources/KiwiDesk/ToolTipDelay.swift
@@ -1,21 +1,7 @@
 import Foundation
 
-/// How long the pointer must rest before hover help appears —
-/// shorter than AppKit's own default, which is long enough that
-/// a greyed control's `GreyOut(help:)` sentence reads as absent
-/// rather than as slow.
-///
-/// Why that trade, why this value, and why not shorter, are
-/// argued once in `docs/design-decisions.md` ▸ "Hover help
-/// appears sooner than AppKit's default". The band this value
-/// must stay inside is asserted by `ToolTipDelayTests`.
-///
-/// `register`, never `set` — a user who has already chosen an
-/// `NSInitialToolTipDelay` (globally or for this app) keeps
-/// their value, since `register` only supplies a fallback.
-/// `ToolTipDelayTests` holds that too: it is the one line here
-/// whose failure mode is silent, overwriting a preference the
-/// user set deliberately.
+/// Registers reduced hover help delay
+/// (`ToolTipDelayTests`, `docs/design-decisions.md`).
 enum ToolTipDelay {
     /// AppKit reads this in milliseconds.
     static let key = "NSInitialToolTipDelay"

--- a/Sources/KiwiDesk/ToolTipDelay.swift
+++ b/Sources/KiwiDesk/ToolTipDelay.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-/// Registers reduced hover help delay
-/// (`ToolTipDelayTests`, `docs/design-decisions.md`).
+/// Registers reduced hover help delay (argued in
+/// `docs/design-decisions.md`; band held by `ToolTipDelayTests`).
+/// `register`, never `set`: a user's own `NSInitialToolTipDelay`
+/// must win — overwriting it would be silent.
 enum ToolTipDelay {
     /// AppKit reads this in milliseconds.
     static let key = "NSInitialToolTipDelay"

--- a/Sources/KiwiDeskCore/Animation/DeadEndBump.swift
+++ b/Sources/KiwiDeskCore/Animation/DeadEndBump.swift
@@ -11,6 +11,8 @@ public struct DeadEndBump {
     private var vel: [Double]
     private let spring: Spring
 
+    /// Settled when both axes are within this of rest — sub-point
+    /// tails are invisible.
     private static let epsilon = 0.3
 
     public init(
@@ -25,7 +27,9 @@ public struct DeadEndBump {
         self.spring = spring
     }
 
-    /// Re-applies wall impulse preserving velocity (#436).
+    /// Re-applies wall impulse preserving velocity, so a held key
+    /// reads as one sustained press, not restarted animations
+    /// (#436 retarget-in-place).
     public mutating func reimpulse(offset: CGVector) {
         pos = [Double(offset.dx), Double(offset.dy)]
     }

--- a/Sources/KiwiDeskCore/Animation/DeadEndBump.swift
+++ b/Sources/KiwiDeskCore/Animation/DeadEndBump.swift
@@ -1,17 +1,8 @@
 import CoreGraphics
 
-/// Pure spring state for the dead-end rubber-band (#436).
-///
-/// A directional focus/swap that finds no window beyond the wall
-/// gets a wordless "nope, nothing there": the focus ring offsets a
-/// few points *toward* the wall and springs back with a small
-/// overshoot — the scroll-overscroll idiom, not the login-shake.
-/// Two independent scalar springs (dx, dy) pull the offset back to
-/// zero after an initial impulse. All math is over plain scalars —
-/// no AX, no AppKit — so it is unit-testable and the animator layer
-/// only feeds the resulting offset to the ring overlay.
+/// Pure spring state for dead-end rubber-band animation (#436).
 public struct DeadEndBump {
-    /// Peak offset toward the wall, in points — a nudge, not a move.
+    /// Peak offset toward the wall, in points.
     public static let defaultAmplitude: CGFloat = 8
     public static let minAmplitude: CGFloat = 1
     public static let maxAmplitude: CGFloat = 20
@@ -20,8 +11,6 @@ public struct DeadEndBump {
     private var vel: [Double]
     private let spring: Spring
 
-    /// Settled when both axes are within this of rest at
-    /// negligible speed. Sub-point tails are invisible.
     private static let epsilon = 0.3
 
     public init(
@@ -36,11 +25,7 @@ public struct DeadEndBump {
         self.spring = spring
     }
 
-    /// Re-applies the impulse toward the wall while keeping the
-    /// current velocity, so a key held against the wall reads as one
-    /// sustained press rather than a stack of restarted animations
-    /// (#436 retarget-in-place). A fresh dead-end on the other axis
-    /// simply overwrites that axis and lets the stale one decay.
+    /// Re-applies wall impulse preserving velocity (#436).
     public mutating func reimpulse(offset: CGVector) {
         pos = [Double(offset.dx), Double(offset.dy)]
     }

--- a/Sources/KiwiDeskCore/App/BootPhase.swift
+++ b/Sources/KiwiDeskCore/App/BootPhase.swift
@@ -1,27 +1,9 @@
 import Foundation
 
-/// How far the boot has got (#802) — structure the GUI narrates,
-/// never a sentence Core built (core-boundaries.md).
-///
-/// The count is `scanned` of `total`, and both halves of it are
-/// deliberate. `total` is the boot QUEUE, which admits only apps
-/// a pass can act on (`EventLoop.bootPassAdmits`): faceless
-/// helpers and ignore-listed apps are filtered at queue build,
-/// because counting them narrated the whole process table —
-/// "apps: 3 of 145" over a desk showing five. And `scanned`
-/// counts apps *visited*, never apps attached: an app can
-/// refuse its observer, so an attach tally can stop short of
-/// its total and read as a progress bar that stalled. Visited
-/// reaches its total, which is what makes the quick menu's row
-/// honest rather than merely accurate.
+/// Startup boot phase progression state (`EventLoop.bootPassAdmits`, #802).
 public enum BootPhase: Equatable, Sendable {
-    /// Nothing started yet, or management is paused (no AX
-    /// permission, a mid-session revoke).
     case idle
-    /// The startup scan is walking the running apps.
     case scanning(scanned: Int, total: Int)
-    /// The scan finished and the first arrangement has landed —
-    /// the mark returning to full strength IS this.
     case ready
 
     /// Whether a readiness signal is owed. One predicate so the

--- a/Sources/KiwiDeskCore/App/BootPhase.swift
+++ b/Sources/KiwiDeskCore/App/BootPhase.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-/// Startup boot phase progression state (`EventLoop.bootPassAdmits`, #802).
+/// Startup boot phase progression state (#802). `total` is the
+/// boot QUEUE (`EventLoop.bootPassAdmits` filters what a pass can
+/// act on, so the count never narrates the whole process table);
+/// `scanned` counts apps VISITED, never attached — an app can
+/// refuse its observer, and an attach tally reads as a stalled
+/// progress bar.
 public enum BootPhase: Equatable, Sendable {
     case idle
     case scanning(scanned: Int, total: Int)

--- a/Sources/KiwiDeskCore/Appearance/PaletteCatalog.swift
+++ b/Sources/KiwiDeskCore/Appearance/PaletteCatalog.swift
@@ -1,11 +1,16 @@
 import Foundation
 
-/// Built-in and default color palette provider (`ColorPaletteTests`, #375).
+/// Built-in and default color palette provider (#375). The default
+/// is DERIVED from the shipped struct defaults at load, so it
+/// always equals reset-to-default and cannot drift.
 public enum PaletteCatalog {
     /// The name of the always-present default palette.
     public static let defaultName = "Kiwi (Default)"
 
-    /// Neon showcase palette name (#358, #578).
+    /// Neon showcase palette name (#358) — color-only like every
+    /// palette; the glow pairing is a GUI link keyed on this name,
+    /// never a side-effect (#578). Must match `bundled.json`
+    /// (`ColorPaletteTests`).
     public static let neonName = "Kiwi Neon"
 
     /// All nine built-ins, default first.

--- a/Sources/KiwiDeskCore/Appearance/PaletteCatalog.swift
+++ b/Sources/KiwiDeskCore/Appearance/PaletteCatalog.swift
@@ -1,22 +1,11 @@
 import Foundation
 
-/// The built-in palettes (#375). "Kiwi (Default)" is derived from
-/// the shipped struct defaults at load — so it always equals a
-/// reset-to-default and never drifts from the real defaults — then
-/// the eight authored palettes come from the bundled resource. The
-/// user-saved palettes live in `PaletteStore`, not here.
+/// Built-in and default color palette provider (`ColorPaletteTests`, #375).
 public enum PaletteCatalog {
     /// The name of the always-present default palette.
     public static let defaultName = "Kiwi (Default)"
 
-    /// The neon showcase palette (#358 follow-up). It is color-only
-    /// like every other bundled palette — it does **not** switch the
-    /// focus-ring glow on (that name-check side-effect was retracted
-    /// in #578: it stuck on, being uncleared by later color-only
-    /// palettes). The GUI keys the Neon swatch's "pair with Glow"
-    /// link on this name instead. Must match its `name` in
-    /// `bundled.json`; `ColorPaletteTests` guards that the entry
-    /// exists.
+    /// Neon showcase palette name (#358, #578).
     public static let neonName = "Kiwi Neon"
 
     /// All nine built-ins, default first.

--- a/Sources/KiwiDeskCore/Appearance/PaletteDocument.swift
+++ b/Sources/KiwiDeskCore/Appearance/PaletteDocument.swift
@@ -1,24 +1,11 @@
 import Foundation
 
-/// The envelope for `palettes.json` (#939): format versioning
-/// plus the list of user palettes.
-///
-/// The format integer is homed HERE, on the file's ROOT type —
-/// the pattern the siblings set (`Profile`, `GuiConfig`,
-/// `SetupBundle`) — never on `ColorPalette`, which also travels
-/// inside `SetupBundle`, where the bundle's own format governs
-/// (#945 review).
+/// Envelope for palettes.json with schema format versioning (#939).
 struct PaletteDocument: Codable {
-    /// Format version of the palettes.json schema (#939).
-    /// Format 0 = unversioned legacy bare array.
+    /// Format version of palettes.json schema (0 = legacy bare array, #939).
     static let currentFormat = 1
 
-    /// The format the file actually carried. Normalized to
-    /// `currentFormat` only by a WRITE, never by the decoder: a
-    /// decoder that normalizes makes every format assertion
-    /// read the decoder back instead of the file, which is how
-    /// the save path's stamp went unguarded (#945 review,
-    /// proven by mutation).
+    /// Decoded format version preserved without normalization (#945).
     var format: Int
     var palettes: [ColorPalette]
 

--- a/Sources/KiwiDeskCore/Appearance/PaletteDocument.swift
+++ b/Sources/KiwiDeskCore/Appearance/PaletteDocument.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Envelope for palettes.json with schema format versioning (#939).
+/// Envelope for palettes.json with schema format versioning
+/// (#939). The format integer is homed HERE, on the file's ROOT
+/// type — never on `ColorPalette`, which also travels inside
+/// `SetupBundle`, where the bundle's own format governs (#945).
 struct PaletteDocument: Codable {
     /// Format version of palettes.json schema (0 = legacy bare array, #939).
     static let currentFormat = 1

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+Drag.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+Drag.swift
@@ -8,6 +8,8 @@ extension AppBarOverlay {
         to windowPoint: CGPoint
     ) {
         guard let m = lastMetrics else { return }
+        // Leave glass hug mode so the mover and its siblings share
+        // `itemContainer`'s coordinate space.
         spanPlainGlassForDrag()
         let mover = draggableView(for: view)
         let point = itemContainer.convert(windowPoint, from: nil)

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+Drag.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+Drag.swift
@@ -1,25 +1,14 @@
 import AppKit
 
-/// Drag-and-drop reordering: an item (a single window or a
-/// whole group) follows the cursor along the bar axis while
-/// the other items reflow live around the slot it would land
-/// in; dropping reports (from, to) through `onMove`, and the
-/// core rewrites the window order.
+/// Drag-and-drop item reordering and reflow for AppBarOverlay.
 extension AppBarOverlay {
-    /// The dragged item rides along the axis (cross-axis
-    /// pinned), floating above its siblings.
+    /// Moves dragged item view and live reflows sibling slots.
     func dragMoved(
         _ view: AppBarItemView,
         to windowPoint: CGPoint
     ) {
         guard let m = lastMetrics else { return }
-        // Plain + glass hug hosts the items in `glassRun` at the
-        // plate's origin; leave hug mode so the mover and its
-        // siblings share `itemContainer`'s coordinate space.
         spanPlainGlassForDrag()
-        // The mover is the item under `boxed`/`plain`, or its glass
-        // box under per-box glass — both live in `itemContainer`,
-        // so the run coordinate space is the same either way.
         let mover = draggableView(for: view)
         let point = itemContainer.convert(windowPoint, from: nil)
         if itemContainer.subviews.last !== mover {

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+Item.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+Item.swift
@@ -1,33 +1,17 @@
 import AppKit
 
-/// One App Bar entry as the driver hands it over. Split from
-/// AppBarOverlay.swift, which sat on the §2.1 file ceiling.
-///
-/// The overlay is a dumb renderer: everything here is already
-/// RESOLVED — the glyph picked over the image (#294), and the
-/// drawn text picked over the app name and capped
-/// (`KiwiCore.barItemText`). Nothing in the render pass decides
-/// what an item says.
+/// Rendered item payload for AppBarOverlay (`KiwiCore.barItemText`, #294).
 extension AppBarOverlay {
     public struct Item {
         public let id: WindowID
-        /// The app's name, used for VoiceOver accessible name
-        /// generation (#901).
+        /// App name for VoiceOver accessibility labeling (#901).
         public let name: String
-        /// The string the item actually draws under a
-        /// text-bearing `Content`: the window's title, already
-        /// capped, with the app name standing in for a collapsed
-        /// group or an empty title. Resolved by the driver
-        /// (`KiwiCore.barItemText`) so the overlay stays a dumb
-        /// renderer, exactly like `glyph`.
+        /// Display text resolved by driver (`KiwiCore.barItemText`).
         public let text: String
         public let icon: NSImage?
-        /// SketchyBar App Font ligature to render instead of
-        /// `icon` (#294); nil = native image. Resolved by the
-        /// driver so the overlay stays a dumb renderer.
+        /// App Font ligature to render instead of icon (#294).
         public let glyph: String?
-        /// Windows behind this item; > 1 for a group of
-        /// adjacent same-app windows (shown as a badge).
+        /// Grouped window count shown as badge.
         public let count: Int
 
         public init(

--- a/Sources/KiwiDeskCore/Bar/BarAccent.swift
+++ b/Sources/KiwiDeskCore/Bar/BarAccent.swift
@@ -1,13 +1,20 @@
 import CoreGraphics
 
-/// Shared active accent metrics and alpha tiers for bar item views.
+/// Shared active accent metrics and alpha tiers for bar item
+/// views, hoisted because the literals were hand-mirrored across
+/// five sites and no parity test can see a drifted constant (§5).
 public enum BarAccent {
     /// Inset of active capsule ring inside item slot.
     public static let capsuleInset: CGFloat = 1.5
 
-    /// Alpha for untinted content on inactive items.
+    /// Alpha for untinted content on inactive items — shape plus
+    /// this dim carry the state. 0.4 (was 0.5) for a clearer
+    /// "not active" read (owner 2026-07-20).
     public static let untintedAlpha: CGFloat = 0.4
 
-    /// Alpha for unfocused app glyphs on active space in Space Bar.
+    /// Space Bar MIDDLE tier: 0.6 steps clearly between the 1.0
+    /// focused and 0.4 inactive tiers. The App Bar keeps
+    /// `untintedAlpha` — its dim is binary; semantic parity over
+    /// literal-value parity (owner 2026-07-20).
     public static let activeUnfocusedAlpha: CGFloat = 0.6
 }

--- a/Sources/KiwiDeskCore/Bar/BarAccent.swift
+++ b/Sources/KiwiDeskCore/Bar/BarAccent.swift
@@ -1,29 +1,13 @@
 import CoreGraphics
 
-/// Shared active-accent metrics for both bars' item views and
-/// their Settings preview twins (the GUI target reads them too).
-/// Hoisted because these literals were hand-mirrored across five
-/// sites and no parity test can see a drifted constant (§5) —
-/// the field-list nets only catch missing properties.
+/// Shared active accent metrics and alpha tiers for bar item views.
 public enum BarAccent {
-    /// Inset of the plain/material capsule ring around the
-    /// active item (ui-designer 2026-07-14): the ring floats
-    /// just inside the slot so its fully-curved ends tuck
-    /// inside the shared plate's rounded corners.
+    /// Inset of active capsule ring inside item slot.
     public static let capsuleInset: CGFloat = 1.5
 
-    /// Alpha for untinted content (native app images, emoji
-    /// identifiers) on an inactive item. Untinted content takes
-    /// no state color, so shape plus this dim carry the state.
-    /// 0.4 (was 0.5): a clearer "not active" read (owner 2026-07-20).
+    /// Alpha for untinted content on inactive items.
     public static let untintedAlpha: CGFloat = 0.4
 
-    /// The Space Bar's MIDDLE tier: an unfocused app's untinted
-    /// glyph on the ACTIVE space. 0.6 (was 0.7) sits between the
-    /// 1.0 focused and 0.4 inactive tiers, a firmer step than 0.7
-    /// so the ladder reads clearly (owner 2026-07-20). The App Bar
-    /// stays at `untintedAlpha`: its dim is a binary signal
-    /// reinforced by the accent ring, no third tier to collide
-    /// with — semantic parity over literal-value parity.
+    /// Alpha for unfocused app glyphs on active space in Space Bar.
     public static let activeUnfocusedAlpha: CGFloat = 0.6
 }

--- a/Sources/KiwiDeskCore/Bar/BarDivider.swift
+++ b/Sources/KiwiDeskCore/Bar/BarDivider.swift
@@ -2,7 +2,9 @@ import AppKit
 
 /// Shared divider geometry and color rendering for Space Bar.
 enum BarDivider {
-    /// Width of front-app section break divider.
+    /// Width of front-app section break divider — heavier than
+    /// the 1 pt in-chip rule so the boundary reads as a bigger
+    /// separation (QA 2026-07-19).
     static let sectionThickness: CGFloat = 2
 
     /// Returns divider color applying SpaceBarStyle.dividerAlpha.

--- a/Sources/KiwiDeskCore/Bar/BarDivider.swift
+++ b/Sources/KiwiDeskCore/Bar/BarDivider.swift
@@ -1,31 +1,17 @@
 import AppKit
 
-/// The divider rule the Space Bar draws — between a space's
-/// identifier and its app glyphs (a minor sub-separator, 1 pt,
-/// cell-height), and before the trailing front-app segment (a
-/// top-level section break, `sectionThickness` pt, full bar
-/// depth). Geometry AND color live here so the two rules can't
-/// drift (QA 2026-07-19); the two callers just pass different
-/// weights.
+/// Shared divider geometry and color rendering for Space Bar.
 enum BarDivider {
-    /// Width of the front-app section-break rule — heavier than
-    /// the 1 pt in-chip rule so the spaces-run ┃ front-app
-    /// boundary reads as a bigger separation (QA 2026-07-19).
+    /// Width of front-app section break divider.
     static let sectionThickness: CGFloat = 2
 
-    /// The rule's color: the muted `item_color` tier at the
-    /// shared divider alpha — structural chrome, never a
-    /// state-driven accent.
+    /// Returns divider color applying SpaceBarStyle.dividerAlpha.
     static func color(textColor: String) -> NSColor {
         NSColor(kiwiHex: textColor)
             .withAlphaComponent(SpaceBarStyle.dividerAlpha)
     }
 
-    /// The rule's frame at `offset` along the bar axis. Spans
-    /// `cell` across and centered in `depth` by default (the
-    /// in-chip rule); `fullDepth` spans the whole strip edge-to-
-    /// edge (the front-app section break). `thickness` is the
-    /// along-axis width.
+    /// Computes divider frame at offset along bar axis.
     static func frame(
         at offset: CGFloat,
         depth: CGFloat,

--- a/Sources/KiwiDeskCore/Bar/GlassHosting.swift
+++ b/Sources/KiwiDeskCore/Bar/GlassHosting.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Bar item hierarchy hosting mode for liquid glass finishes (#407).
+/// Bar item hierarchy hosting mode for liquid glass finishes
+/// (#407): one `resolve` per render feeds one dispatch, so the
+/// "who tears down whom" invariant lives in ONE place — before
+/// this, every entry point tore down the other modes itself.
 enum GlassHosting: Equatable {
     /// Solid plain plate or per-item boxed fill.
     case plainPlate
@@ -13,7 +16,8 @@ enum GlassHosting: Equatable {
     /// Unsupported OS version (below macOS 26) fallback.
     case none
 
-    /// Resolves single hosting mode for bar render (#407).
+    /// Resolves the single hosting mode for a bar render — one
+    /// authority so the two bars can't drift (#407).
     static func resolve(
         available: Bool,
         glassEnabled: Bool,

--- a/Sources/KiwiDeskCore/Bar/GlassHosting.swift
+++ b/Sources/KiwiDeskCore/Bar/GlassHosting.swift
@@ -1,34 +1,19 @@
 import Foundation
 
-/// The single mode naming where a bar item lives for one render
-/// (#407). A bar item physically sits in one of these parentings
-/// depending on the resolved style; before #407 no value named the
-/// current/target mode, so every entry point independently tore
-/// down the *other* modes. Now one `resolve` per render feeds one
-/// dispatch (`prepareGlassHosting` tears down the non-target modes,
-/// `installGlassHosting` installs the target), so the "who tears
-/// down whom" invariant lives in one place. Shared by both bars.
+/// Bar item hierarchy hosting mode for liquid glass finishes (#407).
 enum GlassHosting: Equatable {
-    /// No glass finish: the solid `plain` plate or the per-item
-    /// `boxed` fill. Items ride `itemContainer` on the panel.
+    /// Solid plain plate or per-item boxed fill.
     case plainPlate
-    /// Plain + glass, the run fits: the glass hugs the run wrapper.
+    /// Plain glass hugging run wrapper.
     case plainGlassHug
-    /// Plain + glass, the run overflows: the glass spans the
-    /// scrolling item viewport (`itemContainer`).
+    /// Plain glass spanning scrolling viewport.
     case plainGlassSpan
-    /// Boxed + glass: each item hosted in its own glass box.
+    /// Boxed glass per item.
     case boxGlass
-    /// Below macOS 26 — glass can't render, so nothing is hosted.
-    /// Same parenting as `plainPlate` (items in `itemContainer`);
-    /// named apart so the dispatch documents the below-26 reality.
+    /// Unsupported OS version (below macOS 26) fallback.
     case none
 
-    /// The one hosting mode for this render. `available` is the OS
-    /// gate (`glassAvailable`); `glassEnabled` the resolved finish;
-    /// `boxed` the shape; `overflow` whether the run scrolls (only
-    /// splits plain + glass into hug vs span). One authority so the
-    /// two bars can't drift on the decision.
+    /// Resolves single hosting mode for bar render (#407).
     static func resolve(
         available: Bool,
         glassEnabled: Bool,

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+DragDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+DragDrop.swift
@@ -1,25 +1,16 @@
 import AppKit
 
-/// Drag-drop feedback for one Space item (#372): the synthetic
-/// hover tint during a window drag and the pending-spring ring
-/// sweep. The dwell timing and the decision to spring live on the
-/// driver side; this view only renders the two cues.
+/// Drag-drop hover and spring-sweep feedback rendering for
+/// SpaceBarItemView (#372).
 extension SpaceBarItemView {
-
-    /// Lights (or clears) the synthetic drag-hover tint — the
-    /// same `hoverFillColor` an ordinary mouse hover shows, driven
-    /// from the AX cursor position because tracking areas stay
-    /// silent while another app owns the drag.
+    /// Toggles synthetic drag hover highlight.
     func setDragHover(_ on: Bool) {
         guard isDragHovered != on else { return }
         isDragHovered = on
         restyle()
     }
 
-    /// Starts the ring sweep: a `highlightColor` stroke filling
-    /// 0→1 over `duration`, sitting on top of the hover tint as
-    /// the "this will become active" cue. Reuses the active
-    /// indicator's ring vocabulary (2 pt, `highlightColor`).
+    /// Starts spring-loaded ring sweep animation (#372).
     func beginSpringSweep(
         duration: TimeInterval,
         delay: TimeInterval

--- a/Sources/KiwiDeskCore/Bar/SpaceBarItemView+DragDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarItemView+DragDrop.swift
@@ -3,7 +3,9 @@ import AppKit
 /// Drag-drop hover and spring-sweep feedback rendering for
 /// SpaceBarItemView (#372).
 extension SpaceBarItemView {
-    /// Toggles synthetic drag hover highlight.
+    /// Toggles synthetic drag hover highlight, driven from the AX
+    /// cursor position — tracking areas stay silent while another
+    /// app owns the drag.
     func setDragHover(_ on: Bool) {
         guard isDragHovered != on else { return }
         isDragHovered = on

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+DragDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+DragDrop.swift
@@ -3,7 +3,10 @@ import AppKit
 /// Drag-drop hit testing and visual feedback for SpaceBarOverlay (#372).
 extension SpaceBarOverlay {
 
-    /// Returns SpaceID whose item contains global screen point, or nil.
+    /// Returns SpaceID whose item contains the CURSOR point, never
+    /// the dragged window's frame — a maximized window can graze
+    /// the bar while its grab point is far away. The whole item
+    /// is one drop well.
     func spaceItem(atGlobal cocoaPoint: CGPoint) -> SpaceID? {
         guard isPanelVisible else { return nil }
         let ax = GeometryUtils.axPoint(cocoaPoint)

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+DragDrop.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+DragDrop.swift
@@ -1,19 +1,9 @@
 import AppKit
 
-/// Drag-drop routing for the Space Bar overlay (#372): the
-/// point-based hit test and the per-item hover / spring-sweep
-/// cues. The dwell timing and the spring decision live on the
-/// driver (`KiwiCore`); the overlay only maps a cursor point to a
-/// Space and forwards the visual cues to the matching item view.
+/// Drag-drop hit testing and visual feedback for SpaceBarOverlay (#372).
 extension SpaceBarOverlay {
 
-    /// The Space whose item contains a global (Cocoa, bottom-
-    /// left) screen point, or nil when the point is off the strip
-    /// or over a gap. Point-based — the cursor location, never
-    /// the dragged window's frame: a maximized window can graze
-    /// the bar while its grab point is far away. Glyphs and the
-    /// "+n" badge are not separate targets; the whole item is one
-    /// drop well.
+    /// Returns SpaceID whose item contains global screen point, or nil.
     func spaceItem(atGlobal cocoaPoint: CGPoint) -> SpaceID? {
         guard isPanelVisible else { return nil }
         let ax = GeometryUtils.axPoint(cocoaPoint)

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontAppBox.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontAppBox.swift
@@ -2,7 +2,10 @@ import AppKit
 
 /// Front segment box background and frosted backdrop for SpaceBarOverlay.
 extension SpaceBarOverlay {
-    /// Lays out Boxed fill or per-box glass for front application chip.
+    /// Lays out Boxed fill or per-box glass for the front chip.
+    /// Mirrors `SpaceBarItemView`'s box — keep the two in step on
+    /// any fill/corner change; the radius here resolves from
+    /// `depth`, the chip's from `min(width, height)`.
     func layoutFrontBox(
         _ app: SpaceBarItemView.App,
         from start: CGFloat,

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontAppBox.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+FrontAppBox.swift
@@ -1,24 +1,8 @@
 import AppKit
 
-/// The front segment's chip chrome: the Boxed fill behind its
-/// content and, under per-box glass, the frosted backdrop that
-/// replaces it. Split from SpaceBarOverlay+FrontApp.swift, which
-/// sat on the §2.1 file ceiling.
-///
-/// Content layout — the divider, the glyph and the window title —
-/// stays in that file. What is here is only what sits BEHIND it,
-/// which is why the split falls where it does: this half mirrors
-/// `SpaceBarItemView`'s own box, and the two must stay in step on
-/// any fill or corner change.
+/// Front segment box background and frosted backdrop for SpaceBarOverlay.
 extension SpaceBarOverlay {
-    /// A Boxed-only fill box behind the front-app content, so the
-    /// segment reads as a chip like the Space items (Plain and
-    /// Material draw their shared plate under it instead). Sits
-    /// below the glyph/name, filled `fillColor`, rounded to match.
-    /// Mirrors `SpaceBarItemView`'s box (fill + corner) — keep the
-    /// two in step on any fill/corner change. The radius here
-    /// resolves from cross-axis `depth`; the chip's from
-    /// `min(width, height)` — they read alike but aren't identical.
+    /// Lays out Boxed fill or per-box glass for front application chip.
     func layoutFrontBox(
         _ app: SpaceBarItemView.App,
         from start: CGFloat,

--- a/Sources/KiwiDeskCore/Bar/StateBadgeView.swift
+++ b/Sources/KiwiDeskCore/Bar/StateBadgeView.swift
@@ -1,6 +1,10 @@
 import AppKit
 
-/// Metrics for Space Bar badge family sizing (#414).
+/// Metrics for Space Bar badge family sizing (#414): the count
+/// dot and state marks derive from ONE factor of the glyph cell
+/// so the family shrinks together — one home, since a resize
+/// touching one site would silently miss the others. 0.42→0.38,
+/// 8→7 (owner 2026-07-21).
 enum StateBadgeMetrics {
     static let sizeFactor: CGFloat = 0.38
     static let floor: CGFloat = 7
@@ -11,7 +15,9 @@ enum StateBadgeMetrics {
     }
 }
 
-/// Resolved tints for sticky and floating state mark rendering (#429).
+/// Resolved tints for sticky and floating state mark rendering
+/// (#429), carried as data from `KiwiCore` so the Bar subsystem
+/// never reaches into the sticky/floating namespaces itself.
 public struct StateMarkColors: Sendable, Equatable {
     public let sticky: String
     public let floating: String

--- a/Sources/KiwiDeskCore/Bar/StateBadgeView.swift
+++ b/Sources/KiwiDeskCore/Bar/StateBadgeView.swift
@@ -1,13 +1,6 @@
 import AppKit
 
-/// Shared size for the Space Bar's badge family (#414): the
-/// group-count dot and the sticky/floating state marks all
-/// derive from ONE factor of the glyph cell (floored for
-/// legibility on thin bars), so the three read as one family
-/// and shrink together. One home for the constant so a future
-/// resize can't touch one site and forget the other (§5
-/// mirror hygiene). Trimmed 0.42→0.38 / 8→7 (owner 2026-07-21,
-/// ui-designer consult).
+/// Metrics for Space Bar badge family sizing (#414).
 enum StateBadgeMetrics {
     static let sizeFactor: CGFloat = 0.38
     static let floor: CGFloat = 7
@@ -18,13 +11,7 @@ enum StateBadgeMetrics {
     }
 }
 
-/// The two state-mark tints resolved for one bar render (#429):
-/// the raw hex a sticky / floating badge glyph draws in (empty =
-/// "Automatic", resolved to the adaptive `.labelColor` by
-/// `NSColor.mark`). Carried as data from `KiwiCore` — which owns
-/// both `StickyStyle` and `FloatingStyle` — so the Bar subsystem
-/// renders the marks without reaching into the sticky/floating
-/// namespaces itself.
+/// Resolved tints for sticky and floating state mark rendering (#429).
 public struct StateMarkColors: Sendable, Equatable {
     public let sticky: String
     public let floating: String
@@ -35,14 +22,8 @@ public struct StateMarkColors: Sendable, Equatable {
     }
 }
 
-/// A Space Bar state badge (#414): the count badge's circular
-/// plate wearing a template symbol instead of a count, so the
-/// sticky/floating marks read as the same badge family. Since #429
-/// the fill carries the chosen state color (Automatic falls back
-/// to the count badge's own fill, so the default trio stays
-/// consistent) and the glyph on top is auto-contrasted for
-/// legibility — a filled disc shows its hue far better than a thin
-/// glyph stroke at the 7-9pt badge size (owner + ui-designer).
+/// Space Bar badge view displaying template symbol on circular plate
+/// (#414, #429).
 final class StateBadgeView: NSView {
     let symbol = NSImageView()
 

--- a/Sources/KiwiDeskCore/Borders/SizeLimitOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/SizeLimitOverlay.swift
@@ -1,7 +1,10 @@
 import AppKit
 import CoreGraphics
 
-/// Visual plate and overlay panel for minimum-size refusal pill (#933).
+/// Visual plate and overlay panel for minimum-size refusal pill
+/// (#933). One panel PER window: a blocked grow pills BOTH ends —
+/// the resized window and the blocking one — so two pills must be
+/// able to stand at once (owner ruling 2026-08-22).
 @MainActor
 final class SizeLimitOverlay {
     private struct Pill {

--- a/Sources/KiwiDeskCore/Borders/SizeLimitOverlay.swift
+++ b/Sources/KiwiDeskCore/Borders/SizeLimitOverlay.swift
@@ -1,15 +1,7 @@
 import AppKit
 import CoreGraphics
 
-/// Visual plate and panel for the minimum-size refusal pill (#933).
-///
-/// Flashed at the top-center of a window when a resize attempt
-/// runs into an effective minimum size (`min_window_size` or an
-/// app-enforced `EffectiveSizeBound`). Holds one panel PER
-/// window: a blocked grow pills BOTH ends — the resized window
-/// explains why nothing moved, the blocking window marks itself
-/// at its minimum — so two pills must be able to stand at once
-/// (owner ruling, 2026-08-22).
+/// Visual plate and overlay panel for minimum-size refusal pill (#933).
 @MainActor
 final class SizeLimitOverlay {
     private struct Pill {
@@ -27,7 +19,7 @@ final class SizeLimitOverlay {
 
     init() {}
 
-    /// Flashes the size-limit pill on `window` at `frame` (AX coordinates).
+    /// Flashes size-limit pill on window frame in AX coordinates (#933).
     func flash(
         window: CGWindowID,
         frame: CGRect,

--- a/Sources/KiwiDeskCore/Borders/SkyLightWindowEvents.swift
+++ b/Sources/KiwiDeskCore/Borders/SkyLightWindowEvents.swift
@@ -11,9 +11,7 @@ fileprivate typealias SkyLightNotifyProc =
     ) -> Void
 
 /// Process-lifetime WindowServer notification pump for focus borders
-/// (#285 Tier 2). Registration has no reliable public unregister seam,
-/// so callbacks never retain a `BorderManager`; the current manager is
-/// a weak sink that can be replaced after an in-process stop/start.
+/// (#285 Tier 2).
 @MainActor
 final class SkyLightWindowEvents {
     enum Kind: UInt32, CaseIterable {
@@ -38,9 +36,7 @@ final class SkyLightWindowEvents {
             }
         }
 
-        /// Geometry events (a move/resize burst) coalesce with an
-        /// adjacent one for the same window; control events never
-        /// do, so their order against geometry is preserved.
+        /// Indicates whether event represents geometry change.
         var isGeometry: Bool {
             self == .move || self == .resize
         }
@@ -175,13 +171,7 @@ final class SkyLightWindowEvents {
         self.manager = manager
     }
 
-    /// Requests notifications for these target windows. This private
-    /// API's replacement-vs-additive semantics are undocumented;
-    /// `lastRequested` only suppresses an identical repeat. If it is
-    /// additive, stale deliveries continue but the manager drops any
-    /// window it no longer watches (no overlay and not sticky-tracked
-    /// — see `handleSkyLightEvent`). An empty request is therefore a
-    /// best-effort clear, not a teardown guarantee.
+    /// Requests WindowServer event notifications for target window IDs.
     func watch(_ windows: Set<WindowID>) -> Bool {
         if lastRequested == windows { return true }
         guard let request = Self.requestNotifications else {

--- a/Sources/KiwiDeskCore/Borders/SkyLightWindowEvents.swift
+++ b/Sources/KiwiDeskCore/Borders/SkyLightWindowEvents.swift
@@ -10,8 +10,11 @@ fileprivate typealias SkyLightNotifyProc =
         UnsafeMutableRawPointer?
     ) -> Void
 
-/// Process-lifetime WindowServer notification pump for focus borders
-/// (#285 Tier 2).
+/// Process-lifetime WindowServer notification pump for focus
+/// borders (#285 Tier 2). Registration has no reliable public
+/// unregister seam, so callbacks never retain a `BorderManager`;
+/// the current manager is a weak sink replaceable after an
+/// in-process stop/start.
 @MainActor
 final class SkyLightWindowEvents {
     enum Kind: UInt32, CaseIterable {
@@ -36,7 +39,9 @@ final class SkyLightWindowEvents {
             }
         }
 
-        /// Indicates whether event represents geometry change.
+        /// Geometry events coalesce with an adjacent one for the
+        /// same window; control events never do, so their order
+        /// against geometry is preserved.
         var isGeometry: Bool {
             self == .move || self == .resize
         }
@@ -171,7 +176,10 @@ final class SkyLightWindowEvents {
         self.manager = manager
     }
 
-    /// Requests WindowServer event notifications for target window IDs.
+    /// Requests notifications for these windows. The private API's
+    /// replacement-vs-additive semantics are undocumented; stale
+    /// deliveries are dropped by the manager, and an empty request
+    /// is a best-effort clear, not a teardown guarantee.
     func watch(_ windows: Set<WindowID>) -> Bool {
         if lastRequested == windows { return true }
         guard let request = Self.requestNotifications else {

--- a/Sources/KiwiDeskCore/Commands/AppBarCommandSetting.swift
+++ b/Sources/KiwiDeskCore/Commands/AppBarCommandSetting.swift
@@ -131,7 +131,9 @@ enum AppBarCommandSetting {
         ]
     }
 
-    /// Color setting field constructors by wire key (#375).
+    /// Color setting field constructors by wire key. Internal, not
+    /// private: the palette shelf (#375) routes through these same
+    /// validated setters.
     static var colorFields: [String: (String) -> AppBarCommandSetting] {
         [
             "item_color": Self.itemColor,
@@ -165,7 +167,9 @@ enum AppBarCommandSetting {
         return .success(hex)
     }
 
-    /// Parses title character cap (#58).
+    /// Parses title character cap. Mirrors the SpaceBar twin,
+    /// including clamp-as-Double BEFORE `Int(...)` — `Int(1e300)`
+    /// traps, so a config typo would kill the WM (#58).
     private static func titleCap(
         _ args: [JSONValue]
     ) -> Result<AppBarCommandSetting, AppBarSettingError> {

--- a/Sources/KiwiDeskCore/Commands/AppBarCommandSetting.swift
+++ b/Sources/KiwiDeskCore/Commands/AppBarCommandSetting.swift
@@ -1,9 +1,7 @@
 import CoreGraphics
 import Foundation
 
-/// A bar-setter parse failure, carrying the message shown to the
-/// user. String-literal-expressible so parsers can just write
-/// `.failure("expected boolean")`.
+/// Bar setting error with user-facing message.
 struct AppBarSettingError: Error, Equatable,
     ExpressibleByStringInterpolation
 {
@@ -18,10 +16,7 @@ struct AppBarSettingError: Error, Equatable,
     }
 }
 
-/// One parsed bar assignment. Parsing (and its validation) lives
-/// here once; applying it targets either the global `AppBarStyle`
-/// (concrete, via `app_bar.set_*`) or a layout's `LayoutAppBar` (as an
-/// override, via `monocle.set_app_bar_*` / `scroll.set_app_bar_*`).
+/// Parsed App Bar command setting representation.
 enum AppBarCommandSetting {
     case edge(AppBarEdge)
     case alignment(AppBarStyle.BarAlignment)
@@ -48,9 +43,7 @@ enum AppBarCommandSetting {
     case groupBadgeColor(String)
     case groupBadgeTextColor(String)
 
-    /// Parses a setter `field` — the command name minus its
-    /// prefix (`thickness`, `active_style`, `item_color`, …) —
-    /// and its args. `.failure` carries the error message.
+    /// Parses setter field name and arguments.
     static func parse(
         field: String,
         args: [JSONValue]
@@ -138,11 +131,7 @@ enum AppBarCommandSetting {
         ]
     }
 
-    /// Wire-key → color-field constructor. Internal (not private)
-    /// so the palette shelf (#375) can route a color path through
-    /// the same validated field setters instead of re-mapping
-    /// them. Values are validated via `DragVisual.parseHex` before
-    /// this is called.
+    /// Color setting field constructors by wire key (#375).
     static var colorFields: [String: (String) -> AppBarCommandSetting] {
         [
             "item_color": Self.itemColor,
@@ -176,10 +165,7 @@ enum AppBarCommandSetting {
         return .success(hex)
     }
 
-    /// Mirrors `SpaceBarCommandSetting.glyphCap` — including the
-    /// clamp-as-Double-BEFORE-`Int(...)` order, because
-    /// `Int(1e300)` traps and a config typo would otherwise kill
-    /// the WM (#58).
+    /// Parses title character cap (#58).
     private static func titleCap(
         _ args: [JSONValue]
     ) -> Result<AppBarCommandSetting, AppBarSettingError> {
@@ -196,7 +182,7 @@ enum AppBarCommandSetting {
         return .success(.titleCap(Int(clamped)))
     }
 
-    /// Writes the value into the global style (concrete).
+    /// Applies concrete setting to AppBarStyle.
     func apply(to style: inout AppBarStyle) {
         switch self {
         case .edge(let value): style.edge = value

--- a/Sources/KiwiDeskCore/Commands/BarSettingChoice.swift
+++ b/Sources/KiwiDeskCore/Commands/BarSettingChoice.swift
@@ -1,22 +1,8 @@
 import Foundation
 
-/// Decodes an enum-valued bar setting, and builds its "expected"
-/// message from the enum's own cases (#1033).
-///
-/// Shared by `AppBarCommandSetting` and `SpaceBarCommandSetting`,
-/// which each carried a copy taking that message as a hand-typed
-/// STRING — and both had gone stale the same way:
-/// `active_indicator` told the user to send `ring|edge_mark|gap`
-/// long after the case was renamed `outline`, so the error named
-/// a value its own decoder would reject. Two copies of a list
-/// nothing derives is how that happens twice.
-///
-/// Reading `allCases` here is the same derivation `APIChoice`
-/// makes for `list_commands`: the values a caller is told about
-/// and the values a caller may send are one list, in one place.
+/// Decodes enum bar setting and formats validation error from cases (#1033).
 enum BarSettingChoice {
-    /// The decoded value, or a failure naming every legal
-    /// spelling in the order the enum declares them.
+    /// Decodes value or returns failure listing expected enum cases.
     static func value<T: APIChoiceType>(
         _ args: [JSONValue],
         _ type: T.Type

--- a/Sources/KiwiDeskCore/Commands/Reference/APIChoiceType+Expected.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIChoiceType+Expected.swift
@@ -1,32 +1,15 @@
 import Foundation
 
-/// The one derivation behind "here is what I do accept" (#1033).
-///
-/// A decoder that rejects a value owes the caller the list of
-/// values it would have taken, and that list is the enum's, not
-/// a sentence beside it. Two of these had already gone stale
-/// identically — both bars told the user to send
-/// `ring|edge_mark|gap` long after the case was renamed
-/// `outline` — and the reason is that a hand-typed list is
-/// right on the day it is written and silent every day after.
-///
-/// `quit.set_layout` had derived its message this way since it
-/// shipped; this is that call site's shape, made shareable so
-/// every enum-valued setter can take it.
+/// Dynamic choice type enumeration string derivation for commands (#1033).
 extension APIChoiceType {
-    /// Every case's wire spelling, `a|b|c`, in declaration
-    /// order — the same order `list_commands` prints.
+    /// Pipe-delimited wire spellings in declaration order.
     public static var expectedList: String {
         allCases.map(\.rawValue).joined(separator: "|")
     }
 }
 
 extension CommandResponse {
-    /// A rejection naming every value `type` accepts.
-    ///
-    /// Takes the TYPE, never a message, for the same reason
-    /// `APIArgument.choice` does: a call site that cannot spell
-    /// the list cannot spell it wrongly.
+    /// Rejection naming accepted choice values derived from type (#1033).
     public static func expected<T: APIChoiceType>(
         _ type: T.Type
     ) -> CommandResponse {

--- a/Sources/KiwiDeskCore/Commands/Reference/APIChoiceType+Expected.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIChoiceType+Expected.swift
@@ -9,7 +9,9 @@ extension APIChoiceType {
 }
 
 extension CommandResponse {
-    /// Rejection naming accepted choice values derived from type (#1033).
+    /// Rejection naming accepted choice values (#1033). Takes the
+    /// TYPE, never a message: a call site that cannot spell the
+    /// list cannot spell it wrongly.
     public static func expected<T: APIChoiceType>(
         _ type: T.Type
     ) -> CommandResponse {

--- a/Sources/KiwiDeskCore/Commands/Reference/APIChoiceTypes.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIChoiceTypes.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Census of all enum types accepted by command API arguments (#1033).
+// Census of all enum types accepted by command API arguments
+// (#1033), declared centrally so one file answers "what enums
+// does the API expose". `CaseIterable` stays at each enum's own
+// declaration — Swift synthesizes `allCases` only there.
 
 extension KiwiNotification: APIChoiceType {}
 
@@ -24,6 +27,8 @@ extension MonocleParams.HideStyle: APIChoiceType {}
 extension TrackParams.Axis: APIChoiceType {}
 extension TrackParams.NewWindowTrack: APIChoiceType {}
 
+// `SpaceBarStyle` spells its vocabulary as typealiases of these,
+// so conforming the `AppBarStyle` types covers both bars.
 extension AppBarEdge: APIChoiceType {}
 extension AppBarStyle.BarAlignment: APIChoiceType {}
 extension AppBarStyle.BackgroundStyle: APIChoiceType {}

--- a/Sources/KiwiDeskCore/Commands/Reference/APIChoiceTypes.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIChoiceTypes.swift
@@ -1,23 +1,8 @@
 import Foundation
 
-// The census of every enum an API argument can take (#1033).
-//
-// A conformance here is what lets `APIArgument.choice` read a
-// decoder's cases instead of a record re-typing them. The list
-// is the whole vocabulary the Lua/CLI surface accepts, so the
-// conformance is declared once, centrally, rather than beside
-// each enum: a reader asking "what enums does the API expose?"
-// has one file to read, and phase 2 of #1033 writes records
-// without touching the derivation.
-//
-// `CaseIterable` itself is declared at each enum's own
-// declaration — Swift synthesizes `allCases` only there.
-
-// MARK: - Events
+/// Census of all enum types accepted by command API arguments (#1033).
 
 extension KiwiNotification: APIChoiceType {}
-
-// MARK: - Navigation & modes
 
 extension Direction: APIChoiceType {}
 extension LayoutMode: APIChoiceType {}
@@ -25,8 +10,6 @@ extension SpawnPlacement: APIChoiceType {}
 extension MouseResizeMode: APIChoiceType {}
 extension SizePolicy: APIChoiceType {}
 extension QuitLayoutStyle: APIChoiceType {}
-
-// MARK: - Layout parameters
 
 extension BspParams.Strategy: APIChoiceType {}
 extension ScrollingParams.Anchor: APIChoiceType {}
@@ -41,10 +24,6 @@ extension MonocleParams.HideStyle: APIChoiceType {}
 extension TrackParams.Axis: APIChoiceType {}
 extension TrackParams.NewWindowTrack: APIChoiceType {}
 
-// MARK: - Bars
-
-// `SpaceBarStyle` spells its own vocabulary as typealiases of
-// these, so conforming the `AppBarStyle` types covers both bars.
 extension AppBarEdge: APIChoiceType {}
 extension AppBarStyle.BarAlignment: APIChoiceType {}
 extension AppBarStyle.BackgroundStyle: APIChoiceType {}
@@ -52,8 +31,6 @@ extension AppBarStyle.BackgroundFit: APIChoiceType {}
 extension AppBarStyle.ActiveIndicator: APIChoiceType {}
 extension AppBarStyle.Content: APIChoiceType {}
 extension BarAppIconSource: APIChoiceType {}
-
-// MARK: - Borders & drag visuals
 
 extension BorderStyle.CornerStyle: APIChoiceType {}
 extension BorderStyle.DrawOrder: APIChoiceType {}

--- a/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
+++ b/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
@@ -1,11 +1,7 @@
 import CoreGraphics
 import Foundation
 
-/// One parsed `space_bar.set_*` assignment (#293). Sibling of
-/// `AppBarCommandSetting` with a single apply switch — the Space
-/// Bar is global-only, so there is no override variant. Reuses
-/// the App Bar's error type: the two parsers speak the same
-/// vocabulary and their messages must not drift.
+/// Parsed `space_bar.set_*` command setting representation (#293).
 enum SpaceBarCommandSetting {
     case enabled(Bool)
     case edge(AppBarEdge)
@@ -38,8 +34,7 @@ enum SpaceBarCommandSetting {
     case groupBadgeColor(String)
     case groupBadgeTextColor(String)
 
-    /// Parses a setter `field` (the command name minus
-    /// `space_bar.set_`) and its args.
+    /// Parses a setter field and its arguments into SpaceBarCommandSetting.
     static func parse(
         field: String,
         args: [JSONValue]
@@ -135,9 +130,7 @@ enum SpaceBarCommandSetting {
         ]
     }
 
-    /// Wire-key → color-field constructor. Internal (not private)
-    /// so the palette shelf (#375) can route a color path through
-    /// the same validated field setters; see the AppBar twin.
+    /// Color setting field constructors by wire key (#375).
     static var colorFields: [String: (String) -> SpaceBarCommandSetting] {
         [
             "item_color": Self.itemColor,
@@ -152,9 +145,7 @@ enum SpaceBarCommandSetting {
         ]
     }
 
-    /// Milliseconds, clamped to the Space Bar's valid dwell
-    /// range — a stored out-of-range value can't spring instantly
-    /// or hang.
+    /// Parses dwell spring delay in milliseconds (#58, #386).
     private static func springDelay(
         _ args: [JSONValue]
     ) -> Result<SpaceBarCommandSetting, AppBarSettingError> {
@@ -164,8 +155,7 @@ enum SpaceBarCommandSetting {
             return .failure("expected milliseconds")
         }
         let range = SpaceBarStyle.springDelayRange
-        // Clamp as Double BEFORE Int(...) — `Int(1e300)` traps,
-        // so a config typo would otherwise kill the WM (#58/#386).
+        // Clamp as Double before Int conversion (#58, #386).
         let clamped = min(
             max(value.rounded(), Double(range.lowerBound)),
             Double(range.upperBound)
@@ -173,10 +163,7 @@ enum SpaceBarCommandSetting {
         return .success(.springDelay(Int(clamped)))
     }
 
-    /// Front-segment title length in characters. Mirrors
-    /// `glyphCap` below, including the
-    /// clamp-as-Double-BEFORE-`Int(...)` order (#58), and reads
-    /// the range both bars share.
+    /// Parses title character cap (#58).
     private static func titleCap(
         _ args: [JSONValue]
     ) -> Result<SpaceBarCommandSetting, AppBarSettingError> {
@@ -193,9 +180,7 @@ enum SpaceBarCommandSetting {
         return .success(.titleCap(Int(clamped)))
     }
 
-    /// App-group glyph count, clamped to the Space Bar's valid
-    /// cap range (#376) — a stored out-of-range value can't
-    /// render an empty item or an unscannable row.
+    /// Parses app glyph count cap (#58, #376).
     private static func glyphCap(
         _ args: [JSONValue]
     ) -> Result<SpaceBarCommandSetting, AppBarSettingError> {
@@ -205,8 +190,7 @@ enum SpaceBarCommandSetting {
             return .failure("expected a glyph count")
         }
         let range = SpaceBarStyle.glyphCapRange
-        // Clamp as Double BEFORE Int(...) — `Int(1e300)` traps,
-        // so a config typo would otherwise kill the WM (#58).
+        // Clamp as Double before Int conversion (#58).
         let clamped = min(
             max(value.rounded(), Double(range.lowerBound)),
             Double(range.upperBound)
@@ -234,8 +218,7 @@ enum SpaceBarCommandSetting {
         return .success(hex)
     }
 
-    /// Writes the value into the global style — the only apply
-    /// target (no per-layout mirror).
+    /// Applies setting value to SpaceBarStyle.
     func apply(to style: inout SpaceBarStyle) {
         switch self {
         case .enabled(let value): style.enabled = value

--- a/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
+++ b/Sources/KiwiDeskCore/Commands/SpaceBarCommandSetting.swift
@@ -1,7 +1,9 @@
 import CoreGraphics
 import Foundation
 
-/// Parsed `space_bar.set_*` command setting representation (#293).
+/// Parsed `space_bar.set_*` command setting representation
+/// (#293). Reuses the App Bar's error type: the two parsers speak
+/// one vocabulary and their messages must not drift.
 enum SpaceBarCommandSetting {
     case enabled(Bool)
     case edge(AppBarEdge)
@@ -130,7 +132,9 @@ enum SpaceBarCommandSetting {
         ]
     }
 
-    /// Color setting field constructors by wire key (#375).
+    /// Color setting field constructors by wire key. Internal, not
+    /// private: the palette shelf (#375) routes through these same
+    /// validated setters; see the AppBar twin.
     static var colorFields: [String: (String) -> SpaceBarCommandSetting] {
         [
             "item_color": Self.itemColor,
@@ -155,7 +159,8 @@ enum SpaceBarCommandSetting {
             return .failure("expected milliseconds")
         }
         let range = SpaceBarStyle.springDelayRange
-        // Clamp as Double before Int conversion (#58, #386).
+        // Clamp as Double BEFORE Int(...) — `Int(1e300)` traps, so
+        // a config typo would kill the WM (#58/#386).
         let clamped = min(
             max(value.rounded(), Double(range.lowerBound)),
             Double(range.upperBound)
@@ -190,7 +195,8 @@ enum SpaceBarCommandSetting {
             return .failure("expected a glyph count")
         }
         let range = SpaceBarStyle.glyphCapRange
-        // Clamp as Double before Int conversion (#58).
+        // Clamp as Double BEFORE Int(...) — `Int(1e300)` traps
+        // (#58).
         let clamped = min(
             max(value.rounded(), Double(range.lowerBound)),
             Double(range.upperBound)

--- a/Sources/KiwiDeskCore/Commands/ZOrderGeneration.swift
+++ b/Sources/KiwiDeskCore/Commands/ZOrderGeneration.swift
@@ -1,22 +1,7 @@
 import Foundation
 
-/// The z-order raise generation (#418/#425), in a lock rather
-/// than on the main actor: the drain reads it between raises from
-/// `zOrderQueue` to abandon a sequence a newer one has superseded
-/// (#684), and every other reader is main-actor code that would
-/// otherwise have to hop threads to answer it. It lives beside
-/// the drain rather than in `App/` with the property that holds
-/// it because the off-actor read is the only reason it is not
-/// still an `Int` — a deliberate placement, not an oversight.
-///
-/// **One minting site: `stampZOrderRaise`, on the main actor.**
-/// The compiler used to enforce that by isolation and no longer
-/// can: `@unchecked Sendable` makes a `bump()` from the raise
-/// queue compile, and it would silently invalidate every
-/// in-flight sequence's identity — the identity #684 spent a
-/// round unifying, since one generation now keys the drain's
-/// staleness check, the stamp release and the focus handoff.
-/// Read it anywhere; mint it in one place.
+/// Thread-safe generation counter for z-order raise sequences (#418, #684).
+/// Only minted by `stampZOrderRaise` on MainActor.
 final class ZOrderGeneration: @unchecked Sendable {
     private let lock = NSLock()
     private var current = 0

--- a/Sources/KiwiDeskCore/Commands/ZOrderGeneration.swift
+++ b/Sources/KiwiDeskCore/Commands/ZOrderGeneration.swift
@@ -1,7 +1,11 @@
 import Foundation
 
-/// Thread-safe generation counter for z-order raise sequences (#418, #684).
-/// Only minted by `stampZOrderRaise` on MainActor.
+/// Z-order raise generation (#418/#425) in a lock, not on the
+/// main actor: the drain reads it between raises to abandon a
+/// superseded sequence (#684). Minted ONLY by `stampZOrderRaise`
+/// on MainActor — `@unchecked Sendable` makes an off-actor
+/// `bump()` compile, and it would silently invalidate every
+/// in-flight sequence's identity.
 final class ZOrderGeneration: @unchecked Sendable {
     private let lock = NSLock()
     private var current = 0

--- a/Sources/KiwiDeskCore/Config/ConfigMigration+Stamping.swift
+++ b/Sources/KiwiDeskCore/Config/ConfigMigration+Stamping.swift
@@ -1,21 +1,10 @@
 import Foundation
 
-/// The format-stamp half of the crossing (#938), and the one
-/// step that changes a file's SHAPE rather than a value
-/// (#939) - split from `ConfigMigration.swift` for file
-/// size (AGENTS.md 2.1).
+/// Format stamping and document structure migrations
+/// (`ConfigMigrationRoutingTests`, #938, #939).
 extension ConfigMigration {
-    /// Lifts a legacy bare array of color palettes into the wrapped
-    /// document format `{"format": 1, "palettes": [...]}` (#939).
-    ///
-    /// ASSUMES any top-level JSON array is a legacy palettes
-    /// file — true only because palettes.json is the sole
-    /// array-rooted file among the routed readers
-    /// (`ConfigMigrationRoutingTests` is the census; a second
-    /// array-rooted shape must give this step a narrower gate
-    /// on arrival). An array handed to `readBackup` gets
-    /// wrapped and then refused as not-a-bundle — harmless, but
-    /// the assumption is this sentence, not a law.
+    /// Wraps legacy palette array into format document
+    /// (`PaletteDocument`, #939).
     @Sendable
     static func migratingLegacyPalettesArray(
         _ data: Data
@@ -35,15 +24,7 @@ extension ConfigMigration {
         )
     }
 
-    /// Stamps the target format into `data` if not already
-    /// current (#938).
-    ///
-    /// Shares the envelope with the two rewriting steps
-    /// (`surgicallyApplying`) but differs at the edges in one
-    /// way worth naming: it returns `Data`, never nil, because a
-    /// caller stamps unconditionally and wants the bytes back
-    /// either way. "Nothing changed" therefore reads as
-    /// `?? data` here rather than as a nil the caller inspects.
+    /// Stamps target format integer into JSON document payload (#938).
     static func stamped(_ data: Data) -> Data {
         guard
             let root = try? JSONSerialization.jsonObject(

--- a/Sources/KiwiDeskCore/Config/ConfigMigration+Stamping.swift
+++ b/Sources/KiwiDeskCore/Config/ConfigMigration+Stamping.swift
@@ -4,7 +4,11 @@ import Foundation
 /// (`ConfigMigrationRoutingTests`, #938, #939).
 extension ConfigMigration {
     /// Wraps legacy palette array into format document
-    /// (`PaletteDocument`, #939).
+    /// (`PaletteDocument`, #939). ASSUMES any top-level JSON array
+    /// is a legacy palettes file — true only while palettes.json
+    /// is the sole array-rooted routed reader
+    /// (`ConfigMigrationRoutingTests`); a second array-rooted
+    /// shape must give this step a narrower gate.
     @Sendable
     static func migratingLegacyPalettesArray(
         _ data: Data

--- a/Sources/KiwiDeskCore/Config/KeyLayer.swift
+++ b/Sources/KiwiDeskCore/Config/KeyLayer.swift
@@ -1,13 +1,11 @@
 import Foundation
 
-/// One keybinding layer: a named set of shortcut rows plus an
-/// optional menu bar indicator (SF Symbol name or flat emoji).
+/// Keybinding layer model representing shortcuts and optional bar icon.
 public struct KeyLayer: Codable, Equatable, Sendable,
     Identifiable
 {
     public var name: String
-    /// SF Symbol name (`arrow.left.and.right`) or emoji
-    /// (`📐`). Nil for the default layer's standard icon.
+    /// SF Symbol name or emoji icon. Nil for default layer.
     public var icon: String?
     public var bindings: [KeyBinding]
 
@@ -23,7 +21,7 @@ public struct KeyLayer: Codable, Equatable, Sendable,
         self.bindings = bindings
     }
 
-    /// The always-present default layer (`KiwiDesk.bind`).
+    /// The default keybinding layer (`default`).
     public static let defaultLayer = KeyLayer(
         name: KeyLayer.defaultName
     )
@@ -32,12 +30,11 @@ public struct KeyLayer: Codable, Equatable, Sendable,
     public var isDefault: Bool { name == Self.defaultName }
 }
 
-/// One shortcut row: a key combo bound to a Lua action.
+/// Shortcut row binding a key combo to a Lua action string.
 public struct KeyBinding: Codable, Equatable, Sendable,
     Identifiable
 {
-    /// How the action was authored — display only; the writer
-    /// only consumes `lua`.
+    /// Authoring category for display in settings UI.
     public enum Kind: String, Codable, Sendable {
         case navigation
         case application
@@ -47,8 +44,7 @@ public struct KeyBinding: Codable, Equatable, Sendable,
     public var id = UUID()
     /// Key combo string (`"alt+h"`); empty while unrecorded.
     public var combo: String
-    /// The Lua statement(s) run on trigger — the body placed
-    /// inside `function() ... end`.
+    /// Lua action executed on key trigger.
     public var lua: String
     public var kind: Kind
     /// Row label shown in the editor (nav name / app name).
@@ -101,9 +97,7 @@ public struct KeyBinding: Codable, Equatable, Sendable,
         try container.encode(label, forKey: .label)
     }
 
-    /// `id` is a transient row handle (not persisted), so it is
-    /// excluded from equality — two rows with the same content
-    /// are equal even across a save/load cycle.
+    /// Compares equality of binding content ignoring transient UUID.
     public static func == (
         lhs: KeyBinding,
         rhs: KeyBinding
@@ -112,13 +106,7 @@ public struct KeyBinding: Codable, Equatable, Sendable,
             && lhs.kind == rhs.kind && lhs.label == rhs.label
     }
 
-    /// Semantic identity for the override cascade (#55):
-    /// combo + lua only. `kind` and `label` are display-only
-    /// metadata — the GUI import classifier may upgrade them
-    /// (`.custom` → `.navigation`, label filled), and that
-    /// must never read as divergence from the base, or an
-    /// unchanged edit session would persist spurious profile
-    /// overrides.
+    /// Semantic identity comparison for profile override cascades (#55).
     public func sameAction(as other: KeyBinding) -> Bool {
         combo == other.combo && lua == other.lua
     }

--- a/Sources/KiwiDeskCore/Config/KeyLayer.swift
+++ b/Sources/KiwiDeskCore/Config/KeyLayer.swift
@@ -106,7 +106,10 @@ public struct KeyBinding: Codable, Equatable, Sendable,
             && lhs.kind == rhs.kind && lhs.label == rhs.label
     }
 
-    /// Semantic identity comparison for profile override cascades (#55).
+    /// Semantic identity for the override cascade (#55): combo +
+    /// lua only. The import classifier may upgrade `kind`/`label`,
+    /// and that must never read as divergence from the base, or an
+    /// unchanged edit session persists spurious overrides.
     public func sameAction(as other: KeyBinding) -> Bool {
         combo == other.combo && lua == other.lua
     }

--- a/Sources/KiwiDeskCore/Config/LuaLiteral.swift
+++ b/Sources/KiwiDeskCore/Config/LuaLiteral.swift
@@ -1,14 +1,9 @@
 import CoreGraphics
 import Foundation
 
-/// Formats Swift values as Lua source literals for the config
-/// writer. Deterministic output (stable across runs) so the
-/// generated managed block only changes when settings do.
+/// Formats and parses Swift values as Lua source literals for config writer.
 enum LuaLiteral {
-    /// Integers print without a decimal point; fractions use
-    /// Swift's shortest round-trippable form (`0.5`, `0.62`,
-    /// `0.3333333333333333`) so a value survives write→reload
-    /// exactly. Non-finite values fall back to `0`.
+    /// Formats numbers with minimal round-trippable precision.
     static func number(_ value: Double) -> String {
         guard value.isFinite else { return "0" }
         if value.rounded() == value && abs(value) < 1e15 {
@@ -25,7 +20,7 @@ enum LuaLiteral {
         value ? "true" : "false"
     }
 
-    /// A double-quoted, escaped Lua string.
+    /// Returns double-quoted escaped Lua string literal.
     static func string(_ value: String) -> String {
         var escaped = ""
         for character in value {
@@ -41,12 +36,7 @@ enum LuaLiteral {
         return "\"" + escaped + "\""
     }
 
-    /// The exact inverse of `string(_:)`: the value inside a
-    /// canonical quoted literal, or nil when `literal` is not
-    /// in the form this writer emits (unquoted, an escape this
-    /// writer never authors, a dangling backslash). Strict on
-    /// purpose — callers use it to recognize *generated* Lua
-    /// (#92), never to parse arbitrary hand-written source.
+    /// Inverse of string(_:) recognizing canonical quoted literals (#92).
     static func parseString(_ literal: String) -> String? {
         guard literal.count >= 2, literal.hasPrefix("\""),
             literal.hasSuffix("\"")

--- a/Sources/KiwiDeskCore/Events/EventBus.swift
+++ b/Sources/KiwiDeskCore/Events/EventBus.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// Events external tools can subscribe to (SketchyBar,
-/// JankyBorders, Hammerspoon) via socket or Lua callbacks.
+/// Events external tools can subscribe to via socket or Lua callbacks.
 public enum KiwiNotification: String, CaseIterable, Sendable,
     Codable
 {
@@ -10,24 +9,13 @@ public enum KiwiNotification: String, CaseIterable, Sendable,
     case focusChange = "focus_change"
     case monitorChange = "monitor_change"
     case desktopChange = "desktop_change"
-    // Lifecycle events carry a `reason` (#40), spelled by
-    // `WindowAppearReason` / `WindowGoneReason` — the one copy
-    // of that vocabulary, so a value added there (`.hidden`,
-    // #913) does not owe an edit here. The old
-    // `window_minimized` event was retired into
-    // `reason: minimized` (pre-release, no compat alias per
-    // AGENTS §5).
+    // Lifecycle events carry a `reason` (#40, #913).
     case windowCreated = "window_created"
     case windowDestroyed = "window_destroyed"
     case windowMovedToSpace = "window_moved_to_space"
 }
 
-/// Fans events out to Lua callbacks and generic sinks (the
-/// socket server registers one sink per subscriber).
-///
-/// Per the sandbox rules, a Lua callback that errors or times
-/// out is logged and disabled — one bad callback never breaks
-/// the event stream.
+/// Fans events out to Lua callbacks and generic sinks.
 @MainActor
 public final class EventBus {
     public typealias Sink =
@@ -40,8 +28,6 @@ public final class EventBus {
     private var sinks: [UUID: Sink] = [:]
 
     public init() {}
-
-    // MARK: - Subscriptions
 
     /// Registers a Lua callback (`KiwiDesk.on(event, fn)`).
     public func on(_ event: KiwiNotification, ref: Int32) {
@@ -71,8 +57,6 @@ public final class EventBus {
         }
         luaCallbacks = [:]
     }
-
-    // MARK: - Emission
 
     /// Notifies sinks (JSON payload) and Lua callbacks
     /// (positional arguments, e.g. `(space_id, mode)`).

--- a/Sources/KiwiDeskCore/Events/EventBus.swift
+++ b/Sources/KiwiDeskCore/Events/EventBus.swift
@@ -9,13 +9,18 @@ public enum KiwiNotification: String, CaseIterable, Sendable,
     case focusChange = "focus_change"
     case monitorChange = "monitor_change"
     case desktopChange = "desktop_change"
-    // Lifecycle events carry a `reason` (#40, #913).
+    // Lifecycle events carry a `reason` (#40), spelled by
+    // `WindowAppearReason` / `WindowGoneReason` — the one copy of
+    // that vocabulary, so a value added there (#913) owes no edit
+    // here.
     case windowCreated = "window_created"
     case windowDestroyed = "window_destroyed"
     case windowMovedToSpace = "window_moved_to_space"
 }
 
-/// Fans events out to Lua callbacks and generic sinks.
+/// Fans events out to Lua callbacks and generic sinks. A Lua
+/// callback that errors or times out is logged and disabled — one
+/// bad callback never breaks the event stream.
 @MainActor
 public final class EventBus {
     public typealias Sink =

--- a/Sources/KiwiDeskCore/Keys/KeybindingImporter.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingImporter.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-/// Reconstructs `[KeyLayer]` from live keybindings (`LuaBindingBody`, #4).
+/// Reconstructs `[KeyLayer]` from live keybindings
+/// (`LuaBindingBody`, #4). A row whose action cannot be recovered
+/// is DROPPED, never emitted with an empty body — an empty body
+/// would overwrite a working binding with a no-op on the next
+/// save.
 @MainActor
 enum KeybindingImporter {
     /// Builds layers from manager reading binding source bodies

--- a/Sources/KiwiDeskCore/Keys/KeybindingImporter.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingImporter.swift
@@ -1,26 +1,10 @@
 import Foundation
 
-/// Reconstructs the GUI's `[KeyLayer]` from the live keybindings
-/// (#4). Each bound `(KeyCombo, ref)` becomes a row: the combo is
-/// formatted back to its canonical string, and the action text is
-/// recovered from the source file via `debug.getinfo`'s line
-/// range (`LuaBindingBody`).
-///
-/// Every recovered row is emitted as `.custom` holding the raw
-/// body; the GUI upgrades exact catalog matches to
-/// `.navigation`/`.application` afterwards, since only the GUI
-/// knows that catalog. A row whose action cannot be recovered is
-/// dropped rather than emitted with an empty body — an empty body
-/// would overwrite a working binding with a no-op on the next
-/// save. Combos alone are never enough (issue #4).
-///
-/// `@MainActor`: reads the main-actor `LuaInterpreter` and
-/// `KeybindingManager`, matching its only caller,
-/// `KiwiCore.recoverKeybindings`.
+/// Reconstructs `[KeyLayer]` from live keybindings (`LuaBindingBody`, #4).
 @MainActor
 enum KeybindingImporter {
-    /// Builds layers from `manager`, reading each binding's source
-    /// through `interpreter` and `readFile` (path → contents).
+    /// Builds layers from manager reading binding source bodies
+    /// (`KiwiCore.recoverKeybindings`).
     static func layers(
         from manager: KeybindingManager,
         interpreter: LuaInterpreter,

--- a/Sources/KiwiDeskCore/Keys/KeybindingMerge.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingMerge.swift
@@ -1,7 +1,10 @@
 import Foundation
 
-/// Folds recovered keybinding layers into GuiConfig on shortcut import
-/// (#4, #55).
+/// Folds recovered keybinding layers into GuiConfig on shortcut
+/// import (#4): rows upsert by combo so re-import refreshes, not
+/// duplicates. Sibling `KeyLayerOverride.resolved(onto:)` (#55)
+/// merges the same key with OPPOSITE icon precedence — both are
+/// correct for their direction; do not unify them.
 public enum KeybindingMerge {
     /// Merges every recovered layer into `config` in place.
     public static func merge(

--- a/Sources/KiwiDeskCore/Keys/KeybindingMerge.swift
+++ b/Sources/KiwiDeskCore/Keys/KeybindingMerge.swift
@@ -1,16 +1,7 @@
 import Foundation
 
-/// Folds recovered keybinding layers into an edited `GuiConfig`
-/// for the GUI's "Import current shortcuts" (#4): layers are
-/// matched by name (appended when new) and rows upserted by their
-/// combo, so re-importing refreshes an existing shortcut instead
-/// of duplicating it. Pure and Core-typed, so the dedup logic the
-/// import depends on is unit-tested without the SwiftUI layer.
-///
-/// Sibling keyed merge: `KeyLayerOverride.resolved(onto:)` (#55
-/// profile override) merges by the same name×combo key but with
-/// the OPPOSITE icon precedence (override-wins). Both are
-/// correct for their direction — do not unify them.
+/// Folds recovered keybinding layers into GuiConfig on shortcut import
+/// (#4, #55).
 public enum KeybindingMerge {
     /// Merges every recovered layer into `config` in place.
     public static func merge(
@@ -22,9 +13,7 @@ public enum KeybindingMerge {
         }
     }
 
-    /// Folds one recovered layer into `config` — updating the
-    /// same-named layer's rows, or appending the layer when new. An
-    /// existing layer keeps its icon unless it had none.
+    /// Folds one recovered layer into config, preserving existing layer icons.
     private static func merge(
         _ recovered: KeyLayer,
         into config: inout GuiConfig

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle+Coding.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle+Coding.swift
@@ -1,9 +1,14 @@
 import CoreGraphics
 import Foundation
 
-/// AppBarStyle Decodable implementation and CodingKeys (`AppBarParityTests`).
+/// AppBarStyle Decodable implementation and CodingKeys. The
+/// `Codable` conformance stays in `AppBarStyle.swift` so encode
+/// is synthesized there; a property absent from `CodingKeys` is
+/// silently not encoded — `AppBarParityTests` is the net.
 extension AppBarStyle {
-    /// JSON coding keys for AppBarStyle (`AppBarParityTests`).
+    /// JSON keys are the Lua setters minus `set_`. `CaseIterable`
+    /// is load-bearing — `AppBarParityTests` reflects over
+    /// `allCases`; do not drop it as "unused".
     enum CodingKeys: String, CodingKey, CaseIterable {
         case edge
         case alignment

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle+Coding.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle+Coding.swift
@@ -1,29 +1,9 @@
 import CoreGraphics
 import Foundation
 
-/// `AppBarStyle`'s wire form, split out of the type's own file at
-/// the 350-line ceiling (AGENTS.md §2.1) — the same arrangement
-/// `SpaceBarStyle+Coding.swift` already carries, and for the same
-/// reason.
-///
-/// The `Codable` conformance deliberately stays in
-/// `AppBarStyle.swift`: Swift only synthesizes `encode(to:)`
-/// where the conformance sits, so keeping it there leaves encode
-/// generated rather than hand-written — one fewer field list to
-/// forget. It is NOT a guarantee that a new stored property
-/// reaches the wire: a property absent from `CodingKeys` below
-/// is silently not encoded, with no error. `AppBarParityTests`
-/// (reflection over `CodingKeys.allCases` against the struct's
-/// fields) is the actual net for that.
-///
-/// Sparse by design — every field falls back to `defaults`, so a
-/// profile written before a field existed still loads.
+/// AppBarStyle Decodable implementation and CodingKeys (`AppBarParityTests`).
 extension AppBarStyle {
-    /// JSON keys are the Lua setters (`app_bar.set_*`) minus the
-    /// `set_` verb — the `app_bar` nesting carries the namespace.
-    /// `CaseIterable` is load-bearing: the parity test
-    /// (`AppBarParityTests`) reflects over `allCases` to prove
-    /// every field has a key — do not drop it as "unused".
+    /// JSON coding keys for AppBarStyle (`AppBarParityTests`).
     enum CodingKeys: String, CodingKey, CaseIterable {
         case edge
         case alignment
@@ -51,8 +31,7 @@ extension AppBarStyle {
         case groupBadgeTextColor = "group_badge_text_color"
     }
 
-    /// Manual decoding: profiles saved before a field existed
-    /// must keep loading (missing keys fall back to defaults).
+    /// Decodes AppBarStyle falling back to defaults for missing keys.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle+CopyAppearance.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle+CopyAppearance.swift
@@ -1,23 +1,11 @@
 import CoreGraphics
 import Foundation
 
-/// The one-shot "Copy sizes and style from Space Bar…" action —
-/// the REVERSED twin of `SpaceBarStyle.copyAppearance(from:)`
-/// (owner flipped the direction 2026-08-10: the button sits at
-/// the App Bar card's tail, and a button there should fill in
-/// THIS card's bar from the one already configured, not push
-/// outward). Same contract: a one-time copy of the structural
-/// fields the two styles share, never a live inherit, colours
-/// excluded (Advanced Colours owns any colours-copy).
-///
-/// The copied set is `SpaceBarStyle.copyAppearanceKeys` — the
-/// intersection is symmetric, so this direction deliberately
-/// consumes the SAME set rather than minting a second one; the
-/// exclusions and the colour class live there once.
-/// `SpaceBarParityTests` pins that every shared key changes a
-/// field in BOTH directions.
+/// Appearance copy action from SpaceBarStyle to AppBarStyle
+/// (`SpaceBarParityTests`).
 extension AppBarStyle {
-    /// Copies every shared appearance field from `spaceBar`.
+    /// Copies shared appearance fields from `spaceBar`
+    /// (`SpaceBarStyle.copyAppearanceKeys`).
     public mutating func copyAppearance(
         from spaceBar: SpaceBarStyle
     ) {

--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle+CopyAppearance.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle+CopyAppearance.swift
@@ -1,8 +1,11 @@
 import CoreGraphics
 import Foundation
 
-/// Appearance copy action from SpaceBarStyle to AppBarStyle
-/// (`SpaceBarParityTests`).
+/// Appearance copy action from SpaceBarStyle to AppBarStyle: a
+/// one-time copy of shared structural fields, never a live
+/// inherit, colours excluded. Deliberately consumes
+/// `SpaceBarStyle.copyAppearanceKeys` rather than minting a
+/// second set (`SpaceBarParityTests` pins both directions).
 extension AppBarStyle {
     /// Copies shared appearance fields from `spaceBar`
     /// (`SpaceBarStyle.copyAppearanceKeys`).

--- a/Sources/KiwiDeskCore/Layouts/BspLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/BspLayout.swift
@@ -1,11 +1,6 @@
 import CoreGraphics
 
-/// Binary space partitioning over a flat array (dwindle style):
-/// the first window claims the split ratio of the region, the
-/// rest recurse into the remainder. Side-by-side splits use
-/// `splitRatioH`, stacked splits `splitRatioV` (#56) — two
-/// per-space scalars, not per-node ratios (those need stable
-/// split identity, i.e. a tree, which the flat array forbids).
+/// Binary space partitioning layout over flat window array (#56).
 public struct BspLayout: LayoutSystem {
     public init() {}
 

--- a/Sources/KiwiDeskCore/Layouts/BspLayout.swift
+++ b/Sources/KiwiDeskCore/Layouts/BspLayout.swift
@@ -1,6 +1,9 @@
 import CoreGraphics
 
-/// Binary space partitioning layout over flat window array (#56).
+/// Binary space partitioning layout over flat window array
+/// (dwindle). Two per-space ratio scalars, not per-node ratios —
+/// those need stable split identity, i.e. a tree, which the flat
+/// array forbids (#56).
 public struct BspLayout: LayoutSystem {
     public init() {}
 

--- a/Sources/KiwiDeskCore/Layouts/BspOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/BspOverride.swift
@@ -1,18 +1,6 @@
 import Foundation
 
-/// Per-space overrides of `BspParams` (issue #17). Every field is
-/// an *optional* mirror of the global bsp params: nil inherits the
-/// global value (gray in the GUI), a value overrides just that
-/// field for one space (black). Stored sparsely under
-/// `layout.bsp.override[space_id]` and resolved with
-/// `resolved(onto:)` — the same optional-mirror shape as
-/// `LayoutAppBar`, but keyed by space instead of by layout.
-///
-/// Mirror-parity is guarded by a reflection-based test
-/// (`BspOverrideTests`) per AGENTS.md §5: adding a user-tunable
-/// field to `BspParams` without mirroring it here turns that test
-/// red. `newWindowPlacement` is excluded (it already has a
-/// per-space override via `new_window_placement_override`).
+/// Per-space overrides of BspParams (`BspOverrideTests`, #17).
 public struct BspOverride: Sendable, Equatable {
     public var strategy: BspParams.Strategy?
     public var splitRatioH: Double?
@@ -20,32 +8,24 @@ public struct BspOverride: Sendable, Equatable {
 
     public init() {}
 
-    /// `global` (the layout's own params) with every non-nil
-    /// override applied on top, per field.
+    /// Merges overrides onto global BspParams.
     public func resolved(onto global: BspParams) -> BspParams {
         var out = global
         if let strategy { out.strategy = strategy }
         if let splitRatioH { out.splitRatioH = splitRatioH }
         if let splitRatioV { out.splitRatioV = splitRatioV }
-        // Merged params hold no override map (see ScrollingOverride).
         out.override = [:]
         return out
     }
 
-    /// True when no field is set — a fully-inherited space needs
-    /// no stored override (drives sparse encoding).
+    /// True when no field is set (drives sparse encoding).
     public var isEmpty: Bool {
         strategy == nil && splitRatioH == nil
             && splitRatioV == nil
     }
 }
 
-// MARK: - Codable
-
 extension BspOverride: Codable {
-    /// Same JSON spelling as the `BspParams` fields (the
-    /// `bsp.set_*` setters). Only set overrides are written;
-    /// inherited fields stay absent.
     enum CodingKeys: String, CodingKey {
         case strategy
         case splitRatioH = "ratio_h"

--- a/Sources/KiwiDeskCore/Layouts/BspOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/BspOverride.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Per-space overrides of BspParams (`BspOverrideTests`, #17).
+/// Per-space overrides of BspParams: optional mirror, nil
+/// inherits (`BspOverrideTests`, #17). `newWindowPlacement` is
+/// excluded — it has its own per-space override via
+/// `new_window_placement_override`.
 public struct BspOverride: Sendable, Equatable {
     public var strategy: BspParams.Strategy?
     public var splitRatioH: Double?
@@ -14,6 +17,8 @@ public struct BspOverride: Sendable, Equatable {
         if let strategy { out.strategy = strategy }
         if let splitRatioH { out.splitRatioH = splitRatioH }
         if let splitRatioV { out.splitRatioV = splitRatioV }
+        // Merged params hold no override map (see
+        // ScrollingOverride).
         out.override = [:]
         return out
     }

--- a/Sources/KiwiDeskCore/Layouts/GridOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/GridOverride.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Per-space overrides of GridParams (`GridOverrideTests`, #17).
+/// Per-space overrides of GridParams: optional mirror, nil
+/// inherits (`GridOverrideTests`, #17). `newWindowPlacement` is
+/// excluded — it has its own per-space override via
+/// `new_window_placement_override`.
 public struct GridOverride: Sendable, Equatable {
     public var type: GridParams.GridType?
     public var fillEmptyCells: Bool?
@@ -24,6 +27,8 @@ public struct GridOverride: Sendable, Equatable {
         if let columns { out.columns = columns }
         if let rows { out.rows = rows }
         if let autoSize { out.autoSize = autoSize }
+        // Merged params hold no override map (see
+        // ScrollingOverride).
         out.override = [:]
         return out
     }

--- a/Sources/KiwiDeskCore/Layouts/GridOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/GridOverride.swift
@@ -1,18 +1,6 @@
 import Foundation
 
-/// Per-space overrides of `GridParams` (issue #17). Every field is
-/// an *optional* mirror of the global grid params: nil inherits
-/// the global value (gray in the GUI), a value overrides just that
-/// field for one space (black). Stored sparsely under
-/// `layout.grid.override[space_id]` and resolved with
-/// `resolved(onto:)` — the same optional-mirror shape as
-/// `LayoutAppBar`, but keyed by space instead of by layout.
-///
-/// Mirror-parity is guarded by a reflection-based test
-/// (`GridOverrideTests`) per AGENTS.md §5: adding a user-tunable
-/// field to `GridParams` without mirroring it here turns that test
-/// red. `newWindowPlacement` is excluded (it already has a
-/// per-space override via `new_window_placement_override`).
+/// Per-space overrides of GridParams (`GridOverrideTests`, #17).
 public struct GridOverride: Sendable, Equatable {
     public var type: GridParams.GridType?
     public var fillEmptyCells: Bool?
@@ -23,8 +11,7 @@ public struct GridOverride: Sendable, Equatable {
 
     public init() {}
 
-    /// `global` (the layout's own params) with every non-nil
-    /// override applied on top, per field.
+    /// Merges overrides onto global GridParams.
     public func resolved(onto global: GridParams) -> GridParams {
         var out = global
         if let type { out.type = type }
@@ -37,13 +24,11 @@ public struct GridOverride: Sendable, Equatable {
         if let columns { out.columns = columns }
         if let rows { out.rows = rows }
         if let autoSize { out.autoSize = autoSize }
-        // Merged params hold no override map (see ScrollingOverride).
         out.override = [:]
         return out
     }
 
-    /// True when no field is set — a fully-inherited space needs
-    /// no stored override (drives sparse encoding).
+    /// True when no field is set (drives sparse encoding).
     public var isEmpty: Bool {
         type == nil && fillEmptyCells == nil
             && splitDirection == nil && columns == nil
@@ -51,12 +36,7 @@ public struct GridOverride: Sendable, Equatable {
     }
 }
 
-// MARK: - Codable
-
 extension GridOverride: Codable {
-    /// Same JSON spelling as the `GridParams` fields (the
-    /// `grid.set_*` setters). Only set overrides are written;
-    /// inherited fields stay absent.
     enum CodingKeys: String, CodingKey {
         case type
         case fillEmptyCells = "fill_empty_cells"

--- a/Sources/KiwiDeskCore/Layouts/GridParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/GridParams.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-/// Grid tuning: layout type, empty-space filling, split
-/// direction, and the rigid grid's dimensions. Split out of
-/// `LayoutParams` for file size.
+/// Configuration parameters for Grid layout.
 public struct GridParams: Sendable, Equatable, Codable {
     public enum GridType: String, Sendable, Codable, CaseIterable {
         case dynamic
@@ -22,16 +20,11 @@ public struct GridParams: Sendable, Equatable, Codable {
     /// Rigid grid dimensions.
     public var columns: Int = 3
     public var rows: Int = 2
-    /// When set, the grid's dimensions come from the display —
-    /// as many columns/rows as fit at `min_window_size` — instead
-    /// of the typed `columns`/`rows`. Orthogonal to `type`: it
-    /// caps a dynamic grid and fixes a rigid one alike.
+    /// Derives dimensions dynamically from display size and minWindowSize.
     public var autoSize = false
-    /// Grids read as ordered cells: appending keeps every
-    /// existing cell in place.
+    /// Placement for newly created windows.
     public var newWindowPlacement: SpawnPlacement = .last
-    /// Per-space overrides (`layout.grid.override[space_id]`),
-    /// resolved via `TilingSettings.resolvedGrid(for:)`.
+    /// Per-space overrides resolved via `TilingSettings.resolvedGrid(for:)`.
     public var override: [SpaceID: GridOverride] = [:]
 
     public init() {}

--- a/Sources/KiwiDeskCore/Layouts/GridParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/GridParams.swift
@@ -20,7 +20,9 @@ public struct GridParams: Sendable, Equatable, Codable {
     /// Rigid grid dimensions.
     public var columns: Int = 3
     public var rows: Int = 2
-    /// Derives dimensions dynamically from display size and minWindowSize.
+    /// Derives dimensions from the display (as many cells as fit
+    /// at `min_window_size`). Orthogonal to `type`: it caps a
+    /// dynamic grid and fixes a rigid one alike.
     public var autoSize = false
     /// Placement for newly created windows.
     public var newWindowPlacement: SpawnPlacement = .last

--- a/Sources/KiwiDeskCore/Layouts/MonocleOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/MonocleOverride.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Per-space overrides of MonocleParams (`MonocleOverrideTests`, #17, #293).
+/// Per-space overrides of MonocleParams: optional mirror, nil
+/// inherits (`MonocleOverrideTests`, #17). `appBar` is excluded —
+/// bar-look overrides land with the app-bar tier; only the
+/// orientation is per-space (#293).
 public struct MonocleOverride: Sendable, Equatable {
     public var orientation: MonocleParams.Orientation?
 
@@ -12,6 +15,8 @@ public struct MonocleOverride: Sendable, Equatable {
     ) -> MonocleParams {
         var out = global
         if let orientation { out.orientation = orientation }
+        // Merged params hold no override map (see
+        // ScrollingOverride).
         out.override = [:]
         return out
     }

--- a/Sources/KiwiDeskCore/Layouts/MonocleOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/MonocleOverride.swift
@@ -1,49 +1,28 @@
 import Foundation
 
-/// Per-space overrides of `MonocleParams` (issue #17). Every field
-/// is an *optional* mirror of the global monocle params: nil
-/// inherits the global value (gray in the GUI), a value overrides
-/// just that field for one space (black). Stored sparsely under
-/// `layout.monocle.override[space_id]` and resolved with
-/// `resolved(onto:)` — the same optional-mirror shape as
-/// `LayoutAppBar`, but keyed by space instead of by layout.
-///
-/// Mirror-parity is guarded by a reflection-based test
-/// (`MonocleOverrideTests`) per AGENTS.md §5: adding a user-tunable
-/// field to `MonocleParams` without mirroring it here turns that
-/// test red. `appBar` is excluded — per-space bar *look* overrides
-/// land with the app-bar tier; only the orientation is per-space
-/// here (since #293 it no longer affects the bar edge).
+/// Per-space overrides of MonocleParams (`MonocleOverrideTests`, #17, #293).
 public struct MonocleOverride: Sendable, Equatable {
     public var orientation: MonocleParams.Orientation?
 
     public init() {}
 
-    /// `global` (the layout's own params) with every non-nil
-    /// override applied on top, per field.
+    /// Merges overrides onto global MonocleParams.
     public func resolved(
         onto global: MonocleParams
     ) -> MonocleParams {
         var out = global
         if let orientation { out.orientation = orientation }
-        // Merged params hold no override map (see ScrollingOverride).
         out.override = [:]
         return out
     }
 
-    /// True when no field is set — a fully-inherited space needs
-    /// no stored override (drives sparse encoding).
+    /// True when no field is set (drives sparse encoding).
     public var isEmpty: Bool {
         orientation == nil
     }
 }
 
-// MARK: - Codable
-
 extension MonocleOverride: Codable {
-    /// Same JSON spelling as the `MonocleParams` fields (the
-    /// `monocle.set_*` setters). Only set overrides are written;
-    /// inherited fields stay absent.
     enum CodingKeys: String, CodingKey {
         case orientation
     }

--- a/Sources/KiwiDeskCore/Layouts/StackOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/StackOverride.swift
@@ -1,18 +1,6 @@
 import Foundation
 
-/// Per-space overrides of `StackParams` (issue #17). Every field
-/// is an *optional* mirror of the global stack params: nil
-/// inherits the global value (gray in the GUI), a value overrides
-/// just that field for one space (black). Stored sparsely under
-/// `layout.stack.override[space_id]` and resolved with
-/// `resolved(onto:)` — the same optional-mirror shape as
-/// `LayoutAppBar`, but keyed by space instead of by layout.
-///
-/// Mirror-parity is guarded by a reflection-based test
-/// (`StackOverrideTests`) per AGENTS.md §5: adding a user-tunable
-/// field to `StackParams` without mirroring it here turns that
-/// test red. `newWindowPlacement` is excluded (it already has a
-/// per-space override via `new_window_placement_override`).
+/// Per-space overrides of StackParams (`StackOverrideTests`, #17).
 public struct StackOverride: Sendable, Equatable {
     public var masterCount: Int?
     public var masterRatio: Double?
@@ -22,8 +10,7 @@ public struct StackOverride: Sendable, Equatable {
 
     public init() {}
 
-    /// `global` (the layout's own params) with every non-nil
-    /// override applied on top, per field.
+    /// Merges overrides onto global StackParams.
     public func resolved(onto global: StackParams) -> StackParams {
         var out = global
         if let masterCount { out.masterCount = masterCount }
@@ -33,13 +20,11 @@ public struct StackOverride: Sendable, Equatable {
             out.masterOrientation = masterOrientation
         }
         if let stackPosition { out.stackPosition = stackPosition }
-        // Merged params hold no override map (see ScrollingOverride).
         out.override = [:]
         return out
     }
 
-    /// True when no field is set — a fully-inherited space needs
-    /// no stored override (drives sparse encoding).
+    /// True when no field is set (drives sparse encoding).
     public var isEmpty: Bool {
         masterCount == nil && masterRatio == nil
             && overflowStyle == nil && masterOrientation == nil
@@ -47,12 +32,7 @@ public struct StackOverride: Sendable, Equatable {
     }
 }
 
-// MARK: - Codable
-
 extension StackOverride: Codable {
-    /// Same JSON spelling as the `StackParams` fields (the
-    /// `stack.set_*` setters). Only set overrides are written;
-    /// inherited fields stay absent.
     enum CodingKeys: String, CodingKey {
         case masterCount = "master_count"
         case masterRatio = "master_ratio"

--- a/Sources/KiwiDeskCore/Layouts/StackOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/StackOverride.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Per-space overrides of StackParams (`StackOverrideTests`, #17).
+/// Per-space overrides of StackParams: optional mirror, nil
+/// inherits (`StackOverrideTests`, #17). `newWindowPlacement` is
+/// excluded — it has its own per-space override via
+/// `new_window_placement_override`.
 public struct StackOverride: Sendable, Equatable {
     public var masterCount: Int?
     public var masterRatio: Double?
@@ -20,6 +23,8 @@ public struct StackOverride: Sendable, Equatable {
             out.masterOrientation = masterOrientation
         }
         if let stackPosition { out.stackPosition = stackPosition }
+        // Merged params hold no override map (see
+        // ScrollingOverride).
         out.override = [:]
         return out
     }

--- a/Sources/KiwiDeskCore/Layouts/TrackOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackOverride.swift
@@ -1,17 +1,6 @@
 import Foundation
 
-/// Per-space overrides of `TrackParams` (#128). Every field is
-/// an *optional* mirror of the global track params: nil inherits
-/// the global value, a value overrides just that field for one
-/// space. Stored sparsely under `layout.track.override[space_id]`
-/// and resolved with `resolved(onto:)` — the same optional-mirror
-/// shape as `StackOverride`.
-///
-/// Mirror-parity is guarded by a reflection-based test
-/// (`TrackOverrideTests`) per AGENTS.md §5. `newWindow`,
-/// `newWindowPosition`, and `wrapFocus` are excluded by design:
-/// all three are per-layout behavior, not per-space geometry
-/// (the `ScrollingOverride` precedent for `wrapFocus`).
+/// Per-space overrides of TrackParams (`TrackOverrideTests`, #128).
 public struct TrackOverride: Sendable, Equatable {
     public var axis: TrackParams.Axis?
     public var autoTracks: Bool?
@@ -20,33 +9,25 @@ public struct TrackOverride: Sendable, Equatable {
 
     public init() {}
 
-    /// `global` (the layout's own params) with every non-nil
-    /// override applied on top, per field.
+    /// Merges overrides onto global TrackParams.
     public func resolved(onto global: TrackParams) -> TrackParams {
         var out = global
         if let axis { out.axis = axis }
         if let autoTracks { out.autoTracks = autoTracks }
         if let limit { out.limit = limit }
         if let overflowStyle { out.overflowStyle = overflowStyle }
-        // Merged params hold no override map (see ScrollingOverride).
         out.override = [:]
         return out
     }
 
-    /// True when no field is set — a fully-inherited space needs
-    /// no stored override (drives sparse encoding).
+    /// True when no field is set (drives sparse encoding).
     public var isEmpty: Bool {
         axis == nil && autoTracks == nil && limit == nil
             && overflowStyle == nil
     }
 }
 
-// MARK: - Codable
-
 extension TrackOverride: Codable {
-    /// Same JSON spelling as the `TrackParams` fields (the
-    /// `track.set_*` setters). Only set overrides are written;
-    /// inherited fields stay absent.
     enum CodingKeys: String, CodingKey {
         case axis
         case autoTracks = "auto_tracks"

--- a/Sources/KiwiDeskCore/Layouts/TrackOverride.swift
+++ b/Sources/KiwiDeskCore/Layouts/TrackOverride.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Per-space overrides of TrackParams (`TrackOverrideTests`, #128).
+/// Per-space overrides of TrackParams: optional mirror, nil
+/// inherits (`TrackOverrideTests`, #128). `newWindow`,
+/// `newWindowPosition` and `wrapFocus` are excluded by design —
+/// per-layout behavior, not per-space geometry.
 public struct TrackOverride: Sendable, Equatable {
     public var axis: TrackParams.Axis?
     public var autoTracks: Bool?
@@ -16,6 +19,8 @@ public struct TrackOverride: Sendable, Equatable {
         if let autoTracks { out.autoTracks = autoTracks }
         if let limit { out.limit = limit }
         if let overflowStyle { out.overflowStyle = overflowStyle }
+        // Merged params hold no override map (see
+        // ScrollingOverride).
         out.override = [:]
         return out
     }

--- a/Sources/KiwiDeskCore/Models/DisplayModel.swift
+++ b/Sources/KiwiDeskCore/Models/DisplayModel.swift
@@ -14,29 +14,13 @@ public struct DisplayID: Hashable, Sendable, Codable,
     public var description: String { "display#\(raw)" }
 }
 
-/// A snapshot of one connected monitor.
-///
-/// `fingerprint` uniquely identifies the hardware so profiles can
-/// be re-applied when a known monitor setup is reconnected.
+/// Snapshot of a connected monitor with hardware fingerprint.
 public struct Display: Sendable, Equatable {
     public let id: DisplayID
     public var name: String
-    /// The screen's frame in AppKit's global coordinates, where
-    /// **y grows UP** — so the screen physically above another has
-    /// the LARGER `minY`, and an ascending sort on it reads
-    /// bottom-to-top.
-    ///
-    /// Stated here because this is where every sorter starts, and
-    /// two of them already got it wrong:
-    /// `PositionalDisplays.ordered`'s comment still says "ties
-    /// broken top-to-bottom" over an ascending `minY` (harmless
-    /// there — any deterministic tiebreak serves positional
-    /// addressing), and #752's first screen sort listed a stacked
-    /// pair in reverse while claiming to match the Monitors
-    /// picture. `DeskOrder` is the GUI's one reading-order rule and
-    /// negates y for this reason.
+    /// Frame in AppKit coordinates (y grows up; see `DeskOrder`, #752).
     public var frame: CGRect
-    /// Usable area (frame minus menu bar / Dock).
+    /// Usable area (frame minus menu bar and Dock).
     public var visibleFrame: CGRect
 
     public init(

--- a/Sources/KiwiDeskCore/Models/DisplayModel.swift
+++ b/Sources/KiwiDeskCore/Models/DisplayModel.swift
@@ -18,7 +18,10 @@ public struct DisplayID: Hashable, Sendable, Codable,
 public struct Display: Sendable, Equatable {
     public let id: DisplayID
     public var name: String
-    /// Frame in AppKit coordinates (y grows up; see `DeskOrder`, #752).
+    /// Frame in AppKit global coordinates, where y grows UP: the
+    /// screen physically above another has the LARGER `minY`, so
+    /// an ascending sort reads bottom-to-top — two sorters got
+    /// this wrong already (#752; `DeskOrder` negates y for this).
     public var frame: CGRect
     /// Usable area (frame minus menu bar and Dock).
     public var visibleFrame: CGRect

--- a/Sources/KiwiDeskCore/Models/SessionRatios.swift
+++ b/Sources/KiwiDeskCore/Models/SessionRatios.swift
@@ -1,23 +1,7 @@
 import Foundation
 
-/// Interactive-resize values for a space that has NO authored
-/// config override of the field (#458). Before this layer, a
-/// resize on such a space wrote the GLOBAL ratio, visibly
-/// resizing every other no-override space (obvious with two
-/// monitors showing two spaces). Session-only, like
-/// `stackWeights`: config layers stay untouched — the #290
-/// override editor never fills with overrides the user did not
-/// author — and the value dies with the space, an actual mode
-/// change (`setMode`), or a config reload.
-///
-/// Read precedence is enforced structurally in
-/// `TilingSettings.resolvedBsp/Stack/Scrolling(for: Space)`:
-/// authored override field > session value > global. A space
-/// whose override carries the field routes interactive writes
-/// into that override (pre-#458 behavior), so its session slot
-/// stays empty. Known edge, accepted: removing an override
-/// field mid-session can resurface an older session value
-/// until the next mode change or reload.
+/// Interactive-resize session overrides without persisting to config
+/// (#290, #458).
 public struct SessionRatios: Sendable, Equatable {
     /// BSP side-by-side split (`resize("x")`).
     public var splitRatioH: Double?

--- a/Sources/KiwiDeskCore/Models/SessionRatios.swift
+++ b/Sources/KiwiDeskCore/Models/SessionRatios.swift
@@ -1,7 +1,11 @@
 import Foundation
 
-/// Interactive-resize session overrides without persisting to config
-/// (#290, #458).
+/// Interactive-resize values for a space with NO authored
+/// override of the field (#458): writing the global visibly
+/// resized every other space. Session-only — dies with the
+/// space, `setMode`, or reload; config layers stay untouched
+/// (#290). Precedence (authored field > session > global) is
+/// structural in `TilingSettings.resolvedBsp/Stack/Scrolling`.
 public struct SessionRatios: Sendable, Equatable {
     /// BSP side-by-side split (`resize("x")`).
     public var splitRatioH: Double?

--- a/Sources/KiwiDeskCore/Models/Space+Rekey.swift
+++ b/Sources/KiwiDeskCore/Models/Space+Rekey.swift
@@ -1,23 +1,8 @@
 import Foundation
 
 extension Space {
-    /// Swaps one window id for another in the same layout slot,
-    /// preserving array position, focus, and every per-window
-    /// marker. Used when a native tab group's active tab changes
-    /// (#308): the tracked id is the on-screen tab's `CGWindowID`,
-    /// which changes on switch, but the tile, focus, and weights
-    /// belong to the group, not the tab. No-op if `old` is absent.
-    /// Every id-keyed field here (`windows`, `focused`,
-    /// `stackWeights`, `trackBreaks`, `trackWeights`) is guarded by
-    /// the `WindowRekeyParityTests` reflection net — except
-    /// `scrollRest.slot.window` (#966), which is a bare id inside a
-    /// struct rather than an id-keyed container, so only that
-    /// suite's `String(describing:)` scan sees it and its count pin
-    /// cannot. It migrates for the same reason the rest do: the
-    /// slot is the same slot, at the same position in the row, and
-    /// a rest still naming the retired id reads as "the focus
-    /// moved" — the scrolling viewport would silently stop
-    /// re-anchoring for the tab group that just switched.
+    /// Swaps one window ID for another across all slot/weight state
+    /// (`WindowRekeyParityTests`, #308, #966).
     public mutating func rekey(_ old: WindowID, to new: WindowID) {
         guard let index = windows.firstIndex(of: old) else {
             return

--- a/Sources/KiwiDeskCore/Models/Space+Rekey.swift
+++ b/Sources/KiwiDeskCore/Models/Space+Rekey.swift
@@ -1,8 +1,12 @@
 import Foundation
 
 extension Space {
-    /// Swaps one window ID for another across all slot/weight state
-    /// (`WindowRekeyParityTests`, #308, #966).
+    /// Swaps one window ID for another in place, preserving array
+    /// position, focus and per-window markers (#308); no-op if
+    /// `old` is absent. Id-keyed fields are guarded by
+    /// `WindowRekeyParityTests` — except `scrollRest.slot.window`
+    /// (#966), a bare id only that suite's text scan sees; it
+    /// migrates so the viewport keeps re-anchoring.
     public mutating func rekey(_ old: WindowID, to new: WindowID) {
         guard let index = windows.firstIndex(of: old) else {
             return

--- a/Sources/KiwiDeskCore/Models/WindowServerFacts.swift
+++ b/Sources/KiwiDeskCore/Models/WindowServerFacts.swift
@@ -1,22 +1,7 @@
 import CoreGraphics
 
-/// Empirical WindowServer placement facts, probed against the
-/// live OS. Shared value types so both `Layouts` (pure math)
-/// and `Tiling` (the engine) can consume them without a
-/// dependency edge between the two.
+/// Empirical WindowServer placement limits and constants (#139, #148).
 public enum WindowServerFacts {
-    /// The WindowServer's offscreen-visibility floor: an
-    /// (almost) fully offscreen frame is clamped back until
-    /// roughly this much of it stays visible. Probed
-    /// 2026-07-10 (#148): ~32 pt on bottom/diagonal asks,
-    /// ~40 pt on left/right; partial overflow above the floor
-    /// applies exactly; nothing may go above the top border
-    /// at all (#139). An ask below the floor is unreachable —
-    /// the OS lifts it, the ±2 pt retile tolerance never
-    /// passes, and every retile re-issues the frame (#142,
-    /// #148). Any deliberate offscreen sliver must derive
-    /// from this value plus its own per-intent margin (the
-    /// derived slivers may diverge), so the next probe
-    /// updates exactly one site.
+    /// WindowServer minimum on-screen visibility floor in pt (#142, #148).
     public static let visibilityFloor: CGFloat = 40
 }

--- a/Sources/KiwiDeskCore/Models/WindowServerFacts.swift
+++ b/Sources/KiwiDeskCore/Models/WindowServerFacts.swift
@@ -2,6 +2,14 @@ import CoreGraphics
 
 /// Empirical WindowServer placement limits and constants (#139, #148).
 public enum WindowServerFacts {
-    /// WindowServer minimum on-screen visibility floor in pt (#142, #148).
+    /// WindowServer offscreen-visibility floor: an almost
+    /// offscreen frame is clamped until ~this much stays visible.
+    /// Probed 2026-07-10 (#148): ~32 pt bottom/diagonal, ~40 pt
+    /// left/right; nothing may cross the top border (#139). An
+    /// ask below the floor is unreachable — the OS lifts it, the
+    /// ±2 pt retile tolerance never passes, and every retile
+    /// re-issues the frame (#142). A deliberate offscreen sliver
+    /// must derive from this value plus its own margin, so the
+    /// next probe updates exactly one site.
     public static let visibilityFloor: CGFloat = 40
 }

--- a/Sources/KiwiDeskCore/OS/OutputCapture.swift
+++ b/Sources/KiwiDeskCore/OS/OutputCapture.swift
@@ -1,16 +1,7 @@
 import Foundation
 import os
 
-/// Drains a child's stdout and stderr via `readabilityHandler`
-/// and reports both, off the main thread, once both streams hit
-/// EOF. No thread is ever blocked waiting for a pipe; GCD calls
-/// the handler as data arrives. Split out of `ExecLauncher` for
-/// file size.
-///
-/// Each stream is capped at `streamCap` bytes: data beyond the
-/// cap is still read (keeping the pipe drained so the child can
-/// keep writing without blocking) but discarded after the
-/// truncation marker is appended.
+/// Captures stdout and stderr streams asynchronously with stream capping.
 final class OutputCapture: Sendable {
     /// Maximum bytes captured per stream (~1 MB).
     static let streamCap = 1_048_576
@@ -32,15 +23,11 @@ final class OutputCapture: Sendable {
     init(_ out: Pipe, _ err: Pipe) {
         self.out = out
         self.err = err
-        // Enter for both streams up front: the termination
-        // handler can fire before drain() runs on the main
-        // actor, and an empty group would notify immediately
-        // with empty output.
         group.enter()
         group.enter()
     }
 
-    /// Starts both reads; must be called exactly once.
+    /// Starts draining both pipe readability handlers.
     func drain() {
         attach(out.fileHandleForReading, to: outBuf)
         attach(err.fileHandleForReading, to: errBuf)
@@ -57,7 +44,6 @@ final class OutputCapture: Sendable {
         handle.readabilityHandler = { [group, buf] fh in
             let chunk = fh.availableData
             if chunk.isEmpty {
-                // EOF: all write ends of the pipe are closed.
                 fh.readabilityHandler = nil
                 group.leave()
                 return

--- a/Sources/KiwiDeskCore/OS/OutputCapture.swift
+++ b/Sources/KiwiDeskCore/OS/OutputCapture.swift
@@ -1,7 +1,9 @@
 import Foundation
 import os
 
-/// Captures stdout and stderr streams asynchronously with stream capping.
+/// Captures stdout and stderr streams asynchronously. Data beyond
+/// `streamCap` is still READ (the pipe stays drained so the
+/// child never blocks) but discarded after the truncation marker.
 final class OutputCapture: Sendable {
     /// Maximum bytes captured per stream (~1 MB).
     static let streamCap = 1_048_576
@@ -23,11 +25,13 @@ final class OutputCapture: Sendable {
     init(_ out: Pipe, _ err: Pipe) {
         self.out = out
         self.err = err
+        // Enter up front: the termination handler can fire before
+        // drain() runs, and an empty group notifies immediately.
         group.enter()
         group.enter()
     }
 
-    /// Starts draining both pipe readability handlers.
+    /// Starts both reads; must be called exactly once.
     func drain() {
         attach(out.fileHandleForReading, to: outBuf)
         attach(err.fileHandleForReading, to: errBuf)

--- a/Sources/KiwiDeskCore/OS/SkyLight+WindowRadius.swift
+++ b/Sources/KiwiDeskCore/OS/SkyLight+WindowRadius.swift
@@ -39,8 +39,10 @@ extension SkyLight {
             as: IteratorGetCornerRadiiFn.self
         )
 
-    /// Queries window corner radius via SkyLight, or nil if unavailable
-    /// (#357).
+    /// Queries window corner radius via SkyLight (#357), or nil
+    /// if unavailable — the caller substitutes
+    /// `GeometryUtils.systemWindowCornerRadius` so a failed query
+    /// never blocks a ring.
     static func windowCornerRadius(_ wid: CGWindowID) -> CGFloat? {
         guard let connection,
             let queryWindows = windowQueryWindows,

--- a/Sources/KiwiDeskCore/OS/SkyLight+WindowRadius.swift
+++ b/Sources/KiwiDeskCore/OS/SkyLight+WindowRadius.swift
@@ -1,14 +1,7 @@
 import CoreFoundation
 import CoreGraphics
 
-/// Per-window corner-radius query for the focus border (#357). The
-/// ring's rounded corners must match the *actual* radius of each
-/// window, not a fixed guess — a mismatch leaves a visible gap where
-/// our arc and the window's corner diverge. JankyBorders reads the
-/// radius the same way (`SLSWindowQueryWindows` →
-/// `SLSWindowIteratorGetCornerRadii`), falling back to a default when
-/// the window reports none. Every symbol is optional; a failed lookup
-/// falls back to `GeometryUtils.systemWindowCornerRadius`.
+/// Window corner radius dynamic query via SkyLight SPI (#357).
 extension SkyLight {
     typealias WindowQueryWindowsFn =
         @convention(c) (
@@ -46,11 +39,8 @@ extension SkyLight {
             as: IteratorGetCornerRadiiFn.self
         )
 
-    /// The corner radius (pt) SkyLight reports for `wid`, or `nil`
-    /// when unavailable (symbol missing, window not found, or a
-    /// non-positive radius — matching JankyBorders' "> 0" gate). The
-    /// caller substitutes the shared default so a failed query never
-    /// blocks a ring.
+    /// Queries window corner radius via SkyLight, or nil if unavailable
+    /// (#357).
     static func windowCornerRadius(_ wid: CGWindowID) -> CGFloat? {
         guard let connection,
             let queryWindows = windowQueryWindows,
@@ -66,12 +56,8 @@ extension SkyLight {
         else { return nil }
         let targets = [number] as CFArray
 
-        // `takeRetainedValue` on all three: despite the `…Get…` name,
-        // `SLSWindowIteratorGetCornerRadii` returns an **owned** (+1)
-        // array — JankyBorders `CFRelease`s it (`windows.c`), and it is
-        // too widely deployed for that to be an over-release. So one
-        // release (ARC at scope end) is the correct balance; do NOT
-        // switch this to `takeUnretainedValue` — that would leak.
+        // `takeRetainedValue` matches SLS +1 returned ownership;
+        // do not switch to unretained.
         guard
             let query = queryWindows(connection, targets, 0)?
                 .takeRetainedValue(),
@@ -81,8 +67,6 @@ extension SkyLight {
             CFArrayGetCount(radiiRef) > 0
         else { return nil }
 
-        // Radii are whole points (10/12/16 …); JankyBorders reads them
-        // as `sInt32` the same way.
         let first = unsafeBitCast(
             CFArrayGetValueAtIndex(radiiRef, 0),
             to: CFNumber.self

--- a/Sources/KiwiDeskCore/OS/SkyLight.swift
+++ b/Sources/KiwiDeskCore/OS/SkyLight.swift
@@ -1,13 +1,8 @@
 import CoreFoundation
 import Foundation
 
-/// Runtime bridge to the private SkyLight framework.
-///
-/// Symbols are resolved with `dlsym` instead of `@_silgen_name`:
-/// a linked private symbol that disappears in a macOS update
-/// would crash the app at launch, while a failed lookup here
-/// simply yields `nil` and the caller falls back to the public
-/// Accessibility API. See AGENTS.md guardrails.
+/// Runtime bridge resolving private SkyLight SPI symbols dynamically
+/// via dlsym.
 public enum SkyLight {
     public typealias ConnectionID = Int32
     public typealias SpaceID = UInt64
@@ -19,9 +14,7 @@ public enum SkyLight {
             RTLD_LAZY
         )
 
-    /// Whether the framework loaded — the precondition for
-    /// resolving anything in it, `WMBridge`'s ObjC classes
-    /// included.
+    /// Whether the framework loaded.
     static var isLoaded: Bool { handle != nil }
 
     /// Resolves one C function pointer, or nil if unavailable.
@@ -31,8 +24,6 @@ public enum SkyLight {
         }
         return unsafeBitCast(sym, to: T.self)
     }
-
-    // MARK: - Resolved functions
 
     public typealias MainConnectionFn =
         @convention(c) () -> ConnectionID
@@ -66,8 +57,6 @@ public enum SkyLight {
         as: DisplayCurrentSpaceFn.self
     )
 
-    // MARK: - Display suppression
-
     public typealias DisableUpdateFn =
         @convention(c) (ConnectionID) -> Int32
     public typealias ReenableUpdateFn =
@@ -97,9 +86,7 @@ public enum SkyLight {
         return cid != 0 ? cid : nil
     }
 
-    /// Freezes window-server compositing so multiple AX
-    /// frame-sets composite as one visual update. No-op
-    /// when SkyLight symbols didn't resolve.
+    /// Freezes window-server compositing for batched visual updates.
     public static func suppressDisplay() {
         guard let cid = connection,
             let fn = disableUpdate

--- a/Sources/KiwiDeskCore/OS/WindowControl.swift
+++ b/Sources/KiwiDeskCore/OS/WindowControl.swift
@@ -2,8 +2,14 @@ import ApplicationServices
 import CoreGraphics
 
 /// Public Accessibility API window mover and resizer.
+/// Deliberately NOT MainActor: AX set calls are blocking IPC
+/// into the target app and thread-safe, so the animation
+/// pipeline applies frames from a background queue.
 public enum WindowControl {
-    /// Applies frame to AXUIElement via size-position-size sequence.
+    /// Applies frame via size → position → size: apps clamp
+    /// whichever attribute is set first against the other's old
+    /// value, so setting size on both sides of the move
+    /// converges regardless of direction.
     public static func setFrame(
         _ frame: CGRect,
         of element: AXUIElement

--- a/Sources/KiwiDeskCore/OS/WindowControl.swift
+++ b/Sources/KiwiDeskCore/OS/WindowControl.swift
@@ -1,23 +1,9 @@
 import ApplicationServices
 import CoreGraphics
 
-/// Moves and resizes windows of other applications.
-///
-/// This is the safe fallback path via the public Accessibility
-/// API. A SkyLight fast path (window-server-side transactions)
-/// will be added on top later; the public surface stays the
-/// same so callers never care which path executed.
-///
-/// Deliberately NOT MainActor: AX set calls are blocking IPC
-/// into the target app and are thread-safe, so the animation
-/// pipeline applies frames from a background queue.
+/// Public Accessibility API window mover and resizer.
 public enum WindowControl {
-    /// Applies a frame to a window element.
-    ///
-    /// Size → position → size: apps clamp whichever attribute
-    /// is set first against the other's old value, so setting
-    /// size on both sides of the move converges regardless of
-    /// direction.
+    /// Applies frame to AXUIElement via size-position-size sequence.
     public static func setFrame(
         _ frame: CGRect,
         of element: AXUIElement

--- a/Sources/KiwiDeskCore/Power/SystemBoot.swift
+++ b/Sources/KiwiDeskCore/Power/SystemBoot.swift
@@ -1,8 +1,14 @@
 import Foundation
 
-/// System boot timestamp query via sysctl `kern.boottime` (#633).
+/// System boot timestamp query via sysctl `kern.boottime`
+/// (#633): a `WindowID` is only meaningful within one boot — a
+/// new login session recycles low-integer ids onto unrelated
+/// windows.
 enum SystemBoot {
-    /// Returns machine boot time or `.distantPast` on sysctl failure (#633).
+    /// Boot time, or `.distantPast` on sysctl failure — failing
+    /// OPEN keeps restore working; the gate is hardening. NTP
+    /// steps can mis-gate either way, accepted in
+    /// docs/accepted-limitations.md.
     static func time() -> Date {
         var tv = timeval()
         var size = MemoryLayout<timeval>.size

--- a/Sources/KiwiDeskCore/Power/SystemBoot.swift
+++ b/Sources/KiwiDeskCore/Power/SystemBoot.swift
@@ -1,26 +1,8 @@
 import Foundation
 
-/// The moment the machine booted, via the `kern.boottime`
-/// sysctl.
-///
-/// Feeds the snapshot staleness gate (#633): a `WindowID` is
-/// only meaningful within one boot — WindowServer mints fresh
-/// low-integer `CGWindowID`s per login session, so a snapshot
-/// captured before the current boot describes windows that no
-/// longer exist, under ids the new session will recycle onto
-/// unrelated windows.
+/// System boot timestamp query via sysctl `kern.boottime` (#633).
 enum SystemBoot {
-    /// Boot time, or `.distantPast` when the sysctl fails.
-    /// Failing open (every snapshot counts as same-boot) keeps
-    /// restore working if the call ever breaks — the gate is a
-    /// hardening, not a load-bearing feature. `kern.boottime`
-    /// is wall-clock and moves under NTP steps, like the
-    /// `capturedAt` stamps it is compared against: a forward
-    /// step can wrongly discard a same-boot snapshot (benign —
-    /// fresh rediscovery), a backward step can wrongly admit a
-    /// pre-boot one (the pre-gate status quo, for the one
-    /// launch after a manual clock change). Both accepted —
-    /// see docs/accepted-limitations.md.
+    /// Returns machine boot time or `.distantPast` on sysctl failure (#633).
     static func time() -> Date {
         var tv = timeval()
         var size = MemoryLayout<timeval>.size

--- a/Sources/KiwiDeskCore/Profiles/MonitorSet.swift
+++ b/Sources/KiwiDeskCore/Profiles/MonitorSet.swift
@@ -1,21 +1,10 @@
 import Foundation
 
-/// One concrete monitor combination a profile covers, together
-/// with the space→monitor pins valid for that arrangement (#36).
-///
-/// `monitors` is stored canonically sorted and compared as a
-/// sorted array (a multiset — two identical monitors must not
-/// collapse the way a `Set` would). The pin map is nested here
-/// because a space→fingerprint pair only has meaning inside the
-/// set that contains that fingerprint.
+/// Monitor setup combination and space-to-monitor pin mapping (#36).
 public struct MonitorSet: Codable, Sendable, Equatable {
-    /// Fingerprints (`Name:WxH`) of the covered monitors,
-    /// canonically sorted.
+    /// Fingerprints (`Name:WxH`) of covered monitors, canonically sorted.
     public private(set) var monitors: [String]
-    /// Explicit fingerprint pin per space (sparse; unpinned
-    /// spaces resolve via Main and the positional default).
-    /// Read-only so the init-time invariant (pins reference
-    /// only monitors inside the set) cannot be bypassed.
+    /// Explicit fingerprint pin per space.
     public private(set) var spaceMonitorMap: [SpaceID: String]
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/KiwiDeskCore/Profiles/MonitorSet.swift
+++ b/Sources/KiwiDeskCore/Profiles/MonitorSet.swift
@@ -1,10 +1,15 @@
 import Foundation
 
-/// Monitor setup combination and space-to-monitor pin mapping (#36).
+/// Monitor setup combination and space-to-monitor pin mapping
+/// (#36). `monitors` is compared as a sorted array — a multiset;
+/// two identical monitors must not collapse the way a `Set`
+/// would.
 public struct MonitorSet: Codable, Sendable, Equatable {
     /// Fingerprints (`Name:WxH`) of covered monitors, canonically sorted.
     public private(set) var monitors: [String]
-    /// Explicit fingerprint pin per space.
+    /// Explicit fingerprint pin per space (sparse). Read-only so
+    /// the init-time invariant — pins reference only monitors
+    /// inside the set — cannot be bypassed.
     public private(set) var spaceMonitorMap: [SpaceID: String]
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/KiwiDeskCore/Profiles/PositionalDisplays.swift
+++ b/Sources/KiwiDeskCore/Profiles/PositionalDisplays.swift
@@ -9,8 +9,10 @@ public enum PositionalDisplays {
         DisplayID(CGMainDisplayID())
     }
 
-    /// Orders displays with main display first, then secondaries
-    /// left-to-right.
+    /// Orders displays with main first, then secondaries
+    /// left-to-right, remaining ties broken deterministically
+    /// (`minY`, then fingerprint). A nil or absent `mainID` hands
+    /// the main slot to the leftmost — every position resolves.
     public static func ordered(
         _ displays: [Display],
         mainID: DisplayID?

--- a/Sources/KiwiDeskCore/Profiles/PositionalDisplays.swift
+++ b/Sources/KiwiDeskCore/Profiles/PositionalDisplays.swift
@@ -1,29 +1,16 @@
 import CoreGraphics
 import Foundation
 
-/// Hardware-agnostic monitor ordering for the built-in default
-/// layouts (#53).
-///
-/// User profiles pin spaces to fingerprints; the built-ins can't
-/// (they must work on any hardware), so they address monitors
-/// *positionally*: "main display", "second display", … resolved
-/// against the live setup. Main is whatever macOS says is main
-/// (`CGMainDisplayID`), secondaries follow in physical order
-/// (left to right), which is unambiguous by construction.
+/// Positional monitor ordering for hardware-agnostic space layout defaults
+/// (#53).
 public enum PositionalDisplays {
-    /// The current main display's id (the screen with the menu
-    /// bar). Pure CoreGraphics — safe off the AX path.
+    /// ID of current main display (menu bar display).
     public static var liveMainID: DisplayID {
         DisplayID(CGMainDisplayID())
     }
 
-    /// Orders displays positionally: the main display first,
-    /// then secondaries left-to-right (`frame.minX`), ties
-    /// broken top-to-bottom and finally by fingerprint so the
-    /// order is deterministic for identical coordinates.
-    ///
-    /// When `mainID` is nil or not present, the leftmost display
-    /// takes the main slot — every position still resolves.
+    /// Orders displays with main display first, then secondaries
+    /// left-to-right.
     public static func ordered(
         _ displays: [Display],
         mainID: DisplayID?

--- a/Sources/KiwiDeskCore/Profiles/SpacePlacement.swift
+++ b/Sources/KiwiDeskCore/Profiles/SpacePlacement.swift
@@ -1,22 +1,16 @@
 import Foundation
 
-/// The single space→display precedence (#36): explicit pin →
-/// Main role → the positional default's plan (#53). Both the
-/// runtime (`resolveSpaceDisplays`) and the GUI Canvas resolve
-/// through this one pure function, so they cannot drift.
+/// Space-to-display placement resolution precedence (#36, #53).
 public enum SpacePlacement {
-    /// How one space's display resolved.
+    /// Resolution result for a space's display placement.
     public enum Resolution: Equatable, Sendable {
-        /// Pinned, and the pinned display is connected.
+        /// Pinned to a connected display.
         case pinned(Display)
-        /// Pinned to a disconnected display: placement falls
-        /// back to `fallback`, while the fingerprint (the
-        /// user's intent) is preserved for editing UIs.
+        /// Pinned to a disconnected display with fallback.
         case pinnedAbsent(intent: String, fallback: Display)
-        /// Main role — follows the current main display.
+        /// Main role following active main display.
         case main(Display)
-        /// The positional default's plan, or main when the
-        /// plan does not cover the space.
+        /// Automatic assignment via positional plan.
         case auto(Display)
 
         /// The display the space effectively lands on.
@@ -31,11 +25,7 @@ public enum SpacePlacement {
         }
     }
 
-    /// Resolves one space. `assignment` is the positional
-    /// default's plan (`ProfileComposition.Composed`'s
-    /// `assignment`), composed once by the caller. Nil only
-    /// when no display is connected — otherwise resolution is
-    /// total.
+    /// Resolves target display for a space (`ProfileComposition.Composed`).
     public static func resolve(
         space: SpaceID,
         pins: [SpaceID: String],

--- a/Sources/KiwiDeskCore/Profiles/SpacePlacement.swift
+++ b/Sources/KiwiDeskCore/Profiles/SpacePlacement.swift
@@ -1,12 +1,17 @@
 import Foundation
 
-/// Space-to-display placement resolution precedence (#36, #53).
+/// The single space→display precedence (#36): explicit pin →
+/// Main role → positional plan (#53). Runtime and GUI Canvas
+/// both resolve through this one pure function, so they cannot
+/// drift.
 public enum SpacePlacement {
     /// Resolution result for a space's display placement.
     public enum Resolution: Equatable, Sendable {
         /// Pinned to a connected display.
         case pinned(Display)
-        /// Pinned to a disconnected display with fallback.
+        /// Pinned to a disconnected display: placement falls
+        /// back, the fingerprint (user intent) is preserved for
+        /// editing UIs.
         case pinnedAbsent(intent: String, fallback: Display)
         /// Main role following active main display.
         case main(Display)
@@ -25,7 +30,9 @@ public enum SpacePlacement {
         }
     }
 
-    /// Resolves target display for a space (`ProfileComposition.Composed`).
+    /// Resolves target display for a space
+    /// (`ProfileComposition.Composed`). Nil only when no display
+    /// is connected — otherwise resolution is total.
     public static func resolve(
         space: SpaceID,
         pins: [SpaceID: String],

--- a/Sources/KiwiDeskCore/Tiling/DragTarget.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragTarget.swift
@@ -1,6 +1,10 @@
 import CoreGraphics
 
-/// Cursor-based swap target determination for window dragging (#492).
+/// The drop-target rule shared by live preview and final drop,
+/// so the highlight can never disagree with the drop.
+/// Cursor-keyed, not center-keyed (#492): a big window's center
+/// lags on the origin display long after the pointer — and the
+/// intent — left it.
 enum DragTarget {
     static func swapTarget(
         of id: WindowID,

--- a/Sources/KiwiDeskCore/Tiling/DragTarget.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragTarget.swift
@@ -1,20 +1,6 @@
 import CoreGraphics
 
-/// The drop-target rule, shared by the live preview and the
-/// final drop so the highlight can never disagree with what
-/// the drop does: a drag targets the slot that contains the
-/// mouse CURSOR (AX coordinates), not the dragged window's
-/// frame center.
-///
-/// Cursor-keyed, not center-keyed, so a large window dragged
-/// onto a smaller display resolves its target the moment the
-/// cursor crosses over — a big window's center lags on the
-/// origin display long after the pointer (and the user's
-/// intent) has left it (#492). Dragging is a pointer gesture;
-/// intent lives at the cursor, matching how macOS itself
-/// decides which display a drag belongs to. The slot pool
-/// already spans every visible display (`calculatedFrames`),
-/// so the cursor alone selects both the display and the slot.
+/// Cursor-based swap target determination for window dragging (#492).
 enum DragTarget {
     static func swapTarget(
         of id: WindowID,

--- a/Sources/KiwiDeskCore/Tiling/MouseSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/MouseSettings.swift
@@ -1,18 +1,8 @@
 import Foundation
 
-/// Mouse-pointer behaviour toggles (issue #186).
-///
-/// JSON shape follows the one-vocabulary rule (AGENTS.md §5):
-/// `mouse.set_follows_focus` → `mouse.follows_focus`. The
-/// singular `mouse` namespace leaves room for a later
-/// `focus_follows_mouse` sibling (the inverse behaviour)
-/// without renaming.
+/// Mouse pointer interaction settings (#186).
 public struct MouseSettings: Sendable, Equatable, Codable {
-    /// Warp the pointer to the center of the newly-focused
-    /// window, so the next click, scroll, or hover lands on
-    /// the window the keyboard is working in — the standard
-    /// companion behaviour in i3/sway/yabai. Off by default,
-    /// matching those WMs.
+    /// Warps pointer to center of newly-focused window (#186).
     public var followsFocus = false
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/KiwiDeskCore/Tiling/MouseSettings.swift
+++ b/Sources/KiwiDeskCore/Tiling/MouseSettings.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Mouse pointer interaction settings (#186).
 public struct MouseSettings: Sendable, Equatable, Codable {
     /// Warps pointer to center of newly-focused window (#186).
+    /// Off by default, matching i3/sway/yabai.
     public var followsFocus = false
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/KiwiDeskCore/Tiling/Navigation+Piles.swift
+++ b/Sources/KiwiDeskCore/Tiling/Navigation+Piles.swift
@@ -1,25 +1,7 @@
 import CoreGraphics
 
 extension Navigation {
-    /// The windows sharing the focused window's overflow cascade
-    /// (an `OverlapStack` pile), excluding the focused window
-    /// itself; empty when it is not in a pile.
-    ///
-    /// Piles are read from geometry, so the one detector serves
-    /// every geometric layout (grid, stack, bsp) and feeds the
-    /// track layout's array-order skip alike (#172). A layout's
-    /// tiled slots are disjoint — gaps hold them apart — but a
-    /// cascade's members overlap heavily (the 40 pt offset is far
-    /// under any window's min size). Slots are grouped into
-    /// connected components of *significant* overlap; the focused
-    /// window's component is its pile. A singleton component (the
-    /// normal tiled case) yields the empty set, so a caller that
-    /// filters on it is a no-op unless a real cascade exists.
-    ///
-    /// Connected components, not pairwise overlap: a deep pile's
-    /// first and last members need not overlap directly, but each
-    /// overlaps its neighbor, so the chain still binds them into
-    /// one component.
+    /// Returns windows sharing the focused window's overlap pile (#172).
     public static func pileMates(
         of focused: WindowID,
         among slots: [(id: WindowID, frame: CGRect)]
@@ -40,10 +22,7 @@ extension Navigation {
         return component
     }
 
-    /// Whether two slots overlap enough to be cascade-mates: a
-    /// quarter of the smaller slot's area. Tiled slots never
-    /// overlap (they clear this at 0); cascade members clear it
-    /// easily (consecutive members share all but a 40 pt sliver).
+    /// Checks if two frames overlap by at least 25% of smaller slot area.
     private static func piled(_ a: CGRect, _ b: CGRect) -> Bool {
         let intersection = a.intersection(b)
         guard !intersection.isNull else { return false }

--- a/Sources/KiwiDeskCore/Tiling/Navigation+Piles.swift
+++ b/Sources/KiwiDeskCore/Tiling/Navigation+Piles.swift
@@ -1,7 +1,11 @@
 import CoreGraphics
 
 extension Navigation {
-    /// Returns windows sharing the focused window's overlap pile (#172).
+    /// Returns windows sharing the focused window's overlap pile,
+    /// read from GEOMETRY so one detector serves every layout
+    /// (#172). Connected components of significant overlap, not
+    /// pairwise: a deep pile's ends need not overlap directly. A
+    /// singleton component yields the empty set.
     public static func pileMates(
         of focused: WindowID,
         among slots: [(id: WindowID, frame: CGRect)]
@@ -22,7 +26,10 @@ extension Navigation {
         return component
     }
 
-    /// Checks if two frames overlap by at least 25% of smaller slot area.
+    /// Cascade-mates overlap by ≥ a quarter of the smaller
+    /// slot's area: tiled slots never overlap (0), cascade
+    /// members share all but a 40 pt sliver — both clear it with
+    /// margin.
     private static func piled(_ a: CGRect, _ b: CGRect) -> Bool {
         let intersection = a.intersection(b)
         guard !intersection.isNull else { return false }

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
@@ -1,18 +1,8 @@
 import CoreGraphics
 import Foundation
 
-/// The Codable half of `TilingSettings`, split from the
-/// struct definition for the 350-line file ceiling. JSON
-/// naming mirrors the Lua API (one vocabulary, AGENTS.md
-/// §5); `SettingsCodingTests` pins the shape.
-///
-/// The conformance is declared here, with its implementation:
-/// declared on the struct, a gutted extension would let the
-/// compiler silently synthesize camelCase/flat coding — this
-/// way it is a compile error instead.
+/// Codable conformance for TilingSettings (`SettingsCodingTests`).
 extension TilingSettings: Codable {
-    // MARK: - Codable
-
     enum CodingKeys: String, CodingKey {
         case animations
         case appBar = "app_bar"
@@ -74,8 +64,6 @@ extension TilingSettings: Codable {
     private typealias Container =
         KeyedDecodingContainer<CodingKeys>
 
-    /// Manual decoding: profiles saved before a field existed
-    /// must keep loading (missing keys fall back to defaults).
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(
             keyedBy: CodingKeys.self
@@ -166,9 +154,6 @@ extension TilingSettings: Codable {
                 QuitLayoutStyle.self,
                 forKey: .layout
             ) ?? .grid
-        // Clamp on decode (the `clampedWidth` precedent): a
-        // hand-edited profile can't smuggle a value past the
-        // range the command and GUI enforce.
         let range = QuitGridLayout.targetDepthRange
         quitGridTargetDepth =
             (try quit.decodeIfPresent(
@@ -190,11 +175,7 @@ extension TilingSettings: Codable {
             keyedBy: ResizeKeys.self,
             forKey: .resize
         )
-        // Clamp at the decode boundary so `resizeStep` is always
-        // finite and in the command's range — a hand-edited
-        // `resize.step: 1e300` would otherwise trap the `Int(...)`
-        // read sites (GUI seed, keybinding rows) that assume a
-        // sane value (#386). Mirrors `set_resize_step`.
+        // Clamp at decode boundary to ensure resizeStep stays finite (#386).
         let rawStep =
             try resize.decodeIfPresent(
                 CGFloat.self,

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+Coding.swift
@@ -2,6 +2,10 @@ import CoreGraphics
 import Foundation
 
 /// Codable conformance for TilingSettings (`SettingsCodingTests`).
+/// Declared HERE with its implementation: declared on the
+/// struct, a gutted extension would let the compiler silently
+/// synthesize camelCase/flat coding — this way it is a compile
+/// error instead.
 extension TilingSettings: Codable {
     enum CodingKeys: String, CodingKey {
         case animations
@@ -154,6 +158,8 @@ extension TilingSettings: Codable {
                 QuitLayoutStyle.self,
                 forKey: .layout
             ) ?? .grid
+        // Clamp on decode: a hand-edited profile can't smuggle a
+        // value past the range the command and GUI enforce.
         let range = QuitGridLayout.targetDepthRange
         quitGridTargetDepth =
             (try quit.decodeIfPresent(
@@ -175,7 +181,9 @@ extension TilingSettings: Codable {
             keyedBy: ResizeKeys.self,
             forKey: .resize
         )
-        // Clamp at decode boundary to ensure resizeStep stays finite (#386).
+        // Clamp at the decode boundary: a hand-edited
+        // `resize.step: 1e300` would trap the `Int(...)` read
+        // sites that assume a sane value (#386).
         let rawStep =
             try resize.decodeIfPresent(
                 CGFloat.self,


### PR DESCRIPTION
Comment diet batch 12 (100 files) trimmed to AGENTS.md §2.8 budget.

- All 100 worklist files trimmed
- Preserved all issue refs (#NNN), test suite references, numeric derivations, and contract docstrings
- scripts/lint.sh exit 0 (line lengths <= 79)
- swift test green (4293 tests passing)

Note: Batch 12. Claude will sweep it before merge.