### PR TITLE
chore(comments): trim remaining files to §2.8 budget (batch 13)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Common/AppRuleControls.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/AppRuleControls.swift
@@ -1,17 +1,11 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// An app chooser: a dropdown of installed apps (identified by
-/// bundle id, shown by localized name) plus a "Custom…" option
-/// that reveals a free text field for a bundle id an app that
-/// isn't installed right now would use.
+/// App picker with installed apps list and custom bundle ID text entry.
 struct AppSelector: View {
-    /// The bundle identifier of the chosen app — the stored
-    /// identity (see `AppRef`), not the display name.
+    /// Bundle identifier of chosen app (`AppRef`).
     @Binding var name: String
-    /// Bundle ids to omit from the picker — App Rules passes the
-    /// apps that already have a rule row, since each app carries at
-    /// most one (its space + float facets live on that single row).
+    /// Bundle IDs to omit from the picker.
     var exclude: Set<String> = []
     @State private var custom = false
 

--- a/Sources/KiwiDesk/Settings/Components/Common/AppRuleControls.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/AppRuleControls.swift
@@ -5,7 +5,9 @@ import SwiftUI
 struct AppSelector: View {
     /// Bundle identifier of chosen app (`AppRef`).
     @Binding var name: String
-    /// Bundle IDs to omit from the picker.
+    /// Bundle IDs to omit — App Rules passes the apps that
+    /// already have a rule row, since each app carries at most
+    /// one (its space + float facets live on that single row).
     var exclude: Set<String> = []
     @State private var custom = false
 

--- a/Sources/KiwiDesk/Settings/Components/Common/BorderPreviewScale.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/BorderPreviewScale.swift
@@ -1,16 +1,8 @@
 import CoreGraphics
 
-/// Pure math for the border-width readouts (#786 review): the
-/// ONE remap from the real 1–20 pt border-width band onto a
-/// preview's smaller span, like `GapPreviewScale` one shelf
-/// over. The editor's 96 pt mock windows read through 1–7; the
-/// Home tile's third-size panes read through a proportionally
-/// smaller band — the same real width must carry the same
-/// perceived weight on both pictures (owner, 2026-08-09), and
-/// two textual copies of the remap disagree on the next retune
-/// with every test green (#702's class, one preview down).
+/// Remapping real border-width band to preview scales (#702, #786).
 enum BorderPreviewScale {
-    /// The width band `BorderStyle.clampedWidth` can produce.
+    /// Width band `BorderStyle.clampedWidth` can produce.
     static let real: ClosedRange<CGFloat> = 1...20
 
     static func width(

--- a/Sources/KiwiDesk/Settings/Components/Common/BorderPreviewScale.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/BorderPreviewScale.swift
@@ -1,6 +1,10 @@
 import CoreGraphics
 
-/// Remapping real border-width band to preview scales (#702, #786).
+/// The ONE remap from the real border-width band onto a
+/// preview's smaller span (#786): the same real width must carry
+/// the same perceived weight on every picture, and two textual
+/// copies disagree on the next retune with every test green
+/// (#702's class).
 enum BorderPreviewScale {
     /// Width band `BorderStyle.clampedWidth` can produce.
     static let real: ClosedRange<CGFloat> = 1...20

--- a/Sources/KiwiDesk/Settings/Components/Common/LayoutModeGlyph.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/LayoutModeGlyph.swift
@@ -1,10 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Layout mode SF Symbol glyphs and curated tab ordering (#68 §6.3, #204).
+/// Layout mode SF Symbol glyphs and curated tab ordering
+/// (#68 §6.3, #204). The glyph is never the only signifier — it
+/// always accompanies the label.
 extension LayoutMode {
-    /// Ordered placement layouts for tab strip and search indexing
-    /// (#90, #204).
+    /// Ordered placement layouts — NOT `allCases` order, and
+    /// without Floating (#204). One home: the tab strip renders
+    /// it and search indexes it, so the two can't drift (#90).
     static let placementTabs: [LayoutMode] = [
         .bsp, .stack, .scrolling, .grid, .monocle, .track,
     ]

--- a/Sources/KiwiDesk/Settings/Components/Common/LayoutModeGlyph.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/LayoutModeGlyph.swift
@@ -1,17 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// One glyph per layout mode (#68 §6.3), used wherever a mode
-/// is named — the space rows' mode picker, the Layout Defaults
-/// section headers, the App Bar override headers, the preset
-/// thumbnails — so the association gets learned. The glyph is
-/// never the only signifier; it always accompanies the label.
+/// Layout mode SF Symbol glyphs and curated tab ordering (#68 §6.3, #204).
 extension LayoutMode {
-    /// The placement layouts in the order the Layout Defaults
-    /// pane taught them (#204) — not `allCases` order, and
-    /// without Floating. The one home for that curated list:
-    /// the tab strip renders it and the Settings search indexes
-    /// it, so the two can't drift (review of #90).
+    /// Ordered placement layouts for tab strip and search indexing
+    /// (#90, #204).
     static let placementTabs: [LayoutMode] = [
         .bsp, .stack, .scrolling, .grid, .monocle, .track,
     ]

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FitGapsAction.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FitGapsAction.swift
@@ -2,10 +2,7 @@ import Accessibility
 import KiwiDeskCore
 import SwiftUI
 
-/// Focus Border's opt-in gap transformation (#295). The extra
-/// spacing is a transient action parameter; only the calculated
-/// gap values join the staged profile. A local result and status
-/// make that two-step transaction explicit before the footer Save.
+/// Focus Border gap transformation action controls (#295).
 struct FitGapsAction: View {
     @ObservedObject var model: SettingsModel
     @State private var extraSpacing = 0

--- a/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FitGapsAction.swift
+++ b/Sources/KiwiDesk/Settings/Components/GapsAndBorders/FitGapsAction.swift
@@ -2,7 +2,9 @@ import Accessibility
 import KiwiDeskCore
 import SwiftUI
 
-/// Focus Border gap transformation action controls (#295).
+/// Focus Border gap transformation action controls (#295). The
+/// extra spacing is a transient action parameter; only the
+/// calculated gap values join the staged profile.
 struct FitGapsAction: View {
     @ObservedObject var model: SettingsModel
     @State private var extraSpacing = 0

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingConflictBanner.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingConflictBanner.swift
@@ -1,14 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// A dismissible in-app warning shown when a keybinding
-/// conflict was just introduced (recording a clashing combo, or
-/// a batch check after Adopt / a raw-Lua save). The persistent
-/// per-row ⚠️ + tooltip always reflects live state on its own;
-/// this banner is only a transient nudge toward it. Its text
-/// derives live (`liveKeybindingBanner`), so it disappears
-/// once dismissed — or once the conflicts it names are gone,
-/// however they were fixed.
+/// Dismissible banner warning for keybinding conflicts.
 struct KeybindingConflictBanner: View {
     @ObservedObject var model: SettingsModel
 
@@ -26,11 +19,6 @@ struct KeybindingConflictBanner: View {
                     Image(systemName: "xmark.circle.fill")
                 }
                 .buttonStyle(.borderless)
-                // `warningInk`, not `.secondary` (dark pass):
-                // the hierarchical grey lands at ~3.5:1 on the
-                // warm brown this surface flips to in dark,
-                // and the banner's own ink is the pairing the
-                // token table clears.
                 .foregroundStyle(SettingsTheme.warningInk)
                 .iconButtonAffordance(
                     L(

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingConflictBanner.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingConflictBanner.swift
@@ -1,7 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Dismissible banner warning for keybinding conflicts.
+/// Dismissible banner warning for keybinding conflicts — a
+/// transient nudge toward the per-row ⚠️, which reflects live
+/// state on its own. Its text derives live, so it disappears
+/// once dismissed or once the conflicts it names are gone.
 struct KeybindingConflictBanner: View {
     @ObservedObject var model: SettingsModel
 
@@ -19,6 +22,9 @@ struct KeybindingConflictBanner: View {
                     Image(systemName: "xmark.circle.fill")
                 }
                 .buttonStyle(.borderless)
+                // `warningInk`, not `.secondary`: the
+                // hierarchical grey lands ~3.5:1 on this
+                // surface's dark-mode brown.
                 .foregroundStyle(SettingsTheme.warningInk)
                 .iconButtonAffordance(
                     L(

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/LayoutKeyGlyph.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/LayoutKeyGlyph.swift
@@ -1,18 +1,7 @@
 import Carbon.HIToolbox
 import Foundation
 
-/// Resolves a virtual key code to its base character on the
-/// *active* keyboard layout via `UCKeyTranslate`, so the
-/// keybinding editor renders layout-correct glyphs — a German
-/// layout shows `+` where a US layout shows `]` (#23). Returns nil
-/// for keys with no printable base character (arrows, function
-/// keys); `ComboSymbols` then falls back to a fixed glyph.
-///
-/// Translation uses no modifier state, so it yields the key's base
-/// glyph (the modifiers are shown separately as ⌃⌥⇧⌘). The current
-/// layout is queried first, with the ASCII-capable layout as a
-/// fallback for input sources (some IMEs) that expose no Unicode
-/// layout data.
+/// Resolves virtual key codes to base characters via UCKeyTranslate (#23).
 enum LayoutKeyGlyph {
     static func char(for keyCode: UInt32) -> String? {
         guard let source = currentSource() ?? asciiSource()

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/LayoutKeyGlyph.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/LayoutKeyGlyph.swift
@@ -1,7 +1,12 @@
 import Carbon.HIToolbox
 import Foundation
 
-/// Resolves virtual key codes to base characters via UCKeyTranslate (#23).
+/// Resolves virtual key codes to base characters on the ACTIVE
+/// layout via UCKeyTranslate (#23) — no modifier state, so the
+/// base glyph (modifiers render separately). Nil for keys with
+/// no printable base; `ComboSymbols` then uses a fixed glyph.
+/// The ASCII-capable layout is the fallback for input sources
+/// (some IMEs) that expose no Unicode layout data.
 enum LayoutKeyGlyph {
     static func char(for keyCode: UInt32) -> String? {
         guard let source = currentSource() ?? asciiSource()

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderField+Feedback.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderField+Feedback.swift
@@ -2,8 +2,11 @@ import SwiftUI
 
 /// Live-apply feedback auto-fade for KeyRecorderField (#123).
 extension KeyRecorderField {
-    /// Schedules timed fade of live-apply feedback, respecting
-    /// Reduce Motion (#989).
+    /// Schedules timed fade of live-apply feedback. One writer,
+    /// latest wins: the equality check keeps an older timer from
+    /// clearing a newer caption early. Reduce Motion drops only
+    /// the motion (#989) — the caption still appears and leaves,
+    /// and here the caption IS the affordance.
     func scheduleFeedbackFade(_ feedback: LiveApplyFeedback) {
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 1_500_000_000)

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderField+Feedback.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderField+Feedback.swift
@@ -1,21 +1,9 @@
 import SwiftUI
 
-/// The live-apply caption's own fade (#123), split from
-/// `KeyRecorderField` at AGENTS.md §2.1's line ceiling — the
-/// same reason the conflict popover has its own file.
+/// Live-apply feedback auto-fade for KeyRecorderField (#123).
 extension KeyRecorderField {
-    /// Clears the caption ~1.5 s after it appeared.
-    ///
-    /// One writer, latest wins: a newer recording sets a new
-    /// feedback and starts its own timer, and the equality
-    /// check is what keeps the older timer from clearing it
-    /// early.
-    ///
-    /// **The fade is gated on Reduce Motion (#989).** With it
-    /// on the caption still appears and still leaves — the
-    /// house split drops the motion, never the affordance, and
-    /// here the caption IS the affordance: nothing else says
-    /// the binding applied live.
+    /// Schedules timed fade of live-apply feedback, respecting
+    /// Reduce Motion (#989).
     func scheduleFeedbackFade(_ feedback: LiveApplyFeedback) {
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 1_500_000_000)

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderRejectionRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderRejectionRow.swift
@@ -1,12 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The inline "Assigned to…" row `KeyRecorderField` shows when a
-/// lock-in collides with another KiwiDesk row (#34): Steal /
-/// Go to are link-styled (`.buttonStyle(.link)`), so they get
-/// the pointing-hand cursor explicitly — `.link` sets color but
-/// not the cursor. Split out of `KeyRecorderField` to keep that
-/// file under the line ceiling.
+/// Inline conflict row showing Steal / Go to actions (#34).
 struct KeyRecorderRejectionRow: View {
     let rejection: RecorderRejection
     let onSteal: () -> Void
@@ -15,13 +10,7 @@ struct KeyRecorderRejectionRow: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            // A shape cue beside the red text — the conflict must
-            // not read by colour alone (WCAG 1.4.1). Hidden from
-            // VoiceOver: the text below already states it.
-            //
-            // `danger`, not `.red`: system red is tuned against
-            // the system window background, and this row sits on
-            // the theme's own dark card, where it sinks.
+            // Visual cue for conflict state (WCAG 1.4.1).
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(SettingsTheme.danger)
                 .accessibilityHidden(true)

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderRejectionRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/Recorder/KeyRecorderRejectionRow.swift
@@ -10,7 +10,10 @@ struct KeyRecorderRejectionRow: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            // Visual cue for conflict state (WCAG 1.4.1).
+            // Shape cue beside the red text — the conflict must
+            // not read by colour alone (WCAG 1.4.1); hidden from
+            // VoiceOver, the text states it. `danger`, not
+            // `.red`: system red sinks on the theme's dark card.
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(SettingsTheme.danger)
                 .accessibilityHidden(true)

--- a/Sources/KiwiDesk/Settings/Components/Layouts/PlacementPicker.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/PlacementPicker.swift
@@ -5,9 +5,13 @@ import SwiftUI
 /// (BSP, Stack, Scrolling, Grid).
 struct PlacementPicker: View {
     @Binding var placement: SpawnPlacement
-    /// Row label (defaults to "New window").
+    /// Row label; defaults to "New window". Track passes
+    /// "Position" — its own/focused mode row above makes a
+    /// second "New window" read wrong.
     var label: String? = nil
-    /// Help override string.
+    /// Help override for callers whose picker means something
+    /// else — Track positions a whole track in own-track mode,
+    /// so the window-centric default would lie there.
     var help: String? = nil
 
     var body: some View {

--- a/Sources/KiwiDesk/Settings/Components/Layouts/PlacementPicker.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/PlacementPicker.swift
@@ -1,17 +1,13 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// New-window placement picker shared by every layout (BSP,
-/// Stack, Scrolling, Grid).
+/// New-window placement picker shared across layouts
+/// (BSP, Stack, Scrolling, Grid).
 struct PlacementPicker: View {
     @Binding var placement: SpawnPlacement
-    /// Row label; defaults to "New window". Track passes
-    /// "Position" — it already has a separate own/focused mode
-    /// row above, so a second "New window" would read wrong.
+    /// Row label (defaults to "New window").
     var label: String? = nil
-    /// Help override for callers whose picker means something
-    /// else — Track positions a whole track in own-track mode,
-    /// so the window-centric default would lie there.
+    /// Help override string.
     var help: String? = nil
 
     var body: some View {

--- a/Sources/KiwiDesk/Settings/Components/Layouts/SchematicCardColors.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/SchematicCardColors.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 
-/// Card fan schematic window coloring rules (`SchematicFocusStrokeTests`).
+/// Card-fan schematic window colours (Monocle's fan, Floating's
+/// pile). One statement of the fallback ladder (plate palette →
+/// theme → family constant): what would be duplicated is the
+/// RULE, and a copy drifting on one arm paints the two
+/// schematics differently side by side.
+/// `SchematicFocusStrokeTests` needles both call sites.
 enum SchematicCardColors {
     static func fill(
         front: Bool,

--- a/Sources/KiwiDesk/Settings/Components/Layouts/SchematicCardColors.swift
+++ b/Sources/KiwiDesk/Settings/Components/Layouts/SchematicCardColors.swift
@@ -1,15 +1,6 @@
 import SwiftUI
 
-/// The colours a CARD-FAN schematic draws its windows with —
-/// Monocle's fan and Floating's pile, the two modes that draw a
-/// stack of whole windows rather than a tiling.
-///
-/// One statement of the fallback ladder (plate palette → theme →
-/// family constant), because what would be duplicated is the
-/// RULE rather than a value: a copy that drifts on one arm draws
-/// brand green on the user's own desktop plate in one schematic
-/// and the folded palette in the other, side by side in the same
-/// strip. `SchematicFocusStrokeTests` needles both call sites.
+/// Card fan schematic window coloring rules (`SchematicFocusStrokeTests`).
 enum SchematicCardColors {
     static func fill(
         front: Bool,

--- a/Sources/KiwiDesk/Settings/Components/Lua/CustomLuaBanner.swift
+++ b/Sources/KiwiDesk/Settings/Components/Lua/CustomLuaBanner.swift
@@ -1,12 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Informational banner shown in the visual editor when
-/// `init.lua` contains custom Lua that does NOT touch the
-/// GUI's managed vocabulary (app rules, keybindings, etc.).
-/// Such code coexists safely — the app saves to `gui.json`
-/// and never touches `init.lua` (#55), so there is no
-/// conflict with what the visual editor owns.
+/// Informational banner shown when init.lua contains custom Lua (#55).
 struct CustomLuaBanner: View {
     var body: some View {
         Label {
@@ -20,9 +15,6 @@ struct CustomLuaBanner: View {
                 )
             )
         } icon: {
-            // `ink2`, not `.blue`: a raw system hue in a
-            // green-tinted window, and the note is neutral
-            // information, not a link (dark pass).
             Image(systemName: "info.circle")
                 .foregroundStyle(SettingsTheme.ink2)
         }

--- a/Sources/KiwiDesk/Settings/Components/Lua/CustomLuaBanner.swift
+++ b/Sources/KiwiDesk/Settings/Components/Lua/CustomLuaBanner.swift
@@ -1,7 +1,10 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Informational banner shown when init.lua contains custom Lua (#55).
+/// Informational banner shown when init.lua contains custom Lua
+/// outside the GUI's managed vocabulary. Such code coexists
+/// safely: the app saves to gui.json and never touches
+/// init.lua (#55).
 struct CustomLuaBanner: View {
     var body: some View {
         Label {
@@ -15,6 +18,8 @@ struct CustomLuaBanner: View {
                 )
             )
         } icon: {
+            // `ink2`, not `.blue`: a raw system hue in a
+            // green-tinted window — neutral info, not a link.
             Image(systemName: "info.circle")
                 .foregroundStyle(SettingsTheme.ink2)
         }

--- a/Sources/KiwiDesk/Settings/Components/Profiles/DesktopGlyph.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/DesktopGlyph.swift
@@ -1,4 +1,8 @@
-/// Shared SF Symbol representing a macOS Desktop across UI surfaces.
+/// Shared SF Symbol representing a macOS Desktop. One copy
+/// because two surfaces assert they agree — the Profiles ▸
+/// Desktops card and every Desktop keybinding row; spelled
+/// twice, the first divergent edit pictures one concept two
+/// ways and no test would see it.
 enum DesktopGlyph {
     static let symbol = "square.on.square"
 }

--- a/Sources/KiwiDesk/Settings/Components/Profiles/DesktopGlyph.swift
+++ b/Sources/KiwiDesk/Settings/Components/Profiles/DesktopGlyph.swift
@@ -1,18 +1,4 @@
-/// The SF Symbol that pictures a macOS **Desktop**, wherever the
-/// app draws one.
-///
-/// One copy, because two surfaces assert they agree: the
-/// Profiles ▸ Desktops card marks each bindable Desktop with it,
-/// and every Desktop keybinding row carries it so a Desktop row
-/// reads as a Desktop beside a Space row. Spelled twice, that
-/// agreement is a sentence in a doc comment with nothing holding
-/// it — the first divergent edit makes the two surfaces picture
-/// one concept two ways, and no test would see it.
-///
-/// Here rather than beside the keybinding catalog because the
-/// Profiles card is the older claimant, and a Desktop is a
-/// profiles-and-topology concept that the Shortcuts area
-/// borrows.
+/// Shared SF Symbol representing a macOS Desktop across UI surfaces.
 enum DesktopGlyph {
     static let symbol = "square.on.square"
 }

--- a/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows+StackRows.swift
+++ b/Sources/KiwiDesk/Settings/Components/SpaceOverrides/SpaceOverrideRows+StackRows.swift
@@ -1,12 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The Stack per-space override rows, split out of
-/// `SpaceOverrideRows` when the #222 arrangement rows grew them
-/// past the base file's line budget (same seam as
-/// `SpaceOverrideRows+ModeRows.swift`). `g` and
-/// `binding(_:_:_:)` are internal on the base type; this builder
-/// is called from its `modeRows` switch.
+/// Stack per-space override rows for SpaceOverrideRows (#222).
 extension SpaceOverrideRows {
     @ViewBuilder
     var stackRows: some View {

--- a/Sources/KiwiDesk/Settings/DiscardConfirm.swift
+++ b/Sources/KiwiDesk/Settings/DiscardConfirm.swift
@@ -1,12 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Hosts the one discard dialog for the whole dashboard (#515).
-/// Applied in `SettingsView.body` **above** the `editingLua`
-/// branch: two of the gated actions flip that flag, so a host
-/// inside either arm would be torn down by its own confirm
-/// button. The model half — `PendingDiscard` and the gate — is
-/// `SettingsModel+Discard.swift`.
+/// Hosts the discard confirmation dialog across dashboard views (#515).
 struct DiscardConfirmation: ViewModifier {
     @ObservedObject var model: SettingsModel
 

--- a/Sources/KiwiDesk/Settings/DiscardConfirm.swift
+++ b/Sources/KiwiDesk/Settings/DiscardConfirm.swift
@@ -1,7 +1,11 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// Hosts the discard confirmation dialog across dashboard views (#515).
+/// Hosts the one discard dialog for the whole dashboard (#515).
+/// Applied in `SettingsView.body` ABOVE the `editingLua`
+/// branch: two of the gated actions flip that flag, so a host
+/// inside either arm would be torn down by its own confirm
+/// button.
 struct DiscardConfirmation: ViewModifier {
     @ObservedObject var model: SettingsModel
 

--- a/Sources/KiwiDesk/Settings/DragTransfer.swift
+++ b/Sources/KiwiDesk/Settings/DragTransfer.swift
@@ -1,18 +1,7 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// In-app drag payload for the settings dashboard: a
-/// same-process, model-level drag of a space chip onto a
-/// monitor tile. (The Spaces-list reorder is a plain drag
-/// *gesture*, not a drag session — no payload involved.)
-///
-/// It rides the system `.json` content type rather than a bespoke
-/// `UTType(exportedAs:)`: KiwiDesk ships as a bare SwiftPM
-/// executable with no bundle, so a custom exported type is never
-/// registered with LaunchServices and its drops are silently
-/// rejected (the chip snaps back). `.json` is always registered, so
-/// the drop round-trips, while unrelated text drags still don't
-/// match (`.json` ≠ `.plainText`).
+/// In-app drag payload transferring a space chip onto a monitor tile.
 struct DraggableSpace: Codable, Transferable {
     let raw: String
 

--- a/Sources/KiwiDesk/Settings/DragTransfer.swift
+++ b/Sources/KiwiDesk/Settings/DragTransfer.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// In-app drag payload transferring a space chip onto a monitor tile.
+/// In-app drag payload transferring a space chip onto a monitor
+/// tile. Rides the system `.json` type, never a bespoke
+/// `UTType(exportedAs:)`: a bare SwiftPM executable has no
+/// bundle, so a custom exported type is never registered with
+/// LaunchServices and its drops are silently rejected.
 struct DraggableSpace: Codable, Transferable {
     let raw: String
 

--- a/Sources/KiwiDesk/Settings/FlowLayout.swift
+++ b/Sources/KiwiDesk/Settings/FlowLayout.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 
-/// A left-aligned layout that flows subviews across the available
-/// width and wraps to the next line when the current one is full.
-/// Used for chip palettes (e.g. draggable spaces) where a fixed
-/// grid would waste space.
+/// Left-aligned wrapping flow layout for chips and palettes.
 struct FlowLayout: Layout {
     var spacing: CGFloat = 6
 
@@ -25,11 +22,6 @@ struct FlowLayout: Layout {
         let rows = arrange(subviews, in: bounds.width).rows
         for row in rows {
             for item in row.items {
-                // Clamp to the row width so a lone item wider
-                // than the bounds (the first-in-row case that
-                // arrange can't wrap) truncates to fit instead
-                // of overflowing — otherwise a trailing control
-                // spills past the container's edge.
                 subviews[item.index].place(
                     at: CGPoint(
                         x: bounds.minX + item.x,
@@ -43,8 +35,6 @@ struct FlowLayout: Layout {
             }
         }
     }
-
-    // MARK: - Arrangement
 
     private struct Item {
         let index: Int

--- a/Sources/KiwiDesk/Settings/FlowLayout.swift
+++ b/Sources/KiwiDesk/Settings/FlowLayout.swift
@@ -22,6 +22,9 @@ struct FlowLayout: Layout {
         let rows = arrange(subviews, in: bounds.width).rows
         for row in rows {
             for item in row.items {
+                // Clamp to the row width so a lone item wider
+                // than the bounds truncates instead of spilling
+                // past the container's edge.
                 subviews[item.index].place(
                     at: CGPoint(
                         x: bounds.minX + item.x,

--- a/Sources/KiwiDesk/Settings/HomeCardPlate+Legibility.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardPlate+Legibility.swift
@@ -1,23 +1,14 @@
 import SwiftUI
 
-/// The palette fold's legibility floor (#786, ui-designer).
-/// Split from `HomeCardPlate.swift` at the file-size
-/// ceiling; the fold that consults it stays there.
+/// Palette fold legibility floor calculations (`HomeCardChromeTests`, #786).
 extension HomeCardPlate {
-    /// The plate's own weighted luminance — `previewPlate`'s
-    /// `0x12251A`, restated as arithmetic so the floor below
-    /// can composite translucent user colours against it.
+    /// Plate weighted luminance arithmetic baseline.
     static let plateLuminance =
         0.2126 * (0x12 / 255.0)
         + 0.7152 * (0x25 / 255.0)
         + 0.0722 * (0x1A / 255.0)
 
-    /// Whether a user hex can be seen on the plate at all: its
-    /// alpha-composited weighted luminance must sit a floor's
-    /// width from the plate's own, in either direction — a
-    /// near-plate dark and a translucent wisp both fail.
-    /// Internal so `HomeCardChromeTests` can pin the floor with
-    /// the palettes that motivated it.
+    /// Returns whether hex color meets contrast floor against plate luminance.
     static func plateLegible(_ hex: String) -> Bool {
         guard let c = rgba(hex) else { return false }
         let lum =

--- a/Sources/KiwiDesk/Settings/HomeCardPlate+Legibility.swift
+++ b/Sources/KiwiDesk/Settings/HomeCardPlate+Legibility.swift
@@ -8,7 +8,10 @@ extension HomeCardPlate {
         + 0.7152 * (0x25 / 255.0)
         + 0.0722 * (0x1A / 255.0)
 
-    /// Returns whether hex color meets contrast floor against plate luminance.
+    /// Whether a user hex can be seen on the plate at all: its
+    /// alpha-composited luminance must sit a floor's width from
+    /// the plate's own, in EITHER direction — a near-plate dark
+    /// and a translucent wisp both fail.
     static func plateLegible(_ hex: String) -> Bool {
         guard let c = rgba(hex) else { return false }
         let lum =

--- a/Sources/KiwiDesk/Settings/InactiveDimmed.swift
+++ b/Sources/KiwiDesk/Settings/InactiveDimmed.swift
@@ -1,17 +1,9 @@
 import SwiftUI
 
-/// Fades hand-built chrome while the window is inactive — the
-/// treatment System Settings gives its colored sidebar icons: a
-/// plain alpha fade that keeps the hue, never a desaturate
-/// (settled by eye — grayscale reads as "disabled"). Survived
-/// the sidebar it was built for (#297 → #678 turn 9): the
-/// search field and the Home cards' icon tiles still dim by it.
-/// Deliberately keyed to `.inactive` only — `.active` (window
-/// not key, app still active, e.g. while the shared color panel
-/// is up) must not dim.
+/// View modifier that dims chrome elements when window is inactive
+/// (#297, #678).
 struct InactiveDimmed: ViewModifier {
-    /// The one fade shared by every dimmed element — they key
-    /// off the same state change and must stay in lockstep.
+    /// Shared crossfade animation.
     static let fade = Animation.easeInOut(duration: 0.15)
 
     @Environment(\.controlActiveState) private var activeState

--- a/Sources/KiwiDesk/Settings/InactiveDimmed.swift
+++ b/Sources/KiwiDesk/Settings/InactiveDimmed.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
-/// View modifier that dims chrome elements when window is inactive
-/// (#297, #678).
+/// Dims hand-built chrome while the window is inactive (#297,
+/// #678): a plain alpha fade that keeps the hue, never a
+/// desaturate — grayscale reads as "disabled". Keyed to
+/// `.inactive` ONLY: `.active` (window not key while the shared
+/// color panel is up) must not dim.
 struct InactiveDimmed: ViewModifier {
     /// Shared crossfade animation.
     static let fade = Animation.easeInOut(duration: 0.15)

--- a/Sources/KiwiDesk/Settings/Sections/BehaviorSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/BehaviorSection.swift
@@ -1,14 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// This Profile ▸ Behavior (#68 §3.2): mouse-resize mode and
-/// what happens on quit — per-profile data, labeled as such by
-/// the sidebar group (the old General tab presented them without
-/// any scope cue).
-///
-/// The animation toggles left in #678 Phase 3: the census places
-/// every one of them in Colours & Animations, and half a card on each
-/// page is an area the render-parity guard cannot see whole.
+/// Profile Behavior settings section (#68 §3.2, #678 Phase 3).
 struct BehaviorSection: View {
     @ObservedObject var model: SettingsModel
 

--- a/Sources/KiwiDesk/Settings/Sections/ColorsMotionSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/ColorsMotionSection.swift
@@ -1,14 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// This Profile ▸ Colours & Animations (#678 Phase 3, turn 12a): the
-/// whole of the Simple colour story. A shelf of palettes applied
-/// as a one-time paint, one scene showing what the current colours
-/// actually look like, and the Animations card.
-///
-/// A Simple user meets six colour roles here, not twenty-five —
-/// the per-element page is its own area, and "Save current colors
-/// as…" on the shelf is the one bridge back from it.
+/// Profile Colours & Animations settings section (#678 Phase 3).
 struct ColorsMotionSection: View {
     @ObservedObject var model: SettingsModel
 
@@ -16,10 +9,6 @@ struct ColorsMotionSection: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 PaletteShelf(model: model)
-                // The live-colours scene moved to the detail
-                // PANEL (`PaletteScenePanel`, #678 redesign spec) —
-                // the column beside these rows is where the
-                // draft is watched now.
                 MotionCard(model: model)
             }
             .padding([.horizontal, .bottom], SettingsMetrics.paneInset)

--- a/Sources/KiwiDesk/Settings/Sections/SpaceNameField.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpaceNameField.swift
@@ -26,7 +26,9 @@ struct SpaceNameField: View {
     var body: some View {
         TextField("", text: $draft)
             .textFieldStyle(.roundedBorder)
-            // Accessible label for nameless field (#812).
+            // Accessible label for the nameless field (#812) —
+            // the DIFF ROW's key, not a twin: one key cannot
+            // disagree with itself across ten locales.
             .accessibilityLabel(
                 L("diff.label.space_name", "Space name")
             )

--- a/Sources/KiwiDesk/Settings/Sections/SpaceNameField.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpaceNameField.swift
@@ -24,16 +24,9 @@ struct SpaceNameField: View {
     }
 
     var body: some View {
-        // A visible, fixed-width field: renaming is
-        // discoverable without clicking first, and the fields
-        // align in a column across rows.
         TextField("", text: $draft)
             .textFieldStyle(.roundedBorder)
-            // Nameless otherwise — an empty title, and the row
-            // draws no label beside it (#812). The DIFF ROW's
-            // label key, not a twin: both name the same setting,
-            // and one key cannot disagree with itself across ten
-            // locales (localization audit, 2026-08-24).
+            // Accessible label for nameless field (#812).
             .accessibilityLabel(
                 L("diff.label.space_name", "Space name")
             )

--- a/Sources/KiwiDesk/Settings/Sections/SpacesSection+PinBadge.swift
+++ b/Sources/KiwiDesk/Settings/Sections/SpacesSection+PinBadge.swift
@@ -1,16 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The space row's display-pin badge (#678 Phase 3, turn 8a),
-/// split from `SpacesSection.swift` to stay under the line ceiling
-/// (same seam as `+Drag`/`+Customize`/`+ModePicker`).
-///
-/// Names the display a space is pinned to, or flags a pin whose
-/// display is offline — so the pin is visible on the row without
-/// opening Monitors. The connected/offline split is resolved by
-/// `SpacePinBadge` from the same attached-fingerprint set the
-/// placement resolver reads, so the row and the placement cannot
-/// disagree about whether a pin is live.
+/// Space row display-pin badge view for SpacesSection (#678 Phase 3).
 extension SpacesSection {
     @ViewBuilder
     func pinBadge(_ space: SpaceID) -> some View {

--- a/Sources/KiwiDesk/Settings/SettingsDestination+Area.swift
+++ b/Sources/KiwiDesk/Settings/SettingsDestination+Area.swift
@@ -1,4 +1,8 @@
-/// Destination to census area bijection (`DestinationAreaParityTests`, #678).
+/// Destination ↔ census-area bridge (#678): the destination is
+/// the navigation identity, the area the census's placement
+/// vocabulary. One exhaustive map each way;
+/// `DestinationAreaParityTests` pins the bijection so a new
+/// case on either side reds instead of missing a card.
 extension SettingsDestination {
     /// The census area this destination renders.
     var area: SettingsArea {

--- a/Sources/KiwiDesk/Settings/SettingsDestination+Area.swift
+++ b/Sources/KiwiDesk/Settings/SettingsDestination+Area.swift
@@ -1,13 +1,4 @@
-/// The destination ↔ census-area bridge (#678 turn 9). The two
-/// enums predate each other from opposite ends — the destination
-/// is the navigation identity (American spellings, `Codable`
-/// selection), the area is the census's placement vocabulary
-/// (British spellings) — and Home is where they finally meet:
-/// a card is offered per AREA rule (`minimumMode`, the Monitors
-/// auto-promotion) and opens a DESTINATION. One exhaustive map
-/// each way; `DestinationAreaParityTests` pins the bijection so
-/// a thirteenth case on either side reds instead of silently
-/// missing a card.
+/// Destination to census area bijection (`DestinationAreaParityTests`, #678).
 extension SettingsDestination {
     /// The census area this destination renders.
     var area: SettingsArea {

--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar+Search.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar+Search.swift
@@ -1,14 +1,8 @@
 import KiwiDeskCore
 
-/// The header bar's search context (#678 turn 11) — its own
-/// file for the §2.1 ceiling, not for reuse.
+/// Search context builder for SettingsHeaderBar (#678).
 extension SettingsHeaderBar {
-    /// Everything search may consult, collected here from state
-    /// already in memory (spec 11a: nothing on the search path
-    /// touches AX, the session or the filesystem). Palettes are
-    /// absent by type — `SettingsSearchPlace.Kind` has no case
-    /// for them until an in-memory palette-name seam exists
-    /// (the argument lives on the Kind enum).
+    /// Constructs SettingsSearchContext from in-memory state.
     var searchContext: SettingsSearchContext {
         SettingsSearchContext(
             editingStoredProfile: model.editingStoredProfile,

--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar+Search.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar+Search.swift
@@ -2,7 +2,10 @@ import KiwiDeskCore
 
 /// Search context builder for SettingsHeaderBar (#678).
 extension SettingsHeaderBar {
-    /// Constructs SettingsSearchContext from in-memory state.
+    /// Constructs SettingsSearchContext from state already in
+    /// memory — nothing on the search path touches AX, the
+    /// session or the filesystem (spec 11a). Palettes are absent
+    /// by type; the argument lives on the Kind enum.
     var searchContext: SettingsSearchContext {
         SettingsSearchContext(
             editingStoredProfile: model.editingStoredProfile,

--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar+Status.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar+Status.swift
@@ -2,6 +2,9 @@ import KiwiDeskCore
 import SwiftUI
 
 /// Status row and profile warning views for SettingsHeaderBar.
+/// Takes NO traffic-light inset: it sits below the lights, so
+/// it keeps the bar's ordinary gutter and stays aligned with
+/// the content column beneath.
 extension SettingsHeaderBar {
 
     var showDivergence: Bool {

--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar+Status.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar+Status.swift
@@ -1,16 +1,7 @@
 import KiwiDeskCore
 import SwiftUI
 
-/// The header's SECOND row: the profile status sentence and the
-/// dismissible profile warning, carried whole from the old
-/// header. Split out of `SettingsHeaderBar` when the turn-16b
-/// skin took that file past the §2.1 ceiling — this half is
-/// prose-and-state, the other is the chrome row, and they change
-/// for different reasons.
-///
-/// Unlike the title row it takes NO traffic-light inset: it sits
-/// below the lights, so it keeps the bar's ordinary gutter and
-/// stays aligned with the content column beneath it.
+/// Status row and profile warning views for SettingsHeaderBar.
 extension SettingsHeaderBar {
 
     var showDivergence: Bool {

--- a/Sources/KiwiDesk/Settings/SettingsModePreference.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModePreference.swift
@@ -1,19 +1,6 @@
 import Foundation
 
-/// Where the Simple/Power User pick lives (#678 turn 9).
-///
-/// Storage is app preferences (`UserDefaults`), NOT `gui.json`,
-/// on exactly `AppearancePreference`'s reasoning: the mode is an
-/// app-wide display choice, it is not part of a profile, and
-/// writing it must never create a sidecar — that would flip
-/// `KiwiCore.isGuiManaged` for a user who never adopted the GUI.
-/// It also never enters the dirty-tracked config: the header
-/// segment applies immediately and the footer's Save has nothing
-/// to do with it.
-///
-/// Absent — and any unrecognised value — reads as `.simple`,
-/// the approachable default; `.simple` removes the key so the
-/// default leaves no trace in the domain.
+/// User preferences storage for Simple/Power User settings mode (#678).
 enum SettingsModePreference {
     static let key = "settingsMode"
 

--- a/Sources/KiwiDesk/Settings/SettingsModePreference.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModePreference.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-/// User preferences storage for Simple/Power User settings mode (#678).
+/// Simple/Power User mode storage (#678): `UserDefaults`, NOT
+/// `gui.json` — an app-wide display choice, not profile data,
+/// and writing it must never create a sidecar (that would flip
+/// `KiwiCore.isGuiManaged` for a user who never adopted the
+/// GUI). Absent or unrecognised reads `.simple`; picking
+/// `.simple` removes the key.
 enum SettingsModePreference {
     static let key = "settingsMode"
 

--- a/Sources/KiwiDesk/Settings/SettingsModel+Appearance.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Appearance.swift
@@ -4,6 +4,8 @@ import KiwiDeskCore
 /// Immediate appearance preference handling for SettingsModel (#678).
 extension SettingsModel {
     /// Persists the pick and immediately updates the appearance.
+    /// `.system` hands the decision back to macOS and leaves no
+    /// key behind.
     func setAppearance(_ choice: AppearanceChoice) {
         AppearancePreference.write(choice, to: preferences)
         appearance = choice

--- a/Sources/KiwiDesk/Settings/SettingsModel+Appearance.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Appearance.swift
@@ -1,21 +1,9 @@
 import Foundation
 import KiwiDeskCore
 
-/// The appearance picker's read/write path (#678 item 8).
-///
-/// Sits in the "applies immediately" group with the language
-/// pick, and for the same reason: it is not part of a profile and
-/// ignores the footer's Save entirely. Turn 14b makes that
-/// grouping the design rather than a detail — a row that Revert
-/// appears to undo and does not is the fourth finding from the
-/// 6b audit, and the heading is what stops it.
-///
-/// `@Published` is what re-renders the shell: the pick is read
-/// once at `SettingsModel` init and then lives here, so writing
-/// it both persists and repaints in one step.
+/// Immediate appearance preference handling for SettingsModel (#678).
 extension SettingsModel {
-    /// Persists the pick and repaints the window. `.system` hands
-    /// the decision back to macOS and leaves no key behind.
+    /// Persists the pick and immediately updates the appearance.
     func setAppearance(_ choice: AppearanceChoice) {
         AppearancePreference.write(choice, to: preferences)
         appearance = choice

--- a/Sources/KiwiDesk/Settings/SettingsModel+Language.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Language.swift
@@ -1,17 +1,10 @@
 import Foundation
 import KiwiDeskCore
 
-/// The GUI language picker's write path (issue #9): unlike
-/// every other setting in `config`, a language change is not
-/// dirty-tracked behind the footer's Save — it applies live and
-/// persists immediately, mirroring how the picker itself reads
-/// as "already saved" the moment it changes. Storage is app
-/// preferences (`UserDefaults`), not `gui.json` — a language
-/// pick is documented as side-effect-free and must never create
-/// a sidecar, which would flip `KiwiCore.isGuiManaged` for a
-/// hand-written-Lua user who only wanted a different language.
+/// Immediate language preference application for SettingsModel (#9).
 extension SettingsModel {
-    /// `nil` selects "System default".
+    /// Persists language selection and updates LocalizationManager
+    /// (nil = system default).
     func setLanguage(_ language: String?) {
         LocalizationPreference.write(language)
         LocalizationManager.shared.select(language)

--- a/Sources/KiwiDesk/Settings/SettingsModel+Language.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Language.swift
@@ -1,7 +1,11 @@
 import Foundation
 import KiwiDeskCore
 
-/// Immediate language preference application for SettingsModel (#9).
+/// Immediate language preference application for SettingsModel
+/// (#9): applies live, never dirty-tracked behind the footer
+/// Save. Stored in `UserDefaults`, not `gui.json` — see
+/// `LocalizationPreference` for why a sidecar must never be
+/// created.
 extension SettingsModel {
     /// Persists language selection and updates LocalizationManager
     /// (nil = system default).

--- a/Sources/KiwiDesk/Settings/SettingsModel+LayoutDrift.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+LayoutDrift.swift
@@ -1,11 +1,8 @@
 import KiwiDeskCore
 
-/// Live-vs-saved layout drift for the active space (#123),
-/// split from SettingsModel.swift (file-size ceiling): a
-/// transient snapshot from direct comparison — never latched,
-/// never routed through `isDirty`/`profileDirty`.
+/// Live vs saved layout drift detection for active space (#123).
 extension SettingsModel {
-    /// nil = no drift.
+    /// Live vs saved layout modes (nil = no drift).
     struct LayoutDrift: Equatable {
         let live: LayoutMode
         let saved: LayoutMode
@@ -13,11 +10,7 @@ extension SettingsModel {
 
     var hasLayoutDrift: Bool { layoutDrift != nil }
 
-    /// Recomputes the drift snapshot without reseeding `config`
-    /// — safe mid-edit; the quick menu calls it after a
-    /// session-only layout switch or save. External `set_mode`
-    /// (hotkey/Lua/CLI) refreshes on the next window `show()`.
-    /// The only writer of `layoutDrift`.
+    /// Recomputes drift snapshot without reseeding config.
     func refreshLayoutDrift() {
         layoutDrift = computeLayoutDrift()
     }

--- a/Sources/KiwiDesk/Settings/SettingsModel+LayoutDrift.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+LayoutDrift.swift
@@ -1,6 +1,8 @@
 import KiwiDeskCore
 
-/// Live vs saved layout drift detection for active space (#123).
+/// Live vs saved layout drift detection for active space
+/// (#123): a transient snapshot from direct comparison — never
+/// latched, never routed through `isDirty`/`profileDirty`.
 extension SettingsModel {
     /// Live vs saved layout modes (nil = no drift).
     struct LayoutDrift: Equatable {
@@ -10,7 +12,8 @@ extension SettingsModel {
 
     var hasLayoutDrift: Bool { layoutDrift != nil }
 
-    /// Recomputes drift snapshot without reseeding config.
+    /// Recomputes drift snapshot without reseeding `config` —
+    /// safe mid-edit. The only writer of `layoutDrift`.
     func refreshLayoutDrift() {
         layoutDrift = computeLayoutDrift()
     }

--- a/Sources/KiwiDesk/Settings/SettingsModel+Search.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Search.swift
@@ -2,7 +2,10 @@ import KiwiDeskCore
 
 /// Search enrichment and mode-switch confirmation for SettingsModel (#678).
 extension SettingsModel {
-    /// Returns staged value for census key formatted via SettingsValueReadout.
+    /// Staged value for a census key, as the diff rows narrate
+    /// it — `SettingsValueReadout` with the draft on BOTH sides,
+    /// so the "new" column IS the current value and search
+    /// cannot name a value two ways.
     func searchValue(for key: SettingKey) -> String? {
         SettingsValueReadout.rows(
             for: key,

--- a/Sources/KiwiDesk/Settings/SettingsModel+Search.swift
+++ b/Sources/KiwiDesk/Settings/SettingsModel+Search.swift
@@ -1,15 +1,8 @@
 import KiwiDeskCore
 
-/// The model half of the search rework (#678 turn 11): the value
-/// enrichment read and the one-line mode-switch confirmation.
+/// Search enrichment and mode-switch confirmation for SettingsModel (#678).
 extension SettingsModel {
-    /// Enrichment: the current value of a census key as the diff
-    /// rows would narrate it — `SettingsValueReadout` with the
-    /// draft on both sides, so the "new" column IS the current
-    /// value and search cannot name a value two ways. Reads the
-    /// staged config in memory, nothing else. Nil where the key
-    /// has no scalar to state (families, actions, added/removed
-    /// rows).
+    /// Returns staged value for census key formatted via SettingsValueReadout.
     func searchValue(for key: SettingKey) -> String? {
         SettingsValueReadout.rows(
             for: key,
@@ -20,11 +13,8 @@ extension SettingsModel {
         .newValue
     }
 
-    /// Shows the one-line confirmation after a search pick
-    /// flipped the window into Power User mode (4c): the flip
-    /// itself is `ensureModeAdmits`' and stays silent; this line
-    /// is the only mention. Self-clears; a second flip
-    /// supersedes the first.
+    /// Displays self-clearing confirmation when search flips to
+    /// Power User mode.
     func noteSearchModeSwitch(
         _ destination: SettingsDestination
     ) {

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+AppBar.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+AppBar.swift
@@ -1,12 +1,7 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// Global App Bar rows: every key narrates the one
-/// `AppBarStyle` field its census id names. Enum-valued rows
-/// reuse the option labels the Bars editor renders
-/// (`AppBarOptions`), the auto-sentinel size sliders read
-/// "Automatic" at 0 the way the GUI's slider readout does, and
-/// a colour shows its stored hex verbatim.
+/// Global App Bar settings diff readout generators (`AppBarOptions`).
 extension SettingsValueReadout {
     static func appBarRows(
         _ key: AppBarKey,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Behaviour.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Behaviour.swift
@@ -1,11 +1,6 @@
 import KiwiDeskCore
 
-/// Behaviour rows: the top-level `TilingSettings` knobs. Enum
-/// values reuse the GUI's own option labels where the area
-/// draws a picker (`BehaviorSection`, `PlacementPicker`), so
-/// the diff speaks the words the control does; the Lua-only
-/// keys author their labels here, there being no census text
-/// to resolve.
+/// Behaviour settings diff readout generators.
 extension SettingsValueReadout {
     static func behaviourRows(
         _ key: BehaviourKey,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Borders.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Borders.swift
@@ -1,17 +1,7 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// Borders, marks and drag-visual rows. The two master rows
-/// narrate the shared value the #754 card shows — reading
-/// "mixed" where the strokes disagree, resolved through
-/// `GapsBordersGates.agreedCornerStyle`, the one copy of that
-/// comparison — while the master-written leaves narrate their
-/// own stored values for a Lua edit that split them. The two
-/// fit-gaps rows are actions and store nothing, so they draw
-/// no row. Colours show their stored hex; the two mark tints'
-/// empty sentinel reads "Automatic" the way the colour well's
-/// own field prints it. The value formatters and the row shape
-/// live in `SettingsValueReadout+BordersValues.swift`.
+/// Borders, marks, and drag visual settings diff row generators (#754).
 extension SettingsValueReadout {
     static func bordersRows(
         _ key: BordersKey,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Colours.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Colours.swift
@@ -1,6 +1,9 @@
 import KiwiDeskCore
 
-/// Colours & Animations settings diff readout generators.
+/// Colours & Animations settings diff readout generators. The
+/// palette rows are ACTIONS — they mutate the palette store,
+/// not the draft config — so none stores a value a draft diff
+/// could state.
 extension SettingsValueReadout {
     static func coloursRows(
         _ key: ColoursKey,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Colours.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Colours.swift
@@ -1,10 +1,6 @@
 import KiwiDeskCore
 
-/// Colours & Animations rows: the animation toggles and their two
-/// paces. The palette rows are ACTIONS — apply, save, rename,
-/// export, delete and import mutate the palette store, not the
-/// draft config — and the neon-glow hint is a link, so none of
-/// them stores a value a draft diff could state.
+/// Colours & Animations settings diff readout generators.
 extension SettingsValueReadout {
     static func coloursRows(
         _ key: ColoursKey,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Gaps.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Gaps.swift
@@ -1,11 +1,7 @@
 import CoreGraphics
 import KiwiDeskCore
 
-/// Gaps-area rows. The per-edge keys narrate their own point
-/// value; the two master rows narrate the unified value the
-/// slider shows, reading "mixed" the way `GapsEditor` does when
-/// the edges disagree; the Lua-only per-space override expands
-/// to a row per touched space.
+/// Gaps settings diff readout generators.
 extension SettingsValueReadout {
     static func gapsRows(
         _ key: GapsKey,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+General.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+General.swift
@@ -1,10 +1,6 @@
 import KiwiDeskCore
 
-/// General-area rows. Every key here is app-internal
-/// `UserDefaults` storage, a login-item service read, an
-/// action, or a read-only row — none names a `settings.*` /
-/// `config.*` model path, so the draft diff can never book one
-/// and the readout has nothing to narrate.
+/// General-area diff readout (non-model keys produce no rows, #606).
 extension SettingsValueReadout {
     static func generalRows(
         _ key: GeneralKey,
@@ -18,13 +14,7 @@ extension SettingsValueReadout {
             .advancedResetAll, .onboardingDiscoveryShown,
             .iconPickerRecents, .onboardingOpenAtLogin,
             .advancedExportBackup, .advancedRestoreBackup:
-            // no model path — never booked by the diff.
-            // #606's pair joins the list for the same reason as
-            // the reset actions: `(action) …` is not a model path,
-            // so `SettingsDraftDiff` cannot book one. The
-            // readout's totality guard filters these out and would
-            // not have asked — the COMPILER did, which is the
-            // better of the two nets.
+            // Non-model keys produce no diff rows.
             return []
         }
     }

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Layout.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Layout.swift
@@ -1,12 +1,6 @@
 import KiwiDeskCore
 
-/// Layout Defaults rows — the six layouts' global parameters.
-/// Every value narrates the unit its own Settings row shows:
-/// ratios as the slider's percentage readout, the slot size in
-/// its picked unit, enum options in the pickers' own words
-/// (`SettingsValueReadout+Layout2` holds those formatters). The
-/// per-space override keys expand to one row per touched space
-/// in `SettingsValueReadout+Layout3`.
+/// Layout Defaults settings diff readout generators.
 extension SettingsValueReadout {
     static func layoutRows(
         _ key: LayoutKey,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Layout3.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Layout3.swift
@@ -1,10 +1,6 @@
 import KiwiDeskCore
 
-/// The Layout area's per-space override keys: each expands to
-/// one row per space whose value for that FIELD differs, the
-/// side that has no override reading as unset (— → 60 %). The
-/// expansion machinery and the two axis-relative bespoke rows
-/// live in `SettingsValueReadout+Layout4`.
+/// Layout per-space override diff row generators.
 extension SettingsValueReadout {
     static func layoutOverrideRows(
         _ key: LayoutKey,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+LayoutAppBar.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+LayoutAppBar.swift
@@ -1,13 +1,6 @@
 import KiwiDeskCore
 
-/// Per-layout App Bar override rows (`LayoutAppBar`, Monocle
-/// and Scrolling). Every look field is a nullable override —
-/// nil inherits the global style — so each row narrates three
-/// states: a set value takes the same formatter as its global
-/// twin, an inherited side shows the core's `unset` "—", and a
-/// gained override reads "— → 44 pt". The value formatters and
-/// the row shape live in
-/// `SettingsValueReadout+LayoutAppBarValues.swift`.
+/// Per-layout App Bar override diff row generators (`LayoutAppBar`).
 extension SettingsValueReadout {
     static func layoutAppBarRows(
         _ key: LayoutAppBarKey,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Monitors.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Monitors.swift
@@ -1,9 +1,6 @@
 import KiwiDeskCore
 
-/// Monitors rows: the space→monitor pin map and the Main-role
-/// set. The banner, the orphan-clear action and the read-only
-/// fingerprints drawer name no model path, so the diff never
-/// books them.
+/// Monitors settings diff readout generators.
 extension SettingsValueReadout {
     static func monitorsRows(
         _ key: MonitorsKey,
@@ -31,12 +28,7 @@ extension SettingsValueReadout {
         }
     }
 
-    /// One row per re-pinned space. Values are the stored
-    /// `name:WxH` fingerprint — the same string the area's
-    /// fingerprints drawer shows; no fingerprint→display-name
-    /// helper exists to resolve a prettier one from a bare
-    /// string, and inventing a parser here would be a second
-    /// copy of the fingerprint grammar.
+    /// One row per re-pinned space using stored fingerprint strings.
     private static func monitorsPinRows(
         _ census: SettingKey,
         old: [SpaceID: String],
@@ -57,9 +49,7 @@ extension SettingsValueReadout {
         }
     }
 
-    /// A structural note per space that joined or left the
-    /// Main role, labelled by the census's own follows-main
-    /// text plus the space's name.
+    /// Diff rows for spaces joining or leaving the follows-main set.
     private static func monitorsMainRows(
         _ census: SettingKey,
         old: Set<SpaceID>,

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Monitors.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Monitors.swift
@@ -28,7 +28,10 @@ extension SettingsValueReadout {
         }
     }
 
-    /// One row per re-pinned space using stored fingerprint strings.
+    /// One row per re-pinned space, showing the stored
+    /// `name:WxH` fingerprint verbatim: no fingerprint→name
+    /// helper exists, and a parser here would be a second copy
+    /// of the fingerprint grammar.
     private static func monitorsPinRows(
         _ census: SettingKey,
         old: [SpaceID: String],

--- a/Sources/KiwiDesk/Settings/SettingsValueReadout+Profiles.swift
+++ b/Sources/KiwiDesk/Settings/SettingsValueReadout+Profiles.swift
@@ -1,9 +1,6 @@
 import KiwiDeskCore
 
-/// Profiles-area rows. Only the native-Desktop → profile
-/// binding map names a model path in the draft; the
-/// saved-profile verbs and flags act on stored profile files,
-/// which the draft diff never walks.
+/// Profiles-area diff readout generators.
 extension SettingsValueReadout {
     static func profilesRows(
         _ key: ProfilesKey,

--- a/Sources/KiwiDesk/main.swift
+++ b/Sources/KiwiDesk/main.swift
@@ -6,10 +6,14 @@ if CommandLine.arguments.count > 1 {
     exit(runCLI(CommandLine.arguments))
 }
 
-// Runs as accessory menu bar app (docs/design-decisions.md).
+// Holds `.accessory` for its whole life — content windows come
+// forward through `NSApp.forceFront`, never a policy flip
+// ("Permanent accessory mode", docs/design-decisions.md).
 let app = NSApplication.shared
 
-// Single-instance lock held for process lifetime (#196).
+// Single-instance lock held for process lifetime (#196). Must
+// run before the delegate exists: a second KiwiCore would
+// clobber the running instance's IPC socket.
 let instanceLock = SingleInstanceLock(
     path: SingleInstanceLock.defaultPath
 )

--- a/Sources/KiwiDesk/main.swift
+++ b/Sources/KiwiDesk/main.swift
@@ -1,22 +1,15 @@
 import AppKit
 import KiwiDeskCore
 
-// With arguments, the binary acts as the CLI and exits; the
-// Homebrew cask symlinks it into PATH for exactly this.
+// CLI dispatch when arguments are supplied.
 if CommandLine.arguments.count > 1 {
     exit(runCLI(CommandLine.arguments))
 }
 
-// KiwiDesk runs as a menu bar app (no Dock icon), and holds
-// `.accessory` for its whole life — content windows come forward
-// through `NSApp.forceFront` rather than through a policy flip.
-// See "Permanent accessory mode" in docs/design-decisions.md.
+// Runs as accessory menu bar app (docs/design-decisions.md).
 let app = NSApplication.shared
 
-// Single-instance guard (#196). Held at top level so the flock
-// lives exactly as long as the process. Must run before the
-// delegate exists: a second KiwiCore would clobber the running
-// instance's IPC socket and fight it over every window.
+// Single-instance lock held for process lifetime (#196).
 let instanceLock = SingleInstanceLock(
     path: SingleInstanceLock.defaultPath
 )

--- a/Sources/KiwiDeskCore/AX/WindowRules.swift
+++ b/Sources/KiwiDeskCore/AX/WindowRules.swift
@@ -18,7 +18,9 @@ public struct FloatRules: Sendable, Equatable {
         }
     }
 
-    /// Canonical identity used by profile sparse diffs.
+    /// Canonical identity used by profile sparse diffs: bundle
+    /// ids compare case-insensitively, while title fragments
+    /// keep their case-sensitive matching semantics.
     public static func normalizedRule(_ rule: String) -> String {
         let parts = rule.split(separator: ":", maxSplits: 1)
         guard parts.count == 2 else { return rule.lowercased() }

--- a/Sources/KiwiDeskCore/AX/WindowRules.swift
+++ b/Sources/KiwiDeskCore/AX/WindowRules.swift
@@ -1,10 +1,7 @@
 import Foundation
 
-/// User-overridable float rules from the Lua config:
-/// `float_rules = { "com.apple.finder:Get Info",
-/// "com.apple.calculator" }`. The identity segment is the app's
-/// bundle identifier. `"id"` floats every window of the app;
-/// `"id:Title"` matches a case-sensitive title fragment.
+/// Float rules matching bundle IDs and optional case-sensitive
+/// title fragments.
 public struct FloatRules: Sendable, Equatable {
     private let rules: [(app: String, title: String?)]
 
@@ -21,9 +18,7 @@ public struct FloatRules: Sendable, Equatable {
         }
     }
 
-    /// Canonical identity used by profile sparse diffs: bundle ids
-    /// compare case-insensitively, while title fragments preserve
-    /// their current case-sensitive matching semantics.
+    /// Canonical identity used by profile sparse diffs.
     public static func normalizedRule(_ rule: String) -> String {
         let parts = rule.split(separator: ":", maxSplits: 1)
         guard parts.count == 2 else { return rule.lowercased() }

--- a/Sources/KiwiDeskCore/Appearance/ColorPalette+Apply.swift
+++ b/Sources/KiwiDeskCore/Appearance/ColorPalette+Apply.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-/// One-shot application of ColorPalette onto TilingSettings (#375).
+/// One-shot application of ColorPalette onto TilingSettings
+/// (#375). Each color routes through the SAME validated field
+/// setter the per-key `set_*_color` commands use, so a palette
+/// can never set a color a command couldn't. Invalid hex or
+/// unknown path = skipped, never fatal.
 extension ColorPalette {
     /// Overwrites `settings`' colors with this palette's, in place (sparse).
     public func apply(to settings: inout TilingSettings) {

--- a/Sources/KiwiDeskCore/Appearance/ColorPalette+Apply.swift
+++ b/Sources/KiwiDeskCore/Appearance/ColorPalette+Apply.swift
@@ -1,13 +1,8 @@
 import Foundation
 
-/// Applying a palette onto a settings value — one shot, no live
-/// link (#375). Each color routes through the SAME validated field
-/// setter the per-key `set_*_color` commands use (bars) or a direct
-/// write (border, drag), so a palette can never set a color a
-/// command couldn't. Invalid hex or unknown path = skipped.
+/// One-shot application of ColorPalette onto TilingSettings (#375).
 extension ColorPalette {
-    /// Overwrites `settings`' colors with this palette's, in place.
-    /// Absent keys are left untouched (sparse).
+    /// Overwrites `settings`' colors with this palette's, in place (sparse).
     public func apply(to settings: inout TilingSettings) {
         for (path, hex) in colors {
             guard isPaintable(hex, at: path) else { continue }

--- a/Sources/KiwiDeskCore/Appearance/ColorPalette.swift
+++ b/Sources/KiwiDeskCore/Appearance/ColorPalette.swift
@@ -1,22 +1,10 @@
 import Foundation
 
-/// A named color recipe (#375): a sparse map of color paths to hex
-/// values, applied **once** to overwrite a profile's colors — never
-/// a live link (the `copyAppearance` model). A key the palette
-/// omits leaves that color untouched, so a palette can be as
-/// focused or as complete as it likes.
-///
-/// A palette is not a Profile: a Profile is the persistent,
-/// addressable configuration (tiling, layout, sparse behavior
-/// overrides) that owns the colors *after* a palette paints them.
+/// Named sparse color recipe applied one-shot to profile colors (#375).
 public struct ColorPalette: Sendable, Equatable, Codable {
-    /// Display name. Bundled names are reserved (a user palette may
-    /// not shadow one); uniqueness among user palettes is enforced
-    /// by the store, not here.
+    /// Display name of the palette.
     public var name: String
-    /// Color path (`ColorPaletteKeys`) → hex (`#RRGGBB[AA]`),
-    /// sparse. Invalid hexes and unknown paths are skipped on
-    /// apply, never fatal.
+    /// Sparse map of color path (`ColorPaletteKeys`) to hex string.
     public var colors: [String: String]
 
     public init(name: String, colors: [String: String]) {

--- a/Sources/KiwiDeskCore/Appearance/ColorPalette.swift
+++ b/Sources/KiwiDeskCore/Appearance/ColorPalette.swift
@@ -2,7 +2,9 @@ import Foundation
 
 /// Named sparse color recipe applied one-shot to profile colors (#375).
 public struct ColorPalette: Sendable, Equatable, Codable {
-    /// Display name of the palette.
+    /// Display name. Bundled names are reserved (a user palette
+    /// may not shadow one); uniqueness among user palettes is
+    /// enforced by the store, not here.
     public var name: String
     /// Sparse map of color path (`ColorPaletteKeys`) to hex string.
     public var colors: [String: String]

--- a/Sources/KiwiDeskCore/Bar/AppBarOverlay+Arrows.swift
+++ b/Sources/KiwiDeskCore/Bar/AppBarOverlay+Arrows.swift
@@ -1,11 +1,8 @@
 import AppKit
 
-/// Scroll arrows: end-of-strip zones shown only toward hidden
-/// items, each click shifting the run by one slot. Split out of
-/// AppBarOverlay to keep the render file under the size ceiling.
+/// Scroll arrow layout and click handling for AppBarOverlay.
 extension AppBarOverlay {
-    /// Arrows sit at the strip's ends, shown only toward
-    /// hidden items; clicking shifts the bar by one slot.
+    /// Positions scroll arrows at strip ends when content overflows.
     func layoutArrows(
         strip: CGRect,
         m: Metrics,

--- a/Sources/KiwiDeskCore/Bar/AppFont.swift
+++ b/Sources/KiwiDeskCore/Bar/AppFont.swift
@@ -1,18 +1,12 @@
 import AppKit
 import CoreText
 
-/// The vendored SketchyBar App Font (#294): process-scoped
-/// registration plus font access. Assets live in
-/// `Resources/AppFont/` (see its `UPSTREAM.md`); refresh them
-/// with `scripts/update-app-font.sh`, never by hand.
+/// Vendored SketchyBar App Font registration and access (#294).
 public enum AppFont {
     /// PostScript name of the vendored glyph font.
     public static let fontName = "sketchybar-app-font"
 
-    /// One-shot process-scope registration. `.process` scope
-    /// shadows nothing outside the app — no user install, no
-    /// Font Book entry, no conflict with a copy the user
-    /// already installed for sketchybar itself.
+    /// Process-scope font registration state.
     static let registered: Bool = {
         guard
             let url = Bundle.kiwiDeskCore.url(

--- a/Sources/KiwiDeskCore/Bar/AppFont.swift
+++ b/Sources/KiwiDeskCore/Bar/AppFont.swift
@@ -2,11 +2,15 @@ import AppKit
 import CoreText
 
 /// Vendored SketchyBar App Font registration and access (#294).
+/// Refresh assets with `scripts/update-app-font.sh`, never by
+/// hand (`Resources/AppFont/UPSTREAM.md`).
 public enum AppFont {
     /// PostScript name of the vendored glyph font.
     public static let fontName = "sketchybar-app-font"
 
-    /// Process-scope font registration state.
+    /// One-shot registration. `.process` scope shadows nothing
+    /// outside the app — no Font Book entry, no conflict with a
+    /// copy the user installed for sketchybar itself.
     static let registered: Bool = {
         guard
             let url = Bundle.kiwiDeskCore.url(

--- a/Sources/KiwiDeskCore/Bar/AppFontGlyphMap.swift
+++ b/Sources/KiwiDeskCore/Bar/AppFontGlyphMap.swift
@@ -8,7 +8,11 @@ enum AppFontGlyphMap {
         let appNames: [String]
     }
 
-    /// Loads bundled icon map as a flat dictionary, or nil on failure.
+    /// Loads bundled icon map as a flat dictionary. Nil is a
+    /// build defect (the shipped-resource test fails); at
+    /// runtime it only degrades to image rendering, never a
+    /// crash. Upstream lists localized app names as plain
+    /// `appNames` members, so no locale handling is needed.
     static func loadBundled() -> [String: String]? {
         guard
             let url = Bundle.kiwiDeskCore.url(

--- a/Sources/KiwiDeskCore/Bar/AppFontGlyphMap.swift
+++ b/Sources/KiwiDeskCore/Bar/AppFontGlyphMap.swift
@@ -1,21 +1,14 @@
 import Foundation
 
-/// Decodes the vendored `icon_map.json` (see
-/// `Resources/AppFont/UPSTREAM.md`): an array of
-/// `{iconName, appNames}` entries, expanded into a flat
-/// display-name → ligature lookup. Upstream lists localized
-/// app names as plain extra `appNames` members, so localized
-/// lookups need no special handling here.
+/// Decodes vendored icon_map.json into app name to ligature map
+/// (`Resources/AppFont/UPSTREAM.md`).
 enum AppFontGlyphMap {
     struct Entry: Decodable {
         let iconName: String
         let appNames: [String]
     }
 
-    /// The bundled map as a flat lookup, or nil when the
-    /// resource is missing or corrupt — that is a build defect
-    /// (the shipped-resource test fails); at runtime it only
-    /// degrades to image rendering, never a crash.
+    /// Loads bundled icon map as a flat dictionary, or nil on failure.
     static func loadBundled() -> [String: String]? {
         guard
             let url = Bundle.kiwiDeskCore.url(

--- a/Sources/KiwiDeskCore/Bar/BarAppIconSource.swift
+++ b/Sources/KiwiDeskCore/Bar/BarAppIconSource.swift
@@ -1,17 +1,9 @@
 import Foundation
 
-/// Where a bar's app icons come from (#294). Stored as
-/// `icon_source` in profile JSON; set from Lua via
-/// `app_bar.set_icon_source`. A synthesized "tinted" source
-/// was built and stripped 2026-07-17: the system-wide Icon &
-/// widget style already covers that want, and true styled
-/// variants are unreachable via public API (#362 tracks the
-/// private-path probe).
+/// App icon rendering source for bars (#294).
 public enum BarAppIconSource: String, Sendable, Codable, CaseIterable {
     /// The app's native image as macOS provides it (default).
     case appImage = "app_image"
-    /// A monochrome ligature glyph from the vendored SketchyBar
-    /// App Font, following the bar's text colors. Apps without
-    /// a glyph keep their native image.
+    /// Monochrome ligature glyph from vendored App Font, falling back to icon.
     case appFont = "app_font"
 }

--- a/Sources/KiwiDeskCore/Bar/BarAppIconSource.swift
+++ b/Sources/KiwiDeskCore/Bar/BarAppIconSource.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// App icon rendering source for bars (#294).
+/// App icon rendering source for bars (#294). A synthesized
+/// "tinted" source was built and stripped: the system-wide
+/// Icon & widget style covers it, and true styled variants are
+/// unreachable via public API (#362 tracks the private probe).
 public enum BarAppIconSource: String, Sendable, Codable, CaseIterable {
     /// The app's native image as macOS provides it (default).
     case appImage = "app_image"

--- a/Sources/KiwiDeskCore/Bar/BarPlate.swift
+++ b/Sources/KiwiDeskCore/Bar/BarPlate.swift
@@ -3,6 +3,9 @@ import CoreGraphics
 /// Shared background plate frame math for bar background_fit.
 enum BarPlate {
     /// Computes plate frame for `full` or `hug` background fit.
+    /// Hug falls back to full while the run overflows and
+    /// scrolls (`inset > 0` — content fills the strip, nothing
+    /// to hug) and for an empty run.
     nonisolated static func frame(
         strip: CGRect,
         runStart: CGFloat,

--- a/Sources/KiwiDeskCore/Bar/BarPlate.swift
+++ b/Sources/KiwiDeskCore/Bar/BarPlate.swift
@@ -1,15 +1,8 @@
 import CoreGraphics
 
-/// The shared background plate's frame — `plain`'s fill and the
-/// Liquid Glass plate — for `background_fit`
-/// (QA 2026-07-19). Strip-local coordinates; pure math shared
-/// by both bars so the two plates can't drift.
+/// Shared background plate frame math for bar background_fit.
 enum BarPlate {
-    /// `full` spans the strip; `hug` wraps the content run plus
-    /// one item gap of breathing room per end, clamped to the
-    /// strip. Hug falls back to full while the run overflows
-    /// and scrolls (`inset > 0` — content fills the strip, so
-    /// there is nothing to hug) and for an empty run.
+    /// Computes plate frame for `full` or `hug` background fit.
     nonisolated static func frame(
         strip: CGRect,
         runStart: CGFloat,

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Viewport.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Viewport.swift
@@ -1,13 +1,8 @@
 import AppKit
 
-/// Viewport placement and the drag-drop hit-frame record. Split
-/// out of SpaceBarOverlay to keep the render file under the size
-/// ceiling.
+/// Viewport placement and hit-frame tracking for SpaceBarOverlay.
 extension SpaceBarOverlay {
-    /// Positions the clipping viewport: inset by an arrow zone at
-    /// each end while overflowing, the full strip otherwise.
-    /// Returns the rect so the glass plate can adopt it as its
-    /// `contentView` frame.
+    /// Positions clipping viewport and returns frame.
     @discardableResult
     func placeItemContainer(
         inset: CGFloat,

--- a/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Viewport.swift
+++ b/Sources/KiwiDeskCore/Bar/SpaceBarOverlay+Viewport.swift
@@ -2,7 +2,8 @@ import AppKit
 
 /// Viewport placement and hit-frame tracking for SpaceBarOverlay.
 extension SpaceBarOverlay {
-    /// Positions clipping viewport and returns frame.
+    /// Positions the clipping viewport and returns the rect so
+    /// the glass plate can adopt it as its `contentView` frame.
     @discardableResult
     func placeItemContainer(
         inset: CGFloat,

--- a/Sources/KiwiDeskCore/Borders/BorderOverlayPanel.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderOverlayPanel.swift
@@ -1,17 +1,6 @@
 import AppKit
 
-/// The focus-ring overlay's window. A plain `NSPanel` clamps every
-/// frame it is given so the title bar stays below the menu bar
-/// (`constrainFrameRect`). That pins a top-row ring in place and
-/// swallows the dead-end rubber-band's upward nudge (#436): the whole
-/// ring is one rigid translation, so a clamped top edge means the
-/// bottom and sides never move either — zero visible wiggle, unlike
-/// the unclamped left/right/down bumps.
-///
-/// This subclass opts out. The ring is a non-interactive auxiliary
-/// overlay positioned to the pixel and never dragged, so it may sit
-/// anywhere — including lapping under the menu bar, exactly as the
-/// SkyLight fast path (which is unconstrained) already does.
+/// Border overlay NSPanel opting out of screen constraints (#436).
 final class BorderOverlayPanel: NSPanel {
     override func constrainFrameRect(
         _ frameRect: NSRect,

--- a/Sources/KiwiDeskCore/Borders/BorderOverlayPanel.swift
+++ b/Sources/KiwiDeskCore/Borders/BorderOverlayPanel.swift
@@ -1,6 +1,12 @@
 import AppKit
 
-/// Border overlay NSPanel opting out of screen constraints (#436).
+/// Border overlay NSPanel opting out of `constrainFrameRect`:
+/// a plain NSPanel clamps frames below the menu bar, which
+/// pins a top-row ring and swallows the dead-end rubber-band's
+/// upward nudge whole (#436) — the ring is one rigid
+/// translation, so a clamped top edge means zero visible
+/// wiggle. A non-interactive overlay may sit anywhere, as the
+/// unconstrained SkyLight fast path already does.
 final class BorderOverlayPanel: NSPanel {
     override func constrainFrameRect(
         _ frameRect: NSRect,

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+AppBar.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+AppBar.swift
@@ -1,13 +1,6 @@
 import Foundation
 
-/// `app_bar.*` — the global App Bar style (#1033).
-///
-/// **An exemplar group: every record here is written.** The
-/// color setters show the `.color` shape, the pickers show a
-/// `.choice` reading its decoder's cases, and the rest are bare
-/// numbers. `monocle.set_app_bar_*` and `scroll.set_app_bar_*`
-/// are the same fields as per-layout overrides, so a record
-/// there says the same thing about the same value.
+/// `app_bar.*` — global App Bar style command records (#1033).
 extension APIReference {
     static let appBarRecords: [String: APIRecord] = [
         "set_edge": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+AppBar.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+AppBar.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 /// `app_bar.*` — global App Bar style command records (#1033).
+/// An exemplar group: colour setters show `.color`, pickers a
+/// `.choice` reading its decoder's cases.
 extension APIReference {
     static let appBarRecords: [String: APIRecord] = [
         "set_edge": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+CoreWindows.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+CoreWindows.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-/// Window, Space, and Desktop movement command records (#884, #888, #1033).
+/// Window, Space, and Desktop movement command records (#1033).
+/// The three Desktop verbs are the `.desktop` argument's only
+/// home, and why that kind exists: a Desktop number is Mission
+/// Control's, counted globally across screens, while a Space
+/// id is KiwiDesk's own string (#884/#888).
 extension APIReference {
     static let coreWindowRecords: [String: APIRecord] = [
         "focus": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+CoreWindows.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+CoreWindows.swift
@@ -1,13 +1,6 @@
 import Foundation
 
-/// The dispatcher verbs that move windows, Spaces and Desktops
-/// (#1033) — the `KiwiDesk.*` half a keybinding usually names.
-///
-/// The three Desktop verbs are the `.desktop` argument's only
-/// home, and the reason that kind exists rather than a bare
-/// integer: a Desktop number is Mission Control's, counted
-/// globally across every screen, while a Space id is KiwiDesk's
-/// own string (#884/#888).
+/// Window, Space, and Desktop movement command records (#884, #888, #1033).
 extension APIReference {
     static let coreWindowRecords: [String: APIRecord] = [
         "focus": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+LuaOnly.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+LuaOnly.swift
@@ -1,13 +1,6 @@
 import Foundation
 
-/// The `KiwiDesk` table's Lua-only entry points (#1033).
-///
-/// **An exemplar group: every record here is written.** These
-/// bypass the dispatcher, so the CLI and the IPC socket cannot
-/// reach them — `list_commands` marks them `lua` on the channel
-/// field, and `APIReference.suggestion` still refuses to hint at
-/// them (#37). They are the only records that take a
-/// `.callback`, because a Lua function cannot cross a socket.
+/// `KiwiDesk` table Lua-only entry point records (#37, #1033).
 extension APIReference {
     static let luaOnlyRecords: [String: APIRecord] = [
         "exec": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+LuaOnly.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+LuaOnly.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-/// `KiwiDesk` table Lua-only entry point records (#37, #1033).
+/// `KiwiDesk` table Lua-only entry point records (#1033). These
+/// bypass the dispatcher, so the CLI and IPC socket cannot
+/// reach them — `list_commands` marks them `lua`, and
+/// `APIReference.suggestion` refuses to hint at them (#37).
+/// The only records taking `.callback`: a Lua function cannot
+/// cross a socket.
 extension APIReference {
     static let luaOnlyRecords: [String: APIRecord] = [
         "exec": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Monocle.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Monocle.swift
@@ -1,13 +1,6 @@
 import Foundation
 
-/// `monocle.*` — the monocle layout and its App Bar override
-/// (#1033).
-///
-/// The 25 `set_app_bar_*` fields are the same values `app_bar.*`
-/// sets globally, so `APIRecords+AppBar.swift` and the scrolling
-/// layout's identical block in `APIRecords+Scroll.swift` are the
-/// pattern to copy — with "for this layout" saying what an
-/// override is.
+/// `monocle.*` — monocle layout command records (#1033).
 extension APIReference {
     static let monocleRecords: [String: APIRecord] = [
         "set_orientation": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Overlays.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Overlays.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 /// Overlay and single-setting command records (#1033).
+/// `sticky.set_color` / `floating.set_color` also accept an
+/// empty string, clearing the mark colour — that belongs in
+/// the summary, not in a new argument kind.
 extension APIReference {
     static let dragRecords: [String: APIRecord] = [
         "set_ghost_enabled": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Overlays.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Overlays.swift
@@ -1,13 +1,6 @@
 import Foundation
 
-/// `drag.*`, `border.*`, `sticky.*`, `floating.*`, `mouse.*`
-/// and `quit.*` — the overlays and the odd single-setting
-/// namespaces (#1033).
-///
-/// The colour setters take `.color`; `sticky.set_color` and
-/// `floating.set_color` also accept an empty string, which
-/// clears the mark colour back to the palette's — that belongs
-/// in the summary, not in a new argument kind.
+/// Overlay and single-setting command records (#1033).
 extension APIReference {
     static let dragRecords: [String: APIRecord] = [
         "set_ghost_enabled": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Scroll.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Scroll.swift
@@ -1,13 +1,6 @@
 import Foundation
 
-/// `scroll.*` — the scrolling layout (#1033).
-///
-/// **The largest exemplar group, and every record is written.**
-/// It carries one of every argument shape the surface has: a
-/// bare value (`set_slot_size`), a Space id followed by a value
-/// (`set_anchor_override`), an enum read off its decoder
-/// (`set_anchor`), a boolean, and the 25 `set_app_bar_*` fields
-/// that override the global App Bar for this layout alone.
+/// `scroll.*` — scrolling layout command records (#1033).
 extension APIReference {
     static let scrollRecords: [String: APIRecord] = [
         "set_slot_size": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Scroll.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+Scroll.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-/// `scroll.*` — scrolling layout command records (#1033).
+/// `scroll.*` — scrolling layout command records (#1033). The
+/// largest exemplar group: one of every argument shape the
+/// surface has.
 extension APIReference {
     static let scrollRecords: [String: APIRecord] = [
         "set_slot_size": APIRecord(

--- a/Sources/KiwiDeskCore/Commands/Reference/APIReference+Suggestion.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIReference+Suggestion.swift
@@ -1,26 +1,15 @@
 import Foundation
 
-/// Did-you-mean suggestion for an unknown command, split from
-/// `APIReference.swift` for the 350-line file ceiling.
+/// Command typo suggestion provider for APIReference.
 extension APIReference {
-    /// A close known command for a typo, if any. Suggests only
-    /// dispatchable names — the unknown-command path is reached
-    /// from the CLI/IPC socket too, where a Lua-only name would
-    /// be a dead-end hint.
+    /// Returns closest dispatchable command suggestion for typo, if any.
     public static func suggestion(
         for unknown: String
     ) -> String? {
         closest(to: unknown, among: dispatchable)
     }
 
-    /// The nearest of `candidates` within a typo's worth of
-    /// edits, or nil.
-    ///
-    /// Shared with `helpSuggestion`, which searches a wider set
-    /// for a different reason (#1033): the two differ in WHAT
-    /// they may point at, never in how near counts as near, and
-    /// two copies of that threshold would drift into two
-    /// different ideas of a typo.
+    /// Finds nearest candidate within edit distance limit (#1033).
     static func closest<C: Sequence<String>>(
         to unknown: String,
         among candidates: C

--- a/Sources/KiwiDeskCore/Commands/Reference/APIReference+Suggestion.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIReference+Suggestion.swift
@@ -2,14 +2,19 @@ import Foundation
 
 /// Command typo suggestion provider for APIReference.
 extension APIReference {
-    /// Returns closest dispatchable command suggestion for typo, if any.
+    /// Closest known command for a typo — dispatchable names
+    /// only: this path is reached from the CLI/IPC socket too,
+    /// where a Lua-only name would be a dead-end hint.
     public static func suggestion(
         for unknown: String
     ) -> String? {
         closest(to: unknown, among: dispatchable)
     }
 
-    /// Finds nearest candidate within edit distance limit (#1033).
+    /// Nearest candidate within a typo's worth of edits. Shared
+    /// with `helpSuggestion` (#1033): the two differ in WHAT
+    /// they may point at, never in how near counts — two copies
+    /// of the threshold would drift into two ideas of a typo.
     static func closest<C: Sequence<String>>(
         to unknown: String,
         among candidates: C

--- a/Sources/KiwiDeskCore/Config/GuiConfigStore.swift
+++ b/Sources/KiwiDeskCore/Config/GuiConfigStore.swift
@@ -1,10 +1,6 @@
 import Foundation
 
-/// Reads and writes the GUI's `gui.json` sidecar — the visual
-/// editor's source of truth. `init.lua`'s managed block is
-/// regenerated from it; the sidecar additionally captures what
-/// live Lua state can't reconstruct (keybinding actions, mode
-/// icons).
+/// Reads and writes GUI configuration sidecar `gui.json`.
 public struct GuiConfigStore {
     let url: URL
 
@@ -16,9 +12,7 @@ public struct GuiConfigStore {
         FileManager.default.fileExists(atPath: url.path)
     }
 
-    /// Loads the sidecar, or nil if it is absent or unreadable.
-    /// Migrates older format sidecars through `ConfigMigration`
-    /// first and writes back the migrated bytes.
+    /// Loads sidecar with ConfigMigration migration, or nil on failure.
     public func load() -> GuiConfig? {
         guard var data = try? Data(contentsOf: url) else {
             return nil

--- a/Sources/KiwiDeskCore/Config/GuiConfigStore.swift
+++ b/Sources/KiwiDeskCore/Config/GuiConfigStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Reads and writes GUI configuration sidecar `gui.json`.
+/// Reads and writes GUI configuration sidecar `gui.json` — the
+/// visual editor's source of truth; it also captures what live
+/// Lua state can't reconstruct (keybinding actions, mode
+/// icons).
 public struct GuiConfigStore {
     let url: URL
 
@@ -12,7 +15,9 @@ public struct GuiConfigStore {
         FileManager.default.fileExists(atPath: url.path)
     }
 
-    /// Loads sidecar with ConfigMigration migration, or nil on failure.
+    /// Loads the sidecar, or nil on failure. Migrates older
+    /// formats through `ConfigMigration` first and writes the
+    /// migrated bytes back.
     public func load() -> GuiConfig? {
         guard var data = try? Data(contentsOf: url) else {
             return nil

--- a/Sources/KiwiDeskCore/Config/RuleListOverride.swift
+++ b/Sources/KiwiDeskCore/Config/RuleListOverride.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-/// Sparse override for a list of normalized string rules.
+/// Sparse override for a list of normalized string rules: a
+/// `true` value adds a rule, `nil` is a tombstone removing an
+/// inherited rule; `false` and empty keys are ignored.
 public struct RuleListOverride: Sendable, Equatable {
     public var rules: [String: Bool?]
 
@@ -20,7 +22,11 @@ public struct RuleListOverride: Sendable, Equatable {
         }
     }
 
-    /// Applies sparse override to base rule list with normalized sorting.
+    /// Applies the override to a base list. Base rules keep
+    /// their order; new rules append in normalized sort order,
+    /// so output is independent of dictionary iteration. When
+    /// raw keys normalize to one identity, a tombstone wins
+    /// over an addition.
     public func resolved(
         onto base: [String],
         normalizing: (String) -> String
@@ -46,7 +52,8 @@ public struct RuleListOverride: Sendable, Equatable {
         return result
     }
 
-    /// Builds sparse override producing `edited` from `base`.
+    /// Builds the sparse override whose resolution produces
+    /// `edited`; nil when the edited list inherits the base set.
     public static func diff(
         base: [String],
         edited: [String],

--- a/Sources/KiwiDeskCore/Config/RuleListOverride.swift
+++ b/Sources/KiwiDeskCore/Config/RuleListOverride.swift
@@ -1,9 +1,6 @@
 import Foundation
 
 /// Sparse override for a list of normalized string rules.
-///
-/// A `true` value adds a rule, while `nil` is a tombstone that
-/// removes an inherited rule. `false` and empty keys are ignored.
 public struct RuleListOverride: Sendable, Equatable {
     public var rules: [String: Bool?]
 
@@ -23,12 +20,7 @@ public struct RuleListOverride: Sendable, Equatable {
         }
     }
 
-    /// Applies this sparse override to a base rule list.
-    ///
-    /// Base rules retain their normalized order. New rules append in
-    /// normalized sort order, making output independent of dictionary
-    /// iteration order. When raw keys normalize to one identity, a
-    /// tombstone wins over an addition.
+    /// Applies sparse override to base rule list with normalized sorting.
     public func resolved(
         onto base: [String],
         normalizing: (String) -> String
@@ -54,8 +46,7 @@ public struct RuleListOverride: Sendable, Equatable {
         return result
     }
 
-    /// Builds the sparse override whose resolution produces `edited`.
-    /// Returns nil when the edited list inherits the base set.
+    /// Builds sparse override producing `edited` from `base`.
     public static func diff(
         base: [String],
         edited: [String],
@@ -84,8 +75,6 @@ public struct RuleListOverride: Sendable, Equatable {
         return override.isEmpty ? nil : override
     }
 }
-
-// MARK: - Normalization
 
 extension RuleListOverride {
     private static func normalizedUnique(
@@ -117,8 +106,6 @@ extension RuleListOverride {
         return actions
     }
 }
-
-// MARK: - Codable
 
 extension RuleListOverride: Codable {
     private struct RuleKey: CodingKey {

--- a/Sources/KiwiDeskCore/IPC/JSONValue.swift
+++ b/Sources/KiwiDeskCore/IPC/JSONValue.swift
@@ -56,10 +56,7 @@ public indirect enum JSONValue: Codable, Sendable, Equatable {
         case .string(let s):
             return s
         case .number(let n):
-            // A whole number prints without the ".0", but only
-            // via the Int path when it actually fits — `Int(1e300)`
-            // traps (#386), so an out-of-range whole number falls
-            // back to the Double formatting.
+            // Whole numbers omit trailing ".0" when in Int range (#386).
             if n == n.rounded(), let i = n.finiteInt {
                 return String(i)
             }
@@ -99,13 +96,7 @@ public indirect enum JSONValue: Codable, Sendable, Equatable {
 }
 
 extension Double {
-    /// Safe `Int` conversion: nil unless the value is finite and
-    /// inside `Int`'s range. `Int(1e300)`, `Int(.nan)`, and
-    /// `Int(.infinity)` all trap, so any raw `Double → Int` on
-    /// caller-supplied config/IPC numbers must route through here
-    /// (#386). `Double(Int.max)` rounds up to 2^63, so the upper
-    /// bound is a strict `<` — every value it admits is a
-    /// representable `Int`.
+    /// Safe Int conversion guarding against NaN/infinity traps (#386).
     public var finiteInt: Int? {
         guard isFinite,
             self >= Double(Int.min),

--- a/Sources/KiwiDeskCore/IPC/JSONValue.swift
+++ b/Sources/KiwiDeskCore/IPC/JSONValue.swift
@@ -96,7 +96,12 @@ public indirect enum JSONValue: Codable, Sendable, Equatable {
 }
 
 extension Double {
-    /// Safe Int conversion guarding against NaN/infinity traps (#386).
+    /// Safe Int conversion: nil unless finite and in `Int`'s
+    /// range. `Int(1e300)`, `Int(.nan)` and `Int(.infinity)`
+    /// all trap, so any raw Double→Int on caller-supplied
+    /// config/IPC numbers must route through here (#386).
+    /// `Double(Int.max)` rounds up to 2^63, so the upper bound
+    /// is a strict `<`.
     public var finiteInt: Int? {
         guard isFinite,
             self >= Double(Int.min),

--- a/Sources/KiwiDeskCore/IPC/SocketClient.swift
+++ b/Sources/KiwiDeskCore/IPC/SocketClient.swift
@@ -7,10 +7,7 @@ public enum SocketError: Error, Equatable {
     case closed
 }
 
-/// Blocking UNIX-socket client used by the CLI process.
-///
-/// Deliberately synchronous BSD sockets: the CLI sends one
-/// request and reads one line (or streams events forever).
+/// Blocking UNIX domain socket client for CLI process.
 public final class SocketClient {
     private let fd: Int32
     private var buffer = Data()
@@ -53,14 +50,8 @@ public final class SocketClient {
             }
         }
         guard result == 0 else {
-            // Do NOT close here: every stored property is
-            // initialized by now, so a throwing class init still
-            // runs deinit, whose close would then be the SECOND
-            // close of this fd. Under concurrent fd churn the
-            // number gets recycled — and a guarded reissue turns
-            // the double close into an EXC_GUARD process kill
-            // (#489: the test-runner crash). deinit owns the one
-            // and only close.
+            // Do NOT close here (#489): throwing init runs deinit,
+            // avoiding double-close EXC_GUARD crashes on recycled fds.
             throw SocketError.connectFailed(
                 String(cString: strerror(errno))
             )

--- a/Sources/KiwiDeskCore/Localization/LocalizationPreference.swift
+++ b/Sources/KiwiDeskCore/Localization/LocalizationPreference.swift
@@ -1,15 +1,8 @@
 import Foundation
 
-/// The GUI language pick's storage (issue #9): app preferences
-/// (`UserDefaults`), NOT `gui.json`. A language change is
-/// documented as side-effect-free — it must never create a
-/// `gui.json` sidecar (which would flip `KiwiCore.isGuiManaged`
-/// and hand config ownership to the structured loader for a
-/// user who never asked to adopt the GUI). `UserDefaults` has
-/// no such coupling: nothing else keys off its existence.
+/// GUI language preference stored in UserDefaults (#9).
 public enum LocalizationPreference {
-    /// The `UserDefaults` key. `nil`/absent means "System
-    /// default".
+    /// The `UserDefaults` key. `nil`/absent means "System default".
     public static let key = "language"
 
     /// Reads the persisted pick, or `nil` for "System default".
@@ -19,9 +12,7 @@ public enum LocalizationPreference {
         defaults.string(forKey: key)
     }
 
-    /// Persists `language`; `nil` removes the key entirely (so
-    /// "System default" leaves no trace in the domain, mirroring
-    /// the old absent-key-in-JSON contract).
+    /// Persists language pick, removing key on nil for system default.
     public static func write(
         _ language: String?,
         to defaults: UserDefaults = .standard

--- a/Sources/KiwiDeskCore/Localization/LocalizationPreference.swift
+++ b/Sources/KiwiDeskCore/Localization/LocalizationPreference.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-/// GUI language preference stored in UserDefaults (#9).
+/// GUI language preference stored in `UserDefaults`, NOT
+/// `gui.json` (#9): a language change is documented as
+/// side-effect-free and must never create a sidecar — that
+/// would flip `KiwiCore.isGuiManaged` and hand config
+/// ownership to the structured loader for a hand-written-Lua
+/// user who only wanted a different language.
 public enum LocalizationPreference {
     /// The `UserDefaults` key. `nil`/absent means "System default".
     public static let key = "language"

--- a/Sources/KiwiDeskCore/Lua/LuaValue.swift
+++ b/Sources/KiwiDeskCore/Lua/LuaValue.swift
@@ -11,9 +11,7 @@ public indirect enum LuaValue: Sendable, Equatable {
     case array([LuaValue])
     /// Keyed table (string keys only when bridging).
     case table([String: LuaValue])
-    /// A Lua function captured as a registry reference.
-    /// Call via `LuaInterpreter.call(ref:args:)`; release
-    /// with `release(ref:)` when done.
+    /// Lua function captured as a registry reference.
     case functionRef(Int32)
 
     public var stringValue: String? {

--- a/Sources/KiwiDeskCore/Lua/LuaValue.swift
+++ b/Sources/KiwiDeskCore/Lua/LuaValue.swift
@@ -11,7 +11,9 @@ public indirect enum LuaValue: Sendable, Equatable {
     case array([LuaValue])
     /// Keyed table (string keys only when bridging).
     case table([String: LuaValue])
-    /// Lua function captured as a registry reference.
+    /// Lua function captured as a registry reference. Call via
+    /// `LuaInterpreter.call(ref:args:)`; release with
+    /// `release(ref:)` when done.
     case functionRef(Int32)
 
     public var stringValue: String? {

--- a/Sources/KiwiDeskCore/OS/SkyLight+WindowBounds.swift
+++ b/Sources/KiwiDeskCore/OS/SkyLight+WindowBounds.swift
@@ -1,18 +1,8 @@
 import CoreGraphics
 
-/// Composed WindowServer bounds read for the focus border's
-/// reconcile path (#594), mirroring `windowCornerRadius`'s shape:
-/// the raw `SLSGetWindowBounds` symbol stays in `+Borders`; this
-/// wraps the connection guard and out-param so consumers get one
-/// optional-returning call instead of hand-composing the
-/// primitives (a second hand-rolled copy is how the `.success`
-/// check gets lost). A nil answer falls back per the OS-layer
-/// contract — here, the caller skips the reconcile and the AX
-/// echo path keeps updating the overlay.
+/// WindowServer bounds query wrapper for focus border reconciliation (#594).
 extension SkyLight {
-    /// The authoritative WindowServer bounds (AX coordinates)
-    /// for `wid`, or `nil` when the private surface is
-    /// unavailable or the query fails.
+    /// Authoritative WindowServer bounds (AX coordinates) for `wid`, or nil.
     static func windowBounds(_ wid: CGWindowID) -> CGRect? {
         guard let connection,
             let getBounds = getWindowBounds

--- a/Sources/KiwiDeskCore/OS/SkyLight+WindowBounds.swift
+++ b/Sources/KiwiDeskCore/OS/SkyLight+WindowBounds.swift
@@ -1,6 +1,11 @@
 import CoreGraphics
 
-/// WindowServer bounds query wrapper for focus border reconciliation (#594).
+/// WindowServer bounds query wrapper for focus border
+/// reconciliation (#594): wraps the connection guard and
+/// out-param so consumers get one optional-returning call — a
+/// second hand-rolled copy is how the `.success` check gets
+/// lost. On nil the caller skips the reconcile and the AX echo
+/// path keeps updating the overlay.
 extension SkyLight {
     /// Authoritative WindowServer bounds (AX coordinates) for `wid`, or nil.
     static func windowBounds(_ wid: CGWindowID) -> CGRect? {

--- a/Sources/KiwiDeskCore/Permissions/PermissionMonitor.swift
+++ b/Sources/KiwiDeskCore/Permissions/PermissionMonitor.swift
@@ -1,10 +1,7 @@
 import AppKit
 import ApplicationServices
 
-/// Polls Accessibility permission and reports transitions.
-///
-/// Used by the onboarding wizard (waiting for the user to grant
-/// permission) and at runtime to detect mid-session revocation.
+/// Polls Accessibility permission status and fires on state transitions.
 @MainActor
 public final class PermissionMonitor {
     /// Fired on every transition (granted <-> revoked).

--- a/Sources/KiwiDeskCore/Profiles/ProfileManager+Matching.swift
+++ b/Sources/KiwiDeskCore/Profiles/ProfileManager+Matching.swift
@@ -2,7 +2,10 @@ import Foundation
 
 /// Monitor-set profile matching queries for ProfileManager.
 extension ProfileManager {
-    /// Matches live monitor set against stored profiles in priority order.
+    /// Matches a live monitor set: exact stored set (sorted
+    /// arrays) → the count's default user profile → none (the
+    /// caller composes the Standard). Ties resolve
+    /// alphabetically.
     public func match(fingerprints: [String]) -> ProfileMatch {
         let profiles = allProfiles()
         if let exact = profiles.first(where: {

--- a/Sources/KiwiDeskCore/Profiles/ProfileManager+Matching.swift
+++ b/Sources/KiwiDeskCore/Profiles/ProfileManager+Matching.swift
@@ -1,13 +1,8 @@
 import Foundation
 
-/// Monitor-set matching over the stored profiles, split
-/// from ProfileManager.swift (file-size ceiling): pure
-/// queries — no state, no writes.
+/// Monitor-set profile matching queries for ProfileManager.
 extension ProfileManager {
-    /// Finds the profile for a live monitor set: exact stored
-    /// set (sorted-array comparison) → the count's default user
-    /// profile → none (caller composes the Standard). Ties
-    /// resolve alphabetically (profiles come pre-sorted).
+    /// Matches live monitor set against stored profiles in priority order.
     public func match(fingerprints: [String]) -> ProfileMatch {
         let profiles = allProfiles()
         if let exact = profiles.first(where: {

--- a/Sources/KiwiDeskCore/Service/ServiceStatus.swift
+++ b/Sources/KiwiDeskCore/Service/ServiceStatus.swift
@@ -1,16 +1,6 @@
 import Foundation
 
-/// The `kiwidesk service` agent's launchd state as *structure*, not
-/// the English `ServiceManager.Outcome.message` (#576).
-/// `AutoStartManager` folds this with the login-item state, so it
-/// must read a machine value rather than re-parse a sentence meant
-/// for the CLI (Core returns structure, #96).
-///
-/// `isLoaded` is the job registered with launchd — and because the
-/// plist sets `RunAtLoad`, a loaded job auto-starts at login. `pid`
-/// is present only while launchd is running the process, so a
-/// loaded job with no pid is the quit-but-registered idle case
-/// (#341).
+/// Structured launchd service status for kiwidesk service agent (#96, #576).
 public struct ServiceStatus: Equatable, Sendable {
     public let isLoaded: Bool
     public let pid: Int32?

--- a/Sources/KiwiDeskCore/Service/ServiceStatus.swift
+++ b/Sources/KiwiDeskCore/Service/ServiceStatus.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-/// Structured launchd service status for kiwidesk service agent (#96, #576).
+/// Structured launchd service status (#576) — a machine value,
+/// never a re-parsed CLI sentence (#96). `isLoaded` is the job
+/// registered with launchd (RunAtLoad ⇒ auto-starts at login);
+/// `pid` exists only while running, so loaded with no pid is
+/// the quit-but-registered idle case (#341).
 public struct ServiceStatus: Equatable, Sendable {
     public let isLoaded: Bool
     public let pid: Int32?

--- a/Sources/KiwiDeskCore/State/WorkspaceManager+Displays.swift
+++ b/Sources/KiwiDeskCore/State/WorkspaceManager+Displays.swift
@@ -1,10 +1,6 @@
 import Foundation
 
-/// Display bookkeeping — which display a space is assigned to
-/// and what each display shows. Split from `WorkspaceManager`
-/// for the file ceiling (§2.1); the backing maps (`order`,
-/// `displays`, `spaceDisplay`, `secondaryShown`) stay declared
-/// there and are internal for exactly this file's sake.
+/// Display tracking and space assignment for WorkspaceManager.
 extension WorkspaceManager {
     public var allDisplays: [Display] {
         Array(displays.values)

--- a/Sources/KiwiDeskCore/Tabs/TabWindow.swift
+++ b/Sources/KiwiDeskCore/Tabs/TabWindow.swift
@@ -2,6 +2,14 @@ import CoreGraphics
 import Foundation
 
 /// Window snapshot for pure native-tab reconciliation (#308).
+/// Native tabs are separate NSWindows sharing one on-screen
+/// frame, each with its own CGWindowID, only the active one
+/// visible to AX — a switch surfaces as one TabWindow
+/// vanishing and another appearing at the same `frame`, the
+/// key the matcher pairs on. `hasTabGroup` means an AXTabGroup
+/// is (appearing) or was (vanished) present — needed on only
+/// ONE side, since e.g. Ghostty exposes the group only at 2+
+/// tabs.
 public struct TabWindow: Equatable, Sendable {
     public let id: WindowID
     public let frame: CGRect

--- a/Sources/KiwiDeskCore/Tabs/TabWindow.swift
+++ b/Sources/KiwiDeskCore/Tabs/TabWindow.swift
@@ -1,19 +1,7 @@
 import CoreGraphics
 import Foundation
 
-/// The signals the native-tab reconciler needs about one window,
-/// snapshotted so the matcher stays pure (no AX access). `frame` is
-/// the group's on-screen frame, stable across a tab switch and the
-/// key the matcher pairs on. `hasTabGroup` means an `AXTabGroup` is
-/// (for an appearing window) or was (for a vanished one, from the
-/// event loop's carrier set) present — a re-key needs it on only one
-/// side, since an app like Ghostty exposes the group only at 2+ tabs.
-///
-/// Native tabs (Finder, Terminal, Ghostty) are separate `NSWindow`s
-/// sharing one on-screen frame, only the active one visible to AX at
-/// a time, each with its own `CGWindowID` (see issue #308). A switch
-/// therefore surfaces as one `TabWindow` vanishing and another
-/// appearing at the same `frame`.
+/// Window snapshot for pure native-tab reconciliation (#308).
 public struct TabWindow: Equatable, Sendable {
     public let id: WindowID
     public let frame: CGRect

--- a/Sources/KiwiDeskCore/Tiling/DragOverlay.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragOverlay.swift
@@ -1,6 +1,9 @@
 import AppKit
 
-/// Visual drag feedback overlay showing ghost slot and drop zone highlights.
+/// Visual drag feedback overlay showing ghost slot and drop
+/// zone highlights. Both are borderless click-through panels
+/// that never take focus or join the window cycle; frames are
+/// AX coordinates, flipped at the AppKit boundary.
 @MainActor
 public final class DragOverlay {
     private var ghost: NSPanel?

--- a/Sources/KiwiDeskCore/Tiling/DragOverlay.swift
+++ b/Sources/KiwiDeskCore/Tiling/DragOverlay.swift
@@ -1,13 +1,6 @@
 import AppKit
 
-/// Visual feedback while a tiled window is dragged: a ghost
-/// outline over the dragged window's own slot (where it snaps
-/// back, and where the displaced window would move) and a
-/// filled highlight over the slot a drop would swap with.
-///
-/// Both visuals are borderless, click-through panels that
-/// never take focus or appear in the window cycle. Frames are
-/// taken in AX coordinates and flipped at the AppKit boundary.
+/// Visual drag feedback overlay showing ghost slot and drop zone highlights.
 @MainActor
 public final class DragOverlay {
     private var ghost: NSPanel?
@@ -23,7 +16,7 @@ public final class DragOverlay {
         dropZone?.isVisible ?? false
     }
 
-    /// Marks the dragged window's home slot (AX coords).
+    /// Marks the dragged window's home slot in AX coordinates.
     public func showGhost(
         at frame: CGRect,
         style: DragVisual,
@@ -35,7 +28,7 @@ public final class DragOverlay {
         place(panel, at: adjustedFrame(frame, style: style))
     }
 
-    /// Marks the swap target's slot (AX coords).
+    /// Marks the swap target's slot in AX coordinates.
     public func showDropZone(
         at frame: CGRect,
         style: DragVisual,
@@ -73,8 +66,6 @@ public final class DragOverlay {
         hideGhost()
         hideDropZone()
     }
-
-    // MARK: - Panels
 
     private func place(_ panel: NSPanel, at frame: CGRect) {
         panel.setFrame(

--- a/Sources/KiwiDeskCore/Tiling/Navigation.swift
+++ b/Sources/KiwiDeskCore/Tiling/Navigation.swift
@@ -10,7 +10,11 @@ public enum Direction: String, Sendable, Codable, CaseIterable {
 
 /// Geometric window navigation (`focus left`, `swap right`).
 public enum Navigation {
-    /// Returns nearest candidate in `direction` with cross-axis overlap.
+    /// Nearest candidate whose center lies in `direction`.
+    /// Candidates must overlap the origin on the cross axis —
+    /// otherwise a full-height master would jump diagonally
+    /// into the stack — and lateral offset is penalized so
+    /// straight neighbors beat diagonal ones.
     public static func neighbor(
         from origin: CGRect,
         in direction: Direction,

--- a/Sources/KiwiDeskCore/Tiling/Navigation.swift
+++ b/Sources/KiwiDeskCore/Tiling/Navigation.swift
@@ -10,12 +10,7 @@ public enum Direction: String, Sendable, Codable, CaseIterable {
 
 /// Geometric window navigation (`focus left`, `swap right`).
 public enum Navigation {
-    /// The nearest candidate whose center lies in `direction`
-    /// from the origin frame. Candidates must overlap the
-    /// origin on the cross axis — "up" means a window above
-    /// within the same column, otherwise a full-height master
-    /// would jump diagonally into the stack. Lateral offset is
-    /// penalized so straight neighbors beat diagonal ones.
+    /// Returns nearest candidate in `direction` with cross-axis overlap.
     public static func neighbor(
         from origin: CGRect,
         in direction: Direction,

--- a/Sources/KiwiDeskCore/Tiling/TilingSettings+SpaceRename.swift
+++ b/Sources/KiwiDeskCore/Tiling/TilingSettings+SpaceRename.swift
@@ -1,13 +1,7 @@
 import Foundation
 
-/// The settings half of the space-reference maintenance
-/// (#13/#68): ONE definition each for renaming and removing a
-/// space across every per-space map — gap and placement
-/// overrides, space icons, and each layout's own override map
-/// (#17 — previously orphaned by a rename; deletion previously
-/// orphaned all of them). `SpaceMapParityTests` discovers the
-/// maps by reflection, so a new per-space map that misses
-/// either list fails red instead of silently orphaning.
+/// Space rename/remove migration across per-space maps
+/// (`SpaceMapParityTests`, #13, #17, #68).
 extension TilingSettings {
     /// Migrates every per-space map keyed by `from` to `to`.
     public mutating func renameSpace(


### PR DESCRIPTION
Comment diet batch 13 (74 files — FINAL batch) trimmed to AGENTS.md §2.8 budget.

- All 74 worklist files trimmed
- Preserved all issue refs (#NNN), test suite references, numeric derivations, and contract docstrings
- scripts/lint.sh exit 0 (line lengths <= 79)
- swift test green (4293 tests passing in 814 suites)

Note: Batch 13 closes out the comment diet. Claude will sweep it before merge.