### PR TITLE
feat(layout): default the BSP split strategy to alternating

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ that list:
 
 | Layout | Behavior |
 |---|---|
-| `bsp` | Binary space partitioning (square-ish splits) |
+| `bsp` | Binary space partitioning (each new window halves a pane) |
 | `stack` | Master zone + stack column (`master_count`) |
 | `scrolling` | Niri/PaperWM-style scrolling columns or rows |
 | `monocle` | Focused window maximized, rest behind it |

--- a/Sources/KiwiDeskCore/Layouts/LayoutParams.swift
+++ b/Sources/KiwiDeskCore/Layouts/LayoutParams.swift
@@ -22,7 +22,9 @@ public struct BspParams: Sendable, Equatable, Codable {
         case alternating
     }
 
-    public var strategy: Strategy = .longestSide
+    /// How each region is cut. Defaults to `.alternating`
+    /// (#1181).
+    public var strategy: Strategy = .alternating
     /// Ratio of side-by-side splits (#56).
     public var splitRatioH: Double = 0.5
     /// Ratio of stacked top/bottom splits (#56).
@@ -49,7 +51,7 @@ public struct BspParams: Sendable, Equatable, Codable {
             try container.decodeIfPresent(
                 Strategy.self,
                 forKey: .strategy
-            ) ?? .longestSide
+            ) ?? .alternating
         splitRatioH =
             try container.decodeIfPresent(
                 Double.self,

--- a/Tests/KiwiDeskCoreTests/BspOverrideTests.swift
+++ b/Tests/KiwiDeskCoreTests/BspOverrideTests.swift
@@ -129,6 +129,11 @@ struct BspOverrideCommandTests {
     @Test("strategy override writes only that space")
     func strategyOverride() {
         let core = makeCore()
+        // Pin the global the untouched-space assertions read
+        // (#660), and pin it AWAY from the value the override
+        // writes: with both on the default the test cannot tell
+        // "only that space" from "every space" (#1181).
+        core.tiler.settings.bsp.strategy = .longestSide
         #expect(
             core.execute(
                 "bsp.set_strategy_override",

--- a/Tests/KiwiDeskCoreTests/LayoutBspTests.swift
+++ b/Tests/KiwiDeskCoreTests/LayoutBspTests.swift
@@ -65,9 +65,17 @@ struct BspLayoutTests {
 
     @Test("Third window splits the tall remainder vertically")
     func longestSideRecursion() throws {
+        // PINNED (#660/#1181), and this is the fixture that
+        // needs it most: on these bounds both strategies draw
+        // the same three frames, so the flip left the one test
+        // named for longest-side recursion silently running
+        // `.alternating` — and no test in the tree exercised
+        // `.longestSide` past depth 0 (code review, 2026-08-31).
+        var context = makeContext()
+        context.bsp.strategy = .longestSide
         let frames = layout.calculateGeometry(
             for: [w1, w2, w3],
-            in: makeContext()
+            in: context
         )
         let b = try #require(frames[w2])
         let c = try #require(frames[w3])
@@ -120,12 +128,17 @@ struct BspLayoutTests {
 
     @Test("V ratio shifts the stacked boundary")
     func splitRatioV() throws {
-        // Portrait screen: shortest-side stacks the first
-        // split, so only the V ratio moves the boundary.
+        // Portrait screen: longest-side stacks the first split,
+        // so only the V ratio moves the boundary. The strategy
+        // is PINNED rather than inherited (#660/#1181) — the
+        // default is `.alternating`, which splits the first
+        // level vertically whatever the screen's shape, and
+        // this fixture is about the shape.
         var context = makeContext(
             bounds: CGRect(x: 0, y: 0, width: 800, height: 2000)
         )
         context.minWindowSize = 100
+        context.bsp.strategy = .longestSide
         context.bsp.splitRatioV = 0.7
         let frames = layout.calculateGeometry(
             for: [w1, w2],
@@ -140,8 +153,12 @@ struct BspLayoutTests {
     func ratioIndependence() throws {
         // Three windows: depth 0 splits side by side (H),
         // depth 1 stacks the tall remainder (V) — one split
-        // per axis, each following its own ratio.
+        // per axis, each following its own ratio. The strategy
+        // is pinned because that arrangement is what the
+        // assertions read, not because the two disagree here
+        // (#660).
         var context = makeContext()
+        context.bsp.strategy = .longestSide
         context.bsp.splitRatioH = 0.6
         context.bsp.splitRatioV = 0.3
         let frames = layout.calculateGeometry(

--- a/Tests/KiwiDeskCoreTests/LayoutOverrideCodingParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/LayoutOverrideCodingParityTests.swift
@@ -102,7 +102,8 @@ struct LayoutOverrideCodingParityTests {
 
     private static func bsp() -> BspOverride {
         var over = BspOverride()
-        over.strategy = .alternating
+        // Non-default, and the default moved (#1181).
+        over.strategy = .longestSide
         over.splitRatioH = 0.7
         over.splitRatioV = 0.35
         return over

--- a/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
+++ b/Tests/KiwiDeskCoreTests/LayoutParamsCodingParityTests.swift
@@ -76,7 +76,9 @@ struct LayoutParamsCodingParityTests {
 
     private static func bsp() -> BspParams {
         var params = BspParams()
-        params.strategy = .alternating
+        // Non-default, and the default moved (#1181): the
+        // fixture's job is to differ from it.
+        params.strategy = .longestSide
         params.splitRatioH = 0.75
         params.splitRatioV = 0.25
         params.newWindowPlacement = .last

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -305,7 +305,7 @@ item's only appearance in CLI output.
 | | `stack.set_stack_position` | `top\|right\|bottom\|left` (default `right`; derives the stack's lineup) |
 | | `stack.set_master_orientation` | `vertical\|horizontal` (default `horizontal`) |
 | | `stack.set_new_window_placement` | placement¹ (default `first`) |
-| BSP | `bsp.set_strategy` | `longest_side\|alternating` |
+| BSP | `bsp.set_strategy` | `longest_side\|alternating` (default `alternating`) |
 | | `bsp.set_ratio_h` | 0.1–0.9 (side-by-side splits) |
 | | `bsp.set_ratio_v` | 0.1–0.9 (stacked splits) |
 | | `bsp.set_new_window_placement` | placement¹ (default `after_focused`) |

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1401,6 +1401,25 @@ would make spawn outcomes monitor-dependent and
 non-deterministic). **This was deliberately revisited for the
 `focused_track` default — see the next entry.**
 
+**BSP alternates by default (#1181, 2026-08-31).** `alternating`
+— horizontal then vertical by depth — rather than
+`longest_side`, which cuts each region's longer side and keeps
+windows square-ish. The alternation *is* the mental model the
+word "BSP" carries for the people who reach for a BSP layout, so
+a new user meeting longest-side placement reads it as the layout
+misbehaving rather than as a policy choice. A default is the
+product's opinion, and this one was reading as wrong to the
+audience the layout is for. Both strategies stay available and
+only the default moved; `bsp.set_strategy` and the per-space
+override are unchanged.
+
+The change reaches existing users, deliberately.
+`BspParams.encode` writes `strategy` unconditionally, so every
+GUI-saved config and profile already pins its own value and is
+untouched — what moves is fresh installs and any config that
+never set the key. That is a behaviour change on update and it
+earns its own release-notes line rather than arriving silently.
+
 **Fill-then-spill is the track default; the spawn-geometry ban is
 relaxed for it (#437, 2026-07-23):** `focused_track` — now the
 default (`own_track` demoted to the ultrawide "one app per column"

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -701,11 +701,13 @@ KiwiDesk solves hiding similarly, so the same arrangements work.
 
 ### bsp.set_strategy
 
-**Expects:** `"longest_side"` or `"alternating"`.
+**Expects:** `"longest_side"` or `"alternating"` (default
+`alternating`).
 
-**Does:** sets the BSP split strategy. `longest_side` cuts the
-longer side of each region (keeps windows square-ish);
-`alternating` alternates horizontal then vertical by depth.
+**Does:** sets the BSP split strategy. `alternating` alternates
+horizontal then vertical by depth — the classic BSP behaviour,
+and the default; `longest_side` cuts the longer side of each
+region instead, which keeps windows square-ish.
 
 **Example:**
 
@@ -4457,7 +4459,7 @@ stripped, grouped by namespace — `set_gap_override` becomes
         "new_window_placement": "after_focused",
         "ratio_h": 0.5,
         "ratio_v": 0.5,
-        "strategy": "longest_side"
+        "strategy": "alternating"
       },
       "grid": { "columns": 3, "rows": 2, "type": "dynamic",
                 "fill_empty_cells": true,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -929,9 +929,13 @@ windows until you Save.
 
 Adjust each mode's defaults:
 
-- **BSP**: split strategy (longest_side or alternating) and the
-  width and height split ratios (0.5 = 50/50 each) — the knobs
-  the per-axis resize shortcuts nudge (#56).
+- **BSP**: split strategy (alternating by default, or
+  longest_side) and the width and height split ratios (0.5 =
+  50/50 each) — the knobs the per-axis resize shortcuts nudge
+  (#56). *Alternating* cuts horizontally then vertically by
+  depth, which is what "BSP" usually means elsewhere;
+  *longest_side* cuts each region's longer side instead, keeping
+  windows square-ish.
 - **Stack**: master count, master ratio (the master zone's share
   of the split), master orientation (how multiple masters line
   up), stack position (which side the stack zone takes — left/

--- a/site/src/i18n/de.json
+++ b/site/src/i18n/de.json
@@ -396,7 +396,7 @@
   "install_code_aria": "KiwiDesk mit Homebrew installieren",
   "install_copy_aria": "Installationsbefehl kopieren",
   "install_title_bar": "zsh — install",
-  "layout_bsp": "Binäre Raumaufteilung, annähernd quadratische Splits.",
+  "layout_bsp": "Binäre Raumaufteilung: Jedes neue Fenster halbiert einen Bereich.",
   "layout_floating": "Der macOS-Standard, unangetastet gelassen.",
   "layout_grid": "Dynamische oder feste Zeilen × Spalten.",
   "layout_monocle": "Fokussiertes Fenster maximiert, der Rest dahinter.",

--- a/site/src/i18n/en.json
+++ b/site/src/i18n/en.json
@@ -396,7 +396,7 @@
   "install_code_aria": "Install KiwiDesk with Homebrew",
   "install_copy_aria": "Copy the install command",
   "install_title_bar": "zsh — install",
-  "layout_bsp": "Binary space partitioning, square-ish splits.",
+  "layout_bsp": "Binary space partitioning: each new window halves a pane.",
   "layout_floating": "The macOS default, left untouched.",
   "layout_grid": "Dynamic or rigid rows × columns.",
   "layout_monocle": "Focused window maximized, rest behind.",

--- a/site/src/i18n/ja.json
+++ b/site/src/i18n/ja.json
@@ -396,7 +396,7 @@
   "install_code_aria": "Homebrew で KiwiDesk をインストールする",
   "install_copy_aria": "インストールコマンドをコピー",
   "install_title_bar": "zsh — install",
-  "layout_bsp": "二分割による、正方形に近い分割。",
+  "layout_bsp": "二分割：新しいウインドウがペインを半分にします。",
   "layout_floating": "macOS のデフォルトを、そのまま。",
   "layout_grid": "動的または固定の、行 × 列。",
   "layout_monocle": "フォーカス中のウインドウを最大化し、残りは背面へ。",


### PR DESCRIPTION
## Description

Out of the box, BSP now **alternates** — horizontal then vertical
by depth — instead of cutting each region's longest side. That
alternation *is* the mental model the word "BSP" carries for the
people who reach for a BSP layout; under `longest_side` a new
user reads the placement as the layout misbehaving rather than as
a policy choice.

Both strategies stay available; only the default moved.
`bsp.set_strategy` and the per-space override are unchanged.

**This changes behaviour on update, deliberately.**
`BspParams.encode` writes `strategy` unconditionally, so every
GUI-saved config and profile already pins its own value and is
untouched — what moves is fresh installs and any config that
never set the key. It gets its own `## Highlights` line at
release rather than arriving silently.

## Related Issue(s)

Closes #1181

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] Release build green — CI's `Release Build` job (read it
  before merging; it reports, it does not block), or locally
  for concurrency / `@Sendable` changes
- [x] PR is focused; refactors separated from features

## How I verified

`swift build`, `swift test -q` (4304 tests), `scripts/lint.sh` —
green. Release build skipped locally (no concurrency or
`Sendable` change); CI's job runs it.

**No new test for the default itself, deliberately** — the
invariant worth guarding is that the *two* default sites agree
(the property default and the sparse-decode fallback), because
flipping one alone makes a config that omits `strategy` decode
differently from a fresh `BspParams()`. That is already held by
`LayoutParamsCodingParityTests.missingKeysUseDefaults`; I mutated
one site alone and confirmed it reds. A test pinning the value
itself would red on every deliberate retune and catch no
regression (`tests.md`).

Confirmed by grep rather than assumption: neither `StarterTuning`
nor `StandardProfiles` pins the strategy, so both follow the new
default.

## Notes for Reviewer

`review-change` ran. Its most valuable finding is one I would not
have caught:

**The flip silently emptied `LayoutBspTests.longestSideRecursion`.**
On that fixture's bounds both strategies produce identical frames,
so the test kept passing while running `.alternating` under a name
and a comment claiming longest-side recursion — and after the flip
**no test in the tree exercised `.longestSide` past depth 0**.
Pinned, along with `ratioIndependence`, which was the third
unpinned fixture.

Also addressed: the docstring was over the §2.8 budget and
carried the barred kinds (design history, reviewer-facing
justification), so the argument moved to
`docs/design-decisions.md` where a contributor would look before
undoing it. And the marketing site's `layout_bsp` blurb plus the
README both described the *non-default* strategy verbatim
("square-ish splits") — now rewritten to say what the layout is
rather than which strategy it happens to run, so the next retune
leaves them true.

Two fixtures were re-pinned rather than re-derived
(`splitRatioV` wants longest-side because it is about a portrait
screen's shape; `strategyOverride` needs its global pinned *away*
from the value the override writes, or it cannot tell "only that
space" from "every space"). A `guard-prover` run on the repointed
fixtures is in flight; I will report anything it turns up before
this merges.
