### PR TITLE
fix(gui): land arrival focus on the page, not the back chip

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -875,14 +875,24 @@ claim; the obligations a change here takes on:
   behaviour the rule exists to prevent, and invisible to a
   source-needle guard, which is why the wirings in
   `KeyboardActionParityTests` are keyed on their use sites.
-  The shell states two of these itself (push focuses the back
-  chip, return restores `nav.homeReturnFocus`); a sub-view the
-  shell cannot see states its own, and a deletion reads its
+  The shell states two of these itself (push focuses the
+  CONTENT PANE, return restores `nav.homeReturnFocus`); a
+  sub-view the shell cannot see states its own, and a deletion
+  reads its
   neighbour through the one `DeletionFocus.neighbour` rule
   (#816, PR #842) — BEFORE the mutation, or it names whichever
   row slid into the gap. Naming a destination is a different
   claim from focus arriving there, and on a machine without
   keyboard navigation the two outcomes look identical.
+- **A shell statement hangs on the view that OUTLIVES the
+  transition, never on the one the transition builds** (#996).
+  `onChange` does not fire on a view's first appearance, so a
+  raise hung on the pane it focuses states nothing on the one
+  navigation that creates that pane — #998's defect at the
+  opposite polarity. That is why the arrival raise sits on
+  `structuredShell` rather than beside the `.focused` it drives,
+  which reads like the tidier placement and is the broken one.
+  `KeyboardActionParityTests+Shell` pins the raise to that chain.
 
 ## Colour (#678 turn 16b)
 

--- a/Sources/KiwiDesk/Settings/Components/Common/ClickBornFocus.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ClickBornFocus.swift
@@ -28,7 +28,10 @@ enum ClickBornFocus {
     /// focus change is observed.
     @MainActor static var isClickBorn: Bool {
         if NSEvent.pressedMouseButtons != 0 { return true }
-        switch NSApp.currentEvent?.type {
+        // `NSApp?`, never `NSApp`: it is implicitly unwrapped
+        // and nil in a process with no `NSApplication`, where
+        // the force-unwrap traps (crash, 2026-09-01).
+        switch NSApp?.currentEvent?.type {
         case .leftMouseDown, .leftMouseUp, .rightMouseDown,
             .rightMouseUp, .otherMouseDown, .otherMouseUp:
             return true

--- a/Sources/KiwiDesk/Settings/Components/Common/ClickBornFocus.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ClickBornFocus.swift
@@ -1,0 +1,39 @@
+import AppKit
+
+/// Whether the focus change now landing was caused by the mouse.
+///
+/// macOS 26 gives a `.focusable()` custom view keyboard focus on
+/// a click, where the platform's own controls take none — so a
+/// ring appears for a user who never asked for one (#991's
+/// defect; owner eye-confirm on the Settings pane, 2026-09-01).
+/// Refuse the focus and there is nothing to ring, which is the
+/// direction `docs/design-decisions.md` ▸ *a focus ring is the
+/// platform's* requires.
+///
+/// The PREDICATE is shared; the `onChange` that consults it is
+/// spelled at each site on purpose. Folded into a `ViewModifier`
+/// taking the `FocusState` binding it silently never fires —
+/// reading `wrappedValue` there establishes no dependency, so
+/// the refusal compiles, reads correctly, and does nothing
+/// (measured 2026-09-01: zero firings, keyboard path included).
+///
+/// Distinct from `SettingsInputSource`: "the mouse caused this"
+/// and "the event being dispatched is a key press" answer
+/// different questions, and merging them would refuse
+/// programmatic focus, which this must allow.
+enum ClickBornFocus {
+    /// BOTH readings, because they miss different cases: a
+    /// button still held (a drag), and a click already completed
+    /// on mouse-UP, where nothing is pressed by the time the
+    /// focus change is observed.
+    @MainActor static var isClickBorn: Bool {
+        if NSEvent.pressedMouseButtons != 0 { return true }
+        switch NSApp.currentEvent?.type {
+        case .leftMouseDown, .leftMouseUp, .rightMouseDown,
+            .rightMouseUp, .otherMouseDown, .otherMouseUp:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsSlider.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsSlider.swift
@@ -27,11 +27,10 @@ struct SettingsSlider: View {
         .focusable(isEnabled, interactions: .edit)
         .focused($focused)
         .onChange(of: focused) { _, now in
-            // Refuse click-born focus on macOS 26 (`MouseFollowsFocusTests`,
-            // 2026-08-24).
-            guard now, NSEvent.pressedMouseButtons != 0 else {
-                return
-            }
+            // Refuse click-born focus on macOS 26; the predicate
+            // is shared, the wiring is per-site by necessity
+            // (`ClickBornFocus`).
+            guard now, ClickBornFocus.isClickBorn else { return }
             focused = false
         }
         .onKeyPress(.leftArrow) { nudge(-1) }

--- a/Sources/KiwiDesk/Settings/SettingsHeaderBar.swift
+++ b/Sources/KiwiDesk/Settings/SettingsHeaderBar.swift
@@ -4,7 +4,6 @@ import SwiftUI
 /// Unified settings header bar for Home and area screens (#678).
 struct SettingsHeaderBar: View {
     @ObservedObject var model: SettingsModel
-    @FocusState private var backChipFocused: Bool
     @State private var searchExpanded = false
     @Environment(\.settingsWidth) private var width
     @Environment(\.accessibilityReduceMotion)
@@ -48,12 +47,6 @@ struct SettingsHeaderBar: View {
         .padding(.bottom, 18)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(SettingsTheme.card)
-        // Keyed on the VALUE, never `destination != nil`: an
-        // area→area navigation keeps that Boolean true, so a
-        // Boolean-keyed raise never fires there (#998).
-        .onChange(of: destination) { _, now in
-            if now != nil { backChipFocused = true }
-        }
         .onChange(of: destination) { _, _ in
             searchExpanded = false
         }
@@ -118,7 +111,6 @@ struct SettingsHeaderBar: View {
             .contentShape(ChipMetrics.shape)
         }
         .buttonStyle(.plain)
-        .focused($backChipFocused)
         .keyboardShortcut("[", modifiers: .command)
         .accessibilityLabel(L("home.back", "Home"))
     }

--- a/Sources/KiwiDesk/Settings/SettingsMetrics.swift
+++ b/Sources/KiwiDesk/Settings/SettingsMetrics.swift
@@ -9,6 +9,12 @@ enum SettingsMetrics {
     /// Gutter around destination pane scrolling content.
     static let paneInset: CGFloat = 16
 
+    /// Inset between the pane's content and its arrival focus
+    /// ring (#996). The ring is the platform's and is drawn at
+    /// the pane's bounds, so the pane holds it off its own edges
+    /// rather than the ring being restyled.
+    static let focusRingInset: CGFloat = 3
+
     /// `OverrideChrome` leading padding and checkbox spacing.
     static let overrideRowInset: CGFloat = 8
 

--- a/Sources/KiwiDesk/Settings/SettingsMetrics.swift
+++ b/Sources/KiwiDesk/Settings/SettingsMetrics.swift
@@ -13,7 +13,7 @@ enum SettingsMetrics {
     /// ring (#996). The ring is the platform's and is drawn at
     /// the pane's bounds, so the pane holds it off its own edges
     /// rather than the ring being restyled.
-    static let focusRingInset: CGFloat = 3
+    static let focusRingInset: CGFloat = 6
 
     /// `OverrideChrome` leading padding and checkbox spacing.
     static let overrideRowInset: CGFloat = 8

--- a/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
@@ -86,18 +86,16 @@ extension SettingsView {
                             maxWidth: .infinity,
                             alignment: .center
                         )
-                        // AFTER the frames, never before: applied
-                        // to the pre-layout content the ring is
-                        // drawn round a box the centring then
-                        // clips, losing its leading edge (owner
-                        // eye-confirm, 2026-09-01). The shape is
-                        // stated too — a full-bleed rectangle
-                        // reads as damage rather than as focus,
-                        // and shrinking what is focusable is the
-                        // sanctioned answer where hiding the ring
-                        // is not (docs/design-decisions.md ▸ a
+                        // AFTER the frames, never before: drawn
+                        // round the pre-layout content, the ring
+                        // loses its leading edge to the centring
+                        // that follows (owner, 2026-09-01). The
+                        // shape is stated too — a full-bleed
+                        // rectangle reads as damage rather than
+                        // as focus. Shrinking what is focusable
+                        // is the sanctioned answer where hiding
+                        // the ring is not (design-decisions ▸ a
                         // focus ring is the platform's).
-                        .padding(SettingsMetrics.focusRingInset)
                         .contentShape(
                             .focusEffect,
                             RoundedRectangle(
@@ -108,6 +106,22 @@ extension SettingsView {
                         )
                         .focusable()
                         .focused($contentFocused)
+                        // A click must not ring the pane, and
+                        // the wiring is spelled HERE because a
+                        // modifier handed the binding never
+                        // fires (owner eye-confirm, 2026-09-01).
+                        .onChange(of: contentFocused) { _, now in
+                            guard now, ClickBornFocus.isClickBorn
+                            else { return }
+                            contentFocused = false
+                        }
+                        // LAST, so the ring sits inside it. Pad
+                        // before `.focusable()` and the padded —
+                        // larger — view is the one focused, which
+                        // puts the ring on the window's own edges
+                        // where both sides are clipped away
+                        // (owner, 2026-09-01).
+                        .padding(SettingsMetrics.focusRingInset)
                         // Animated surface reflow on mode switch (#760).
                         .animation(
                             reduceMotion

--- a/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
@@ -74,8 +74,6 @@ extension SettingsView {
                 // nameless one is worse than the presses it saves.
                 if let destination = model.destination {
                     detail(destination)
-                        .focusable()
-                        .focused($contentFocused)
                         // Every section's root is a scroll view,
                         // which VoiceOver lands on as a bare
                         // "scroll area" (owner, #812 session 2) —
@@ -88,6 +86,28 @@ extension SettingsView {
                             maxWidth: .infinity,
                             alignment: .center
                         )
+                        // AFTER the frames, never before: applied
+                        // to the pre-layout content the ring is
+                        // drawn round a box the centring then
+                        // clips, losing its leading edge (owner
+                        // eye-confirm, 2026-09-01). The shape is
+                        // stated too — a full-bleed rectangle
+                        // reads as damage rather than as focus,
+                        // and shrinking what is focusable is the
+                        // sanctioned answer where hiding the ring
+                        // is not (docs/design-decisions.md ▸ a
+                        // focus ring is the platform's).
+                        .padding(SettingsMetrics.focusRingInset)
+                        .contentShape(
+                            .focusEffect,
+                            RoundedRectangle(
+                                cornerRadius:
+                                    SettingsTheme.cardRadius,
+                                style: .continuous
+                            )
+                        )
+                        .focusable()
+                        .focused($contentFocused)
                         // Animated surface reflow on mode switch (#760).
                         .animation(
                             reduceMotion

--- a/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
@@ -69,49 +69,56 @@ extension SettingsView {
             }
             // Single reader across all sections (#277).
             ScrollViewReader { proxy in
-                detail(model.destination)
-                    // Every section's root is a scroll view,
-                    // which VoiceOver lands on as a bare "scroll
-                    // area" (owner, #812 session 2) — the area's
-                    // title names it.
-                    .accessibilityLabel(model.destination?.title ?? "")
-                    .frame(
-                        maxWidth: SettingsTheme.contentMaxWidth
-                    )
-                    .frame(
-                        maxWidth: .infinity,
-                        alignment: .center
-                    )
-                    // Animated surface reflow on mode switch (#760).
-                    .animation(
-                        reduceMotion
-                            ? nil
-                            : .easeOut(
-                                duration: SettingsReveal.scroll
-                            ),
-                        value: model.settingsMode
-                    )
-                    .contentMargins(
-                        .top,
-                        SettingsMetrics.paneInset,
-                        for: .scrollContent
-                    )
-                    .environment(\.settingsFlash, model.nav.flash)
-                    .environment(
-                        \.settingsRevealTarget,
-                        model.nav.revealTarget
-                    )
-                    .onChange(of: model.nav.pendingScroll) {
-                        _,
-                        anchor in
-                        reveal(anchor, proxy: proxy)
-                    }
-                    .onAppear {
-                        reveal(
-                            model.nav.pendingScroll,
-                            proxy: proxy
+                // Hoisted so the label cannot resolve empty: this
+                // is now the arrival focus stop (#996), and a
+                // nameless one is worse than the presses it saves.
+                if let destination = model.destination {
+                    detail(destination)
+                        .focusable()
+                        .focused($contentFocused)
+                        // Every section's root is a scroll view,
+                        // which VoiceOver lands on as a bare
+                        // "scroll area" (owner, #812 session 2) —
+                        // the area's title names it.
+                        .accessibilityLabel(destination.title)
+                        .frame(
+                            maxWidth: SettingsTheme.contentMaxWidth
                         )
-                    }
+                        .frame(
+                            maxWidth: .infinity,
+                            alignment: .center
+                        )
+                        // Animated surface reflow on mode switch (#760).
+                        .animation(
+                            reduceMotion
+                                ? nil
+                                : .easeOut(
+                                    duration: SettingsReveal.scroll
+                                ),
+                            value: model.settingsMode
+                        )
+                        .contentMargins(
+                            .top,
+                            SettingsMetrics.paneInset,
+                            for: .scrollContent
+                        )
+                        .environment(\.settingsFlash, model.nav.flash)
+                        .environment(
+                            \.settingsRevealTarget,
+                            model.nav.revealTarget
+                        )
+                        .onChange(of: model.nav.pendingScroll) {
+                            _,
+                            anchor in
+                            reveal(anchor, proxy: proxy)
+                        }
+                        .onAppear {
+                            reveal(
+                                model.nav.pendingScroll,
+                                proxy: proxy
+                            )
+                        }
+                }
             }
         }
     }

--- a/Sources/KiwiDesk/Settings/SettingsView.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView.swift
@@ -10,6 +10,10 @@ struct SettingsView: View {
     /// Preview card state per mount; nil follows width class default
     /// (`DetailPanelTests`).
     @State var previewShown: Bool?
+    /// Arrival destination: the pane the raise below focuses, and
+    /// the one element that is also the area's named target
+    /// (#996). Non-private — `contentColumn` is in an extension.
+    @FocusState var contentFocused: Bool
     @Environment(\.accessibilityReduceMotion)
     var reduceMotion
 
@@ -112,6 +116,17 @@ struct SettingsView: View {
         .ignoresSafeArea(.container, edges: .top)
         .onExitCommand {
             if selection != nil { selection = nil }
+        }
+        // Arrival focus, stated by the SHELL: the pane is created
+        // by this very transition, so the same `onChange` hung on
+        // the pane would never fire on Home→area (#996). Keyed on
+        // the VALUE, never `destination != nil`, or an area→area
+        // navigation states nothing (#998); `now != nil` leaves
+        // the pop to `HomeScreen`'s own restore. A reveal into the
+        // destination already showing moves no focus, deliberately
+        // — the user is there and the keyboard stays put.
+        .onChange(of: model.destination) { _, now in
+            if now != nil { contentFocused = true }
         }
         .environment(\.settingsNavigate) { destination in
             // Third #18 enforcement point beside the grid's offer

--- a/Tests/KiwiDeskGuiTests/AnnouncedValuePinTests.swift
+++ b/Tests/KiwiDeskGuiTests/AnnouncedValuePinTests.swift
@@ -172,9 +172,12 @@ struct AnnouncedValuePinTests {
                 ".focusable(isEnabled, interactions: .edit)"
             )
         )
-        // The click-focus refusal (#812 session 3): focus
-        // arriving with a mouse button down is handed back.
-        #expect(source.contains("NSEvent.pressedMouseButtons"))
+        // The click-focus refusal (#812 session 3): focus the
+        // mouse caused is handed back. The predicate moved to
+        // the shared `ClickBornFocus` when a third control
+        // needed it (#996) — the wiring stays here, since a
+        // modifier handed the `FocusState` binding never fires.
+        #expect(source.contains("ClickBornFocus.isClickBorn"))
         for key in ["leftArrow", "rightArrow", "upArrow", "downArrow"] {
             #expect(
                 source.contains(".onKeyPress(.\(key))"),

--- a/Tests/KiwiDeskGuiTests/ArrivalRingTests.swift
+++ b/Tests/KiwiDeskGuiTests/ArrivalRingTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// The two things the #996 QA sitting cost an eye-confirm to
+/// find, both invisible to every other guard because both are
+/// about modifier ORDER rather than about which modifiers exist.
+///
+/// Neither can say what the ring looks like. What they hold is
+/// the shape of the decision, so the next refactor that reorders
+/// this chain is told what it broke instead of shipping it.
+@Suite("Arrival focus ring (#996)")
+struct ArrivalRingTests {
+    private func pane() throws -> String {
+        let file = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(
+                "Sources/KiwiDesk/Settings/SettingsView+Detail.swift"
+            )
+        let source = SourceScan.stripComments(
+            try String(contentsOf: file, encoding: .utf8)
+        )
+        #expect(source.count > 200, "the pane file read empty")
+        return source.split(whereSeparator: \.isWhitespace).joined()
+    }
+
+    /// The ring is drawn at the FOCUSED view's bounds, so padding
+    /// applied before `.focusable()` pads the focused view itself
+    /// and puts the ring on the window's own edges — where both
+    /// vertical sides are clipped away (owner eye-confirm,
+    /// 2026-09-01). Order is the whole fix; the modifiers are
+    /// unchanged either way, which is why nothing else sees it.
+    @Test("the pane is padded after it is made focusable")
+    func paddingFollowsFocusable() throws {
+        let source = try pane()
+        let focusable = try #require(
+            source.range(of: ".focusable()"),
+            "the pane is no longer focusable — #996's destination"
+        )
+        let padding = try #require(
+            source.range(
+                of: ".padding(SettingsMetrics.focusRingInset)"
+            ),
+            "the pane no longer insets its ring"
+        )
+        #expect(
+            padding.lowerBound > focusable.upperBound,
+            Comment(
+                rawValue:
+                    "the ring inset is applied BEFORE "
+                    + "`.focusable()`, so the padded — larger — "
+                    + "view is the focused one and the ring lands "
+                    + "on the window's edges with both sides "
+                    + "clipped (#996)"
+            )
+        )
+    }
+
+    /// `.focusable()` must also follow the two `.frame` calls:
+    /// applied to the pre-layout content, the ring is drawn round
+    /// a box the centring then clips, losing its leading edge.
+    @Test("the pane is made focusable after it is laid out")
+    func focusableFollowsLayout() throws {
+        let source = try pane()
+        let centred = try #require(
+            source.range(
+                of: ".frame(maxWidth:.infinity,alignment:.center)"
+            ),
+            "the content column no longer centres itself"
+        )
+        let focusable = try #require(
+            source.range(of: ".focusable()"),
+            "the pane is no longer focusable"
+        )
+        #expect(
+            focusable.lowerBound > centred.upperBound,
+            Comment(
+                rawValue:
+                    "`.focusable()` is applied before the column "
+                    + "is sized and centred, so the ring is drawn "
+                    + "round the pre-layout content and loses its "
+                    + "leading edge to the centring (#996)"
+            )
+        )
+    }
+
+    /// Who refuses click-born focus, held as a closed set.
+    ///
+    /// A control that takes `.focusable()` and skips the refusal
+    /// rings on every click — the defect #991 exists to remove,
+    /// re-entering through a control rather than through a
+    /// navigation. An entry here is a decision; a missing one is
+    /// an omission nothing else would report.
+    @Test("every focusable custom control refuses a click")
+    func clickRefusalCensus() throws {
+        let root = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDesk/Settings")
+        let files = try SourceScan.swiftSources(under: root)
+        #expect(files.count > 50)
+        var consults: [String] = []
+        var raw: [String] = []
+        for file in files {
+            let source = SourceScan.stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            .split(whereSeparator: \.isWhitespace).joined()
+            if source.contains("ClickBornFocus.isClickBorn") {
+                consults.append(file.lastPathComponent)
+            }
+            if source.contains("NSEvent.pressedMouseButtons") {
+                raw.append(file.lastPathComponent)
+            }
+        }
+        #expect(
+            consults.sorted() == [
+                "SettingsSlider.swift", "SettingsView+Detail.swift",
+            ],
+            Comment(
+                rawValue:
+                    "the click-born refusal is consulted by "
+                    + "\(consults.sorted()) — a `.focusable()` "
+                    + "control that skips it draws a ring on "
+                    + "every click (#991, #996)"
+            )
+        )
+        // And the reading itself has ONE home: a hand-rolled copy
+        // beside a view is how the predicate drifts, and it took
+        // two spellings to get right.
+        #expect(
+            raw == ["ClickBornFocus.swift"],
+            Comment(
+                rawValue:
+                    "`NSEvent.pressedMouseButtons` is read in "
+                    + "\(raw) — route it through "
+                    + "`ClickBornFocus.isClickBorn`, which also "
+                    + "reads the current event, a case the button "
+                    + "state alone misses (#996)"
+            )
+        )
+    }
+}

--- a/Tests/KiwiDeskGuiTests/KeyboardActionParityTests+Shell.swift
+++ b/Tests/KiwiDeskGuiTests/KeyboardActionParityTests+Shell.swift
@@ -12,7 +12,7 @@ import Testing
 /// convention, so the small wiring/squash pair below is a
 /// deliberate copy of that file's.
 ///
-/// The header needle spans the WHOLE `onChange` closure,
+/// The raise needle spans the WHOLE `onChange` closure,
 /// including its key: #998 shipped as a wiring keyed on
 /// `destination != nil`, which fires on Home→area and never on
 /// area→area (a cross-reference, a search pick into another
@@ -20,20 +20,33 @@ import Testing
 /// destination on one navigation path. A needle on the
 /// assignment alone would have stayed green through exactly
 /// that.
+///
+/// The push pair moved out of `SettingsHeaderBar` in #996: the
+/// destination is the content pane, so the raise has to live on
+/// `structuredShell` rather than on the pane it focuses —
+/// `onChange` does not fire on a view's first appearance, and
+/// the pane is CREATED by the Home→area transition, so the same
+/// closure hung there would state nothing on exactly the
+/// navigation #998 was about. The needle names the shell file
+/// for that reason, and moving it back is the regression.
 extension KeyboardActionParityTests {
     @Test("the shell states its two focus destinations")
     func shellStatesItsFocusDestinations() throws {
         let wirings: [ShellWiring] = [
             ShellWiring(
-                "SettingsHeaderBar.swift",
-                ".focused($backChipFocused)",
-                "the back chip is the push destination — an "
-                    + "unattached @FocusState moves focus nowhere"
+                "SettingsView+Detail.swift",
+                ".focusable() .focused($contentFocused)",
+                "the content pane is the push destination (#996) "
+                    + "— and BOTH halves: an unattached "
+                    + "@FocusState moves focus nowhere, and a "
+                    + "container that never took `.focusable()` "
+                    + "cannot be assigned to in the first place, "
+                    + "which is the half a Button gave free"
             ),
             ShellWiring(
-                "SettingsHeaderBar.swift",
-                ".onChange(of: destination) { _, now in "
-                    + "if now != nil { backChipFocused = true } }",
+                "SettingsView.swift",
+                ".onChange(of: model.destination) { _, now in "
+                    + "if now != nil { contentFocused = true } }",
                 "and the raise is keyed on the VALUE: keyed on "
                     + "`destination != nil` it fires on Home→area "
                     + "only, so an area→area navigation destroys "

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -190,6 +190,11 @@ menus, checkboxes, and buttons are skipped. Turn on **System
 Settings ▸ Keyboard ▸ Keyboard navigation** and Tab reaches every
 control.
 
+Opening an area puts focus on the page itself, so the next Tab
+reaches that page's first control instead of walking the header.
+The **← Home** chip is still there — Shift-Tab reaches it, and
+**⌘[** or Escape goes back without any tabbing at all.
+
 Leave it off and the keyboard paths here still *run*, they just
 have nowhere to land: deleting a space moves focus to the next
 row's layout picker, and with keyboard navigation off a pop-up


### PR DESCRIPTION
## What & why

fixes #996

Arriving at a Settings area focused the header's back chip, leaving five header stops between a keyboard user and the page they asked for — **six presses to the first field**, paid on every navigation (owner measurement on the issue).

The destination moves to the **content pane**. It is drawn by construction of the branch it lives in, exists once rather than twelve times by hand, and already carried the area's accessibility label — so the focus target and the named target are one element and cannot drift.

The shape was ruled by `ui-designer` before it was built, as the issue asked. Focusing each section's first control instead would have meant twelve destinations each owing a judgement that its target is drawn in both modes, at all three widths and under `editingStoredProfile` — twelve chances to repeat #816, which shipped once already.

**The one thing worth reviewing closely:** the raise lives on `structuredShell`, *not* on the pane it focuses. `onChange` does not fire on a view's first appearance, and the pane is created by the Home→area transition — so the same closure hung on the pane would state nothing on exactly the navigation #998 was about. It keeps #998's value-keying for the other half of that lesson.

The label is hoisted out of `model.destination?.title ?? ""`; an empty fallback was tolerable on a label nobody could focus, but a nameless Tab stop is worse than the presses it replaces.

The back chip keeps `⌘[` and Escape (both already documented) and stays Shift-Tab reachable.

## Verification

Full gate green: `swift build`, `swift test -q` (4315 tests / 819 suites), `scripts/lint.sh`, plus the site build because `docs/` is one of its inputs. Release build skipped — no concurrency or `Sendable` surface; read CI's `Release Build` job.

`guard-prover` (isolated worktree) red-proofed all four sub-diff mutations: `.focusable()` removed with `.focused()` left in place, `.focused()` removed with `.focusable()` left, the raise re-keyed on `destination != nil`, and the raise moved out of the shell file.

It also found a **real gap**, reported rather than papered over: moving the raise *within* `SettingsView.swift` onto the `selection == nil` branch — firing from the subtree the transition is tearing down — kept the guard green. That is closed on the stacked #991 branch, where the needle grows to carry its neighbour and pin the raise to `structuredShell`'s own chain.

## Not verified here

**Focus ARRIVING is not something a needle can show.** Both shell needles say only that a destination was named; `gui.md` is explicit that nothing headless separates "drawn" from "focusable". The device confirm with **keyboard navigation ON** is outstanding — the checks to run are listed on the issue, and the discriminator is: from arrival, one Tab must reach the section's first control. If the assignment fell through, that first Tab lands on the profile chip instead.

Opened as a **draft** deliberately: 1.1.2 is being tagged in a parallel session, and nothing may reach `main` before that tag.

