### PR TITLE
fix(gui): a segmented control costs one Tab stop, not one per segment

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Capsule segmented picker with animated sliding accent pill (#68).
@@ -9,6 +10,7 @@ struct SegmentedPicker<Value: Hashable>: View {
     private let help: String?
     @Namespace private var pillSpace
     @State private var hoveredIndex: Int?
+    @FocusState private var focused: Bool
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
     @Environment(\.isEnabled) private var isEnabled
@@ -75,6 +77,27 @@ struct SegmentedPicker<Value: Hashable>: View {
                 lineWidth: 0.5
             )
         )
+        // ONE Tab stop for the whole control, the way a native
+        // segmented control behaves — the segments opt out below,
+        // and the track takes the stop they gave up (#997).
+        .focusable(isEnabled)
+        .focused($focused)
+        .onChange(of: focused) { _, now in
+            // Refuse click-born focus on macOS 26, the same
+            // refusal `SettingsSlider` carries: without it every
+            // click on a segment draws a keyboard focus ring
+            // (#991's family, which this stop would otherwise
+            // introduce here).
+            guard now, NSEvent.pressedMouseButtons != 0 else {
+                return
+            }
+            focused = false
+        }
+        // ← / → only. ↑ / ↓ are left alone so vertical traversal
+        // still leaves the row, which is what the native control
+        // does too.
+        .onKeyPress(.leftArrow) { move(-1) }
+        .onKeyPress(.rightArrow) { move(1) }
         .accessibilityElement(children: .contain)
         // Group value announcement for accessibility (#812, 2026-08-24).
         .accessibilityValue(
@@ -83,6 +106,24 @@ struct SegmentedPicker<Value: Hashable>: View {
         .onChange(of: isEnabled) { _, now in
             if !now { hoveredIndex = nil }
         }
+    }
+
+    /// Moves the SELECTION one segment, which is what a native
+    /// segmented control does on an arrow — a highlight that
+    /// moved without selecting would announce a choice the
+    /// binding never took.
+    private func move(_ direction: Int) -> KeyPress.Result {
+        guard isEnabled,
+            let next = SegmentedPickerKeys.step(
+                from: selectedIndex,
+                by: direction,
+                count: options.count
+            )
+        else { return .ignored }
+        // Clamped, so the end segments swallow their own arrow
+        // rather than letting it walk out of the control.
+        if next != selectedIndex { select(options[next].value) }
+        return .handled
     }
 
     private func segment(
@@ -100,6 +141,11 @@ struct SegmentedPicker<Value: Hashable>: View {
             )
         }
         .buttonStyle(.plain)
+        // The stop this Button gave free is the defect: N
+        // segments cost N Tab stops where the native control
+        // costs one. Click, VoiceOver and `isEnabled` all stay —
+        // only the focus stop goes, to the track (#997).
+        .focusable(false)
         .onHover { inside in
             updateHover(
                 inside: inside,

--- a/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 /// Capsule segmented picker with animated sliding accent pill (#68).
@@ -83,11 +82,9 @@ struct SegmentedPicker<Value: Hashable>: View {
         .focusable(isEnabled)
         .focused($focused)
         .onChange(of: focused) { _, now in
-            // Click-born focus, refused as `SettingsSlider` does:
-            // this stop would otherwise ring on every click.
-            guard now, NSEvent.pressedMouseButtons != 0 else {
-                return
-            }
+            // This stop would otherwise ring on every click
+            // (`ClickBornFocus`).
+            guard now, ClickBornFocus.isClickBorn else { return }
             focused = false
         }
         // ← / → only: ↑ / ↓ must still leave the row.

--- a/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
@@ -78,24 +78,19 @@ struct SegmentedPicker<Value: Hashable>: View {
             )
         )
         // ONE Tab stop for the whole control, the way a native
-        // segmented control behaves — the segments opt out below,
-        // and the track takes the stop they gave up (#997).
+        // segmented control behaves — the segments opt out below
+        // (#997).
         .focusable(isEnabled)
         .focused($focused)
         .onChange(of: focused) { _, now in
-            // Refuse click-born focus on macOS 26, the same
-            // refusal `SettingsSlider` carries: without it every
-            // click on a segment draws a keyboard focus ring
-            // (#991's family, which this stop would otherwise
-            // introduce here).
+            // Click-born focus, refused as `SettingsSlider` does:
+            // this stop would otherwise ring on every click.
             guard now, NSEvent.pressedMouseButtons != 0 else {
                 return
             }
             focused = false
         }
-        // ← / → only. ↑ / ↓ are left alone so vertical traversal
-        // still leaves the row, which is what the native control
-        // does too.
+        // ← / → only: ↑ / ↓ must still leave the row.
         .onKeyPress(.leftArrow) { move(-1) }
         .onKeyPress(.rightArrow) { move(1) }
         .accessibilityElement(children: .contain)
@@ -108,19 +103,21 @@ struct SegmentedPicker<Value: Hashable>: View {
         }
     }
 
-    /// Moves the SELECTION one segment, which is what a native
-    /// segmented control does on an arrow — a highlight that
-    /// moved without selecting would announce a choice the
-    /// binding never took.
+    /// Moves the SELECTION one segment, as a native segmented
+    /// control does: a highlight that moved without selecting
+    /// would announce a choice the binding never took.
+    ///
+    /// No `isEnabled` guard — the track is `.focusable(isEnabled)`,
+    /// so a disabled control receives no key press to answer.
     private func move(_ direction: Int) -> KeyPress.Result {
-        guard isEnabled,
+        guard
             let next = SegmentedPickerKeys.step(
                 from: selectedIndex,
                 by: direction,
                 count: options.count
             )
         else { return .ignored }
-        // Clamped, so the end segments swallow their own arrow
+        // Clamped, so an end segment swallows its own arrow
         // rather than letting it walk out of the control.
         if next != selectedIndex { select(options[next].value) }
         return .handled
@@ -141,10 +138,8 @@ struct SegmentedPicker<Value: Hashable>: View {
             )
         }
         .buttonStyle(.plain)
-        // The stop this Button gave free is the defect: N
-        // segments cost N Tab stops where the native control
-        // costs one. Click, VoiceOver and `isEnabled` all stay —
-        // only the focus stop goes, to the track (#997).
+        // Only the focus stop goes, to the track; click,
+        // VoiceOver and `isEnabled` stay (#997).
         .focusable(false)
         .onHover { inside in
             updateHover(

--- a/Sources/KiwiDesk/Settings/Components/Common/SegmentedPickerKeys.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SegmentedPickerKeys.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// The arrow-key arithmetic, lifted out of the view so it can be
+/// read without a host (`SegmentedPickerKeyTests`, #997).
+enum SegmentedPickerKeys {
+    /// Index an arrow press lands on, or nil when there is
+    /// nothing to land on. Clamped, never wrapping — a native
+    /// segmented control stops at its ends — and an UNMATCHED
+    /// selection (nil, #754) lands on the first option rather
+    /// than stepping from an index it does not have.
+    static func step(
+        from current: Int?,
+        by direction: Int,
+        count: Int
+    ) -> Int? {
+        guard count > 0 else { return nil }
+        guard let current else { return 0 }
+        return min(max(current + direction, 0), count - 1)
+    }
+}

--- a/Tests/KiwiDeskGuiTests/ArrivalRingTests.swift
+++ b/Tests/KiwiDeskGuiTests/ArrivalRingTests.swift
@@ -12,6 +12,13 @@ import Testing
 /// this chain is told what it broke instead of shipping it.
 @Suite("Arrival focus ring (#996)")
 struct ArrivalRingTests {
+    /// The pane's OWN chain, scoped to `contentColumn`.
+    ///
+    /// Read file-wide, both order tests answer against whichever
+    /// `.focusable()` comes first in the file: with an earlier
+    /// one present, `paddingFollowsFocusable` goes FAIL-OPEN on
+    /// the shipped bug and `focusableFollowsLayout` goes
+    /// false-red on a correct chain (`guard-prover`, 2026-09-01).
     private func pane() throws -> String {
         let file = SourceScan.repoRoot(from: #filePath)
             .appendingPathComponent(
@@ -21,7 +28,31 @@ struct ArrivalRingTests {
             try String(contentsOf: file, encoding: .utf8)
         )
         #expect(source.count > 200, "the pane file read empty")
-        return source.split(whereSeparator: \.isWhitespace).joined()
+        let scope = try #require(
+            SourceScan.declarationBody(
+                after: "private var contentColumn: some View",
+                in: source
+            ),
+            "`contentColumn` is gone from the pane file"
+        )
+        let squashed =
+            scope
+            .split(whereSeparator: \.isWhitespace).joined()
+        // Scoping answers an earlier `.focusable()` in the FILE;
+        // a second one inside this scope reproduces both failure
+        // modes, so the scope holds exactly one.
+        #expect(
+            squashed.components(separatedBy: ".focusable()").count
+                == 2,
+            Comment(
+                rawValue:
+                    "`contentColumn` declares more than one "
+                    + "`.focusable()`, so the order tests below "
+                    + "answer against whichever comes first "
+                    + "rather than against the pane's (#996)"
+            )
+        )
+        return squashed
     }
 
     /// The ring is drawn at the FOCUSED view's bounds, so padding
@@ -84,57 +115,78 @@ struct ArrivalRingTests {
         )
     }
 
-    /// Who refuses click-born focus, held as a closed set.
+    /// Every control that OPTS INTO focus owes the refusal.
     ///
-    /// A control that takes `.focusable()` and skips the refusal
-    /// rings on every click — the defect #991 exists to remove,
-    /// re-entering through a control rather than through a
-    /// navigation. An entry here is a decision; a missing one is
-    /// an omission nothing else would report.
+    /// Derived from the population, not from a list of the
+    /// compliant: a list agrees only with itself, so adding a
+    /// CORRECT control reds it (a speed bump) while adding an
+    /// INCORRECT one — `.focusable()` with no refusal — leaves it
+    /// green, which is the harm. `guard-prover` (2026-09-01)
+    /// found one already in the tree that way.
+    ///
+    /// An exemption names what makes it right, the idiom
+    /// `ReduceMotionGateTests` and `ActivationPolicySeamTests`
+    /// already use here.
     @Test("every focusable custom control refuses a click")
     func clickRefusalCensus() throws {
+        let allowed: [String: String] = [
+            "SpaceAssignmentChip.swift":
+                "UNRULED, not exempt: a drag-source chip whose "
+                + "click-born ring nobody has judged yet. It "
+                + "predates the refusal and is recorded here so "
+                + "the question is visible rather than absent — "
+                + "rule it, then either add the refusal or "
+                + "replace this with the reason it does not."
+        ]
         let root = SourceScan.repoRoot(from: #filePath)
             .appendingPathComponent("Sources/KiwiDesk/Settings")
         let files = try SourceScan.swiftSources(under: root)
         #expect(files.count > 50)
-        var consults: [String] = []
         var raw: [String] = []
         for file in files {
+            let name = file.lastPathComponent
             let source = SourceScan.stripComments(
                 try String(contentsOf: file, encoding: .utf8)
             )
             .split(whereSeparator: \.isWhitespace).joined()
-            if source.contains("ClickBornFocus.isClickBorn") {
-                consults.append(file.lastPathComponent)
-            }
             if source.contains("NSEvent.pressedMouseButtons") {
-                raw.append(file.lastPathComponent)
+                raw.append(name)
             }
-        }
-        #expect(
-            consults.sorted() == [
-                "SettingsSlider.swift", "SettingsView+Detail.swift",
-            ],
-            Comment(
-                rawValue:
-                    "the click-born refusal is consulted by "
-                    + "\(consults.sorted()) — a `.focusable()` "
-                    + "control that skips it draws a ring on "
-                    + "every click (#991, #996)"
+            // `.focusable(false)` is an opt-OUT: it removes a
+            // stop rather than taking one, so it owes nothing.
+            let optsIn =
+                source.contains(".focusable(")
+                && source.replacingOccurrences(
+                    of: ".focusable(false)",
+                    with: ""
+                ).contains(".focusable(")
+            guard optsIn, allowed[name] == nil else { continue }
+            #expect(
+                source.contains("ClickBornFocus.isClickBorn"),
+                Comment(
+                    rawValue:
+                        "\(name) takes `.focusable(` and never "
+                        + "refuses click-born focus, so it draws "
+                        + "a keyboard ring on every click — the "
+                        + "defect #991 removes, re-entering "
+                        + "through a control. Consult "
+                        + "`ClickBornFocus.isClickBorn`, or add "
+                        + "an `allowed` entry saying what makes "
+                        + "this control different."
+                )
             )
-        )
-        // And the reading itself has ONE home: a hand-rolled copy
-        // beside a view is how the predicate drifts, and it took
-        // two spellings to get right.
+        }
+        // And the reading itself has ONE home per question: a
+        // hand-rolled copy beside a view is how it drifts, and it
+        // took two spellings to get right — the button state
+        // alone misses a click completed on mouse-up.
         #expect(
-            raw == ["ClickBornFocus.swift"],
+            raw.sorted() == ["ClickBornFocus.swift"],
             Comment(
                 rawValue:
                     "`NSEvent.pressedMouseButtons` is read in "
-                    + "\(raw) — route it through "
-                    + "`ClickBornFocus.isClickBorn`, which also "
-                    + "reads the current event, a case the button "
-                    + "state alone misses (#996)"
+                    + "\(raw.sorted()) — route it through "
+                    + "`ClickBornFocus.isClickBorn` (#996)"
             )
         )
     }

--- a/Tests/KiwiDeskGuiTests/SegmentedPickerKeyTests.swift
+++ b/Tests/KiwiDeskGuiTests/SegmentedPickerKeyTests.swift
@@ -130,58 +130,6 @@ struct SegmentedPickerKeyTests {
         }
     }
 
-    /// A focusable custom control owes a click-born-focus
-    /// refusal, and this change makes the second one.
-    ///
-    /// The refusal is five readable lines and copying it is the
-    /// cheaper move at two sites — but nothing was counting, so
-    /// the third would be an omission rather than a decision.
-    /// The set is held EXACTLY: a control that becomes focusable
-    /// and skips the refusal reds here, and one that gains the
-    /// refusal without needing it does too.
-    ///
-    /// `NSApp.currentEvent` — #991's seam for "did a keyboard
-    /// drive this navigation" — is a DIFFERENT question and is
-    /// counted by `SettingsInputSourceSeamTests`. "A mouse
-    /// button is physically down" and "the current event is a
-    /// key press" must not be merged: the second refuses
-    /// programmatic focus, which this one must allow.
-    @Test("who refuses click-born focus is a closed set")
-    func clickBornRefusalCensus() throws {
-        let root = SourceScan.repoRoot(from: #filePath)
-            .appendingPathComponent("Sources/KiwiDesk")
-        let files = try SourceScan.swiftSources(under: root)
-        // A scan that read nothing would pass having looked at
-        // nothing (#635).
-        #expect(files.count > 50)
-        var readers: [String] = []
-        for file in files {
-            let source = SourceScan.stripComments(
-                try String(contentsOf: file, encoding: .utf8)
-            )
-            if squashed(source).contains(
-                "NSEvent.pressedMouseButtons"
-            ) {
-                readers.append(file.lastPathComponent)
-            }
-        }
-        #expect(
-            readers.sorted() == [
-                "SegmentedPicker.swift", "SettingsSlider.swift",
-            ],
-            Comment(
-                rawValue:
-                    "the click-born-focus refusal is spelled in "
-                    + "\(readers.sorted()) — a custom control "
-                    + "that takes `.focusable` owes this refusal "
-                    + "or it rings on every click (#991's family, "
-                    + "#997). At a third copy, home it beside "
-                    + "#991's input-source seam instead of adding "
-                    + "an entry here."
-            )
-        )
-    }
-
     /// The balanced body of `declaration`, so a needle is read
     /// against the subview that must carry it. Fails loudly
     /// rather than scanning "" if the declaration is renamed.

--- a/Tests/KiwiDeskGuiTests/SegmentedPickerKeyTests.swift
+++ b/Tests/KiwiDeskGuiTests/SegmentedPickerKeyTests.swift
@@ -130,6 +130,58 @@ struct SegmentedPickerKeyTests {
         }
     }
 
+    /// A focusable custom control owes a click-born-focus
+    /// refusal, and this change makes the second one.
+    ///
+    /// The refusal is five readable lines and copying it is the
+    /// cheaper move at two sites — but nothing was counting, so
+    /// the third would be an omission rather than a decision.
+    /// The set is held EXACTLY: a control that becomes focusable
+    /// and skips the refusal reds here, and one that gains the
+    /// refusal without needing it does too.
+    ///
+    /// `NSApp.currentEvent` — #991's seam for "did a keyboard
+    /// drive this navigation" — is a DIFFERENT question and is
+    /// counted by `SettingsInputSourceSeamTests`. "A mouse
+    /// button is physically down" and "the current event is a
+    /// key press" must not be merged: the second refuses
+    /// programmatic focus, which this one must allow.
+    @Test("who refuses click-born focus is a closed set")
+    func clickBornRefusalCensus() throws {
+        let root = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDesk")
+        let files = try SourceScan.swiftSources(under: root)
+        // A scan that read nothing would pass having looked at
+        // nothing (#635).
+        #expect(files.count > 50)
+        var readers: [String] = []
+        for file in files {
+            let source = SourceScan.stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            if squashed(source).contains(
+                "NSEvent.pressedMouseButtons"
+            ) {
+                readers.append(file.lastPathComponent)
+            }
+        }
+        #expect(
+            readers.sorted() == [
+                "SegmentedPicker.swift", "SettingsSlider.swift",
+            ],
+            Comment(
+                rawValue:
+                    "the click-born-focus refusal is spelled in "
+                    + "\(readers.sorted()) — a custom control "
+                    + "that takes `.focusable` owes this refusal "
+                    + "or it rings on every click (#991's family, "
+                    + "#997). At a third copy, home it beside "
+                    + "#991's input-source seam instead of adding "
+                    + "an entry here."
+            )
+        )
+    }
+
     /// The balanced body of `declaration`, so a needle is read
     /// against the subview that must carry it. Fails loudly
     /// rather than scanning "" if the declaration is renamed.

--- a/Tests/KiwiDeskGuiTests/SegmentedPickerKeyTests.swift
+++ b/Tests/KiwiDeskGuiTests/SegmentedPickerKeyTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// A segmented control costs ONE Tab stop and answers ← / →,
+/// which is two claims a source scan and some arithmetic can
+/// hold between them — and neither can say focus arrived, so
+/// #997's device confirm is the third leg, not an optional one.
+@Suite("Segmented picker keyboard (#997)")
+struct SegmentedPickerKeyTests {
+    // MARK: - The arithmetic
+
+    @Test("an arrow steps one segment and stops at the ends")
+    func stepClampsAtBothEnds() {
+        #expect(SegmentedPickerKeys.step(from: 0, by: 1, count: 3) == 1)
+        #expect(SegmentedPickerKeys.step(from: 1, by: 1, count: 3) == 2)
+        #expect(SegmentedPickerKeys.step(from: 1, by: -1, count: 3) == 0)
+        // The ends swallow their own arrow rather than wrapping:
+        // a native segmented control does not cycle, and a wrap
+        // would jump the selection across the whole control on a
+        // key the user pressed to nudge it.
+        #expect(SegmentedPickerKeys.step(from: 2, by: 1, count: 3) == 2)
+        #expect(SegmentedPickerKeys.step(from: 0, by: -1, count: 3) == 0)
+    }
+
+    @Test("an unmatched selection lands on the first option")
+    func unmatchedSelectionLandsFirst() {
+        // #754's nil: there is no index to step FROM, and
+        // treating it as 0 would make ← land on 0 and → land on
+        // 1, skipping the first option on one of the two keys.
+        #expect(SegmentedPickerKeys.step(from: nil, by: 1, count: 3) == 0)
+        #expect(SegmentedPickerKeys.step(from: nil, by: -1, count: 3) == 0)
+    }
+
+    @Test("an empty control has nowhere to land")
+    func emptyControlRefuses() {
+        #expect(SegmentedPickerKeys.step(from: nil, by: 1, count: 0) == nil)
+        #expect(SegmentedPickerKeys.step(from: 0, by: 1, count: 0) == nil)
+    }
+
+    // MARK: - The stop count, which only the source can show
+
+    /// The arithmetic above is reachable from the keyboard only
+    /// if the track is the focus stop AND the segments have given
+    /// theirs up. Both halves are needled, and each is read
+    /// inside the declaration that must carry it rather than
+    /// against the whole file.
+    ///
+    /// The scoping is not tidiness. Read file-wide, every needle
+    /// below stays green while the focus pair is MOVED onto the
+    /// segment — SwiftUI takes the last `.focusable`, so each
+    /// segment is a stop again and the track is not, which is
+    /// #997's original defect restored under a green guard
+    /// (`guard-prover`, 2026-09-01; the same class `tests.md`
+    /// records for `WorkflowSource.workflowStep`).
+    @Test("the track takes one stop and the segments take none")
+    func trackIsTheOnlyStop() throws {
+        let file = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Components/Common/"
+                    + "SegmentedPicker.swift"
+            )
+        let source = SourceScan.stripComments(
+            try String(contentsOf: file, encoding: .utf8)
+        )
+        let track = try body("private var track: some View", source)
+        let segment = try body("private func segment(", source)
+        let move = try body("private func move(", source)
+
+        let needles: [(String, String, String)] = [
+            (
+                track, ".focusable(isEnabled).focused($focused)",
+                "the TRACK is the control's one focus stop, and "
+                    + "an unattached @FocusState moves focus "
+                    + "nowhere"
+            ),
+            (
+                track, ".onKeyPress(.leftArrow){move(-1)}",
+                "← moves the selection"
+            ),
+            (
+                track, ".onKeyPress(.rightArrow){move(1)}",
+                "and → moves it the other way — the pair is what "
+                    + "makes one stop enough to reach every "
+                    + "segment"
+            ),
+            (
+                segment, ".buttonStyle(.plain).focusable(false)",
+                "and each SEGMENT gives its own stop up — "
+                    + "without this the track's stop is ADDED to "
+                    + "the per-segment ones, which is the "
+                    + "reported defect plus one"
+            ),
+            (
+                move, "SegmentedPickerKeys.step(",
+                "and the move reads the ONE arithmetic the tests "
+                    + "above hold, rather than a second copy "
+                    + "beside the view"
+            ),
+        ]
+        for (scope, needle, why) in needles {
+            #expect(
+                squashed(scope).contains(squashed(needle)),
+                Comment(
+                    rawValue:
+                        "SegmentedPicker.swift lost `\(needle)` "
+                        + "— \(why), and the failure is silent to "
+                        + "everything except a person using the "
+                        + "keyboard (#997)"
+                )
+            )
+        }
+
+        // The other direction, because SwiftUI takes the LAST
+        // `.focusable`: a segment that opts back in re-earns its
+        // stop while every positive needle above still matches.
+        for banned in [".focusable(true)", ".focused("] {
+            #expect(
+                !squashed(segment).contains(squashed(banned)),
+                Comment(
+                    rawValue:
+                        "a segment declares `\(banned)` — the "
+                        + "last `.focusable` on a chain wins, so "
+                        + "the segments are focus stops again and "
+                        + "the control costs one press per "
+                        + "segment (#997)"
+                )
+            )
+        }
+    }
+
+    /// The balanced body of `declaration`, so a needle is read
+    /// against the subview that must carry it. Fails loudly
+    /// rather than scanning "" if the declaration is renamed.
+    private func body(
+        _ declaration: String,
+        _ source: String
+    ) throws -> String {
+        try #require(
+            SourceScan.declarationBody(
+                after: declaration,
+                in: source
+            ),
+            "`\(declaration)` is gone from SegmentedPicker.swift"
+        )
+    }
+
+    private func squashed(_ text: String) -> String {
+        text.split(whereSeparator: \.isWhitespace).joined()
+    }
+}

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -214,6 +214,12 @@ With it on, a slider takes focus like any other control and the
 arrow keys step it: ← / ↓ down one step, → / ↑ up one — the same
 step the readout beside it counts in.
 
+A segmented control — the **Simple | Power User** switch, and
+every pick-one strip in the panes — costs one Tab stop for the
+whole control rather than one per segment, and ← / → move the
+choice. ↑ / ↓ are left alone, so they still carry you out of the
+row.
+
 Where a row carries extra moves behind a right-click (renaming a
 palette, exporting it, deleting it, or reordering spaces), press
 **⌃.** (**Control-Period**) on the focused row or item to open its


### PR DESCRIPTION
## What & why

fixes #997

`SegmentedPicker` built its track as a `Button` per segment, and every `Button` is a focus stop — so the header's two-segment mode switch cost two Tab presses and a three-segment control cost three, **across 30 call sites**. A native segmented control costs one stop for the whole thing and moves the choice on ← / →.

The track takes the stop the segments give up: `.focusable(isEnabled)` on the track, `.focusable(false)` on each segment.

**Both halves are load-bearing.** With only the first, the control *gains* a stop instead of trading N for one — the reported defect plus one press per control. The guard needles both, and the negative clause beside them covers the same escape from the other side (SwiftUI takes the last `.focusable` on a chain).

The segments stay `Button`s, so everything the issue said must not regress is untouched by construction: the click path, the per-segment `.isSelected` trait, the group's #812 announcement, and `isEnabled`.

## Two judgement calls worth a look

**← / → move the selection, not a highlight.** That is what the native control does, and a highlight that moved without selecting would announce a choice the binding never took. ↑ / ↓ are deliberately *not* consumed, so vertical traversal still carries you out of the row. Arrows clamp rather than wrap; an unmatched selection (nil, #754) lands on the first option rather than stepping from an index it does not have.

**The track refuses click-born focus**, the way `SettingsSlider` already does. Without it, making the track focusable would draw a keyboard focus ring on every mouse click on a segment — which is #991's defect, introduced here by this fix. It is in scope because this change would otherwise cause it.

## Verification

Full gate green: build, `swift test -q` (4319 tests / 820 suites), lint, site build (`docs/` touched). Release build skipped — no concurrency surface.

`guard-prover` (isolated worktree) red-proofed 8 sub-diff mutations across the 4 new tests — wrap-instead-of-clamp, the nil case treated as 0, the removed empty guard, `.focusable(false)` deleted *and* flipped to `true`, the track's focusable deleted, an arrow wiring deleted, and the shared arithmetic replaced by a behaviourally identical inline copy. It also confirmed `swift format` reflowing a needled call across lines does not red the needles.

**It found a real fail-open**, now fixed: read file-wide, every needle stayed green while the focus pair was *moved* onto the segment — this defect restored under a green guard. Each needle is now read inside the declaration that must carry it (`SourceScan.declarationBody`), and I reproduced the prover's exact mutation against the fixed guard to confirm it reds.

## Not verified here

A scan can say the control builds one focusable element instead of N; **it cannot say focus behaves.** Device confirm with keyboard navigation ON is outstanding, batched with #996/#991 into one sitting. The checks: the header's Simple | Power User switch costs **one** Tab press, ← / → move between segments while focused, clicking a segment draws no ring, and a disabled picker is skipped entirely.

Draft while 1.1.2 is being tagged.

