### PR TITLE
feat(bars): default the bar title length to 10 characters

### DIFF
--- a/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/AppBarStyle.swift
@@ -23,7 +23,7 @@ public struct AppBarStyle: Sendable, Equatable {
     public var content: Content = .iconAndTitle
     /// Longest title drawn per item before tail-truncation. Default 25
     /// (owner 2026-08-19).
-    public var titleCap = 25
+    public var titleCap = 10
     /// App icon source: native image or SketchyBar App Font glyph (#294).
     public var iconSource: BarAppIconSource = .appImage
     /// Group adjacent windows of the same app with a count badge.

--- a/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
+++ b/Sources/KiwiDeskCore/Layouts/SpaceBarStyle.swift
@@ -46,7 +46,7 @@ public struct SpaceBarStyle: Sendable, Equatable {
     /// Trailing front-app segment; off by default (ui-designer verdict 6).
     public var showFrontApp = false
     /// Front-segment character limit to prevent layout shifts. Default 25.
-    public var titleCap = 25
+    public var titleCap = 10
     /// Hides empty spaces except current; off by default (verdict 4).
     public var hideEmpty = false
     /// Sticky/floating state badges on space items (#414). Default true.

--- a/Tests/KiwiDeskCoreTests/BarTitleCapTests.swift
+++ b/Tests/KiwiDeskCoreTests/BarTitleCapTests.swift
@@ -66,14 +66,25 @@ struct BarTitleCapTests {
     /// range; it says nothing about where the two bars start.
     /// Moving either default was inert across the whole suite
     /// (guard-prover, 2026-08-19), while the commit message,
-    /// `docs/lua-reference.md` and `docs/user-guide.md` all
-    /// state "8-80, default 25" for both — an unguarded number
-    /// restated in three places is what `rule-authoring.md`
-    /// bans.
+    /// `docs/lua-reference.md`, `docs/user-guide.md` and
+    /// `docs/design-decisions.md` all state the range and the
+    /// default for both — an unguarded number restated in four
+    /// places is what `rule-authoring.md` bans.
+    ///
+    /// The number itself is a TASTE call and this is the home
+    /// for its argument (tests.md, #1021). It was 25 until
+    /// #1171. The bars show window TITLES rather than app names
+    /// by default, and 25 characters of a title makes every item
+    /// wide — every item on a bar is sized from the widest, so a
+    /// long default spends the whole bar's width before the user
+    /// has chosen anything. The owner tested 10 against a 12-14
+    /// middle ground and ruled 10 (2026-08-31). Retuning it
+    /// again means moving this pin, the two styles and the four
+    /// prose copies together, which is the point of the pin.
     @Test("Both bars default to the same cap")
     func bothBarsDefaultAlike() {
-        #expect(AppBarStyle().titleCap == 25)
-        #expect(SpaceBarStyle().titleCap == 25)
+        #expect(AppBarStyle().titleCap == 10)
+        #expect(SpaceBarStyle().titleCap == 10)
         #expect(
             AppBarStyle().titleCap == SpaceBarStyle().titleCap,
             "the same window must not read two lengths"

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -7328,7 +7328,7 @@ optional.** (Same ruling.) Two consequences fall out of drawing
 a string the user edits, and both are load-bearing rather than
 polish.
 
-`app_bar.set_title_cap` (8–80, default 25) exists because App
+`app_bar.set_title_cap` (8–80, default 10) exists because App
 Bar slots are **uniform and measured from the widest item**
 (`AppBarOverlay.autoSlotWidth`). On that same sample the app
 names ran 6–20 characters and the titles to 57. One long title

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -1912,7 +1912,7 @@ app_bar.set_content("icon_and_title")
 
 ### app_bar.set_title_cap
 
-**Expects:** a character count, 8–80 (default `25`). Values
+**Expects:** a character count, 8–80 (default `10`). Values
 outside the range are clamped.
 
 **Does:** sets how much of a window's title an item shows;
@@ -2426,7 +2426,7 @@ space_bar.set_show_front_app(false)
 
 ### space_bar.set_title_cap
 
-**Expects:** a character count, 8–80 (default `25`). Values
+**Expects:** a character count, 8–80 (default `10`). Values
 outside the range are clamped.
 
 **Does:** sets how much of the focused window's title the

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1617,7 +1617,7 @@ rest; the rest behind **Style**):
   bar on screen sits on a vertical edge; your choice returns
   when one moves back to a horizontal edge.
 - **Title length**: how many characters of a title an item
-  shows before it's shortened at the end (8–80, default 25).
+  shows before it's shortened at the end (8–80, default 10).
   Worth knowing why it matters: every item on a bar is the same
   size, and on **auto** item size that size comes from the
   widest item — so one long title widens *every* slot until the
@@ -1818,7 +1818,7 @@ shortcut) and **Show front app** — a trailing segment with the
 focused window of the Space each display currently shows: its
 app's icon, then that window's **title** (its app's name
 instead if it reports no title yet). Icon-only on vertical bars.
-**Title length** caps that title (8–80 characters, default 25)
+**Title length** caps that title (8–80 characters, default 10)
 and is greyed while the segment is off. **Spring delay** sets
 how long a dragged window must hover a Space before the view
 springs to it (default 1.5 s, 1–4 s).


### PR DESCRIPTION
## What & why

`fixes #1171`

The App Bar and Space Bar capped titles at 25 characters by default, which makes every item wide: the bars show window **titles** rather than app names by default, and each item on a bar is sized from the widest one — so a long default spends the bar's width before the user has chosen anything.

Owner tested 10 against a 12–14 middle ground and ruled 10 (2026-08-31, deliberately a taste call, recorded on the issue).

## No migration owed

A **default retune**, not a stored-value rename. A config that sets `title_cap` explicitly is untouched; an unset one picks up the new default. The 8–80 range and the per-layout `title_cap` override are unchanged.

## What moved with it

`BarTitleCapTests` already pinned this number on both bars, for the reason its own docstring gives — the value is restated in prose the compiler cannot reach. That pin moves with the default, and the **retuning argument now lives in the docstring beside it**, which is where `tests.md` (#1021) puts the argument for a number a guard holds.

Four prose copies move in the same change set: `docs/user-guide.md` (twice), `docs/lua-reference.md` (both verbs) and `docs/design-decisions.md`. A sweep for `default 25` / ``default `25` `` comes back empty.

The two `set_title_cap(25)` **examples** in `docs/lua-reference.md` are left alone on purpose: they show a call being made, not the default, and the "Expects" line directly above each states the default explicitly.

## Verification

Full gate green: build, `swift test -q` (4315 tests / 819 suites), lint, site build (`docs/` touched). Release build skipped — no concurrency surface.

No `guard-prover` run: no assertion is new or changed in what it *claims*. `BarTitleCapTests.bothBarsDefaultAlike` watches the same invariant it always did (both bars start equal, inside the range they clamp to); only the literal it is pinned to moved, together with the thing it pins. Its previous prover run (2026-08-19) established that moving either default is otherwise inert across the suite, which is exactly why the pin exists.

The visual result is a taste call the owner already made on-device; nothing here needs a second sitting.

Draft while 1.1.2 is being tagged.
