### PR TITLE
feat(gui): picking an app adds its rule immediately

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Common/AppRuleControls.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/AppRuleControls.swift
@@ -2,6 +2,12 @@ import KiwiDeskCore
 import SwiftUI
 
 /// App picker with installed apps list and custom bundle ID text entry.
+///
+/// Picking from the list IS the add — there is no separate
+/// confirm, because choosing an app already says everything
+/// (#1172). Free text cannot work that way: every keystroke of
+/// `com.apple.Safari` is a prefix of it, so the typed path keeps
+/// a commit and is the one exception the issue rules.
 struct AppSelector: View {
     /// Bundle identifier of chosen app (`AppRef`).
     @Binding var name: String
@@ -9,6 +15,9 @@ struct AppSelector: View {
     /// already have a rule row, since each app carries at most
     /// one (its space + float facets live on that single row).
     var exclude: Set<String> = []
+    /// Called with the bundle id the user committed. The caller
+    /// owns normalisation and dedup; this view only says when.
+    let onCommit: (String) -> Void
     @State private var custom = false
 
     var body: some View {
@@ -22,6 +31,15 @@ struct AppSelector: View {
                     text: $name
                 )
                 .textFieldStyle(.roundedBorder)
+                .onSubmit(commitCustom)
+                Button(action: commitCustom) {
+                    Image(systemName: "checkmark.circle")
+                }
+                .buttonStyle(.borderless)
+                .disabled(name.trimmed.isEmpty)
+                .iconButtonAffordance(
+                    L("app_rules.add_rule", "Add app rule")
+                )
                 Button {
                     custom = false
                     name = ""
@@ -48,7 +66,10 @@ struct AppSelector: View {
                     : KeybindingCatalog.displayName(
                         forBundleID: name
                     ),
-                onPick: { name = $0.bundleID },
+                onPick: { app in
+                    name = app.bundleID
+                    onCommit(app.bundleID)
+                },
                 escapeLabel: L("app_selector.custom", "Custom…"),
                 onEscape: {
                     custom = true
@@ -59,6 +80,26 @@ struct AppSelector: View {
             // Hug the content (no fixed column to align with, just
             // the trailing "+" button) instead of filling the row.
             .fixedSize()
+            // The picker is the add affordance now that the
+            // button is gone, so it carries the census's name —
+            // and gives back the choice the name replaces, which
+            // for this Button is the text drawn inside it.
+            .accessibilityLabel(
+                L("app_rules.add_rule", "Add app rule")
+            )
+            .accessibilityValue(
+                name.isEmpty
+                    ? L("shortcuts.choose_app", "Choose app…")
+                    : KeybindingCatalog.displayName(
+                        forBundleID: name
+                    )
+            )
         }
+    }
+
+    private func commitCustom() {
+        guard !name.trimmed.isEmpty else { return }
+        onCommit(name)
+        custom = false
     }
 }

--- a/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
+++ b/Sources/KiwiDesk/Settings/Sections/AppRulesSection.swift
@@ -126,29 +126,31 @@ struct AppRulesSection: View {
 
     private var addRow: some View {
         HStack {
-            AppSelector(name: $newApp, exclude: Set(apps))
-            Button {
-                // Lower-cased so a hand-typed mixed-case bundle
-                // id (osascript reports `com.apple.Safari`) keys
-                // the same as the normalized `appBundleID` the
-                // engine and dropdown use — otherwise dedup and
-                // the open-title list silently miss (#262 review).
-                let app = newApp.trimmed.lowercased()
-                guard !app.isEmpty else { return }
-                if !apps.contains(app) {
-                    draftApps.append(app)
-                }
-                newApp = ""
-            } label: {
-                Label(
-                    L("app_rules.add_rule", "Add app rule"),
-                    systemImage: "plus"
-                )
-            }
-            .settingsActionButton()
-            .disabled(newApp.trimmed.isEmpty)
+            AppSelector(
+                name: $newApp,
+                exclude: Set(apps),
+                onCommit: add
+            )
             Spacer()
         }
+    }
+
+    /// Adds the rule the selector committed. Picking an app is
+    /// the whole gesture (#1172), so this runs straight off the
+    /// pick — the picked-but-not-added state it replaces was
+    /// also the one state that drew no icon.
+    private func add(_ picked: String) {
+        // Lower-cased so a hand-typed mixed-case bundle
+        // id (osascript reports `com.apple.Safari`) keys
+        // the same as the normalized `appBundleID` the
+        // engine and dropdown use — otherwise dedup and
+        // the open-title list silently miss (#262 review).
+        let app = picked.trimmed.lowercased()
+        guard !app.isEmpty else { return }
+        if !apps.contains(app) {
+            draftApps.append(app)
+        }
+        newApp = ""
     }
 
     /// Removes app rules and updates focus target (#816, #109, 2026-08-12).

--- a/Tests/KiwiDeskGuiTests/AppRulesAddOnSelectTests.swift
+++ b/Tests/KiwiDeskGuiTests/AppRulesAddOnSelectTests.swift
@@ -20,9 +20,29 @@ struct AppRulesAddOnSelectTests {
                 "Sources/KiwiDesk/Settings/Components/Common/"
                     + "AppRuleControls.swift"
             )
-        return SourceScan.stripComments(
+        let source = SourceScan.stripComments(
             try String(contentsOf: file, encoding: .utf8)
         )
+        // A read that came back empty would satisfy nothing
+        // positive but would fail-open the moment a NEGATIVE
+        // clause joined this suite (`guard-prover`, 2026-09-01).
+        #expect(source.count > 200, "AppRuleControls.swift read empty")
+        return source
+    }
+
+    /// The picker's own modifier chain — everything from the
+    /// `AppPickerButton(` call to the end of the `else` branch.
+    /// Read scoped rather than file-wide because both census
+    /// clauses below were proved green with the label and the
+    /// value moved onto the OTHER branch's controls, which is
+    /// the state they exist to forbid.
+    private func pickerChain() throws -> String {
+        let source = try controls()
+        let start = try #require(
+            source.range(of: "AppPickerButton("),
+            "the picker is gone from AppRuleControls.swift"
+        )
+        return String(source[start.lowerBound...])
     }
 
     private func squashed(_ text: String) -> String {
@@ -31,18 +51,27 @@ struct AppRulesAddOnSelectTests {
 
     @Test("picking an app commits it, with nothing in between")
     func pickCommits() throws {
-        let source = squashed(try controls())
+        // Anchored on what the closure cannot LOSE — a commit
+        // reached from the pick — rather than on its body
+        // verbatim: the first cut pinned the closure's parameter
+        // name, so renaming a local binding red the suite with a
+        // regression message that was false (`guard-prover`,
+        // 2026-09-01).
+        let chain = squashed(try pickerChain())
+        let pick = try #require(
+            chain.range(of: squashed("onPick:")),
+            "the picker states no onPick at all"
+        )
+        let escape = chain.range(of: squashed("escapeLabel:"))
+        let body = String(
+            chain[
+                pick
+                    .upperBound..<(escape?.lowerBound
+                    ?? chain.endIndex)
+            ]
+        )
         #expect(
-            source.contains(
-                squashed(
-                    """
-                    onPick: { app in
-                        name = app.bundleID
-                        onCommit(app.bundleID)
-                    }
-                    """
-                )
-            ),
+            body.contains("onCommit("),
             Comment(
                 rawValue:
                     "the picker no longer commits what it picked "
@@ -90,21 +119,19 @@ struct AppRulesAddOnSelectTests {
     /// here the picker's own accessible name.
     @Test("the census key is still drawn by the add affordance")
     func censusKeyStillRendered() throws {
+        // DERIVED from the census rather than restated beside
+        // it: hand-typed on both sides, the two agree with each
+        // other and with nothing else, and renaming the key reds
+        // here instead of at the drawing site.
+        guard case .key(let key) = AppRulesKey.appRulesAdd.text.label
+        else {
+            Issue.record("appRulesAdd no longer names a key")
+            return
+        }
+        let chain = squashed(try pickerChain())
         #expect(
-            AppRulesKey.appRulesAdd.text
-                == .text("app_rules.add_rule"),
-            "the census still claims this key names the add row"
-        )
-        let source = squashed(try controls())
-        #expect(
-            source.contains(
-                squashed(
-                    """
-                    .accessibilityLabel(
-                        L("app_rules.add_rule", "Add app rule")
-                    )
-                    """
-                )
+            chain.contains(
+                squashed(".accessibilityLabel(L(\"\(key)\"")
             ),
             Comment(
                 rawValue:
@@ -117,7 +144,7 @@ struct AppRulesAddOnSelectTests {
         // Naming a control REPLACES what it announced, so the
         // name owes the value back — here the Button's own text.
         #expect(
-            source.contains(".accessibilityValue("),
+            chain.contains(".accessibilityValue("),
             Comment(
                 rawValue:
                     "the picker is named but not valued — "

--- a/Tests/KiwiDeskGuiTests/AppRulesAddOnSelectTests.swift
+++ b/Tests/KiwiDeskGuiTests/AppRulesAddOnSelectTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// Picking an app IS the add (#1172) — there is no second step,
+/// and the picked-but-not-added state it removes was also the one
+/// state that drew no icon.
+///
+/// The whole change is a wiring change, so the whole guard is a
+/// wiring guard: nothing headless can click a popover row. What
+/// it holds is that the pick reaches a commit, that the free-text
+/// path — the one exception the issue rules — keeps one, and that
+/// the census key survived the button it used to label.
+@Suite("App Rules add-on-select (#1172)")
+struct AppRulesAddOnSelectTests {
+    private func controls() throws -> String {
+        let file = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Components/Common/"
+                    + "AppRuleControls.swift"
+            )
+        return SourceScan.stripComments(
+            try String(contentsOf: file, encoding: .utf8)
+        )
+    }
+
+    private func squashed(_ text: String) -> String {
+        text.split(whereSeparator: \.isWhitespace).joined()
+    }
+
+    @Test("picking an app commits it, with nothing in between")
+    func pickCommits() throws {
+        let source = squashed(try controls())
+        #expect(
+            source.contains(
+                squashed(
+                    """
+                    onPick: { app in
+                        name = app.bundleID
+                        onCommit(app.bundleID)
+                    }
+                    """
+                )
+            ),
+            Comment(
+                rawValue:
+                    "the picker no longer commits what it picked "
+                    + "— an app chosen from the list would sit in "
+                    + "`name` with no rule added and no button "
+                    + "left to add it, which is worse than the "
+                    + "two-step this replaced (#1172)"
+            )
+        )
+    }
+
+    /// The exception, and the reason it is one: every keystroke
+    /// of `com.apple.Safari` is a prefix of `com.apple.Safari`,
+    /// so free text has no moment that means "this is the app".
+    /// BOTH affordances are pinned — Return alone is invisible,
+    /// and a button alone loses the keyboard.
+    @Test("the typed path keeps a commit, on both channels")
+    func customPathKeepsACommit() throws {
+        let source = squashed(try controls())
+        for (needle, why) in [
+            (".onSubmit(commitCustom)", "Return commits"),
+            (
+                "Button(action: commitCustom)",
+                "and a visible confirm commits too, so the only "
+                    + "way to add a typed bundle id is not an "
+                    + "unlabelled key press"
+            ),
+        ] {
+            #expect(
+                source.contains(squashed(needle)),
+                Comment(
+                    rawValue:
+                        "the custom bundle-id field lost "
+                        + "`\(needle)` — \(why), and without it a "
+                        + "typed identifier is silently discarded "
+                        + "when the field loses focus (#1172)"
+                )
+            )
+        }
+    }
+
+    /// gui.md: a Settings-row change updates its census entry in
+    /// the same change set. The key outlived the Button it used
+    /// to label, so it has to be drawn by whatever replaced it —
+    /// here the picker's own accessible name.
+    @Test("the census key is still drawn by the add affordance")
+    func censusKeyStillRendered() throws {
+        #expect(
+            AppRulesKey.appRulesAdd.text
+                == .text("app_rules.add_rule"),
+            "the census still claims this key names the add row"
+        )
+        let source = squashed(try controls())
+        #expect(
+            source.contains(
+                squashed(
+                    """
+                    .accessibilityLabel(
+                        L("app_rules.add_rule", "Add app rule")
+                    )
+                    """
+                )
+            ),
+            Comment(
+                rawValue:
+                    "`app_rules.add_rule` is claimed by the "
+                    + "census but drawn nowhere — the Button that "
+                    + "used to carry it is gone, so the picker "
+                    + "that replaced it has to (#1172, #678)"
+            )
+        )
+        // Naming a control REPLACES what it announced, so the
+        // name owes the value back — here the Button's own text.
+        #expect(
+            source.contains(".accessibilityValue("),
+            Comment(
+                rawValue:
+                    "the picker is named but not valued — "
+                    + "VoiceOver then says \"Add app rule\" and "
+                    + "never which app is chosen (#812)"
+            )
+        )
+    }
+}

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2407,13 +2407,16 @@ app's windows open, and whether they tile — so the row states
 what the app does rather than asking you to assemble it from
 labelled fields.
 
-Click **Add app rule** to add one. Choose an app from the list —
-start typing to filter it by name, and each app shows its icon.
-Apps are remembered by their bundle identifier, so a rule keeps
-working across system-language changes and app renames. For an
-app that isn't installed right now, use **Custom…** and enter
-its bundle identifier by hand (see
-[Finding a bundle identifier](lua-reference.md#finding-a-bundle-identifier)).
+Click **Choose app…** and pick one — that adds the rule; there
+is nothing to confirm. Start typing to filter the list by name,
+and each app shows its icon. Apps are remembered by their bundle
+identifier, so a rule keeps working across system-language
+changes and app renames. For an app that isn't installed right
+now, use **Custom…** and type its bundle identifier by hand (see
+[Finding a bundle identifier](lua-reference.md#finding-a-bundle-identifier));
+that one path does need confirming, since every keystroke of a
+bundle identifier is a prefix of it — press Return or click the
+checkmark.
 Use a row's trash button to delete it, which removes every rule
 for that app. Rows are ordered alphabetically by the app's
 display name so a long list stays scannable.


### PR DESCRIPTION
## What & why

`fixes #1172`

Adding an app rule was a two-step: pick the app, then click a separate **Add app rule** button. The button was pure friction — picking an app already says everything — and the intermediate picked-but-not-added state was also the one state that drew no icon, which read as a glitch.

Both complaints go with one change. The picker commits what it picked, the button is gone, and the state between them no longer exists to render wrongly.

## The exception, and why it is one

Free text keeps a commit, as the issue rules. The reason is worth stating: **every keystroke of `com.apple.Safari` is a prefix of `com.apple.Safari`**, so the typed path has no moment that means "this is the app".

It keeps a commit on **both channels** — Return *and* a visible checkmark. Return alone is invisible; a button alone loses the keyboard. Without either, a typed identifier is discarded silently when the field loses focus, which is a worse failure than the button this PR removes.

## The census obligation

`app_rules.add_rule` outlived the Button it used to label. gui.md requires a Settings-row change to update its census entry in the same change set, so the picker that replaced the button now carries that key as its **accessible name**.

Naming a control replaces what VoiceOver derived from the text drawn inside it, so the name gives the value back: the picker announces "Add app rule" *and* which app is chosen, where before it announced only the app. (`AnnouncedValueTests`' walker matches `Picker(`/`Menu {` only, so this Button is outside its census — the obligation is met by hand and pinned by this PR's own guard.)

## Verification

Full gate green: build, `swift test -q` (4318 tests / 820 suites), lint, site build (`docs/` touched). Release build skipped — no concurrency surface.

Worth flagging: **the suite passed unchanged before I added a guard**, which is exactly the "a behavior change owes a test that fails without it" case. The whole change is a wiring change, so the guard is a wiring guard — nothing headless can click a popover row. New `AppRulesAddOnSelectTests` holds three things: the pick reaches a commit, the typed path keeps both commit channels, and the census key is still drawn by whatever replaced the button.

`guard-prover` is running; findings will be posted here and addressed before this leaves draft.

## Not verified here

The feel of it — that picking now lands a row with its icon and nothing flickers between — is an eye check. Cheap to fold into the keyboard-navigation sitting already queued for #996/#991/#997, though it needs no special system setting.

Draft while 1.1.2 is being tagged.
