### PR TITLE
fix(gui): the space chip refuses click-born focus too

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
@@ -26,6 +26,7 @@ struct SpaceAssignmentChip: View {
     let kind: SpaceAssignment.Kind
     /// Target displays for move actions in picture order.
     let displays: [Display]
+    @FocusState private var focused: Bool
 
     var body: some View {
         capsule
@@ -42,6 +43,16 @@ struct SpaceAssignmentChip: View {
             .accessibilityLabel(space.raw)
             .accessibilityValue(hint)
             .focusable()
+            .focused($focused)
+            // A click must not ring the chip (#996 ruling,
+            // owner 2026-09-01). Wired here rather than shared:
+            // a modifier handed the binding never fires.
+            .onChange(of: focused) { _, now in
+                guard now, ClickBornFocus.isClickBorn else {
+                    return
+                }
+                focused = false
+            }
             .rowActions { menu }
     }
 

--- a/Tests/KiwiDeskGuiTests/ArrivalRingTests.swift
+++ b/Tests/KiwiDeskGuiTests/ArrivalRingTests.swift
@@ -129,15 +129,10 @@ struct ArrivalRingTests {
     /// already use here.
     @Test("every focusable custom control refuses a click")
     func clickRefusalCensus() throws {
-        let allowed: [String: String] = [
-            "SpaceAssignmentChip.swift":
-                "UNRULED, not exempt: a drag-source chip whose "
-                + "click-born ring nobody has judged yet. It "
-                + "predates the refusal and is recorded here so "
-                + "the question is visible rather than absent — "
-                + "rule it, then either add the refusal or "
-                + "replace this with the reason it does not."
-        ]
+        // Empty, and that is the claim: every control
+        // that opts into focus refuses a click. An entry here
+        // must say what makes its control different.
+        let allowed: [String: String] = [:]
         let root = SourceScan.repoRoot(from: #filePath)
             .appendingPathComponent("Sources/KiwiDesk/Settings")
         let files = try SourceScan.swiftSources(under: root)


### PR DESCRIPTION
## What & why

Owner ruling, 2026-09-01, closing the one question the focus trio left open.

`SpaceAssignmentChip` took `.focusable()` and consulted no click refusal, so clicking it drew a keyboard focus ring macOS would not have drawn — #991's defect surviving in the one control nothing was watching.

It needed a `@FocusState` to refuse with: `.focusable()` on its own gives nothing to bind to, which is part of why it was missed for so long.

## The census got stronger, not just longer

`allowed` is now **empty**, and that is the point. It used to read "these three controls comply", which agrees only with itself — adding a *correct* control red it, while adding an *incorrect* one left it green. It now reads "every control that opts into focus refuses a click", derived from the population, and an entry from here on has to say what makes its control different.

`guard-prover` found the chip while proving that census — and the same run showed why the old shape could never have found it.

## Verification

Full gate green: build, `swift test -q` (4328 tests / 823 suites, zero issues), lint. Release build skipped — no concurrency surface; CI's `Release Build` job covers it.

No new assertions, so no `guard-prover` run is owed: the census clause that now covers the chip is the same one proved on #1194, and removing the `allowed` entry is what puts the chip under it. I verified the direction that matters by hand while building #1194 — stripping the refusal from a compliant control reds the census with the right message.

## Not verified here

Whether the ring actually stops appearing on a click is a device fact, like the rest of this family. It is a small check to fold into the next Settings sitting: click a space chip under Monitors, expect no ring; Tab to it, expect one.
