### PR TITLE
fix(animation): port StrandDetector capture log to the onLog seam

### DIFF
--- a/Sources/KiwiDeskCore/Animation/StrandDetector.swift
+++ b/Sources/KiwiDeskCore/Animation/StrandDetector.swift
@@ -7,6 +7,10 @@ final class StrandDetector {
     /// Reads a window's actual on-screen frame via AX.
     var frameReader: (WindowID) -> CGRect? = { _ in nil }
 
+    /// Capture diagnostic sink — never `NSLog`, which macOS
+    /// redacts in `log show` (#887; core-boundaries.md).
+    var onLog: @MainActor (String) -> Void = CoreLog.write
+
     /// Whether checks run (`KIWIDESK_STRAND_LOG`).
     var isEnabled = false
 
@@ -34,11 +38,9 @@ final class StrandDetector {
             guard let self, let actual = self.frameReader(id)
             else { return }
             if !Self.landed(actual, on: target, within: tolerance) {
-                NSLog(
-                    "KiwiDesk STRAND: window %@ target %@ actual %@",
-                    String(describing: id),
-                    String(describing: target),
-                    String(describing: actual)
+                self.onLog(
+                    "STRAND: window \(id) target \(target) "
+                        + "actual \(actual)"
                 )
             }
         }

--- a/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+Bootstrap.swift
@@ -41,6 +41,7 @@ extension KiwiCore {
         // — an unobservable rescue is how a loud failure becomes
         // a quiet one.
         tiler.animation.onLog = log
+        strandDetector.onLog = log
         // QA lever (#596), read once: `KIWIDESK_NO_WS_TRACKING`
         // pins the ring and mark to the AX-fallback path.
         borders.configureFromEnvironment()

--- a/Tests/KiwiDeskCoreTests/LogSeamDiscovery.swift
+++ b/Tests/KiwiDeskCoreTests/LogSeamDiscovery.swift
@@ -61,6 +61,7 @@ extension KeybindingManager: LogSeamOwner {}
 extension ProfileManager: LogSeamOwner {}
 extension SleepWakeManager: LogSeamOwner {}
 extension SocketServer: LogSeamOwner {}
+extension StrandDetector: LogSeamOwner {}
 // `KiwiCore` deliberately does not conform. It is the sink these
 // forward *into*, not a seam, and it is exempted by identity
 // below rather than by name — see `SeamWalk.exempt`.

--- a/Tests/KiwiDeskCoreTests/SeamRegister.swift
+++ b/Tests/KiwiDeskCoreTests/SeamRegister.swift
@@ -36,6 +36,7 @@ enum SeamRegister {
         "ProfileManager",
         "SleepWakeManager",
         "SocketServer",
+        "StrandDetector",
     ]
 
 }


### PR DESCRIPTION
## Description

`StrandDetector` wrote its strand diagnostic through `NSLog`,
which macOS redacts to `<private>` in `log show` — so a
`KIWIDESK_STRAND_LOG=1` capture reads nothing (the #952 trap,
re-hit in #887's diagnostic pass, where the standing ruling
makes the strand line part of the evidence). This is the #887
lane's pre-step: the fix itself stays pending the owner go.

The port takes the standard seam shape (core-boundaries.md):
`var onLog` defaulting to `CoreLog.write`, wired in
`KiwiCore+Bootstrap` beside the other seams, conformed for the
seam walk and added to `SeamRegister.reachable` — so all four
log-seam guards cover it from day one.

## Related Issue(s)

Refs #887 (pre-step only — does not close it)

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/` (none —
  diagnostic channel only; the tests.md lever table's
  description is unchanged)
- [x] No contradictions between code and docs
- [x] Release build green — run locally (the change adds a
  `@MainActor` closure seam)
- [x] PR is focused; refactors separated from features

## How I verified

Full gate: `swift build`, `swift test` (4315 tests — the only
2 issues were the documented `MouseWarpHoldTests` live-mouse
flake, #1199; green re-run alone), `scripts/lint.sh`, and
`swift build -c release`. guard-prover (isolated worktree)
red-proofed all three guards: deleting the bootstrap wiring
reds `LogSeamWiringTests` and the probe round-trip; removing
the stored reference reds `LogSeamProbeTests`' register
equality; a `{ _ in }` default reds `LogSeamDefaultTests`.

Not exercised live: a strand repro needs `KIWIDESK_STRAND_LOG`
device QA — the next #887 capture sitting is the live proof,
which is exactly what this change exists to make readable.

## Notes for Reviewer

The seam register entry is what makes a source-only revert red
(the probe's reachability equality). Log line becomes
`KiwiDesk: STRAND: …` (CoreLog prefix), still greppable by the
capture tooling's `KiwiDesk`/`STRAND` needles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)