### PR TITLE
docs(cli): export the log for a time frame to a file (#1209)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,8 +72,13 @@ body:
         Paste the output of these commands (one per block):
         - `kiwidesk get_state` (print as JSON)
         - `kiwidesk get_layout_info` (current layout details)
-        - `log show --predicate 'eventMessage contains[c] "KiwiDesk"'`
-        (copy lines mentioning KiwiDesk)
+
+        Then export the log for the stretch that covers the problem
+        and **attach the file** (drag it into this field) instead
+        of pasting fragments — reach back to just before it
+        happened (`--last 15m`, `--last 2h`):
+        `/usr/bin/log show --last 15m --predicate 'subsystem == "com.kiwicanopy.kiwidesk"' --style compact > ~/Desktop/kiwidesk-log.txt`
+        This works on the shipped app, no debug build needed.
       placeholder: |
         ## kiwidesk get_state
         { "spaces": {...}, ... }
@@ -81,8 +86,8 @@ body:
         ## kiwidesk get_layout_info
         { "layout": "bsp", ... }
 
-        ## System log (KiwiDesk filter)
-        [timestamp] ...
+        ## Log
+        (attached: kiwidesk-log.txt, --last 15m)
 
   - type: checkboxes
     id: other_tools

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -220,6 +220,36 @@ when the login item is *also* on — telling you two mechanisms
 will start KiwiDesk, and to run one. These strings are the login
 item's only appearance in CLI output.
 
+## Exporting the Log
+
+KiwiDesk writes every diagnostic line to the macOS unified log
+under its own subsystem, at default level and with the text
+public — so the shipped app's log is readable on any Mac with no
+debug build and no extra permission. To hand it over with a bug
+report, export the last stretch to a file:
+
+```sh
+/usr/bin/log show --last 15m \
+  --predicate 'subsystem == "com.kiwicanopy.kiwidesk"' \
+  --style compact > ~/Desktop/kiwidesk-log.txt
+```
+
+Reach back to just before the problem happened — `--last 15m`,
+`--last 2h`, or `--start "2026-09-02 09:40:00"` for an exact
+window — and attach the file to the issue rather than pasting
+fragments. `/usr/bin/log`, spelled out, because a shell alias
+named `log` is common. To watch live while reproducing:
+
+```sh
+/usr/bin/log stream --predicate 'subsystem == "com.kiwicanopy.kiwidesk"' --style compact
+```
+
+The subsystem filter is the right one: filtering on the word
+"KiwiDesk" misses the system daemons' lines a report sometimes
+needs and catches unrelated apps mentioning the name. (`kiwidesk
+debug_log <message>` WRITES a marker line into this same log,
+which is useful to bracket a repro; it exports nothing.)
+
 ## Commands
 
 | Category | Command | Arguments |


### PR DESCRIPTION
## Summary

Read-only over what KiwiDesk already writes (owner constraint on #1209): the CLI reference gains an *Exporting the Log* section with the unified-log recipe — the subsystem predicate, a time window, output to a file, the live-stream variant — and the bug template's log field points reporters at it (attach the file, reach back to before the problem) instead of the old unbounded `eventMessage contains` filter. Notes that the shipped build's log is readable with no debug build, and that `debug_log` writes a marker and exports nothing.

The Settings **Export Log…** control ruled on #1209 is the next step and will re-point the template at itself when it lands.

## Verification
- `scripts/lint.sh`, `RuleCitationTests`/`InstructionPinTests`/`CiPathFilterTests`, site build: green. Template YAML parses.

Refs #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)