### PR TITLE
docs(skills): the needs-feedback label for undecided feature requests

### DIFF
--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -36,6 +36,21 @@ Then:
 gh issue create --title "<prefix> <title>" --body-file <file>
 ```
 
+### An undecided feature request
+
+A feature request the owner has not ruled in or out — filed to
+record the idea, not to schedule it — takes the `needs-feedback`
+label (the feature twin of `needs-evidence`) and opens its body
+with the line that tells a visitor what to do:
+
+```
+> **Not scheduled.** Leave a 👍 on this issue if you want it — it
+> is picked up when demand shows (label `needs-feedback`).
+```
+
+Owner ruling 2026-09-02 (#1222 is the first). It still gets a
+Type, Priority (`Low`) and Effort like any other issue.
+
 ## 2. Set the Type
 
 Set it explicitly — `Bug`, `Feature`, or `Task`, matching the


### PR DESCRIPTION
## Description

Records the owner's ruling of 2026-09-02 in the `file-issue`
skill: an undecided feature request — filed to record the idea,
not to schedule it — takes the new `needs-feedback` label (the
feature twin of `needs-evidence`) and opens its body with the line
asking visitors to 👍 it. #1222 is the first.

## Related Issue(s)

#1222 (the first issue carrying the convention).

## Checklist

- [x] I understand what this change does (prose only)
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested — n/a, prose
- [x] User-facing changes are documented in `docs/` — n/a, a
  contributor skill
- [x] No contradictions between code and docs
- [ ] Release build green — CI's `Release Build` job
- [x] PR is focused

## How I verified

Full gate in a worktree: `swift build`, `swift test -q` (4453
green), lint via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
