### PR TITLE
fix(state): the boot census does not seed a parked window (#1234)

### DIFF
--- a/.claude/rules/state-and-layout.md
+++ b/.claude/rules/state-and-layout.md
@@ -220,7 +220,20 @@ editing here:
   on a compositor-confirmed `vanished` (`KiwiCore.handleWindowGone`)
   and by the boot seed (`seedAwayWindows`) — a new FILING goes
   through one of those two, never an assignment beside a call
-  site (review's: nothing scans for one). The enders differ by
+  site (review's: nothing scans for one). **The BOOT SEED admits
+  only a window that is UP** (#1234, `AwayBootSeedTests` ▸
+  `skipsParked`, `allParkedArmsNothing`): every reader requires
+  it, so a parked entry serves nobody, and it can only LEAK —
+  nothing tracks such a window, so no return ends it, and the
+  compositor still hosts it, so no prune does either. An immortal
+  entry keeps the 5 s census armed for the life of the process,
+  which is why this is a leak with a cost rather than clutter.
+  The gone handler needs no such clause and carries no guard for
+  one: it writes only for a window that WAS tracked, and a
+  tracked window that is minimized stays tracked, so it never
+  reaches that path parked. A THIRD writer would owe the seed's
+  clause and a case of its own — the two above see
+  `seedAwayWindows` alone (measured, `guard-prover` 2026-09-03). The enders differ by
   what they mean: the RETURN pays whatever named the window (the
   create fold and the arrival arms), the #634 reset forgets the
   memory with everything else (`forgetDesktopFocus`), and the two

--- a/Sources/KiwiDeskCore/App/KiwiCore+AwayWindows.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+AwayWindows.swift
@@ -126,11 +126,23 @@ extension KiwiCore {
     }
 
     /// The boot census (#1146): every layer-0 window of an
-    /// observed app that sits on a Desktop nobody shows joins
+    /// observed app that sits UP on a Desktop nobody shows joins
     /// the ledger, filed under the session snapshot's space
     /// where the id is in it (`.restored`, #1010), else the
     /// Desktop's remembered Space, else UNFILED — known to the
     /// classifier and Open-or-Focus, filed at its reveal.
+    ///
+    /// **A PARKED window is not seeded (#1234)**, which applies
+    /// at boot the rule the runtime already applies: every
+    /// consumer requires `isUp` — `awayMembers(of:)` filters on
+    /// it and the reach re-reads it from its own census — so a
+    /// parked entry can serve nobody, and "minimized while away
+    /// is not reachable" is #1146's own ruled residue. It could
+    /// only ever LEAK: nothing tracks such a window, so no
+    /// return ends its entry, and the compositor still hosts it,
+    /// so no prune does either. Six immortal entries on the dev
+    /// machine kept the 5 s census armed for the life of the
+    /// process (the probe is on the issue).
     func seedAwayWindows() {
         let spaces = NativeSpaces.allSpaces()
         guard let census = desktopMemory.readCensus(spaces) else { return }
@@ -146,6 +158,7 @@ extension KiwiCore {
             $0.key.raw < $1.key.raw
         }) {
             guard census.isAway(id),
+                host.isUp,
                 state.windows[id] == nil,
                 state.awayWindows[id] == nil,
                 eventLoop.observes(pid: host.pid),

--- a/Tests/KiwiDeskCoreTests/AwayBootSeedTests.swift
+++ b/Tests/KiwiDeskCoreTests/AwayBootSeedTests.swift
@@ -7,8 +7,8 @@ import Testing
 /// The boot census (#1146): a window of an observed app on a
 /// Desktop nobody shows joins the ledger — filed under the
 /// snapshot's space, else the Desktop's remembered Space, else
-/// unfiled — and an unobserved app's, a tracked one and one on a
-/// shown Desktop do not.
+/// unfiled — and an unobserved app's, a tracked one, one on a
+/// shown Desktop and a PARKED one do not.
 @MainActor
 @Suite("Boot seeds the away ledger", .serialized)
 struct AwayBootSeedTests {
@@ -108,6 +108,53 @@ struct AwayBootSeedTests {
         // No snapshot, no Desktop memory: unfiled.
         #expect(core.state.rememberedSpace(of: WindowID(7)) == nil)
         #expect(core.deferred.isScheduled(.awayCensus))
+    }
+
+    @Test("a parked window is not seeded")
+    func skipsParked() {
+        defer { resetAuthorityOverrides() }
+        let core = makeCore()
+        core.desktopMemory.readCensus = { _ in
+            DesktopCensus(
+                hosts: [
+                    WindowID(7): DesktopCensus.Host(
+                        space: 4,
+                        pid: self.observed,
+                        isUp: false
+                    ),
+                    WindowID(8): self.host(4, pid: self.observed),
+                ],
+                shown: [1]
+            )
+        }
+        core.seedAwayWindows()
+        // The UP sibling proves the fixture reaches the seed at
+        // all, so the skip is a decision rather than an empty run.
+        #expect(Set(core.state.awayWindows.keys) == [WindowID(8)])
+    }
+
+    @Test("an all-parked census leaves the task unarmed")
+    func allParkedArmsNothing() {
+        defer { resetAuthorityOverrides() }
+        let core = makeCore()
+        core.desktopMemory.readCensus = { _ in
+            DesktopCensus(
+                hosts: [
+                    WindowID(7): DesktopCensus.Host(
+                        space: 4,
+                        pid: self.observed,
+                        isUp: false
+                    )
+                ],
+                shown: [1]
+            )
+        }
+        core.seedAwayWindows()
+        // The reported harm (#1234): a seeded parked window can
+        // never be pruned, so the ledger never empties and the
+        // 5 s census re-arms for the life of the process.
+        #expect(core.state.awayWindows.isEmpty)
+        #expect(!core.deferred.isScheduled(.awayCensus))
     }
 
     @Test("the snapshot's space files it, else the Desktop's remembered Space")

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -3216,13 +3216,24 @@ and the choices, each argued against its alternative:
   `activate()` runs, as before — a faked switch was refused
   under [the bridge is not a SIP escape hatch](#the-window-management-bridge-is-not-a-sip-escape-hatch).
 - **Boot records what it can attribute, unfiled where it must.**
-  A window on an away Desktop at boot is filed under the session
-  snapshot's space, else the Desktop's remembered Space, else
-  recorded with no Space at all — known to the classifier and to
-  Open or Focus, drawn on no bar until its reveal files it
-  through the newcomer rules. Dropping it until shown was the
-  alternative, and it would have kept the cold-boot duplicate
-  launch the issue names.
+  A window UP on an away Desktop at boot is filed under the
+  session snapshot's space, else the Desktop's remembered Space,
+  else recorded with no Space at all — known to the classifier
+  and to Open or Focus, filed at its reveal through the newcomer
+  rules. Dropping it until shown was the alternative, and it
+  would have kept the cold-boot duplicate launch the issue names.
+
+  **A parked window is not recorded at all**
+  ([#1234](https://github.com/KiwiCanopy/KiwiDesk/issues/1234)),
+  which is the runtime's own rule applied at boot: every reader
+  of the ledger requires the window to be up, so a parked entry
+  serves nobody, and "minimized while away is not reachable" is
+  already this feature's accepted residue. Recording one could
+  only leak — nothing tracks such a window, so no return ends its
+  entry, and the compositor still hosts it, so no prune does
+  either. An immortal entry is not merely untidy: the ledger's
+  five-second census re-arms while it is non-empty, so a handful
+  of them poll the compositor for the life of the process.
 - **The sweep keeps its one-way trust.** The on-screen census may
   refuse a removal, never cause one
   ([#1157](https://github.com/KiwiCanopy/KiwiDesk/issues/1157)),


### PR DESCRIPTION
Closes #1234. Found on device 2026-09-03 while verifying #1228 — a leak from #1146, which merged the same day.

## The symptom

Six away-ledger entries on the dev machine named **Desktop 1, the Desktop on screen**, and could never leave: `storeuid` ×3, `loginwindow`, a minimized Ghostty window, Telegram.

```
w42 Ghostty      host space 1  up=false  AWAY=false
w17003 storeuid  host space 1  up=false  AWAY=false
...all six identical
shown user spaces: [1, 1348]
```

A read-only probe (recorded on the issue, script kept in `plan/`) showed all six hosted on the *current* space, so `isAway` is false for every one of them now. They were admitted at the boot census before the topology settled.

## Why they are immortal — and why that costs

Nothing can remove such an entry. **The return** cannot: nothing tracks the window, so there is no return. **The prune** cannot: `pruneAwayWindow` fires only when the census stops hosting an id, and these exist.

So the ledger is permanently non-empty — and `scheduleAwayCensus` re-arms while it is. KiwiDesk reads the compositor **every five seconds for the life of the process** on a desk with nothing meaningfully away. #1146's design says the timer census is "bounded rather than live by design"; this made it unbounded in practice.

## Why the fix is `isUp`, and why at the seed

**At the seed**, because it is the one writer that can admit a window state will never adopt — the gone handler only ever writes for a window that *was* tracked.

**`isUp` rather than a policy predicate**, because every reader already requires it: `awayMembers` filters on it, the reach re-reads it from its own census, and the un-park path (`restoreOneMinimizedIfNothingVisible`) reads the app's own window census rather than the ledger, so *it keeps working on exactly the same windows either way*. A parked entry serves nobody. And "minimized while away is not reachable" was already this feature's accepted residue — the seed simply was not applying at boot the rule the runtime applies everywhere else.

**The alternative is refused:** retiring an entry that is "no longer away" would destroy the #1207 `rememberedSpaces` and `departedSlots` records that `forgetAway` clears alongside it — exactly what the return needs to restore a slot and its focus.

## Verification

Full gate green: build, **4523 tests**, lint.

`guard-prover` red-proofed both cases and answered two questions I could not settle by reading:

- **Is the scheduling assertion a real guard?** It fires *alone* under an isolating mutation (keep the `isUp` filter, break only the arming guard), so it pins the actual reported harm rather than restating the ledger assertion.
- **Is `isUp` load-bearing?** Under the revert the parked window is admitted, so it had already satisfied every other clause of the guard — `isUp` is the sole excluding one.

It also found the rule sentence over-claimed ("a writer" when the guards see only `seedAwayWindows`); `state-and-layout.md` now names the seed, says why the gone handler needs no such clause, and states what a third writer would owe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
