### PR TITLE
docs: lua-reference no longer denies the Desktop move verbs

### DIFF
--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -4590,9 +4590,10 @@ if a display change ever makes that Desktop the main screen's.
 With the option off, or with one screen, the main screen's
 Desktop is the global one and everything reads as before.
 
-KiwiDesk never moves windows between Desktops — windows stay on
-their Desktop, and KiwiDesk manages the ones on the Desktop you're
-looking at.
+KiwiDesk moves a window between Desktops only when you ask it to,
+with `move_to_desktop` or `move_to_desktop_and_follow` above.
+Nothing else does: a window stays on its Desktop, and KiwiDesk
+arranges the ones on the Desktop you're looking at.
 
 Each Desktop the main screen shows also remembers which
 KiwiDesk space it was showing: switch away and back, and you


### PR DESCRIPTION
The macOS Desktops section of `docs/lua-reference.md` stated:

> KiwiDesk never moves windows between Desktops — windows stay on their Desktop, and KiwiDesk manages the ones on the Desktop you're looking at.

`move_to_desktop` and `move_to_desktop_and_follow` (#884) do exactly that, and are documented about 250 lines earlier **in the same file**. The sentence predates the bridge landing and was never swept.

Found while writing `docs/spaces-and-desktops.md` (#1231, merged in #1236), which states the corrected version — so leaving this would ship two pages disagreeing about the one fact that page exists to make clear. It reached the thread after that branch was already committed, hence its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)