### PR TITLE
test(events): the hidden arm's active-Space gate gets a guard, and the bounce fixture its pin (#1161)

### DIFF
--- a/Tests/KiwiDeskCoreTests/PlacementBounceTests.swift
+++ b/Tests/KiwiDeskCoreTests/PlacementBounceTests.swift
@@ -62,8 +62,9 @@ private func makeFixture(
 /// focus of its own. Straddling, not wholly outside: `contains`
 /// must read it as crossing, and `intersects` would not.
 private let offscreen = CGRect(x: 1200, y: 100, width: 400, height: 300)
-/// A frame wholly on screen, where a window that is not there
-/// yet is merely sliding — never a bounce.
+/// A frame wholly on screen — the flipped on-screen test can tell
+/// the collapsed arm from the edge arm only while this stays
+/// inside the pinned bounds (`fixtureIsOnScreen`).
 private let onscreen = CGRect(x: 800, y: 100, width: 400, height: 300)
 
 @MainActor
@@ -154,8 +155,17 @@ struct PlacementBounceTests {
         #expect(focused(core) == other)
     }
 
-    /// An ON-screen placement the window has not reached is a
-    /// slide, not a bounce: a cmd-tab onto it is honored.
+    /// The flipped on-screen test below tells the collapsed arm
+    /// from the edge arm only while `onscreen` lies inside the
+    /// pinned bounds; retune either alone and it passes on both
+    /// (guard-prover, 2026-09-05).
+    @Test("The fixture's on-screen placement sits inside the bounds")
+    func fixtureIsOnScreen() {
+        let core = makeCore()
+        let screen = NSScreen.main ?? NSScreen.screens[0]
+        #expect(core.tiler.visibleBounds(screen).contains(onscreen))
+    }
+
     /// The ruled trade (device 21:03): the emulator bounces after
     /// any pan that moves it, on screen or off, so in the active
     /// scrolling row a live placement is the whole verdict — a
@@ -264,6 +274,10 @@ struct PlacementBounceTests {
     func compliantStashFollows() {
         let core = makeCore()
         let (target, _) = makeFixture(core)
+        // A SCROLLING destination: the hidden arm must hold on the
+        // active-Space gate alone, not on the mode gate (guard-prover,
+        // 2026-09-05 — a bsp destination left that clause inert).
+        core.state.workspaces.ensureSpace(SpaceID(2), mode: .scrolling)
         core.moveWindow(target, to: SpaceID(2), follow: false)
         core.moveLatch.stamp(
             target,


### PR DESCRIPTION
## Description

Two test-only follow-ups from the last `guard-prover` round on #1268, landed separately because that PR was already in the merge queue:

- The active-Space clause of `placementBounce`'s hidden arm could be deleted with nothing red: the compliant-stash test minted its hidden Space as bsp, so the mode gate covered it. The stash destination is now scrolling, which turns `compliantStashFollows` into that clause's guard — the prover showed it red under the mutation with this change and green without it.
- `PlacementBounceTests` pins its on-screen rect inside the pinned bounds (`fixtureIsOnScreen`), as `PlacementDisplacementTests` already did: the flipped on-screen test tells the collapsed arm from the edge arm only while that holds.

## Related Issue(s)

Follows #1268 (#1161).

## Checklist

- [x] I understand what this change does and have run it in the app to confirm it works as intended (tests only — no app behavior changes; `swift test --filter PlacementBounce` green, 17 tests)
- [x] Commits follow Conventional Commits format (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code required)
- [x] User-facing changes are documented in `docs/` (none)
- [x] No contradictions between code and docs
- [x] Release build green — CI's `Release Build` job (read it before merging; it reports, it does not block)
- [x] PR is focused; refactors separated from features

## How I verified

`swift test --filter PlacementBounce` (17 tests, 2 suites), `scripts/lint.sh`. The mutation each guard now holds was run by `guard-prover` on f538ddca before this change (the active-Space clause deleted, both with and without the scrolling destination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
