### PR TITLE
docs: the release build is a required check, so the template stops asking

### DIFF
--- a/.claude/rules/packaging-and-release.md
+++ b/.claude/rules/packaging-and-release.md
@@ -499,9 +499,10 @@ and locale checks with it.
 `main` and on PRs targeting it. Both jobs are gated on a `changes`
 job, so a change confined to `.github/ci-ignore.txt`'s list leaves
 them skipped. A red build blocks merging. The release build runs
-as a separate, non-blocking job (#532) — when to run it locally
-instead is decided by the `verify-gate` skill, which owns that
-call.
+as a separate job (#532), required on `main` exactly like the
+build-lint-test one — `scripts/protect-main.sh`'s `CONTEXTS`
+names both — and when to run it locally as well is decided by
+the `verify-gate` skill, which owns that call.
 
 **`ci.yml` filters by exclusion; `site.yml` filters by
 inclusion.** Keep it that way. The site build's inputs are a

--- a/.claude/skills/verify-gate/SKILL.md
+++ b/.claude/skills/verify-gate/SKILL.md
@@ -56,19 +56,17 @@ its **exit code** decides.
 The release build enables the optimizer and stricter concurrency
 diagnostics (e.g. non-Sendable captures in `@Sendable` closures)
 that the debug build silently misses. CI runs it as a parallel
-job on every PR (#532), so it is **not** a mandatory local step.
+job on every PR (#532), and that job is a **required status
+check** on `main` — `scripts/protect-main.sh`'s `CONTEXTS` is
+the one copy of which checks are (#487) — so a red release build
+cannot merge. It is therefore **not** a mandatory local step.
 
 Run it locally when the change touches concurrency, `@Sendable`
 boundaries, or `Sendable` conformances — there the ~2min buys
 back a PR round-trip. Otherwise skip it and let CI catch it, and
-say in the report that it was skipped and why.
-
-CI **reports** this job, it does not **block** on it (required
-status checks need branch protection, which this plan does not
-offer for a private repo — #487). So when you skip it locally,
-say in the report that the `Release Build` job must be read
-before merging — and run it locally anyway for anything landing
-without a PR.
+say in the report that it was skipped and why. Run it locally
+anyway for anything landing without a PR, where no check gates
+the push.
 
 ## Report
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,9 +17,6 @@ Closes #... (if applicable)
   required)
 - [ ] User-facing changes are documented in `docs/`
 - [ ] No contradictions between code and docs
-- [ ] Release build green — CI's `Release Build` job (read it
-  before merging; it reports, it does not block), or locally
-  for concurrency / `@Sendable` changes
 - [ ] PR is focused; refactors separated from features
 
 ## How I verified


### PR DESCRIPTION
## Description

The PR template, the `verify-gate` skill and `packaging-and-release.md` all still said CI's `Release Build` job "reports, it does not block". That was true when #487 could not put required status checks on a private repo; it has been false since `scripts/protect-main.sh` named both `Build, Lint & Test` and `Release Build` as required contexts on `main` (confirmed against the live branch protection: both are listed). A red release build cannot merge, so the checkbox asked contributors to read a job the queue already refuses on.

- Drop the checkbox from the PR template.
- The skill and the rule now say the job is required, name the protect script's `CONTEXTS` as the one copy of which checks gate `main`, and keep the local run for concurrency changes and for anything landing without a PR.

## Related Issue(s)

None — a stale claim the owner spotted while filling in a PR (#1273).

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] PR is focused; refactors separated from features

## How I verified

Prose only, nothing to run in the app. `gh api repos/{owner}/{repo}/branches/main/protection` lists both contexts as required. Full gate run anyway because `.claude/` is pinned by `RuleCitationTests` / `InstructionPinTests`: `swift build`, `swift test -q` (4776 tests green), `scripts/lint.sh` OK.

## Notes for Reviewer

`ci.yml`'s own comment on the job never claimed it was non-blocking, so it is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
