### PR TITLE
feat(gui): the Space chips say they can be picked up (#1240)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Monitors/DisplayCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/DisplayCard.swift
@@ -27,8 +27,13 @@ struct DisplayCard: View {
             maxHeight: .infinity,
             alignment: .topLeading
         )
+        // The wash sits UNDER the chips, not over them: it is a
+        // ground signal, and painted on top it dimmed the very
+        // assignments you are dragging onto — worst for the
+        // automatic chip, which has no fill to survive it
+        // (#1240, owner 2026-09-06).
+        .background(dropWash)
         .background(plate)
-        .overlay(dropWash)
         .overlay(border)
         .clipShape(RoundedRectangle(cornerRadius: 6))
         // Main display accent glow (#758, ui-designer 2026-08-09).
@@ -173,7 +178,8 @@ struct DisplayCard: View {
 
     /// Drop targeting is a WASH, not a heavier border: dragging
     /// onto an already-selected card has to change something, and
-    /// two states sharing the border channel changed nothing.
+    /// two states sharing the border channel changed nothing. It
+    /// is laid behind the content — see the call site.
     @ViewBuilder private var dropWash: some View {
         if targeted {
             RoundedRectangle(cornerRadius: 6)

--- a/Sources/KiwiDesk/Settings/Components/Monitors/DisplayCard.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/DisplayCard.swift
@@ -133,7 +133,15 @@ struct DisplayCard: View {
             .lineLimit(1)
             .frame(width: MonitorCardChips.markerWidth)
             .padding(.vertical, 3)
-            .background(Capsule().fill(.tint.opacity(0.15)))
+            // The SHARED adaptive chip, not the pinned chip's
+            // fill: this opens a popover, and wearing a drag
+            // source's costume is what diluted the chips' own
+            // rest cue (#1240). `padding: 0` keeps it inside the
+            // reserved marker column.
+            .hoverHighlight(
+                cornerRadius: MonitorCardChips.chipHeight / 2,
+                padding: 0
+            )
         }
         .buttonStyle(.plain)
         .accessibilityLabel(

--- a/Sources/KiwiDesk/Settings/Components/Monitors/FollowsMainTray.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/FollowsMainTray.swift
@@ -116,7 +116,15 @@ struct FollowsMainTray: View {
                 .lineLimit(1)
                 .frame(width: MonitorCardChips.markerWidth)
                 .padding(.vertical, 3)
-                .background(Capsule().fill(.tint.opacity(0.15)))
+                // The SHARED adaptive chip, not the pinned
+                // chip's fill: this opens a popover, and wearing
+                // a drag source's costume is what diluted the
+                // chips' own rest cue (#1240). `padding: 0`
+                // keeps it inside the reserved marker column.
+                .hoverHighlight(
+                    cornerRadius: MonitorCardChips.chipHeight / 2,
+                    padding: 0
+                )
         }
         .buttonStyle(.plain)
         .accessibilityLabel(

--- a/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
@@ -101,28 +101,50 @@ struct SpaceAssignmentChip: View {
         // edge at half a point, which is a half-pixel at 1x.
         .overlay(
             Capsule().strokeBorder(
-                .tint.opacity(kind == .auto ? 0.35 : 0.6),
+                .tint.opacity(strokeAlpha),
                 lineWidth: 1
             )
         )
+        // A CONCRETE ink, not `.secondary`: hierarchical inks are
+        // derived from the container's foreground, and this chip
+        // renders under the card's drop wash and inside a
+        // popover, so the one kind that was already faintest
+        // dimmed further exactly while being dragged onto
+        // (gui.md ▸ prefer a concrete ink).
         .foregroundStyle(
             kind == .auto
-                ? AnyShapeStyle(.secondary)
+                ? AnyShapeStyle(SettingsTheme.ink2)
                 : AnyShapeStyle(.primary)
         )
     }
 
-    /// Rest fill by kind, lifted by the shared chip's hover step.
+    /// Rest fill by kind, lifted on hover.
     ///
     /// Outline-vs-fill is the ruled KIND channel, so hover must
-    /// not spend it: `.auto` keeps no rest fill and gains only
-    /// the hover wash, which is both the +0.06 lift and the
-    /// hover-only 0.06 `ui-patterns.md` gives a control with no
-    /// rest fill. Hover CONFIRMS the drag; the caption still
-    /// carries it in words.
+    /// not spend it: an `.auto` chip's hover fill stays clearly
+    /// under a pinned chip's REST fill, or a hovered automatic
+    /// chip starts impersonating a pinned one.
     private var fillAlpha: Double {
-        let rest = kind == .auto ? 0.0 : 0.15
-        return hovering ? rest + 0.06 : rest
+        switch (kind == .auto, hovering) {
+        case (true, false): return 0
+        case (true, true): return 0.10
+        case (false, false): return 0.15
+        case (false, true): return 0.30
+        }
+    }
+
+    /// The edge carries most of the hover, because it is the
+    /// channel a filled and an unfilled chip share — and the
+    /// automatic chip, which has no fill to lift, is the one
+    /// most worth dragging (#1240, owner 2026-09-06: the first
+    /// pass lifted the fill alone and read as nothing).
+    private var strokeAlpha: Double {
+        switch (kind == .auto, hovering) {
+        case (true, false): return 0.65
+        case (true, true): return 1.0
+        case (false, false): return 0.6
+        case (false, true): return 0.95
+        }
     }
 
     /// Clear-pin button overlay on trailing-top corner (#758).

--- a/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
@@ -27,11 +27,18 @@ struct SpaceAssignmentChip: View {
     /// Target displays for move actions in picture order.
     let displays: [Display]
     @FocusState private var focused: Bool
+    @State private var hovering = false
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
 
     var body: some View {
         capsule
+            .overlay(alignment: .topTrailing) { clearBadge }
             .fixedSize()
-            .draggable(DraggableSpace(raw: space.raw))
+            // The badge is a REMOVE affordance; snapshotted into
+            // the lifted chip it reads as "release to clear the
+            // pin", which is the opposite of what the drag does.
+            .draggable(DraggableSpace(raw: space.raw)) { capsule }
             .help(
                 L(
                     "monitor_chip.help_full",
@@ -54,6 +61,11 @@ struct SpaceAssignmentChip: View {
                 focused = false
             }
             .rowActions { menu }
+            .onHover { hovering = $0 }
+            .animation(
+                reduceMotion ? nil : .easeOut(duration: 0.12),
+                value: hovering
+            )
     }
 
     private var capsule: some View {
@@ -80,15 +92,17 @@ struct SpaceAssignmentChip: View {
         .padding(.leading, 8)
         .padding(.trailing, kind == .auto ? 8 : 14)
         .padding(.vertical, 3)
-        .background(
-            Capsule().fill(
-                .tint.opacity(kind == .auto ? 0 : 0.15)
-            )
-        )
+        .background(Capsule().fill(.tint.opacity(fillAlpha)))
+        // ONE weight for every kind, the kind moving the alpha
+        // alone: a closed full-perimeter edge is what makes a
+        // chip read as a piece lying on the plate rather than
+        // ink printed on it, which is the rest half of the drag
+        // affordance (#1240). The pinned chip drew the FAINTER
+        // edge at half a point, which is a half-pixel at 1x.
         .overlay(
             Capsule().strokeBorder(
-                .tint.opacity(kind == .auto ? 0.35 : 0.5),
-                lineWidth: kind == .auto ? 1 : 0.5
+                .tint.opacity(kind == .auto ? 0.35 : 0.6),
+                lineWidth: 1
             )
         )
         .foregroundStyle(
@@ -96,7 +110,19 @@ struct SpaceAssignmentChip: View {
                 ? AnyShapeStyle(.secondary)
                 : AnyShapeStyle(.primary)
         )
-        .overlay(alignment: .topTrailing) { clearBadge }
+    }
+
+    /// Rest fill by kind, lifted by the shared chip's hover step.
+    ///
+    /// Outline-vs-fill is the ruled KIND channel, so hover must
+    /// not spend it: `.auto` keeps no rest fill and gains only
+    /// the hover wash, which is both the +0.06 lift and the
+    /// hover-only 0.06 `ui-patterns.md` gives a control with no
+    /// rest fill. Hover CONFIRMS the drag; the caption still
+    /// carries it in words.
+    private var fillAlpha: Double {
+        let rest = kind == .auto ? 0.0 : 0.15
+        return hovering ? rest + 0.06 : rest
     }
 
     /// Clear-pin button overlay on trailing-top corner (#758).

--- a/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
@@ -92,7 +92,16 @@ struct SpaceAssignmentChip: View {
         .padding(.leading, 8)
         .padding(.trailing, kind == .auto ? 8 : 14)
         .padding(.vertical, 3)
-        .background(Capsule().fill(.tint.opacity(fillAlpha)))
+        .background(
+            Capsule().fill(
+                .tint.opacity(
+                    SpaceChipTint.fill(
+                        auto: isAuto,
+                        hovering: hovering
+                    )
+                )
+            )
+        )
         // ONE weight for every kind, the kind moving the alpha
         // alone: a closed full-perimeter edge is what makes a
         // chip read as a piece lying on the plate rather than
@@ -101,16 +110,20 @@ struct SpaceAssignmentChip: View {
         // edge at half a point, which is a half-pixel at 1x.
         .overlay(
             Capsule().strokeBorder(
-                .tint.opacity(strokeAlpha),
+                .tint.opacity(
+                    SpaceChipTint.stroke(
+                        auto: isAuto,
+                        hovering: hovering
+                    )
+                ),
                 lineWidth: 1
             )
         )
-        // A CONCRETE ink, not `.secondary`: hierarchical inks are
+        // A CONCRETE ink, not `.secondary`: a hierarchical ink is
         // derived from the container's foreground, and this chip
-        // renders under the card's drop wash and inside a
-        // popover, so the one kind that was already faintest
-        // dimmed further exactly while being dragged onto
-        // (gui.md ▸ prefer a concrete ink).
+        // renders inside two overflow popovers as well as the
+        // card, so the faintest kind dimmed further wherever an
+        // ancestor set one (gui.md ▸ prefer a concrete ink).
         .foregroundStyle(
             kind == .auto
                 ? AnyShapeStyle(SettingsTheme.ink2)
@@ -118,34 +131,7 @@ struct SpaceAssignmentChip: View {
         )
     }
 
-    /// Rest fill by kind, lifted on hover.
-    ///
-    /// Outline-vs-fill is the ruled KIND channel, so hover must
-    /// not spend it: an `.auto` chip's hover fill stays clearly
-    /// under a pinned chip's REST fill, or a hovered automatic
-    /// chip starts impersonating a pinned one.
-    private var fillAlpha: Double {
-        switch (kind == .auto, hovering) {
-        case (true, false): return 0
-        case (true, true): return 0.10
-        case (false, false): return 0.15
-        case (false, true): return 0.30
-        }
-    }
-
-    /// The edge carries most of the hover, because it is the
-    /// channel a filled and an unfilled chip share — and the
-    /// automatic chip, which has no fill to lift, is the one
-    /// most worth dragging (#1240, owner 2026-09-06: the first
-    /// pass lifted the fill alone and read as nothing).
-    private var strokeAlpha: Double {
-        switch (kind == .auto, hovering) {
-        case (true, false): return 0.65
-        case (true, true): return 1.0
-        case (false, false): return 0.6
-        case (false, true): return 0.95
-        }
-    }
+    private var isAuto: Bool { kind == .auto }
 
     /// Clear-pin button overlay on trailing-top corner (#758).
     @ViewBuilder private var clearBadge: some View {

--- a/Sources/KiwiDesk/Settings/Components/Monitors/SpaceChipTint.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/SpaceChipTint.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// The Space chip's tint alphas — one table, so the relation
+/// between them can be asserted (#1240).
+///
+/// The load-bearing decision is not any single number, it is an
+/// ORDER: an automatic chip's HOVER fill stays under a pinned
+/// chip's REST fill. Outline-versus-fill is the ruled kind
+/// channel (`docs/design-decisions.md` ▸ Monitors), so spending
+/// it on discoverability makes a hovered automatic chip read as
+/// a pinned one. Left inline on the view, that relation was a
+/// sentence in a doc comment; here `SpaceChipTintTests` holds
+/// it, and a retune that inverts it reds.
+///
+/// The EDGE carries most of the hover because it is the one
+/// channel both kinds share — the automatic chip has no fill to
+/// lift, and it is the one most worth dragging. Retuning any of
+/// these is fine; inverting an order is what must not pass.
+enum SpaceChipTint {
+    /// Capsule fill alpha. Zero at rest for `auto`, which is how
+    /// the kind reads as an outline.
+    static func fill(auto: Bool, hovering: Bool) -> Double {
+        switch (auto, hovering) {
+        case (true, false): return 0
+        case (true, true): return 0.10
+        case (false, false): return 0.15
+        case (false, true): return 0.30
+        }
+    }
+
+    /// Capsule edge alpha. The WIDTH never varies by kind — a
+    /// sub-point stroke is a half-pixel at 1x and can vanish on
+    /// an external screen, which is the display this page is
+    /// about.
+    static func stroke(auto: Bool, hovering: Bool) -> Double {
+        switch (auto, hovering) {
+        case (true, false): return 0.65
+        case (true, true): return 1.0
+        case (false, false): return 0.6
+        case (false, true): return 0.95
+        }
+    }
+}

--- a/Tests/KiwiDeskGuiTests/SpaceChipAffordanceTests.swift
+++ b/Tests/KiwiDeskGuiTests/SpaceChipAffordanceTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// What makes a Space chip read as something you can pick up
+/// (#1240), as three shapes rather than three numbers.
+///
+/// The Monitors picture says *Drag a Space onto the display it
+/// belongs to* in words, and the chips said nothing back. Paint
+/// alone cannot say "draggable", so what the change buys is
+/// narrower and has to be guarded as such: the drag SOURCES are
+/// the only things on the page wearing a closed edge, hover
+/// confirms the hit area, and the lifted chip does not show a
+/// remove button. Each clause below is the decision, not the
+/// value it currently resolves to — retuning an alpha leaves
+/// them green, undoing a decision reds them.
+@Suite("Space chip drag affordance")
+struct SpaceChipAffordanceTests {
+    private static let monitors =
+        "Sources/KiwiDesk/Settings/Components/Monitors"
+
+    private func squashed(_ file: String) throws -> String {
+        let url = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(Self.monitors)
+            .appendingPathComponent(file)
+        let source = SourceScan.stripComments(
+            try String(contentsOf: url, encoding: .utf8)
+        )
+        #expect(
+            source.count > 200,
+            Comment(
+                rawValue: "\(file) read empty — proves nothing"
+            )
+        )
+        return source.split(whereSeparator: \.isWhitespace)
+            .joined()
+    }
+
+    /// The edge is one weight for every kind.
+    ///
+    /// A chip's KIND is carried by fill-vs-outline and its glyph;
+    /// the edge carries "this is a piece, not printed ink", which
+    /// is the same for all three. The pinned chip used to draw
+    /// the FAINTER edge at half a point — a half-pixel at 1x, so
+    /// on exactly the external screens this page is about its
+    /// perimeter could vanish. A `lineWidth` that varies by kind
+    /// is that defect returning, whatever the number.
+    @Test("the chip's edge weight does not vary by kind")
+    func edgeWeightIsUniform() throws {
+        let source = try squashed("SpaceAssignmentChip.swift")
+        let stroke = try #require(
+            source.range(of: "Capsule().strokeBorder("),
+            Comment(
+                rawValue:
+                    "the chip no longer draws a closed edge — "
+                    + "the rest half of the affordance"
+            )
+        )
+        let tail = balanced(from: stroke.upperBound, in: source)
+        #expect(
+            !tail.contains("lineWidth:kind"),
+            Comment(
+                rawValue:
+                    "the chip's edge weight varies by kind "
+                    + "again (`\(tail)`) — the kind belongs in "
+                    + "the alpha, and a sub-point edge "
+                    + "disappears at 1x"
+            )
+        )
+    }
+
+    /// The argument list from `start` up to the paren that
+    /// CLOSES it.
+    ///
+    /// A `prefix(while: != ")")` stops at the first `)`, which
+    /// here belongs to the nested `.opacity(` — so the scan
+    /// never reached `lineWidth:` and the clause above passed
+    /// on a restored defect. Found by mutating it (2026-09-06);
+    /// the depth count is what makes the needle reach its own
+    /// argument.
+    private func balanced(
+        from start: String.Index,
+        in source: String
+    ) -> String {
+        var depth = 1
+        var out = ""
+        for character in source[start...] {
+            if character == "(" { depth += 1 }
+            if character == ")" {
+                depth -= 1
+                if depth == 0 { break }
+            }
+            out.append(character)
+        }
+        return out
+    }
+
+    /// The `+n` marker is not dressed as a chip.
+    ///
+    /// It draws a popover; it is not a drag source. It used to
+    /// wear the pinned chip's rest fill byte for byte, so the
+    /// page's paint said "chip" for two different kinds of
+    /// thing and any rest cue the chips gained was diluted by a
+    /// neighbour mimicking it. Routed through the shared
+    /// adaptive chip instead — the seam, never which alpha.
+    @Test("the +n marker takes the shared chip, not the chip's")
+    func overflowMarkerIsNotAChip() throws {
+        for file in ["DisplayCard.swift", "FollowsMainTray.swift"] {
+            let source = try squashed(file)
+            #expect(
+                source.contains(".hoverHighlight("),
+                Comment(
+                    rawValue:
+                        "\(file)'s `+n` marker no longer takes "
+                        + "the shared adaptive chip"
+                )
+            )
+            #expect(
+                !source.contains("Capsule().fill(.tint.opacity("),
+                Comment(
+                    rawValue:
+                        "\(file) draws a tinted capsule fill "
+                        + "again — that is the drag source's "
+                        + "costume, and this marker is a button"
+                )
+            )
+        }
+    }
+
+    /// The lifted chip carries no clear button.
+    ///
+    /// `.draggable` snapshots the view it is applied to. With
+    /// the badge inside that view the drag preview shows an ⓧ,
+    /// which reads as "release to remove" — the opposite of what
+    /// releasing does. So the badge is applied OUTSIDE the
+    /// dragged view and the preview is stated explicitly; an
+    /// argument-less `.draggable` is the defect returning.
+    @Test("the drag preview is stated and excludes the badge")
+    func dragPreviewExcludesTheClearBadge() throws {
+        let source = try squashed("SpaceAssignmentChip.swift")
+        #expect(
+            source.contains(
+                ".draggable(DraggableSpace(raw:space.raw)){capsule}"
+            ),
+            Comment(
+                rawValue:
+                    "the chip no longer states its drag "
+                    + "preview — the default snapshots whatever "
+                    + "the badge is attached to"
+            )
+        )
+        // …and the badge really is outside that view: inside
+        // `capsule` the explicit preview would carry it anyway.
+        let capsule = try #require(
+            source.range(of: "privatevarcapsule:someView{")
+        )
+        let badge = try #require(
+            source.range(of: "overlay(alignment:.topTrailing)")
+        )
+        #expect(
+            badge.lowerBound < capsule.lowerBound,
+            Comment(
+                rawValue:
+                    "the clear badge moved back inside the "
+                    + "dragged view, so the preview carries it"
+            )
+        )
+    }
+}

--- a/Tests/KiwiDeskGuiTests/SpaceChipAffordanceTests.swift
+++ b/Tests/KiwiDeskGuiTests/SpaceChipAffordanceTests.swift
@@ -128,6 +128,38 @@ struct SpaceChipAffordanceTests {
         }
     }
 
+    /// The drop wash is a GROUND, so it goes behind the chips.
+    ///
+    /// It exists because the selected card already owns the
+    /// border channel, so drop-targeting needed one of its own —
+    /// that ruling stands. But as an `.overlay` it painted over
+    /// the assignments being dragged onto, and the automatic
+    /// chip has no fill to survive it, so the card dimmed
+    /// exactly what the drag is about (#1240, owner
+    /// 2026-09-06). Layer, not alpha: retuning the wash leaves
+    /// this green.
+    @Test("the drop wash is drawn behind the chips")
+    func dropWashSitsUnderTheContent() throws {
+        let source = try squashed("DisplayCard.swift")
+        #expect(
+            source.contains(".background(dropWash)"),
+            Comment(
+                rawValue:
+                    "the drop wash is no longer a background — "
+                    + "as an overlay it dims the chips the drag "
+                    + "is about"
+            )
+        )
+        #expect(
+            !source.contains(".overlay(dropWash)"),
+            Comment(
+                rawValue:
+                    "the drop wash is an overlay again, so it "
+                    + "paints over the card's own chips"
+            )
+        )
+    }
+
     /// The lifted chip carries no clear button.
     ///
     /// `.draggable` snapshots the view it is applied to. With

--- a/Tests/KiwiDeskGuiTests/SpaceChipAffordanceTests.swift
+++ b/Tests/KiwiDeskGuiTests/SpaceChipAffordanceTests.swift
@@ -37,6 +37,47 @@ struct SpaceChipAffordanceTests {
             .joined()
     }
 
+    /// `declaration`'s own balanced body, so a clause asks the
+    /// subject rather than the file.
+    ///
+    /// Every evasion `guard-prover` found in the first draft
+    /// (2026-09-06) was the same fault: a file-scoped needle
+    /// satisfied — or broken — by a neighbour. A tinted capsule
+    /// somewhere else reported the marker; a hover chip on the
+    /// CARD satisfied the marker's presence clause.
+    private func scope(
+        _ declaration: String,
+        in source: String,
+        open: Character = "{",
+        close: Character = "}"
+    ) throws -> String {
+        let text = Array(source)
+        let marker = Array(declaration)
+        let head = try #require(
+            (0...(text.count - marker.count)).first {
+                Array(text[$0..<($0 + marker.count)]) == marker
+            },
+            Comment(rawValue: "no `\(declaration)` to scan")
+        )
+        // Past the signature to the declaration's own opener —
+        // a `func` carries a parameter list between the two.
+        var cursor = head + marker.count
+        while cursor < text.count, text[cursor] != open {
+            cursor += 1
+        }
+        return try #require(
+            SourceScan.balanced(
+                text,
+                from: &cursor,
+                open: open,
+                close: close
+            ),
+            Comment(
+                rawValue: "`\(declaration)` has no balanced body"
+            )
+        )
+    }
+
     /// The edge is one weight for every kind.
     ///
     /// A chip's KIND is carried by fill-vs-outline and its glyph;
@@ -44,56 +85,85 @@ struct SpaceChipAffordanceTests {
     /// is the same for all three. The pinned chip used to draw
     /// the FAINTER edge at half a point — a half-pixel at 1x, so
     /// on exactly the external screens this page is about its
-    /// perimeter could vanish. A `lineWidth` that varies by kind
-    /// is that defect returning, whatever the number.
-    @Test("the chip's edge weight does not vary by kind")
+    /// perimeter could vanish.
+    ///
+    /// What it TRADES: only the INLINE `lineWidth: kind …`
+    /// spelling reds. A width behind a computed property — the
+    /// shape the two alphas themselves took — passes, because a
+    /// scan cannot follow it. The alphas are guarded by value
+    /// instead, in `SpaceChipTintTests`; a width moved there
+    /// would owe the same.
+    @Test("every edge draws at one literal weight")
     func edgeWeightIsUniform() throws {
         let source = try squashed("SpaceAssignmentChip.swift")
-        let stroke = try #require(
-            source.range(of: "Capsule().strokeBorder("),
-            Comment(
-                rawValue:
-                    "the chip no longer draws a closed edge — "
-                    + "the rest half of the affordance"
-            )
-        )
-        let tail = balanced(from: stroke.upperBound, in: source)
-        #expect(
-            !tail.contains("lineWidth:kind"),
-            Comment(
-                rawValue:
-                    "the chip's edge weight varies by kind "
-                    + "again (`\(tail)`) — the kind belongs in "
-                    + "the alpha, and a sub-point edge "
-                    + "disappears at 1x"
-            )
-        )
-    }
-
-    /// The argument list from `start` up to the paren that
-    /// CLOSES it.
-    ///
-    /// A `prefix(while: != ")")` stops at the first `)`, which
-    /// here belongs to the nested `.opacity(` — so the scan
-    /// never reached `lineWidth:` and the clause above passed
-    /// on a restored defect. Found by mutating it (2026-09-06);
-    /// the depth count is what makes the needle reach its own
-    /// argument.
-    private func balanced(
-        from start: String.Index,
-        in source: String
-    ) -> String {
-        var depth = 1
-        var out = ""
-        for character in source[start...] {
-            if character == "(" { depth += 1 }
-            if character == ")" {
-                depth -= 1
-                if depth == 0 { break }
+        let text = Array(source)
+        let marker = Array("Capsule().strokeBorder")
+        var widths: [String] = []
+        var index = 0
+        while index + marker.count <= text.count {
+            guard Array(text[index..<(index + marker.count)]) == marker
+            else {
+                index += 1
+                continue
             }
-            out.append(character)
+            var cursor = index + marker.count
+            let args = try #require(
+                SourceScan.balanced(
+                    text,
+                    from: &cursor,
+                    open: "(",
+                    close: ")"
+                )
+            )
+            let key = "lineWidth:"
+            let at = try #require(
+                args.range(of: key),
+                Comment(rawValue: "a stroke with no width: \(args)")
+            )
+            widths.append(
+                String(
+                    args[at.upperBound...]
+                        .prefix { $0 != "," }
+                )
+            )
+            index = cursor
         }
-        return out
+        #expect(
+            !widths.isEmpty,
+            Comment(
+                rawValue:
+                    "the chip draws no closed edge at all — the "
+                    + "rest half of the affordance"
+            )
+        )
+        // EVERY stroke, and each width a bare literal: an
+        // expression is how a kind gets back in, whether it
+        // spells `kind`, hides behind a computed property or
+        // wears a pair of parentheses — all three of which
+        // `guard-prover` walked past a `lineWidth:kind` needle
+        // with (2026-09-06). A second overlay draws on TOP of
+        // the first, so one stroke is not the population.
+        for width in widths {
+            #expect(
+                Double(width) != nil,
+                Comment(
+                    rawValue:
+                        "an edge width is the expression "
+                        + "`\(width)` rather than a constant — a "
+                        + "kind-varying weight draws a sub-point "
+                        + "perimeter that vanishes at 1x"
+                )
+            )
+        }
+        #expect(
+            Set(widths).count == 1,
+            Comment(
+                rawValue:
+                    "the chip draws edges at \(Set(widths)) — one "
+                    + "weight for every kind, the kind moving the "
+                    + "alpha instead"
+            )
+        )
     }
 
     /// The `+n` marker is not dressed as a chip.
@@ -104,25 +174,44 @@ struct SpaceChipAffordanceTests {
     /// thing and any rest cue the chips gained was diluted by a
     /// neighbour mimicking it. Routed through the shared
     /// adaptive chip instead — the seam, never which alpha.
-    @Test("the +n marker takes the shared chip, not the chip's")
+    @Test("the +n marker draws no tint of its own")
     func overflowMarkerIsNotAChip() throws {
         for file in ["DisplayCard.swift", "FollowsMainTray.swift"] {
-            let source = try squashed(file)
+            let body = try scope(
+                "privatefuncoverflowChip",
+                in: try squashed(file)
+            )
+            // CONTIGUOUS, and `padding:0` is the load-bearing
+            // half: the default 4 widens the marker past the
+            // column `MonitorCardChips.markerWidth` reserves,
+            // and that suite's needle stays green through it
+            // because it reads the inner frame.
             #expect(
-                source.contains(".hoverHighlight("),
+                body.contains(
+                    ".hoverHighlight(cornerRadius:MonitorCardChips"
+                        + ".chipHeight/2,padding:0)"
+                ),
                 Comment(
                     rawValue:
                         "\(file)'s `+n` marker no longer takes "
-                        + "the shared adaptive chip"
+                        + "the shared adaptive chip at the "
+                        + "padding its reserved column allows"
                 )
             )
+            // The invariant is that the marker wears NO tint —
+            // not that one spelling of a tinted capsule is
+            // absent. `guard-prover` respelled the same costume
+            // as `.background(_:in:)` and walked past a
+            // `Capsule().fill(.tint.opacity(` needle, while an
+            // unrelated capsule elsewhere in the file reported
+            // the marker for a fill it never drew (2026-09-06).
             #expect(
-                !source.contains("Capsule().fill(.tint.opacity("),
+                !body.contains(".tint"),
                 Comment(
                     rawValue:
-                        "\(file) draws a tinted capsule fill "
-                        + "again — that is the drag source's "
-                        + "costume, and this marker is a button"
+                        "\(file)'s `+n` marker draws a tint — "
+                        + "that is the drag source's costume, and "
+                        + "this marker opens a popover"
                 )
             )
         }
@@ -182,21 +271,41 @@ struct SpaceChipAffordanceTests {
                     + "the badge is attached to"
             )
         )
-        // …and the badge really is outside that view: inside
-        // `capsule` the explicit preview would carry it anyway.
-        let capsule = try #require(
-            source.range(of: "privatevarcapsule:someView{")
-        )
-        let badge = try #require(
-            source.range(of: "overlay(alignment:.topTrailing)")
-        )
+        // Asked of `body`, not of `capsule`: an indirection
+        // between them (`capsule` returning a view that carries
+        // the badge) leaves `capsule`'s own text clean while the
+        // ⓧ is back in the preview, which is how `guard-prover`
+        // beat the first shape of this clause (2026-09-06). The
+        // badge has exactly one home, and it is the chain the
+        // preview is NOT taken from.
+        let body = try scope("varbody:someView", in: source)
         #expect(
-            badge.lowerBound < capsule.lowerBound,
+            body.contains(
+                ".overlay(alignment:.topTrailing){clearBadge}"
+            ),
             Comment(
                 rawValue:
-                    "the clear badge moved back inside the "
-                    + "dragged view, so the preview carries it"
+                    "the clear badge is no longer applied in "
+                    + "`body` — wherever it went, the dragged "
+                    + "view may now carry it"
+            )
+        )
+        #expect(
+            !(try scope("privatevarcapsule:someView", in: source))
+                .contains("clearBadge"),
+            Comment(
+                rawValue:
+                    "the clear badge is inside `capsule` again, "
+                    + "so the drag preview carries it"
             )
         )
     }
+
+    /// `declaration`'s own balanced body, so a clause asks the
+    /// subject rather than the file.
+    ///
+    /// Every evasion `guard-prover` found in the first draft
+    /// (2026-09-06) was the same fault: a file-scoped needle
+    /// satisfied — or broken — by a neighbour. A tinted capsule
+    /// somewhere else reported the marker; a hover chip on the
 }

--- a/Tests/KiwiDeskGuiTests/SpaceChipTintTests.swift
+++ b/Tests/KiwiDeskGuiTests/SpaceChipTintTests.swift
@@ -1,0 +1,93 @@
+import Testing
+
+@testable import KiwiDesk
+
+/// The Space chip's tint alphas as a ranked family (#1240).
+///
+/// Every clause here is an ORDER derived from the shipped table,
+/// never one of its numbers: retuning any alpha leaves them
+/// green, and inverting a relation reds. That is the whole
+/// reason the table is a value rather than two `switch`es inside
+/// the view — as doc-comment prose the load-bearing relation was
+/// guarded by nobody, and a retune to `0.16` would have spent
+/// the kind channel with every source scan still passing (code
+/// review 2026-09-06).
+@Suite("Space chip tint order")
+struct SpaceChipTintTests {
+    /// The one that carries the ruling: outline-versus-fill is
+    /// how the two kinds are told apart
+    /// (`docs/design-decisions.md` ▸ Monitors), so hover may not
+    /// push an automatic chip up to where a pinned chip RESTS.
+    /// It would not be wrong-looking, it would be a chip of the
+    /// wrong kind.
+    @Test("a hovered automatic chip stays under a pinned rest")
+    func hoverNeverReachesTheOtherKind() {
+        #expect(
+            SpaceChipTint.fill(auto: true, hovering: true)
+                < SpaceChipTint.fill(auto: false, hovering: false),
+            """
+            the automatic chip's hover fill has reached a pinned \
+            chip's rest fill — hover is spending the channel that \
+            says which kind this is
+            """
+        )
+    }
+
+    /// An outline kind is an outline kind: zero fill at rest is
+    /// what makes the distinction legible before any pointer
+    /// arrives.
+    @Test("the automatic chip has no rest fill")
+    func automaticRestsUnfilled() {
+        #expect(SpaceChipTint.fill(auto: true, hovering: false) == 0)
+    }
+
+    /// Hover LIFTS, on both channels and for both kinds. The
+    /// edge matters most for the automatic chip, which has no
+    /// fill worth lifting and is the one most worth dragging.
+    @Test("hover raises both channels for both kinds")
+    func hoverRaisesEveryChannel() {
+        for auto in [true, false] {
+            let kind = auto ? "automatic" : "pinned"
+            #expect(
+                SpaceChipTint.fill(auto: auto, hovering: true)
+                    > SpaceChipTint.fill(auto: auto, hovering: false),
+                Comment(
+                    rawValue:
+                        "the \(kind) chip's fill does not rise on "
+                        + "hover"
+                )
+            )
+            #expect(
+                SpaceChipTint.stroke(auto: auto, hovering: true)
+                    > SpaceChipTint.stroke(
+                        auto: auto,
+                        hovering: false
+                    ),
+                Comment(
+                    rawValue:
+                        "the \(kind) chip's edge does not rise on "
+                        + "hover — the channel both kinds share"
+                )
+            )
+        }
+    }
+
+    /// Every alpha is a legal alpha. A `1.1` compiles, clamps
+    /// silently, and quietly retires the hover step above it.
+    @Test("every alpha is within range")
+    func alphasAreInRange() {
+        for auto in [true, false] {
+            for hovering in [true, false] {
+                for alpha in [
+                    SpaceChipTint.fill(auto: auto, hovering: hovering),
+                    SpaceChipTint.stroke(
+                        auto: auto,
+                        hovering: hovering
+                    ),
+                ] {
+                    #expect(alpha >= 0 && alpha <= 1)
+                }
+            }
+        }
+    }
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -8929,10 +8929,16 @@ needs, which is why the restored route is a chord and a hidden
 anchor rather than a control shape that takes the drag (the
 argument lives on `SpaceAssignmentChip`; the ruling is ▸ The
 row menu's keyboard route, #845). The
-clear affordance never participates in the chip's layout: a
-pinned chip and an automatic chip measure identically — the ⓧ
-rides the trailing-top corner as an overlay, and hover may
-change only its tint, never its presence or any metric —
+clear affordance never participates in the chip's layout: the ⓧ
+rides the trailing-top corner as an overlay rather than an
+in-flow slot, and hover may change only its tint, never its
+presence or any metric. (It is not free of the layout, and this
+sentence used to claim it was: a chip that HAS a badge reserves
+6 pt more trailing padding to sit under it, so the kinds do not
+measure identically. The flow arithmetic absorbs that because
+`minChipWidth` is the narrowest chip and capacity is an upper
+bound — the correction is #1240's, which found the sentence
+read as licence to assume equal metrics.)
 because the chips are sized by a flow layout whose arithmetic
 (`MonitorCardChips.minChipWidth`) must hold for both states,
 and both a hover-revealed button and an in-flow trailing slot

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -8929,20 +8929,19 @@ needs, which is why the restored route is a chord and a hidden
 anchor rather than a control shape that takes the drag (the
 argument lives on `SpaceAssignmentChip`; the ruling is ▸ The
 row menu's keyboard route, #845). The
-clear affordance never participates in the chip's layout: the ⓧ
-rides the trailing-top corner as an overlay rather than an
-in-flow slot, and hover may change only its tint, never its
-presence or any metric. (It is not free of the layout, and this
-sentence used to claim it was: a chip that HAS a badge reserves
-6 pt more trailing padding to sit under it, so the kinds do not
-measure identically. The flow arithmetic absorbs that because
-`minChipWidth` is the narrowest chip and capacity is an upper
-bound — the correction is #1240's, which found the sentence
-read as licence to assume equal metrics.)
+clear affordance never takes a slot in the chip's FLOW — the ⓧ
+rides the trailing-top corner as an overlay, and hover may
+change only its tint, never its presence or any metric —
 because the chips are sized by a flow layout whose arithmetic
 (`MonitorCardChips.minChipWidth`) must hold for both states,
 and both a hover-revealed button and an in-flow trailing slot
-have shipped and died of that measurement. Decoration may ride
+have shipped and died of that measurement. It is not free of
+the layout, though: a chip that HAS a badge reserves 6 pt more
+trailing padding to sit under it, which that arithmetic absorbs
+because `minChipWidth` is the narrowest chip and capacity is an
+upper bound. This passage used to say the two kinds "measure
+identically", which #1240 found reading as licence to assume
+equal metrics. Decoration may ride
 the accent (the main card's bloom); the answer never rides hue
 alone (the "main" badge).
 

--- a/docs/ui-patterns.md
+++ b/docs/ui-patterns.md
@@ -1089,13 +1089,32 @@ pulsing and stays put, so the sentence it belongs to is still
 marked, and the tour's progress row fills the same pips without
 the crossfade between them.
 
+**A drag source is legible at rest, not on hover.** Paint cannot
+say "draggable", and hover arrives only once the pointer is
+already there — so a token you can pick up wears a closed,
+full-perimeter edge at a real weight, which is what makes it
+read as a piece lying on the plate rather than ink printed on
+it. Two obligations follow, and the second is the one that
+actually earns the first: the edge is **one weight for every
+kind** (a kind moves its alpha, never its width — a sub-point
+stroke is a half-pixel at 1x and can vanish on an external
+screen), and **nothing that is not a drag source wears that
+costume.** The Monitors `+n` marker wore the pinned chip's fill
+byte for byte while opening a popover, which is why the page's
+paint meant nothing until it was moved to the shared chip
+(#1240). A rest cue only reads as one if its neighbours lack it.
+
 **Hover confirms custom hit areas; it never creates the only
 affordance.** Native bordered/prominent buttons, sidebars,
 toggles, sliders, and fields keep system hover. Ambiguous
 icon-only borderless actions use the shared adaptive chip
 (`0.06` rest → `0.12` hover); custom full-row picker entries
 use a hover-only `0.06` fill; unselected custom segments and
-mode chips lift their existing fill by about `0.05`. No scale,
+mode chips lift their existing fill by about `0.05`; a draggable
+token chip lifts its own rest fill by `0.06`, whichever that
+is — so the one with no rest fill gains exactly the hover-only
+wash above, and the kind channel (outline versus fill) is not
+spent on discoverability. No scale,
 movement, shadow, or pointing-hand cursor on ordinary buttons
 (the hand remains link-only). Disabled controls never react;
 under Reduce Motion the color change is immediate. Every such

--- a/docs/ui-patterns.md
+++ b/docs/ui-patterns.md
@@ -1110,11 +1110,13 @@ toggles, sliders, and fields keep system hover. Ambiguous
 icon-only borderless actions use the shared adaptive chip
 (`0.06` rest → `0.12` hover); custom full-row picker entries
 use a hover-only `0.06` fill; unselected custom segments and
-mode chips lift their existing fill by about `0.05`; a draggable
-token chip lifts its own rest fill by `0.06`, whichever that
-is — so the one with no rest fill gains exactly the hover-only
-wash above, and the kind channel (outline versus fill) is not
-spent on discoverability. No scale,
+mode chips lift their existing fill by about `0.05`. A draggable
+token chip is the one case stated as an ORDER rather than a
+step, because its kinds are drawn apart by outline-versus-fill
+and hover must not spend that channel: the outlined kind's
+*hover* fill stays below the filled kind's *rest* fill, and the
+edge carries the rest of the lift — which is also the only
+channel the outlined kind has, having no fill to raise. No scale,
 movement, shadow, or pointing-hand cursor on ordinary buttons
 (the hand remains link-only). Disabled controls never react;
 under Reduce Motion the color change is immediate. Every such


### PR DESCRIPTION
## Description

In Settings ▸ Monitors the caption says *Drag a Space onto the display it belongs to*, and the chips said nothing back — no hover, and a rest treatment that read as a static label. Paint cannot say "draggable" on its own, so what this buys is narrower and is guarded as such: the drag **sources** become the only things on the page wearing a closed edge, and hover confirms the hit area the caption already promised.

- **The rest edge was inverted.** The *filled* pinned chip drew the *fainter* edge at 0.5 pt — a half-pixel at 1×, so on exactly the external screens this page is about its perimeter could vanish. One weight for every kind now; the kind moves the alpha.
- **Hover lifts both fill and edge**, with the edge carrying most of it. That is the one channel both kinds share, and the automatic chip — the one most worth dragging — has no fill to lift.
- **The `+n` overflow marker wore the pinned chip's rest fill byte for byte** while being a popover button, so the page's paint said "chip" for two different kinds of thing and diluted any cue the chips gained. It takes the shared adaptive chip instead.
- **The drag wash was an `.overlay`** — a ground signal painted over the content it is a ground for, dimming the very assignments you drag onto, worst for the automatic chip which has no fill to survive it. It is a background now.
- **The lifted chip no longer carries its clear button.** `.draggable` snapshots the view it is applied to, so the drag preview showed an ⓧ reading "release to remove" — the opposite of what releasing does.

## Related Issue(s)

Fixes #1240

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] PR is focused; refactors separated from features

## How I verified

**Eye-confirmed on device across two rounds** (owner, 2026-09-06), on a signed build. The first round is why this PR is bigger than the issue:

- The first hover pass **read as nothing**, because it lifted only the fill — and the automatic chip has none. The edge now carries it.
- Hovering also surfaced the wash layering: *"why at drag over it the background changes"*. The reason for the wash is good (a selected card already owns the border channel, so drop-targeting needed its own), but it was on the wrong layer.
- Final treatment reviewed against the shipped tokens in and out of the app, light and dark, on an ordinary card, a main + selected card, and mid-drag.

Neither of those was reachable by reasoning about tokens, and both were obvious within seconds of hovering.

## Notes for Reviewer

**Two markers, not extracted.** `DisplayCard` and `FollowsMainTray` carry near-identical `overflowChip` bodies. Two mirrors is the duplication §2.4 prefers, and extracting would move per-file needles in `MonitorCardChipsTests` and `MonitorsGateWiringTests`; the property that matters is guarded in both files instead.

**The load-bearing number is a relation, not a value.** An automatic chip's *hover* fill (0.10) stays under a pinned chip's *rest* fill (0.15), because outline-versus-fill is how the two kinds are told apart — push it past and a hovered automatic chip reads as a pinned one. Review found that relation stated only in a doc comment and guarded by nobody, so the alphas moved onto `SpaceChipTint` and `SpaceChipTintTests` asserts the ORDER: retune freely, invert and it reds.

**`guard-prover` beat four of the first-draft clauses**, and every evasion was one fault — a file-scoped needle satisfied or broken by a neighbour:

- a kind-varying edge width hidden behind a computed property, or behind a pair of parentheses `swift format` could add on its own, or in a *second* overlay drawn on top of the first;
- a hover chip on the **card** satisfying the marker's presence clause while the marker's costume, respelled `.background(_:in:)`, walked past its absence clause;
- the badge put back into the dragged view through an indirection, while a pure declaration reorder redded a correct file.

Each clause now reads its own subject's balanced body, and the bans are on the property rather than on one spelling of it. Re-proved against all six.

**One correction to settled prose.** `docs/design-decisions.md` claimed a pinned and an automatic chip "measure identically". They differ by 6 pt of trailing padding reserved for the badge — the ⓧ being out of the *flow* is the real ruling and is unchanged. The sentence was reading as licence to assume equal metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)