### PR TITLE
feat(shortcuts): picking an app adds it (#1235)

### DIFF
--- a/Sources/KiwiDesk/Settings/Components/Keybindings/AppPickRefusal.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/AppPickRefusal.swift
@@ -1,0 +1,14 @@
+import Foundation
+import KiwiDeskCore
+
+/// A pick that created nothing, and where it was made (#1235).
+///
+/// The app rather than a message: the sentence is derived from
+/// the live question each render, so freeing a behavior clears
+/// it with nothing having to notice. The row is what lets the
+/// caption appear at the picker that refused.
+struct AppPickRefusal: Equatable {
+    let app: KeybindingCatalog.InstalledApp
+    /// The binding whose picker refused, or nil for the add row.
+    let row: UUID?
+}

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup+AddRow.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup+AddRow.swift
@@ -3,54 +3,105 @@ import SwiftUI
 
 /// Add-row view and application binding creation for ApplicationsGroup (#334).
 extension ApplicationsGroup {
+    /// The picker IS the add: picking commits, exactly as the app
+    /// rules row does (#1235). There is no confirm step because a
+    /// confirm that can only ever be pressed once after a
+    /// selection carries no information.
     var addRow: some View {
-        HStack {
+        VStack(alignment: .leading, spacing: 4) {
             AppPickerButton(
                 placeholder: L(
                     "shortcuts.choose_app",
                     "Choose app…"
                 ),
-                selection: newApp?.name,
-                onPick: { newApp = $0 },
+                selection: nil,
+                onPick: { add($0) },
                 escapeLabel: L(
                     "shortcuts.other_ellipsis",
                     "Other…"
                 ),
                 onEscape: {
                     if let app = pickBundleFromPanel() {
-                        newApp = app
+                        add(app)
                     }
                 },
                 exclude: fullyBoundBundleIDs()
             )
-            // Hug the content, like the per-row picker.
+            // Hug the content, like the per-row picker. Alone in
+            // the row it would otherwise stretch to the section
+            // width, read as a field rather than a control, and
+            // stop lining up with the row pickers above it.
             .fixedSize()
-            Button {
-                addApplication()
-            } label: {
-                Label(
-                    L(
-                        "shortcuts.add_application",
-                        "Add application"
-                    ),
-                    systemImage: "plus"
-                )
+            // The picker is the add affordance now that the
+            // button is gone, so it carries the census's name —
+            // and gives back the choice that name replaces
+            // (#812). It shows the placeholder permanently,
+            // which is right for an add VERB: its result appears
+            // as a new row above.
+            .accessibilityLabel(
+                L("shortcuts.add_application", "Add application")
+            )
+            .accessibilityValue(
+                L("shortcuts.choose_app", "Choose app…")
+            )
+            if let notice = allBoundNotice(for: nil) {
+                Text(notice)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            .settingsActionButton()
-            .disabled(newApp == nil || newAppFullyBound)
         }
+        // The caption wraps beneath the picker instead of
+        // widening the row into a sentence.
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func addApplication() {
-        guard let app = newApp else { return }
-        // Seed the first behavior not already bound for this app, so
-        // re-adding it lands on a distinct behavior instead of a
-        // duplicate default. Both taken ⇒ nothing to add (the Add
-        // button is greyed for that case).
+    /// Why a pick at `row` created nothing, or nil.
+    ///
+    /// DERIVED, never a stored message: it re-asks the live
+    /// question, so freeing a behavior by deleting one of that
+    /// app's rows clears the sentence without anything having to
+    /// notice. `refusal` only says which app to ask about and
+    /// where the pick was made.
+    func allBoundNotice(for row: UUID?) -> String? {
+        guard let refusal, refusal.row == row else { return nil }
+        return allBoundNotice(about: refusal.app)
+    }
+
+    /// The sentence for one app, asked of live state.
+    ///
+    /// Takes the app rather than reading `refusal` back, so the
+    /// announcement never round-trips through the `@State` its
+    /// own caller has just written in the same tick.
+    func allBoundNotice(
+        about app: KeybindingCatalog.InstalledApp
+    ) -> String? {
+        guard firstAvailableBehavior(for: app.bundleID) == nil
+        else { return nil }
+        return L(
+            "shortcuts.apps.all_bound",
+            "\u{201C}%1$@\u{201D} already has a key for each way "
+                + "to open it. Change one of its shortcuts above "
+                + "to give it another.",
+            app.name
+        )
+    }
+
+    /// Commits a pick, or records why it could not.
+    ///
+    /// The refusal has to live somewhere: the picker list omits
+    /// fully-bound apps, but `pickBundleFromPanel()` bypasses
+    /// that list entirely, so the "Other…" route can still name
+    /// one. The greyed Add button used to be the only thing
+    /// standing there, and a dim is not a sentence (#1235).
+    func add(_ app: KeybindingCatalog.InstalledApp) {
+        // Seed the first behavior not already bound for this app,
+        // so re-adding it lands on a distinct behavior instead of
+        // a duplicate default.
         guard
             let behavior = firstAvailableBehavior(for: app.bundleID)
         else {
-            newApp = nil
+            refuse(app, at: nil)
             return
         }
         var binding = KeyBinding(kind: .application)
@@ -60,15 +111,44 @@ extension ApplicationsGroup {
             behavior: behavior
         )
         bindings.append(binding)
-        newApp = nil
+        clearRefusal()
     }
 
-    /// Greys the Add button (grey-don't-hide) — a backstop for the
-    /// "Other…" panel, which can still reach a fully-bound bundle
-    /// the picker list already omits.
-    private var newAppFullyBound: Bool {
-        guard let app = newApp else { return false }
-        return firstAvailableBehavior(for: app.bundleID) == nil
+    /// Records a refusal and speaks it once.
+    ///
+    /// The caption is reachable in the rotor afterwards, but the
+    /// refusal lands as a modal panel dismisses and focus returns
+    /// to the picker — so it is announced too. The delay is
+    /// `SettingsFooter`'s measured one, taken FROM it rather than
+    /// restated: a post landing in the same instant as a
+    /// control's own announcement was dropped on device (#812).
+    func refuse(
+        _ app: KeybindingCatalog.InstalledApp,
+        at row: UUID?
+    ) {
+        refusal = AppPickRefusal(app: app, row: row)
+        refusalAnnouncement?.cancel()
+        guard let sentence = allBoundNotice(about: app) else {
+            return
+        }
+        let work = DispatchWorkItem {
+            AccessibilityNotification.Announcement(sentence).post()
+        }
+        refusalAnnouncement = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + SettingsFooter.announceDelay,
+            execute: work
+        )
+    }
+
+    /// Retires a refusal, cancelling a post that has not landed —
+    /// so a sentence cannot be spoken after it stopped being
+    /// true, which is the one place the derived caption could
+    /// not protect itself.
+    func clearRefusal() {
+        refusalAnnouncement?.cancel()
+        refusalAnnouncement = nil
+        refusal = nil
     }
 
     /// Bundle IDs that already carry every launch behavior (#334).

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup+Row.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup+Row.swift
@@ -6,6 +6,19 @@ extension ApplicationsGroup {
     func row(
         _ binding: Binding<KeyBinding>
     ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            rowBody(binding)
+            // The refusal draws at the picker that raised it,
+            // keyed by this row's id — so it is one sentence at
+            // the place it is about, never gui.md's caption
+            // stamped under every child of the `ForEach`.
+            rowNotice(binding)
+        }
+    }
+
+    private func rowBody(
+        _ binding: Binding<KeyBinding>
+    ) -> some View {
         HStack {
             HStack(spacing: 6) {
                 appMenu(binding)
@@ -96,6 +109,20 @@ extension ApplicationsGroup {
         .fixedSize()
     }
 
+    /// This row's own refusal, if the last one was raised here.
+    @ViewBuilder func rowNotice(
+        _ binding: Binding<KeyBinding>
+    ) -> some View {
+        if let notice = allBoundNotice(
+            for: binding.wrappedValue.id
+        ) {
+            Text(notice)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
     private func assign(
         _ binding: Binding<KeyBinding>,
         app: KeybindingCatalog.InstalledApp
@@ -106,9 +133,15 @@ extension ApplicationsGroup {
             in: bindings,
             excluding: id
         )
+        // Says why instead of dropping the pick: this row's
+        // picker excludes fully-bound apps, but its "Other…"
+        // panel does not, so it could reach one and do nothing
+        // at all (#1235). One refusal channel, two pick routes.
         guard taken.count < AppLaunchBehavior.allCases.count else {
+            refuse(app, at: id)
             return
         }
+        clearRefusal()
         let current =
             KeybindingCatalog.appLaunchBehavior(
                 from: binding.wrappedValue.lua

--- a/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup.swift
+++ b/Sources/KiwiDesk/Settings/Components/Keybindings/KeybindingAppGroup.swift
@@ -12,7 +12,23 @@ struct ApplicationsGroup: View {
     var disabledSystemShortcuts
     @Environment(\.keybindingLayerName)
     var layerName
-    @State var newApp: KeybindingCatalog.InstalledApp?
+    /// The last pick that created nothing: WHICH app to ask
+    /// about, and WHERE it was picked. Never the sentence, which
+    /// `allBoundNotice` derives live (#1235).
+    ///
+    /// `row` is nil for the add row. It exists so the caption
+    /// draws at the picker that refused rather than at the
+    /// bottom of the group — a refusal raised from row 2 of
+    /// twenty would otherwise paint below row 20, which for any
+    /// scrolling list is silent for a sighted user (code review
+    /// 2026-09-06). Keyed, so it is still ONE sentence and not
+    /// gui.md's caption stamped under every child.
+    @State var refusal: AppPickRefusal?
+
+    /// The pending announcement, cancelled by the next pick so a
+    /// post cannot land after its sentence stopped being true —
+    /// the shape `SettingsFooter` uses for the same reason.
+    @State var refusalAnnouncement: DispatchWorkItem?
     /// Alphabetical display order snapshotted on section entry
     /// (#333). NOT recomputed on `bindings` mutation: the row's
     /// control is a `KeyRecorderField` capture, and a live re-sort
@@ -53,7 +69,13 @@ struct ApplicationsGroup: View {
         // The section view is reused across modes (no per-mode
         // `.id`), so `onAppear` fires once — re-snapshot on mode
         // change or later modes render in raw array order.
-        .onChange(of: layerName) { _, _ in recomputeOrder() }
+        // A layer switch is a different set of bindings, so the
+        // caption would be unprompted rather than wrong — the
+        // derivation keeps it true either way.
+        .onChange(of: layerName) { _, _ in
+            recomputeOrder()
+            clearRefusal()
+        }
     }
 
     /// Application binding IDs in snapshot alpha order with new rows
@@ -113,6 +135,11 @@ struct ApplicationsGroup: View {
         panel.directoryURL = URL(
             fileURLWithPath: "/Applications"
         )
+        // Two nils, one narrated: a cancelled panel is the user
+        // saying no, but a bundle with no identifier is a pick
+        // that silently does nothing — a residue #1235's refusal
+        // channel does NOT cover, stated rather than left to be
+        // rediscovered.
         guard panel.runModal() == .OK, let url = panel.url,
             let bundleID = Bundle(url: url)?
                 .bundleIdentifier?.lowercased()

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -998,6 +998,7 @@
   "shortcuts.app_behavior.open_new": "Open New",
   "shortcuts.app_behavior.open_new.badge": "Opens a new instance",
   "shortcuts.app_behavior.open_or_focus": "Open or Focus",
+  "shortcuts.apps.all_bound": "“%1$@” already has a key for each way to open it. Change one of its shortcuts above to give it another.",
   "shortcuts.apps.empty": "No app has a key of its own yet. Add one and its key brings that app's window to the Space you're on, or launches the app if it isn't running.",
   "shortcuts.base_layer_protected": "Base layers can't be removed here",
   "shortcuts.choose_app": "Choose app…",

--- a/Tests/KiwiDeskGuiTests/AppShortcutAddOnSelectTests.swift
+++ b/Tests/KiwiDeskGuiTests/AppShortcutAddOnSelectTests.swift
@@ -114,12 +114,20 @@ struct AppShortcutAddOnSelectTests {
     /// The confirm step is gone, and stays gone.
     @Test("no second press stands between the pick and the row")
     func noConfirmStep() throws {
-        let body = try declarationBody(
-            "varaddRow:someView",
-            in: squashed(
+        // The WHOLE add-row file, plus the body that mounts it:
+        // `guard-prover` evaded a body-only scan twice, once with
+        // the button extracted to a computed property the body
+        // merely references, once with it placed beside `addRow`
+        // in the group's own body — both render a confirm press
+        // (2026-09-06).
+        let body =
+            squashed(
                 try source("KeybindingAppGroup+AddRow.swift")
             )
-        )
+            + (try declarationBody(
+                "varbody:someView",
+                in: squashed(try source("KeybindingAppGroup.swift"))
+            ))
         // A STANDALONE `Button`, so `AppPickerButton` is not a
         // match — and every spelling of one, since `Button{`
         // alone let `Button(action:)`, `Button("…")` and
@@ -171,34 +179,69 @@ struct AppShortcutAddOnSelectTests {
         // the suite with a message that was false — the lesson
         // `AppRulesAddOnSelectTests` already records from its
         // own guard-prover round.
-        for (file, function) in [
-            ("KeybindingAppGroup+AddRow.swift", "funcadd("),
-            ("KeybindingAppGroup+Row.swift", "privatefuncassign("),
+        // Anchored on the branch's own CONDITION, never on "the
+        // first `else{`": `guard-prover` put an EARLIER guard
+        // above the real one, whose window swallowed a
+        // `refuse(` while the fully-bound branch returned bare —
+        // the whole suite green on exactly the regression this
+        // clause exists for. It also false-redded on a
+        // behaviour-free `if/else` inserted above (2026-09-06).
+        // A condition is what the branch cannot lose.
+        for (file, function, condition) in [
+            (
+                "KeybindingAppGroup+AddRow.swift", "funcadd(",
+                "firstAvailableBehavior(for:app.bundleID)"
+            ),
+            (
+                "KeybindingAppGroup+Row.swift",
+                "privatefuncassign(",
+                "AppLaunchBehavior.allCases.count"
+            ),
         ] {
             let body = try declarationBody(
                 function,
                 in: squashed(try source(file))
             )
-            let guardClause = try #require(
-                body.range(of: "else{").map {
-                    String(body[$0.upperBound...].prefix(60))
+            let at = try #require(
+                body.range(of: condition),
+                Comment(
+                    rawValue:
+                        "\(file)'s \(function) no longer asks "
+                        + "`\(condition)` — the refusal has no "
+                        + "branch to live in"
+                )
+            )
+            let rest = Array(String(body[at.upperBound...]))
+            let needle = Array("else{")
+            let elseAt = try #require(
+                (0..<max(0, rest.count - needle.count)).first {
+                    Array(rest[$0..<($0 + needle.count)]) == needle
                 },
                 Comment(
                     rawValue:
-                        "\(file)'s \(function) no longer guards "
-                        + "the no-behavior case at all"
+                        "\(file)'s no-behavior case no longer "
+                        + "guards at all"
+                )
+            )
+            var cursor = elseAt + needle.count - 1
+            let branch = try #require(
+                SourceScan.balanced(
+                    rest,
+                    from: &cursor,
+                    open: "{",
+                    close: "}"
                 )
             )
             #expect(
-                guardClause.contains("refuse("),
+                branch.contains("refuse("),
                 Comment(
                     rawValue:
                         "\(file)'s no-behavior branch returns "
                         + "without recording a refusal "
-                        + "(`\(guardClause.prefix(40))`) — an "
-                        + "\u{201C}Other\u{2026}\u{201D} pick of "
-                        + "a fully-bound app would create nothing "
-                        + "and say nothing"
+                        + "(`\(branch.prefix(50))`) — an "
+                        + "\u{201C}Other\u{2026}\u{201D} pick "
+                        + "of a fully-bound app would create "
+                        + "nothing and say nothing"
                 )
             )
             // Both routes RETIRE it too, or the channel this
@@ -245,8 +288,16 @@ struct AppShortcutAddOnSelectTests {
     @Test("the refusal draws at the picker that raised it")
     func refusalDrawsAtItsOwnPicker() throws {
         let row = squashed(try source("KeybindingAppGroup+Row.swift"))
+        // Scoped to `rowNotice`, which is what DRAWS: read
+        // file-wide, the needled spelling survived in a
+        // non-drawing site while `rowNotice` regressed to the
+        // add row's key, so every row painted the add row's
+        // refusal (`guard-prover`, 2026-09-06).
         #expect(
-            row.contains("allBoundNotice(for:binding.wrappedValue.id)"),
+            try declarationBody("funcrowNotice(", in: row)
+                .contains(
+                    "allBoundNotice(for:binding.wrappedValue.id)"
+                ),
             Comment(
                 rawValue:
                     "a row no longer asks for ITS refusal — the "

--- a/Tests/KiwiDeskGuiTests/AppShortcutAddOnSelectTests.swift
+++ b/Tests/KiwiDeskGuiTests/AppShortcutAddOnSelectTests.swift
@@ -1,0 +1,296 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// Picking an app IS the add here too (#1235) — the sibling of
+/// `AppRulesAddOnSelectTests`, one surface later.
+///
+/// The two rows used the same picker with different contracts:
+/// app rules created on pick, app shortcuts only remembered, and
+/// asked for a second press that could only ever say yes to a
+/// decision already made. This is a wiring change, so this is a
+/// wiring guard — nothing headless clicks a popover row.
+///
+/// It carries a **fourth** clause the app-rules suite does not
+/// need, and that clause is the whole reason this change was not
+/// a deletion: the removed button was the ONE thing refusing an
+/// app the "Other…" panel can still reach, so its branch has to
+/// SAY so rather than return bare.
+@Suite("App shortcut add-on-select (#1235)")
+struct AppShortcutAddOnSelectTests {
+    private static let directory =
+        "Sources/KiwiDesk/Settings/Components/Keybindings/"
+
+    private func source(_ file: String) throws -> String {
+        let url = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(Self.directory)
+            .appendingPathComponent(file)
+        let text = SourceScan.stripComments(
+            try String(contentsOf: url, encoding: .utf8)
+        )
+        // A read that came back empty satisfies every NEGATIVE
+        // clause below for free.
+        #expect(
+            text.count > 200,
+            Comment(rawValue: "\(file) read empty")
+        )
+        return text
+    }
+
+    private func squashed(_ text: String) -> String {
+        text.split(whereSeparator: \.isWhitespace).joined()
+    }
+
+    /// `declaration`'s own balanced body, via the shared scoper.
+    private func declarationBody(
+        _ declaration: String,
+        in source: String
+    ) throws -> String {
+        try #require(
+            SourceScan.declarationBody(
+                of: declaration,
+                in: source
+            ),
+            Comment(rawValue: "no `\(declaration)` to scan")
+        )
+    }
+
+    /// The picker's OWN modifier chain — from the
+    /// `AppPickerButton(` call to the end of its arguments plus
+    /// the modifiers hung on it, stopping before the caption
+    /// beside it.
+    ///
+    /// The first cut of this ran to end-of-file and called
+    /// itself scoped; the picker is the first thing in the file,
+    /// so "scoped" was "everything" and both census clauses
+    /// below would have passed with the label moved onto the
+    /// enclosing `VStack` — which is the #812 defect they exist
+    /// to forbid, since a name on the container swallows the
+    /// control's own (code review 2026-09-06).
+    private func pickerChain() throws -> String {
+        let text = squashed(
+            try source("KeybindingAppGroup+AddRow.swift")
+        )
+        let start = try #require(
+            text.range(of: "AppPickerButton("),
+            Comment(rawValue: "the add row has no picker at all")
+        )
+        let rest = text[start.upperBound...]
+        // The caption is the picker's sibling, so the chain ends
+        // where the `if let notice` branch begins.
+        let end = rest.range(of: "ifletnotice")
+        return String(rest[..<(end?.lowerBound ?? rest.endIndex)])
+    }
+
+    @Test("both pick routes reach the add, with nothing between")
+    func bothRoutesCommit() throws {
+        let chain = try pickerChain()
+        // The LIST route and the "Other…" panel route both land
+        // on the same call. Anchored on reaching `add(`, not on
+        // a closure body verbatim — the app-rules suite red on a
+        // renamed local once already.
+        #expect(
+            chain.contains("onPick:{add("),
+            Comment(
+                rawValue:
+                    "picking from the list no longer adds — the "
+                    + "app would sit chosen with no row created "
+                    + "and no button left to create it, which is "
+                    + "worse than the two-step this replaced"
+            )
+        )
+        #expect(
+            chain.contains("pickBundleFromPanel(){add("),
+            Comment(
+                rawValue:
+                    "the \u{201C}Other\u{2026}\u{201D} panel no "
+                    + "longer reaches the add, so a bundle "
+                    + "chosen there is silently discarded"
+            )
+        )
+    }
+
+    /// The confirm step is gone, and stays gone.
+    @Test("no second press stands between the pick and the row")
+    func noConfirmStep() throws {
+        let body = try declarationBody(
+            "varaddRow:someView",
+            in: squashed(
+                try source("KeybindingAppGroup+AddRow.swift")
+            )
+        )
+        // A STANDALONE `Button`, so `AppPickerButton` is not a
+        // match — and every spelling of one, since `Button{`
+        // alone let `Button(action:)`, `Button("…")` and
+        // `Button(L(…))` reinstate the step this bans.
+        let letters = CharacterSet.alphanumerics.union(
+            CharacterSet(charactersIn: "_")
+        )
+        var found = false
+        var index = body.startIndex
+        while let hit = body.range(of: "Button", range: index..<body.endIndex)
+        {
+            let before =
+                hit.lowerBound == body.startIndex
+                ? nil : body[body.index(before: hit.lowerBound)]
+            if before == nil
+                || !(before!.unicodeScalars.allSatisfy {
+                    letters.contains($0)
+                })
+            {
+                found = true
+                break
+            }
+            index = hit.upperBound
+        }
+        #expect(
+            !found,
+            Comment(
+                rawValue:
+                    "the add row grew a button again — a confirm "
+                    + "after a pick carries no information, and "
+                    + "the app rules row beside it has none"
+            )
+        )
+    }
+
+    /// **The clause this surface earns and app rules does not.**
+    ///
+    /// The picker list omits fully-bound apps, but
+    /// `pickBundleFromPanel()` bypasses that list, so the
+    /// "Other…" route can still name one. The greyed button used
+    /// to stand there; with it gone the branch must record the
+    /// refusal, or the pick does nothing and says nothing —
+    /// strictly worse than the friction removed.
+    @Test("a refused pick records instead of returning bare")
+    func refusalIsRecordedNotDropped() throws {
+        // Anchored on the BRANCH reaching a refusal, not on its
+        // spelling: the first cut pinned the local parameter
+        // name in two files, so renaming it would have redded
+        // the suite with a message that was false — the lesson
+        // `AppRulesAddOnSelectTests` already records from its
+        // own guard-prover round.
+        for (file, function) in [
+            ("KeybindingAppGroup+AddRow.swift", "funcadd("),
+            ("KeybindingAppGroup+Row.swift", "privatefuncassign("),
+        ] {
+            let body = try declarationBody(
+                function,
+                in: squashed(try source(file))
+            )
+            let guardClause = try #require(
+                body.range(of: "else{").map {
+                    String(body[$0.upperBound...].prefix(60))
+                },
+                Comment(
+                    rawValue:
+                        "\(file)'s \(function) no longer guards "
+                        + "the no-behavior case at all"
+                )
+            )
+            #expect(
+                guardClause.contains("refuse("),
+                Comment(
+                    rawValue:
+                        "\(file)'s no-behavior branch returns "
+                        + "without recording a refusal "
+                        + "(`\(guardClause.prefix(40))`) — an "
+                        + "\u{201C}Other\u{2026}\u{201D} pick of "
+                        + "a fully-bound app would create nothing "
+                        + "and say nothing"
+                )
+            )
+            // Both routes RETIRE it too, or the channel this
+            // change calls one channel is retired from one of
+            // them and a caption narrates a pick two actions old.
+            #expect(
+                body.contains("clearRefusal()"),
+                Comment(
+                    rawValue:
+                        "\(file)'s successful path no longer "
+                        + "clears the refusal, so its caption "
+                        + "stands after a later pick succeeds"
+                )
+            )
+        }
+        // DERIVED, not stored: the sentence re-asks the live
+        // question, so freeing a behavior clears it with nothing
+        // having to notice.
+        let notice = try declarationBody(
+            "funcallBoundNotice(aboutapp:",
+            in: squashed(try source("KeybindingAppGroup+AddRow.swift"))
+        )
+        #expect(
+            notice.contains(
+                "firstAvailableBehavior(for:app.bundleID)==nil"
+            ),
+            Comment(
+                rawValue:
+                    "the refusal notice no longer re-derives "
+                    + "from live state (`\(notice.prefix(60))`) — "
+                    + "a stored message stands after the user "
+                    + "frees a behavior"
+            )
+        )
+    }
+
+    /// The caption belongs to the picker that refused.
+    ///
+    /// Drawn only at the add row, a refusal raised from row 2 of
+    /// twenty painted below row 20 — silent for a sighted user on
+    /// any list long enough to scroll (code review 2026-09-06).
+    /// Keyed rather than per-row-unconditional, so it stays ONE
+    /// sentence instead of gui.md's caption under every child.
+    @Test("the refusal draws at the picker that raised it")
+    func refusalDrawsAtItsOwnPicker() throws {
+        let row = squashed(try source("KeybindingAppGroup+Row.swift"))
+        #expect(
+            row.contains("allBoundNotice(for:binding.wrappedValue.id)"),
+            Comment(
+                rawValue:
+                    "a row no longer asks for ITS refusal — the "
+                    + "sentence would print at the bottom of the "
+                    + "group, away from the pick that raised it"
+            )
+        )
+        #expect(
+            try declarationBody("funcrow(", in: row)
+                .contains("rowNotice(binding)"),
+            Comment(
+                rawValue:
+                    "the row no longer draws its notice at all"
+            )
+        )
+    }
+
+    /// gui.md: a Settings-row change updates its census entry in
+    /// the same change set, and naming a control REPLACES what it
+    /// announced. The key outlived the Button it labelled.
+    @Test("the add key is drawn by whatever replaced the button")
+    func addKeyStillRendered() throws {
+        let chain = try pickerChain()
+        #expect(
+            chain.contains(
+                squashed(".accessibilityLabel(L(\"shortcuts.add_application\"")
+            ),
+            Comment(
+                rawValue:
+                    "`shortcuts.add_application` is drawn "
+                    + "nowhere — the Button that carried it is "
+                    + "gone, so the picker that replaced it has "
+                    + "to, or the last row of the section never "
+                    + "says it creates a shortcut"
+            )
+        )
+        #expect(
+            chain.contains(".accessibilityValue("),
+            Comment(
+                rawValue:
+                    "the picker is named but not valued — "
+                    + "VoiceOver then says \"Add application\" "
+                    + "and never what the control shows (#812)"
+            )
+        )
+    }
+}

--- a/Tests/KiwiDeskGuiTests/SourceScan+FunctionBody.swift
+++ b/Tests/KiwiDeskGuiTests/SourceScan+FunctionBody.swift
@@ -71,3 +71,49 @@ extension SourceScan {
         ) ?? ""
     }
 }
+
+extension SourceScan {
+    /// `declaration`'s own balanced body, taken from already-read
+    /// SOURCE TEXT rather than from a `KiwiDeskCore` path — the
+    /// sibling of `functionBody(of:in:under:)` for the GUI tree,
+    /// and for a scan that has its own file in hand.
+    ///
+    /// Extracted at the second consumer (#1235), on the
+    /// divergence ground `tests.md` names: `guard-prover` beat
+    /// four clauses of the #1240 suite that read a whole FILE
+    /// instead of their subject, so a copy that scoped less
+    /// would restore exactly that hole while reading as though
+    /// it did not. `open`/`close` because one caller scopes a
+    /// declaration by braces and another an argument list by
+    /// parentheses.
+    static func declarationBody(
+        of declaration: String,
+        in source: String,
+        open: Character = "{",
+        close: Character = "}"
+    ) -> String? {
+        let text = Array(source)
+        let marker = Array(declaration)
+        guard text.count >= marker.count else { return nil }
+        guard
+            let head = (0...(text.count - marker.count)).first(
+                where: { index in
+                    Array(text[index..<(index + marker.count)])
+                        == marker
+                }
+            )
+        else { return nil }
+        // Past the signature to the declaration's own opener — a
+        // `func` carries a parameter list between the two.
+        var cursor = head + marker.count
+        while cursor < text.count, text[cursor] != open {
+            cursor += 1
+        }
+        return balanced(
+            text,
+            from: &cursor,
+            open: open,
+            close: close
+        )
+    }
+}

--- a/Tests/KiwiDeskGuiTests/SpaceChipAffordanceTests.swift
+++ b/Tests/KiwiDeskGuiTests/SpaceChipAffordanceTests.swift
@@ -37,44 +37,21 @@ struct SpaceChipAffordanceTests {
             .joined()
     }
 
-    /// `declaration`'s own balanced body, so a clause asks the
-    /// subject rather than the file.
-    ///
-    /// Every evasion `guard-prover` found in the first draft
-    /// (2026-09-06) was the same fault: a file-scoped needle
-    /// satisfied — or broken — by a neighbour. A tinted capsule
-    /// somewhere else reported the marker; a hover chip on the
-    /// CARD satisfied the marker's presence clause.
-    private func scope(
+    /// `declaration`'s own balanced body — the shared scoper,
+    /// which every evasion `guard-prover` found in this suite's
+    /// first draft (2026-09-06) was the absence of: a needle
+    /// read against the FILE is satisfied, or broken, by a
+    /// neighbour.
+    private func declarationBody(
         _ declaration: String,
-        in source: String,
-        open: Character = "{",
-        close: Character = "}"
+        in source: String
     ) throws -> String {
-        let text = Array(source)
-        let marker = Array(declaration)
-        let head = try #require(
-            (0...(text.count - marker.count)).first {
-                Array(text[$0..<($0 + marker.count)]) == marker
-            },
-            Comment(rawValue: "no `\(declaration)` to scan")
-        )
-        // Past the signature to the declaration's own opener —
-        // a `func` carries a parameter list between the two.
-        var cursor = head + marker.count
-        while cursor < text.count, text[cursor] != open {
-            cursor += 1
-        }
-        return try #require(
-            SourceScan.balanced(
-                text,
-                from: &cursor,
-                open: open,
-                close: close
+        try #require(
+            SourceScan.declarationBody(
+                of: declaration,
+                in: source
             ),
-            Comment(
-                rawValue: "`\(declaration)` has no balanced body"
-            )
+            Comment(rawValue: "no `\(declaration)` to scan")
         )
     }
 
@@ -177,7 +154,7 @@ struct SpaceChipAffordanceTests {
     @Test("the +n marker draws no tint of its own")
     func overflowMarkerIsNotAChip() throws {
         for file in ["DisplayCard.swift", "FollowsMainTray.swift"] {
-            let body = try scope(
+            let body = try declarationBody(
                 "privatefuncoverflowChip",
                 in: try squashed(file)
             )
@@ -278,7 +255,7 @@ struct SpaceChipAffordanceTests {
         // beat the first shape of this clause (2026-09-06). The
         // badge has exactly one home, and it is the chain the
         // preview is NOT taken from.
-        let body = try scope("varbody:someView", in: source)
+        let body = try declarationBody("varbody:someView", in: source)
         #expect(
             body.contains(
                 ".overlay(alignment:.topTrailing){clearBadge}"
@@ -291,7 +268,7 @@ struct SpaceChipAffordanceTests {
             )
         )
         #expect(
-            !(try scope("privatevarcapsule:someView", in: source))
+            !(try declarationBody("privatevarcapsule:someView", in: source))
                 .contains("clearBadge"),
             Comment(
                 rawValue:

--- a/docs/ui-patterns.md
+++ b/docs/ui-patterns.md
@@ -1104,6 +1104,35 @@ byte for byte while opening a popover, which is why the page's
 paint meant nothing until it was moved to the shared chip
 (#1240). A rest cue only reads as one if its neighbours lack it.
 
+**Picking from a picker IS the add.** Where a control's whole
+job is to choose a thing that then becomes a row, the choice
+commits it — there is no second button, because a confirm that
+can only ever be pressed once after a selection asks for a
+decision the picker already took. Both the app rules row and the
+app shortcuts row work this way. The typed free-text path is the
+one exception that keeps a commit of its own, because every
+keystroke of an identifier is a prefix of that identifier and no
+moment in it means "this is the one".
+
+That leaves a duty the removed button was carrying, and it has
+to be paid rather than deleted. These pickers exclude the
+entries that cannot be added, but their escape route bypasses
+the exclusion — a typed identifier in the app rules row, a file
+panel in the app shortcuts row — so a pick can still arrive that
+creates nothing. **Where a pick can be refused, the refusal
+speaks as a caption at the picker that refused it**, derived
+from live state so it clears itself the moment the user frees
+what was taken, and announced once for VoiceOver, since the
+refusal can land as a panel dismisses. It is not a dimmed
+control: with the button gone there is nothing left to dim, and
+a dim was never a sentence anyway. It is keyed to the picker
+rather than to the section, or a list of rows prints one
+sentence under every one of them.
+
+Only the app shortcuts row has a refusal today (#1235); the app
+rules row still drops a typed duplicate silently, and owes the
+same channel.
+
 **Hover confirms custom hit areas; it never creates the only
 affordance.** Native bordered/prominent buttons, sidebars,
 toggles, sliders, and fields keep system hover. Ambiguous


### PR DESCRIPTION
## Description

Adding an **app rule** took one action: pick the app, the rule exists. Adding an **app shortcut** took two — pick, then press *Add application* — from the same picker, for the same task, and the second press asked for a decision the user had already made by picking. It commits on pick now, and the button is gone.

**The button was not redundant**, though, and the issue's own body was wrong about that — its comment corrected it. The picker list omits fully-bound apps, but `pickBundleFromPanel()` bypasses the list entirely, so the "Other…" route can still name one, and the greyed button was the only thing standing there. Deleting it without a replacement would have made that pick create nothing and say nothing, which is strictly worse than the friction removed.

So the refusal speaks: a caption **derived** from the live question rather than stored, so freeing a behavior clears it with nothing having to notice, and **keyed** to the picker that refused so it appears where the pick happened.

**One channel, two callers.** The per-row picker has had this same silent drop since #334 — `assign` guards and returns saying nothing — and gets a voice for free.

## Related Issue(s)

Fixes #1235

## Checklist

- [ ] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] PR is focused; refactors separated from features

## How I verified

Gate green (4811 tests, 916 suites, lint clean). **Device eyeball pending — the box above is deliberately unticked.**

What it needs:

1. **Shortcuts ▸ Open applications.** Pick an app from the add row's picker — the row should appear immediately, no second press.
2. **The refusal.** Use **Other…** and choose an app that already has *both* launch behaviors bound. Nothing is created, and a caption should say why, under that picker.
3. **The same from a row's picker**, which is the path that was silent before this change — the caption should appear at that row, not at the bottom of the group.
4. **VoiceOver**, if convenient: the picker should announce "Add application" and its value, and a refusal should be spoken once.

## Notes for Reviewer

**`shortcuts.add_application` is not retired.** It moves to the picker's accessible name, exactly as `app_rules.add_rule` did in #1172 — without it the last row of the section announces only "Choose app…" and never says it creates a shortcut. Minted through the scripts, never a hand-edited catalog.

**Review caught four things worth naming**, all shipped-blind risks:

- The caption first drew only at the **add row**, so a refusal raised at row 2 of twenty painted below row 20 — silent for a sighted user on any list long enough to scroll. It is keyed now, which also keeps it one sentence rather than `gui.md`'s caption stamped under every child of a `ForEach`.
- Only `add` retired the refusal; `assign` did not, so a later successful pick left a caption narrating a pick two actions old. The change called itself "one channel, two routes" and was half true.
- The new suite's scope was **inert** — it ran to end-of-file while claiming to be scoped, so both census clauses would have passed with the label moved onto the enclosing `VStack`, which is the #812 defect they exist to forbid.
- Two doc claims were false: the app rules escape opens a text field rather than a file panel, and app rules has **no** refusal channel at all, so the paragraph promised a convention only one surface implements. Scoped, with the app-rules half named as owed.

**Announcement:** delayed on `SettingsFooter.announceDelay` — taken from it rather than restated, since it is the same measured fact (#812) — and cancellable, so a sentence cannot be spoken after it stops being true.

**A residue, stated rather than left to be rediscovered:** `pickBundleFromPanel()` returns nil for a bundle with no identifier, and that pick is still silent. The fully-bound case is now spoken for; this one is not.

**`SourceScan.declarationBody` joins the scan family** so a clause can ask its subject rather than its file — and #1240's suite, which `guard-prover` beat four times on exactly that, moves onto it in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)