### PR TITLE
fix(events): the mouse-button read is one injected seam (#1199, #1103)

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -591,14 +591,20 @@ as a cause (#1103/#1199; four different tests in one
 `MouseWarpHoldTests` session, 2026-08-29, and — pinning the
 mask held to measure it, 2026-09-06 — two more in
 `SizeBoundAnswerChannelTests`, where a claimed gesture opens a
-drag session and the retile issues no frame). `MouseTracker
-.pressedButtons` is the seam, `makeTestCore` pins it to
-"nothing held", and a test that wants a held button states the
-mask (`MouseButtonSeamTests`, `MouseFollowsFocusTests`).
-`MouseButtonSeamGuardTests` holds the read to its two homes —
-a sibling of `MachineTouchTests` because that file is at the
-§2.1 ceiling, the split `StatusItemSeamGuardTests` already
-carries.
+drag session and the retile issues no frame).
+`MouseTracker.pressedButtons` is the seam; `makeTestCore` pins
+it to "nothing held" — as it does the cursor read `wireDrag`
+also makes live — and a test that wants a held button states
+the mask (`MouseButtonSeamTests`, `MouseFollowsFocusTests`).
+`MouseButtonSeamGuardTests` holds the read to its two homes
+AND both pins into both twins, a deletion from both being
+silent otherwise; it is a sibling of `MachineTouchTests`
+because that file is at the §2.1 ceiling, the split
+`StatusItemSeamGuardTests` already carries. The key-repeat
+delay `HoldGlide.initialDelay` reads is the same shape and
+stays residue: it is a system PREFERENCE rather than hand
+state, so it cannot move a red between runs, and the two
+hold-glide fixtures pin it where it is armed.
 
 Deliberate residue a run does still touch, as audited
 2026-09-06 — a change adding a residue class extends and

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -593,9 +593,14 @@ mask held to measure it, 2026-09-06 — two more in
 `SizeBoundAnswerChannelTests`, where a claimed gesture opens a
 drag session and the retile issues no frame).
 `MouseTracker.pressedButtons` is the seam; `makeTestCore` pins
-it to "nothing held" — as it does the cursor read `wireDrag`
-also makes live — and a test that wants a held button states
+it to "nothing held" and a test that wants a held button states
 the mask (`MouseButtonSeamTests`, `MouseFollowsFocusTests`).
+The cursor read `wireDrag` also makes live is pinned beside it
+and is PRECAUTIONARY — a run reaches the seam, but no assertion
+depends on the value, so no hostile cursor flips a verdict
+(guard-prover, 2026-09-06); it is kept for the next drag test
+that forgets its own pin, not for a live defect. Do not read
+the two as equals.
 `MouseButtonSeamGuardTests` holds the read to its two homes
 AND both pins into both twins, a deletion from both being
 silent otherwise; it is a sibling of `MachineTouchTests`

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -579,8 +579,29 @@ construction routes. Adding a production type whose
 (live default in production, an injected fake in tests) and a
 needle in one of those guards.
 
+**A production default that reads live host state gets the
+same shape even when no initializer touches the OS.** The
+button mask was read at three Core decision points, so a
+developer using their Mac while the suite ran changed the
+verdict of whichever test happened to be running — the warp
+gate refusing, `isResizeGesture` claiming a gesture, the drag
+pipeline opening a session — and the red moved between suites
+each run, which is what made it read as flakiness rather than
+as a cause (#1103/#1199; four different tests in one
+`MouseWarpHoldTests` session, 2026-08-29, and — pinning the
+mask held to measure it, 2026-09-06 — two more in
+`SizeBoundAnswerChannelTests`, where a claimed gesture opens a
+drag session and the retile issues no frame). `MouseTracker
+.pressedButtons` is the seam, `makeTestCore` pins it to
+"nothing held", and a test that wants a held button states the
+mask (`MouseButtonSeamTests`, `MouseFollowsFocusTests`).
+`MouseButtonSeamGuardTests` holds the read to its two homes —
+a sibling of `MachineTouchTests` because that file is at the
+§2.1 ceiling, the split `StatusItemSeamGuardTests` already
+carries.
+
 Deliberate residue a run does still touch, as audited
-2026-08-21 — a change adding a residue class extends and
+2026-09-06 — a change adding a residue class extends and
 re-dates this list in the same change set: throwaway AF_UNIX
 sockets under temp paths (`SocketTests`), real `CADisplayLink`s
 from animation-keyed suites, repo-script children drained by
@@ -590,15 +611,8 @@ test` run needs that AGENTS.md §4 calls optional, which is why
 `SparkleKeyDerivationTests` carries an `.enabled(if:)` rather
 than redding a host without it — one inert `true` child when
 `FirstRunSeedTests`' executed hooks fixture fires, scratch
-`UserDefaults` suites cleaned on both sides, live
-`NSEvent.pressedMouseButtons` reads — a human touching the
-mouse mid-run reds `MouseFollowsFocusTests` AND
-`MouseWarpHoldTests`, which #689 split out of it and which
-inherits the same exposure through `mouseWarpEligible`; that
-gate is consulted BEFORE the hold branch, so a click surfaces
-as `pendingMouseWarp == nil` in whichever test was running and
-reads as an unrelated flake (four different tests in that one
-suite, one device-QA session, 2026-08-29) — `GeometryUtils.menuBarAutoHides`, a read-only
+`UserDefaults` suites cleaned on both sides,
+`GeometryUtils.menuBarAutoHides`, a read-only
 global-defaults lookup that only reaches fixtures which didn't
 pin their bounds, and one read-only `NSScreen.screens` read per
 lifecycle suite that drives `EventLoop.beginScan()` with faked

--- a/Sources/KiwiDeskCore/App/KiwiCore+MouseWarp.swift
+++ b/Sources/KiwiDeskCore/App/KiwiCore+MouseWarp.swift
@@ -42,7 +42,7 @@ extension KiwiCore {
     /// owns it.
     func mouseWarpEligible(_ id: WindowID) -> Bool {
         tiler.settings.mouse.followsFocus
-            && NSEvent.pressedMouseButtons == 0
+            && !mouse.anyButtonHeld
             && (state.workspaces.space(of: id)
                 == state.workspaces.activeSpace
                 // A sticky window is visible on EVERY space

--- a/Sources/KiwiDeskCore/Events/MouseTracker.swift
+++ b/Sources/KiwiDeskCore/Events/MouseTracker.swift
@@ -22,8 +22,11 @@ public final class MouseTracker {
 
     /// Which mouse buttons are down, as a mask — the one home
     /// in Core for `NSEvent.pressedMouseButtons` (#1103/#1199).
-    /// Live in production; `makeTestCore` pins "nothing held",
-    /// so a suite's verdict never follows the developer's hand.
+    /// Live in production; `makeTestCore` pins "nothing held"
+    /// on the core's OWN tracker, so a suite's verdict never
+    /// follows the developer's hand. That pin reaches no tracker
+    /// a suite builds itself — a bare `MouseTracker()` asking
+    /// these reads states the mask first.
     var pressedButtons: @MainActor () -> Int = {
         NSEvent.pressedMouseButtons
     }

--- a/Sources/KiwiDeskCore/Events/MouseTracker.swift
+++ b/Sources/KiwiDeskCore/Events/MouseTracker.swift
@@ -19,6 +19,23 @@ public final class MouseTracker {
     }
 
     public private(set) var press: Press?
+
+    /// Which mouse buttons are down, as a mask — the one home
+    /// in Core for `NSEvent.pressedMouseButtons` (#1103/#1199).
+    /// Live in production; `makeTestCore` pins "nothing held",
+    /// so a suite's verdict never follows the developer's hand.
+    var pressedButtons: @MainActor () -> Int = {
+        NSEvent.pressedMouseButtons
+    }
+
+    /// The left button alone — drags and mouse resizes are
+    /// left-button gestures.
+    var leftButtonHeld: Bool { pressedButtons() & 1 == 1 }
+
+    /// Any button — a warp must not yank the pointer out of a
+    /// gesture, whichever button started it.
+    var anyButtonHeld: Bool { pressedButtons() != 0 }
+
     private var monitors: [Any] = []
 
     /// Fired once per left press, in Cocoa screen space, with the

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+Drag.swift
@@ -22,8 +22,8 @@ extension KiwiCore {
         drag.onDragEnd = { [weak self] id, start, frame in
             self?.handleDragEnd(id, start: start, frame: frame)
         }
-        drag.isMousePressed = {
-            NSEvent.pressedMouseButtons & 1 == 1
+        drag.isMousePressed = { [weak self] in
+            self?.mouse.leftButtonHeld == true
         }
         drag.cursorLocation = { NSEvent.mouseLocation }
         wireSpaceBarDrop()

--- a/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
+++ b/Sources/KiwiDeskCore/Tiling/KiwiCore+MouseResizeEnd.swift
@@ -14,7 +14,7 @@ extension KiwiCore {
     /// (where resize drags begin; app-initiated resizes like
     /// a zoom button don't match).
     func isResizeGesture(_ id: WindowID) -> Bool {
-        if NSEvent.pressedMouseButtons & 1 == 1 {
+        if mouse.leftButtonHeld {
             return true
         }
         guard let press = mouse.press,

--- a/Tests/KiwiDeskCoreTests/MouseButtonSeamTests.swift
+++ b/Tests/KiwiDeskCoreTests/MouseButtonSeamTests.swift
@@ -1,0 +1,44 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// The mouse-button read is one injected seam
+/// (`MouseTracker.pressedButtons`, #1103/#1199), and its two
+/// gesture consumers reach it rather than `NSEvent`.
+///
+/// Neither is otherwise observable: `isResizeGesture`'s held-button
+/// arm returns before every input a fixture controls, and
+/// `drag.isMousePressed` is wired once at bootstrap, so a wiring
+/// that went back to the live read would leave every drag and
+/// resize suite green while the developer's hand decided their
+/// verdicts again. The warp's own branch is pinned by
+/// `MouseFollowsFocusTests`, the suite #1199 was filed against.
+@Suite("Mouse-button seam (#1103/#1199)", .serialized)
+@MainActor
+struct MouseButtonSeamTests {
+    @Test("isResizeGesture reads the seam, left button only")
+    func resizeGestureFollowsTheSeam() {
+        let core = makeTestCore()
+        let id = WindowID(1)
+        // No press recorded, so the trailing-event branch cannot
+        // answer: the button is the only thing left to say yes.
+        #expect(!core.isResizeGesture(id))
+        core.mouse.pressedButtons = { 1 }
+        #expect(core.isResizeGesture(id))
+        // A right-click is not a resize drag.
+        core.mouse.pressedButtons = { 1 << 1 }
+        #expect(!core.isResizeGesture(id))
+    }
+
+    @Test("The drag pipeline's press check reads the seam")
+    func dragPressCheckFollowsTheSeam() {
+        let core = makeTestCore()
+        #expect(!core.drag.isMousePressed())
+        core.mouse.pressedButtons = { 1 }
+        #expect(core.drag.isMousePressed())
+        core.mouse.pressedButtons = { 1 << 1 }
+        #expect(!core.drag.isMousePressed())
+    }
+}

--- a/Tests/KiwiDeskCoreTests/MouseFollowsFocusTests.swift
+++ b/Tests/KiwiDeskCoreTests/MouseFollowsFocusTests.swift
@@ -57,8 +57,6 @@ struct MouseFollowsFocusTests {
 
     @Test("The warp guard chain gates on toggle and space")
     func eligibility() {
-        // NSEvent.pressedMouseButtons is assumed 0 while the
-        // suite runs (nobody is clicking during `swift test`).
         let core = makeCore()
         core.state.apply(
             .windowCreated(
@@ -78,6 +76,31 @@ struct MouseFollowsFocusTests {
         core.zOrderRestoresInFlight = 0
         // A window on no (or an inactive) space never warps.
         #expect(!core.mouseWarpEligible(WindowID(99)))
+    }
+
+    @Test("A held button refuses the warp, whichever it is")
+    func heldButtonRefusesTheWarp() {
+        // Both branches stated, because before #1103/#1199 this
+        // read the host live: the developer's own hand decided
+        // the positive cases above, and the suite passed or
+        // failed with it.
+        let core = makeCore()
+        core.state.apply(
+            .windowCreated(
+                ManagedWindow(id: WindowID(1), pid: 1, appName: "A")
+            )
+        )
+        let id = WindowID(1)
+        core.tiler.settings.mouse.followsFocus = true
+        #expect(core.mouseWarpEligible(id))
+        // Left, and a button that is not the left one: the warp
+        // stands down for any gesture, not just a drag.
+        core.mouse.pressedButtons = { 1 }
+        #expect(!core.mouseWarpEligible(id))
+        core.mouse.pressedButtons = { 1 << 1 }
+        #expect(!core.mouseWarpEligible(id))
+        core.mouse.pressedButtons = { 0 }
+        #expect(core.mouseWarpEligible(id))
     }
 
     @Test("A partial mouse object keeps the off default")

--- a/Tests/KiwiDeskCoreTests/TestCore.swift
+++ b/Tests/KiwiDeskCoreTests/TestCore.swift
@@ -127,10 +127,14 @@ func makeTestCore(
     // read defaults LIVE, and three gesture decisions consult
     // it — the warp gate, `isResizeGesture` and the drag
     // pipeline — so a developer holding a button while the
-    // suite runs changed the verdict in whichever test happened
-    // to be running, four different ones in one session. Pin
+    // suite ran decided whichever test was running. Pin
     // "nothing held"; a test that wants the branch states the
     // mask itself.
     core.mouse.pressedButtons = { 0 }
+    // Same class, ninth time (#1103): `wireDrag` also makes the
+    // drop-target cursor read live, and the pointer moves under
+    // a hand that never presses. Two drag suites already pin it
+    // per file; this is the default they were working around.
+    core.drag.cursorLocation = { .zero }
     return core
 }

--- a/Tests/KiwiDeskCoreTests/TestCore.swift
+++ b/Tests/KiwiDeskCoreTests/TestCore.swift
@@ -131,10 +131,13 @@ func makeTestCore(
     // "nothing held"; a test that wants the branch states the
     // mask itself.
     core.mouse.pressedButtons = { 0 }
-    // Same class, ninth time (#1103): `wireDrag` also makes the
-    // drop-target cursor read live, and the pointer moves under
-    // a hand that never presses. Two drag suites already pin it
-    // per file; this is the default they were working around.
+    // Same class, ninth time (#1103) — but PRECAUTIONARY, not
+    // load-bearing like the eighth: `wireDrag` also makes the
+    // drop-target cursor read live and a run reaches it, yet no
+    // assertion today depends on the value, so no hostile cursor
+    // flips a verdict (guard-prover, 2026-09-06). Kept for the
+    // next drag test that forgets its own pin, which the two
+    // pinning it per file are the precedent for.
     core.drag.cursorLocation = { .zero }
     return core
 }

--- a/Tests/KiwiDeskCoreTests/TestCore.swift
+++ b/Tests/KiwiDeskCoreTests/TestCore.swift
@@ -123,5 +123,14 @@ func makeTestCore(
     // stamping suite takes the live writer back explicitly, with
     // the bridge itself faked.
     core.desktopMemory.writeStamp = { _, _ in false }
+    // Same class, eighth time (#1103/#1199): the mouse-button
+    // read defaults LIVE, and three gesture decisions consult
+    // it — the warp gate, `isResizeGesture` and the drag
+    // pipeline — so a developer holding a button while the
+    // suite runs changed the verdict in whichever test happened
+    // to be running, four different ones in one session. Pin
+    // "nothing held"; a test that wants the branch states the
+    // mask itself.
+    core.mouse.pressedButtons = { 0 }
     return core
 }

--- a/Tests/KiwiDeskGuiTests/ArrivalRingTests.swift
+++ b/Tests/KiwiDeskGuiTests/ArrivalRingTests.swift
@@ -137,16 +137,12 @@ struct ArrivalRingTests {
             .appendingPathComponent("Sources/KiwiDesk/Settings")
         let files = try SourceScan.swiftSources(under: root)
         #expect(files.count > 50)
-        var raw: [String] = []
         for file in files {
             let name = file.lastPathComponent
             let source = SourceScan.stripComments(
                 try String(contentsOf: file, encoding: .utf8)
             )
             .split(whereSeparator: \.isWhitespace).joined()
-            if source.contains("NSEvent.pressedMouseButtons") {
-                raw.append(name)
-            }
             // `.focusable(false)` is an opt-OUT: it removes a
             // stop rather than taking one, so it owes nothing.
             let optsIn =
@@ -171,18 +167,13 @@ struct ArrivalRingTests {
                 )
             )
         }
-        // And the reading itself has ONE home per question: a
-        // hand-rolled copy beside a view is how it drifts, and it
-        // took two spellings to get right — the button state
-        // alone misses a click completed on mouse-up.
-        #expect(
-            raw.sorted() == ["ClickBornFocus.swift"],
-            Comment(
-                rawValue:
-                    "`NSEvent.pressedMouseButtons` is read in "
-                    + "\(raw.sorted()) — route it through "
-                    + "`ClickBornFocus.isClickBorn` (#996)"
-            )
-        )
+        // Where the host read itself may live is
+        // `MouseButtonSeamGuardTests`', over both production
+        // trees (#1103/#1199) — this census owns which controls
+        // must CONSULT `ClickBornFocus`, not who may read the
+        // mask. A hand-rolled copy beside a view is how it
+        // drifts, and it took two spellings to get right: the
+        // button state alone misses a click completed on
+        // mouse-up.
     }
 }

--- a/Tests/KiwiDeskGuiTests/MouseButtonSeamGuardTests.swift
+++ b/Tests/KiwiDeskGuiTests/MouseButtonSeamGuardTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+/// The live mouse-button read stays behind its seam
+/// (#1103/#1199) — the same defect class as tests seizing the
+/// real global hotkey chords (#565), one step removed: no
+/// initializer touches the OS here, the touch is a production
+/// DEFAULT reading live host state on every decision.
+///
+/// Three Core sites consulted `NSEvent.pressedMouseButtons`
+/// directly — the mouse-follows-focus gate, `isResizeGesture`
+/// and the drag pipeline's press check — so a developer using
+/// their Mac while `swift test` ran changed the verdict of
+/// whichever test happened to be running, and the red moved
+/// between suites each time (four different tests in one
+/// `MouseWarpHoldTests` session, 2026-08-29). They now read
+/// `MouseTracker.pressedButtons`, which `makeTestCore` pins.
+///
+/// A sibling of `MachineTouchTests` rather than a needle inside
+/// it: that file is at the §2.1 ceiling, and this is the same
+/// split `StatusItemSeamGuardTests` already carries.
+@Suite("The live mouse-button read stays behind its seam")
+struct MouseButtonSeamGuardTests {
+    private static let root = SourceScan.repoRoot(
+        from: #filePath
+    )
+    private static let productionTrees = [
+        root.appendingPathComponent("Sources/KiwiDeskCore"),
+        root.appendingPathComponent("Sources/KiwiDesk"),
+    ]
+
+    /// The two homes, one per tree: Core's injected seam, and
+    /// the GUI's click-born-focus reading, which `ArrivalRingTests`
+    /// separately holds every focusable Settings control to.
+    private static let allowed = [
+        "ClickBornFocus.swift",
+        "MouseTracker.swift",
+    ]
+
+    @Test("the button mask is read in exactly its two homes")
+    func buttonsReadOnlyBehindTheSeam() throws {
+        let sites = try Self.productionTrees.flatMap {
+            try SourceScan.identifierSites(
+                of: "NSEvent.pressedMouseButtons",
+                under: $0
+            )
+        }
+        // Counted, not just filtered: zero means the scan looks
+        // at the wrong tree or the needle rotted, and a SECOND
+        // read grown *inside* an allowed file is exactly what
+        // the stray filter cannot see.
+        #expect(sites.count == Self.allowed.count)
+        let strays = sites.filter {
+            !Self.allowed.contains($0.file.lastPathComponent)
+        }
+        let listed = strays.map(\.site).joined(separator: ", ")
+        #expect(
+            strays.isEmpty,
+            "live mouse-button read outside the seam: \(listed)"
+        )
+    }
+}

--- a/Tests/KiwiDeskGuiTests/MouseButtonSeamGuardTests.swift
+++ b/Tests/KiwiDeskGuiTests/MouseButtonSeamGuardTests.swift
@@ -11,14 +11,21 @@ import Testing
 /// directly — the mouse-follows-focus gate, `isResizeGesture`
 /// and the drag pipeline's press check — so a developer using
 /// their Mac while `swift test` ran changed the verdict of
-/// whichever test happened to be running, and the red moved
-/// between suites each time (four different tests in one
-/// `MouseWarpHoldTests` session, 2026-08-29). They now read
-/// `MouseTracker.pressedButtons`, which `makeTestCore` pins.
+/// whichever test happened to be running. They now read
+/// `MouseTracker.pressedButtons`, which `makeTestCore` pins;
+/// `.claude/rules/tests.md` carries the measurements.
 ///
 /// A sibling of `MachineTouchTests` rather than a needle inside
 /// it: that file is at the §2.1 ceiling, and this is the same
-/// split `StatusItemSeamGuardTests` already carries.
+/// split `StatusItemSeamGuardTests` already carries. It is also
+/// the one register of who may read that mask — the Settings
+/// census in `ArrivalRingTests` routes focusable controls
+/// through `ClickBornFocus` and defers the home question here.
+///
+/// Stated residue: the needle is ONE spelling of the host read.
+/// A second reading of the same fact through another API
+/// (`CGEventSource.buttonState`) is invisible to it — widen the
+/// matcher before excusing a site that takes one.
 @Suite("The live mouse-button read stays behind its seam")
 struct MouseButtonSeamGuardTests {
     private static let root = SourceScan.repoRoot(
@@ -45,11 +52,21 @@ struct MouseButtonSeamGuardTests {
                 under: $0
             )
         }
-        // Counted, not just filtered: zero means the scan looks
-        // at the wrong tree or the needle rotted, and a SECOND
-        // read grown *inside* an allowed file is exactly what
-        // the stray filter cannot see.
-        #expect(sites.count == Self.allowed.count)
+        // Counted PER FILE, not as a total: a total stays green
+        // when a read migrates from one allowed home into the
+        // other. One each — zero means the scan looks at the
+        // wrong tree or the needle rotted, and a SECOND read
+        // grown *inside* an allowed file is exactly what the
+        // stray filter below cannot see.
+        for home in Self.allowed {
+            let reads = sites.filter {
+                $0.file.lastPathComponent == home
+            }
+            #expect(
+                reads.count == 1,
+                "\(home) reads the mask \(reads.count) times"
+            )
+        }
         let strays = sites.filter {
             !Self.allowed.contains($0.file.lastPathComponent)
         }
@@ -58,5 +75,37 @@ struct MouseButtonSeamGuardTests {
             strays.isEmpty,
             "live mouse-button read outside the seam: \(listed)"
         )
+    }
+
+    /// The two live host reads `wireDrag` and the seam default
+    /// leave on every core a suite builds. Deleting a pin from
+    /// BOTH twins is otherwise silent: the twins-identical scan
+    /// sees only a one-sided deletion, and a behavioural read
+    /// answers 0 on a quiet host either way — which is exactly
+    /// the run where the defect is invisible. The
+    /// `DesktopCensusSeamTests` shape, one subsystem over.
+    @Test("makeTestCore pins both live mouse reads")
+    func testCorePinsBothMouseReads() throws {
+        let twins = ["KiwiDeskCoreTests", "KiwiDeskGuiTests"]
+            .map {
+                Self.root.appendingPathComponent(
+                    "Tests/\($0)/TestCore.swift"
+                )
+            }
+        for twin in twins {
+            let source = try SourceScan.strippedSource(at: twin)
+            #expect(
+                source.contains(
+                    "mouse.pressedButtons = { 0 }"
+                )
+                    && source.contains(
+                        "drag.cursorLocation = { .zero }"
+                    ),
+                .init(
+                    rawValue:
+                        "\(twin.lastPathComponent) misses a pin"
+                )
+            )
+        }
     }
 }

--- a/Tests/KiwiDeskGuiTests/MouseButtonSeamGuardTests.swift
+++ b/Tests/KiwiDeskGuiTests/MouseButtonSeamGuardTests.swift
@@ -22,10 +22,15 @@ import Testing
 /// census in `ArrivalRingTests` routes focusable controls
 /// through `ClickBornFocus` and defers the home question here.
 ///
-/// Stated residue: the needle is ONE spelling of the host read.
-/// A second reading of the same fact through another API
-/// (`CGEventSource.buttonState`) is invisible to it — widen the
-/// matcher before excusing a site that takes one.
+/// Stated residue, both of it. The needle is ONE spelling of the
+/// host read: a second reading of the same fact through another
+/// API (`CGEventSource.buttonState`) is invisible to it — widen
+/// the matcher before excusing a site that takes one. And a
+/// census answers WHERE the read lives, never what reads it, so
+/// a `pressedButtons` default gutted to a constant beside a read
+/// left elsewhere in the file passes; no behavioural test can
+/// close that, since the live default answers whatever the host
+/// does (guard-prover, 2026-09-06).
 @Suite("The live mouse-button read stays behind its seam")
 struct MouseButtonSeamGuardTests {
     private static let root = SourceScan.repoRoot(

--- a/Tests/KiwiDeskGuiTests/MouseButtonSeamGuardTests.swift
+++ b/Tests/KiwiDeskGuiTests/MouseButtonSeamGuardTests.swift
@@ -89,6 +89,11 @@ struct MouseButtonSeamGuardTests {
     /// answers 0 on a quiet host either way — which is exactly
     /// the run where the defect is invisible. The
     /// `DesktopCensusSeamTests` shape, one subsystem over.
+    ///
+    /// Residue, same class as the read census above: the needles
+    /// are one spelling each, so a pin re-written equivalently
+    /// (`{ CGPoint.zero }`) reads as missing. Fail-closed, and
+    /// the message names the target it is missing from.
     @Test("makeTestCore pins both live mouse reads")
     func testCorePinsBothMouseReads() throws {
         let twins = ["KiwiDeskCoreTests", "KiwiDeskGuiTests"]
@@ -99,6 +104,10 @@ struct MouseButtonSeamGuardTests {
             }
         for twin in twins {
             let source = try SourceScan.strippedSource(at: twin)
+            // Both twins ARE `TestCore.swift`, so the message
+            // names the target directory instead.
+            let target = twin.deletingLastPathComponent()
+                .lastPathComponent
             #expect(
                 source.contains(
                     "mouse.pressedButtons = { 0 }"
@@ -106,10 +115,7 @@ struct MouseButtonSeamGuardTests {
                     && source.contains(
                         "drag.cursorLocation = { .zero }"
                     ),
-                .init(
-                    rawValue:
-                        "\(twin.lastPathComponent) misses a pin"
-                )
+                .init(rawValue: "\(target) misses a pin")
             )
         }
     }

--- a/Tests/KiwiDeskGuiTests/TestCore.swift
+++ b/Tests/KiwiDeskGuiTests/TestCore.swift
@@ -100,5 +100,14 @@ func makeTestCore(
     // stamping suite takes the live writer back explicitly, with
     // the bridge itself faked.
     core.desktopMemory.writeStamp = { _, _ in false }
+    // Same class, eighth time (#1103/#1199): the mouse-button
+    // read defaults LIVE, and three gesture decisions consult
+    // it — the warp gate, `isResizeGesture` and the drag
+    // pipeline — so a developer holding a button while the
+    // suite runs changed the verdict in whichever test happened
+    // to be running, four different ones in one session. Pin
+    // "nothing held"; a test that wants the branch states the
+    // mask itself.
+    core.mouse.pressedButtons = { 0 }
     return core
 }

--- a/Tests/KiwiDeskGuiTests/TestCore.swift
+++ b/Tests/KiwiDeskGuiTests/TestCore.swift
@@ -108,10 +108,13 @@ func makeTestCore(
     // "nothing held"; a test that wants the branch states the
     // mask itself.
     core.mouse.pressedButtons = { 0 }
-    // Same class, ninth time (#1103): `wireDrag` also makes the
-    // drop-target cursor read live, and the pointer moves under
-    // a hand that never presses. Two drag suites already pin it
-    // per file; this is the default they were working around.
+    // Same class, ninth time (#1103) — but PRECAUTIONARY, not
+    // load-bearing like the eighth: `wireDrag` also makes the
+    // drop-target cursor read live and a run reaches it, yet no
+    // assertion today depends on the value, so no hostile cursor
+    // flips a verdict (guard-prover, 2026-09-06). Kept for the
+    // next drag test that forgets its own pin, which the two
+    // pinning it per file are the precedent for.
     core.drag.cursorLocation = { .zero }
     return core
 }

--- a/Tests/KiwiDeskGuiTests/TestCore.swift
+++ b/Tests/KiwiDeskGuiTests/TestCore.swift
@@ -104,10 +104,14 @@ func makeTestCore(
     // read defaults LIVE, and three gesture decisions consult
     // it — the warp gate, `isResizeGesture` and the drag
     // pipeline — so a developer holding a button while the
-    // suite runs changed the verdict in whichever test happened
-    // to be running, four different ones in one session. Pin
+    // suite ran decided whichever test was running. Pin
     // "nothing held"; a test that wants the branch states the
     // mask itself.
     core.mouse.pressedButtons = { 0 }
+    // Same class, ninth time (#1103): `wireDrag` also makes the
+    // drop-target cursor read live, and the pointer moves under
+    // a hand that never presses. Two drag suites already pin it
+    // per file; this is the default they were working around.
+    core.drag.cursorLocation = { .zero }
     return core
 }


### PR DESCRIPTION
## Description

`NSEvent.pressedMouseButtons` was read live at three Core
decision points — the mouse-follows-focus warp gate,
`isResizeGesture`, and the drag pipeline's press check — so a
developer holding a mouse button while `swift test` ran changed
the verdict of whichever test happened to be running, and the
red moved between suites each run. That is a false regression
signal during exactly the sessions where someone is using the
machine, which is when device QA happens.

The read is now one injected seam, `MouseTracker.pressedButtons`,
in the shape #565 established: live default in production, pinned
to "nothing held" by the `makeTestCore` twins, stated explicitly
by any test that wants a branch.

**`SizeBoundAnswerChannelTests` is a second instance — measured,
not guessed.** #1103's thread suspected it and said it "may be
plain timing". With the mask pinned held, two of its tests red:
`genuineResizeForgets` at the assertion the issue reported, and
`confirmPlacesResidueImmediately`. The mechanism is
`isResizeGesture` claiming a gesture, which opens a drag session,
after which the retile issues no frame. Same live read, one
consumer over.

## Related Issue(s)

Closes #1199
Closes #1103

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended (see "How I
  verified" below and CONTRIBUTING.md → Using AI Assistants)
- [x] Commits follow Conventional Commits format
  (see AGENTS.md §3)
- [x] New behavior is tested (pure logic / layout code
  required)
- [x] User-facing changes are documented in `docs/` — n/a, no
  user-facing behavior changes; the production verdicts are
  identical
- [x] No contradictions between code and docs
- [x] PR is focused; refactors separated from features

## How I verified

**No app run, deliberately: production behavior is unchanged.**
Every consumer asks the same question of the same host API — the
call now goes through a stored closure whose default is that API.
There is nothing to see on the device.

What was measured instead, twice and independently:

- I pinned the mask to a held left button and re-ran. Five
  `MouseWarpHoldTests` tests and two `SizeBoundAnswerChannelTests`
  tests redded — the defect, reproduced on demand for the first
  time.
- `guard-prover`, in an isolated worktree, went further: it set
  the *production* default to a permanently-held button. With the
  pins intact, 21 tests green; with the Core twin's pin removed,
  the original five `MouseWarpHoldTests` reds plus the
  `SizeBoundAnswerChannelTests` one came back.

Gate on every batch: `swift build`, `swift test -q`
(4838 tests / 925 suites), `scripts/lint.sh` — all green.
Release build skipped: no `Sendable` boundary or concurrency
change, and CI's required job covers it.

## Notes for Reviewer

**Two review rounds and two `guard-prover` rounds ran before
this PR; four things changed because of them.**

1. *The pin was itself unguarded.* Deleting
   `core.mouse.pressedButtons = { 0 }` from **both** twins was
   silent — the twins-identical scan only sees a one-sided
   deletion, and a behavioural read answers 0 on a quiet host
   anyway, which is exactly the run where the defect is
   invisible. `MouseButtonSeamGuardTests` now scans both twins
   for both pins (the `DesktopCensusSeamTests` shape).
   `guard-prover` confirmed `MachineTouchTests` stays **green**
   under a two-sided deletion, so the gap was real.
2. *The home count was a total.* The first prover round recorded
   the blind spot — a read moving from one allowed home to the
   other kept the total at 2 and passed. It is per-file now, and
   the second round proved that exact mutation reds twice and
   names both wrong homes.
3. *One register per question.* `ArrivalRingTests` kept its
   focusable-control census and defers the mask's homes here.
4. *Scope, stated.* The `drag.cursorLocation` pin is **wider
   than #1103's three named sites** and is **precautionary, not
   load-bearing** — measured: a Core run reaches that seam 8
   times, but off-screen, in-fixture and per-read-random cursors
   all left 3505 tests passing, whereas gutting the button pin
   reds 6. It is kept for the next drag test that forgets its own
   pin, and the twins, the guard and `tests.md` all say so rather
   than implying parity. Say the word if you would rather it came
   out and became a residue line.

**One deviation from #1103's stated fix shape:** it asked for the
needle in `MachineTouchTests`. That file was 323 lines and the
addition pushed it to 362, over the 350 hard ceiling, so it went
into a sibling suite — the split `StatusItemSeamGuardTests`
already carries.

**Residues stated rather than papered over**, both unclosable:
the needles pin one API spelling each, and a census answers
*where* a read lives, never *what* reads it — no behavioural net
can close the second, since the live default answers whatever the
host does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
