### PR TITLE
fix(gui): a click that starts text editing is not a stray ring (#1309)

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -1027,6 +1027,19 @@ claim; the obligations a change here takes on:
   both statements run after the dispatching event is gone, so
   asking at the use site reads whatever event is current then,
   which is the bug rather than the fix.
+- **A refusal spelled on a CONTAINER's focus binding says
+  whether its focus can land on a descendant** (#1309). A
+  container's `.focused($x)` reads "focus is WITHIN me", so a
+  click into a `TextField` inside it turns the binding true
+  exactly as the container's own ring would — and a refusal that
+  cannot tell them apart clears the field the user aimed at,
+  which shipped as a dead hex field and, before that, as a
+  deleted one (#1279). The choice is the CALLER's and is stated
+  at the call, never inferred: `ClickBornFocusTests` derives the
+  population the way `ArrivalRingTests.clickRefusalCensus` does
+  and reds on a focusable control that rules neither value. A
+  leaf passes `false`, which keeps #991's ring reachable for it
+  rather than merely likely.
 
 ## Colour (#678 turn 16b)
 

--- a/Sources/KiwiDesk/Settings/Components/Common/ClickBornFocus.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ClickBornFocus.swift
@@ -1,6 +1,7 @@
 import AppKit
 
-/// Whether the focus change now landing was caused by the mouse.
+/// Whether the focus change now landing was caused by the mouse
+/// AND is a stray ring rather than the focus the click asked for.
 ///
 /// macOS 26 gives a `.focusable()` custom view keyboard focus on
 /// a click, where the platform's own controls take none — so a
@@ -22,15 +23,50 @@ import AppKit
 /// different questions, and merging them would refuse
 /// programmatic focus, which this must allow.
 enum ClickBornFocus {
+    /// The decision, pure so both its answers are pinned without
+    /// an `NSApplication` (`ClickBornFocusTests`).
+    ///
+    /// `textEditingOwnsFocus` is the #1309 arm and it comes
+    /// FIRST. A container's `.focused($x)` reads "focus is
+    /// somewhere within me", so a click into a `TextField`
+    /// inside the Settings detail pane turns the pane's binding
+    /// true — and a refusal spelled on that signal answered by
+    /// the button state alone clears the field the user just
+    /// clicked, as collateral. Measured on device 2026-09-07:
+    /// every failing click logged `focused=true`, then the
+    /// pane's refusal, then `focused=false`, so the hex field
+    /// took the caret for one to six milliseconds and lost it.
+    ///
+    /// The arm is narrow on purpose. It withholds the refusal
+    /// only where a click has put the caret in an editable
+    /// field, which no `.focusable()` custom view can be — so a
+    /// leaf control's refusal (a slider, a segmented picker, a
+    /// chip) is untouched and #991 keeps every ring it removed.
+    static func refuses(
+        mouseHeld: Bool,
+        dispatchingMouseEvent: Bool,
+        textEditingOwnsFocus: Bool
+    ) -> Bool {
+        if textEditingOwnsFocus { return false }
+        return mouseHeld || dispatchingMouseEvent
+    }
+
     /// BOTH readings, because they miss different cases: a
     /// button still held (a drag), and a click already completed
     /// on mouse-UP, where nothing is pressed by the time the
     /// focus change is observed.
     @MainActor static var isClickBorn: Bool {
-        if NSEvent.pressedMouseButtons != 0 { return true }
-        // `NSApp?`, never `NSApp`: it is implicitly unwrapped
-        // and nil in a process with no `NSApplication`, where
-        // the force-unwrap traps (crash, 2026-09-01).
+        refuses(
+            mouseHeld: NSEvent.pressedMouseButtons != 0,
+            dispatchingMouseEvent: dispatchingMouseEvent,
+            textEditingOwnsFocus: textEditingOwnsFocus
+        )
+    }
+
+    /// `NSApp?`, never `NSApp`: it is implicitly unwrapped and
+    /// nil in a process with no `NSApplication`, where the
+    /// force-unwrap traps (crash, 2026-09-01).
+    @MainActor private static var dispatchingMouseEvent: Bool {
         switch NSApp?.currentEvent?.type {
         case .leftMouseDown, .leftMouseUp, .rightMouseDown,
             .rightMouseUp, .otherMouseDown, .otherMouseUp:
@@ -38,5 +74,24 @@ enum ClickBornFocus {
         default:
             return false
         }
+    }
+
+    /// Whether an editable text responder holds the focus.
+    ///
+    /// A control that takes focus for itself installs its own
+    /// responder — a field editor — where a plain focusable view
+    /// leaves the `NSHostingView` in place. That is the one fact
+    /// separating "the pane took a ring" from "the field took
+    /// the caret", because the pane's `FocusState` says the same
+    /// thing in both. Device log, 2026-09-07: a hex-field click
+    /// reports `_SystemTextFieldFieldEditor`, a click on the
+    /// pane's own background reports the hosting view, and by
+    /// the time a background click is seen the previous field's
+    /// editor is already gone.
+    @MainActor private static var textEditingOwnsFocus: Bool {
+        guard
+            let text = NSApp?.keyWindow?.firstResponder as? NSText
+        else { return false }
+        return text.isEditable
     }
 }

--- a/Sources/KiwiDesk/Settings/Components/Common/ClickBornFocus.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/ClickBornFocus.swift
@@ -1,7 +1,6 @@
 import AppKit
 
-/// Whether the focus change now landing was caused by the mouse
-/// AND is a stray ring rather than the focus the click asked for.
+/// Whether the focus change now landing was caused by the mouse.
 ///
 /// macOS 26 gives a `.focusable()` custom view keyboard focus on
 /// a click, where the platform's own controls take none — so a
@@ -23,42 +22,40 @@ import AppKit
 /// different questions, and merging them would refuse
 /// programmatic focus, which this must allow.
 enum ClickBornFocus {
-    /// The decision, pure so both its answers are pinned without
-    /// an `NSApplication` (`ClickBornFocusTests`).
+    /// The decision, pure so every answer is pinned without an
+    /// `NSApplication` (`ClickBornFocusTests`).
     ///
-    /// `textEditingOwnsFocus` is the #1309 arm and it comes
-    /// FIRST. A container's `.focused($x)` reads "focus is
-    /// somewhere within me", so a click into a `TextField`
-    /// inside the Settings detail pane turns the pane's binding
-    /// true — and a refusal spelled on that signal answered by
-    /// the button state alone clears the field the user just
-    /// clicked, as collateral. Measured on device 2026-09-07:
-    /// every failing click logged `focused=true`, then the
-    /// pane's refusal, then `focused=false`, so the hex field
-    /// took the caret for one to six milliseconds and lost it.
-    ///
-    /// The arm is narrow on purpose. It withholds the refusal
-    /// only where a click has put the caret in an editable
-    /// field, which no `.focusable()` custom view can be — so a
-    /// leaf control's refusal (a slider, a segmented picker, a
-    /// chip) is untouched and #991 keeps every ring it removed.
+    /// `focusMayBeADescendant` is the caller's, never inferred:
+    /// a CONTAINER's `.focused($x)` reads "focus is within me",
+    /// so a click into a `TextField` inside it turns the binding
+    /// true and the refusal clears the field the user aimed at
+    /// (#1309). A leaf control has no descendant to confuse
+    /// itself with and passes `false`, which is what keeps
+    /// #991's rings — the arm is unreachable for it rather than
+    /// merely unlikely.
     static func refuses(
         mouseHeld: Bool,
         dispatchingMouseEvent: Bool,
+        focusMayBeADescendant: Bool,
         textEditingOwnsFocus: Bool
     ) -> Bool {
-        if textEditingOwnsFocus { return false }
+        if focusMayBeADescendant, textEditingOwnsFocus {
+            return false
+        }
         return mouseHeld || dispatchingMouseEvent
     }
 
-    /// BOTH readings, because they miss different cases: a
+    /// BOTH mouse readings, because they miss different cases: a
     /// button still held (a drag), and a click already completed
     /// on mouse-UP, where nothing is pressed by the time the
     /// focus change is observed.
-    @MainActor static var isClickBorn: Bool {
+    @MainActor static func isClickBorn(
+        focusMayBeADescendant: Bool
+    ) -> Bool {
         refuses(
             mouseHeld: NSEvent.pressedMouseButtons != 0,
             dispatchingMouseEvent: dispatchingMouseEvent,
+            focusMayBeADescendant: focusMayBeADescendant,
             textEditingOwnsFocus: textEditingOwnsFocus
         )
     }
@@ -76,18 +73,20 @@ enum ClickBornFocus {
         }
     }
 
-    /// Whether an editable text responder holds the focus.
+    /// Whether an editable text responder holds the focus — the
+    /// one fact separating "a container took a ring" from "the
+    /// field inside it took the caret", which its `FocusState`
+    /// spells identically (#1309).
     ///
-    /// A control that takes focus for itself installs its own
-    /// responder — a field editor — where a plain focusable view
-    /// leaves the `NSHostingView` in place. That is the one fact
-    /// separating "the pane took a ring" from "the field took
-    /// the caret", because the pane's `FocusState` says the same
-    /// thing in both. Device log, 2026-09-07: a hex-field click
-    /// reports `_SystemTextFieldFieldEditor`, a click on the
-    /// pane's own background reports the hosting view, and by
-    /// the time a background click is seen the previous field's
-    /// editor is already gone.
+    /// Stated residue: this asks the KEY window, not the window
+    /// the binding lives in, which no `FocusState` reading can
+    /// reach from here. A click into a background window makes
+    /// it key before the focus change is observed, so the two
+    /// agree on the measured path — an editable responder in a
+    /// panel above (`NSColorPanel` carries hex fields of its
+    /// own) is the case that owes a device sitting rather than
+    /// an argument. `ClickAwayResignsFocus` (#93) asks the same
+    /// question of its own window, and resigns what this reads.
     @MainActor private static var textEditingOwnsFocus: Bool {
         guard
             let text = NSApp?.keyWindow?.firstResponder as? NSText

--- a/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SegmentedPicker.swift
@@ -84,7 +84,11 @@ struct SegmentedPicker<Value: Hashable>: View {
         .onChange(of: focused) { _, now in
             // This stop would otherwise ring on every click
             // (`ClickBornFocus`).
-            guard now, ClickBornFocus.isClickBorn else { return }
+            guard now,
+                ClickBornFocus.isClickBorn(
+                    focusMayBeADescendant: false
+                )
+            else { return }
             focused = false
         }
         // ← / → only: ↑ / ↓ must still leave the row.

--- a/Sources/KiwiDesk/Settings/Components/Common/SettingsSlider.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/SettingsSlider.swift
@@ -30,7 +30,11 @@ struct SettingsSlider: View {
             // Refuse click-born focus on macOS 26; the predicate
             // is shared, the wiring is per-site by necessity
             // (`ClickBornFocus`).
-            guard now, ClickBornFocus.isClickBorn else { return }
+            guard now,
+                ClickBornFocus.isClickBorn(
+                    focusMayBeADescendant: false
+                )
+            else { return }
             focused = false
         }
         .onKeyPress(.leftArrow) { nudge(-1) }

--- a/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
+++ b/Sources/KiwiDesk/Settings/Components/Monitors/SpaceAssignmentChip.swift
@@ -55,7 +55,11 @@ struct SpaceAssignmentChip: View {
             // owner 2026-09-01). Wired here rather than shared:
             // a modifier handed the binding never fires.
             .onChange(of: focused) { _, now in
-                guard now, ClickBornFocus.isClickBorn else {
+                guard now,
+                    ClickBornFocus.isClickBorn(
+                        focusMayBeADescendant: false
+                    )
+                else {
                     return
                 }
                 focused = false

--- a/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
+++ b/Sources/KiwiDesk/Settings/SettingsView+Detail.swift
@@ -111,7 +111,10 @@ extension SettingsView {
                         // modifier handed the binding never
                         // fires (owner eye-confirm, 2026-09-01).
                         .onChange(of: contentFocused) { _, now in
-                            guard now, ClickBornFocus.isClickBorn
+                            guard now,
+                                ClickBornFocus.isClickBorn(
+                                    focusMayBeADescendant: true
+                                )
                             else { return }
                             contentFocused = false
                         }

--- a/Tests/KiwiDeskGuiTests/ClickBornFocusTests.swift
+++ b/Tests/KiwiDeskGuiTests/ClickBornFocusTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+
+@testable import KiwiDesk
+
+/// The #1309 arm on `ClickBornFocus`, held at both its answers.
+///
+/// The defect it closes is not a stray ring but the opposite: a
+/// refusal firing on a click the user aimed at a text field. A
+/// container's `.focused($x)` reads "focus is within me", so the
+/// Settings detail pane's binding turns true when a hex field
+/// takes the caret — and the refusal answered by the button
+/// state alone then cleared that field. Every failing click on
+/// the device logged the same three lines in the same order:
+/// the swatch focused, the pane refused, the swatch unfocused
+/// (2026-09-07). Disabling only the refusal made every field
+/// clickable on the same build, which is the causal half.
+///
+/// These pin the DECISION rather than the live read: the live
+/// property needs an `NSApplication` and a key window, neither
+/// of which a test host has. What holds the wiring between the
+/// two is `refusalIsWiredToTheLiveRead` below — the function
+/// being right buys nothing if the caller stops passing it.
+@Suite("A click that starts text editing is not a stray ring")
+struct ClickBornFocusTests {
+    @Test("text editing withholds the refusal, however clicked")
+    func editingNeverRefused() {
+        for held in [true, false] {
+            for dispatching in [true, false] {
+                #expect(
+                    ClickBornFocus.refuses(
+                        mouseHeld: held,
+                        dispatchingMouseEvent: dispatching,
+                        textEditingOwnsFocus: true
+                    ) == false
+                )
+            }
+        }
+    }
+
+    /// The other value of the same argument, or the arm above
+    /// would pass on a function that refuses nothing at all.
+    @Test("either mouse reading alone still refuses")
+    func mouseStillRefused() {
+        #expect(
+            ClickBornFocus.refuses(
+                mouseHeld: true,
+                dispatchingMouseEvent: false,
+                textEditingOwnsFocus: false
+            )
+        )
+        #expect(
+            ClickBornFocus.refuses(
+                mouseHeld: false,
+                dispatchingMouseEvent: true,
+                textEditingOwnsFocus: false
+            )
+        )
+    }
+
+    /// #991 allows programmatic focus, and the arrival ring
+    /// (#996) is exactly that — the first line of the device log
+    /// is `clickBorn=false pressed=0`, an allowed focus.
+    @Test("a focus change with no mouse behind it stands")
+    func programmaticFocusStands() {
+        #expect(
+            ClickBornFocus.refuses(
+                mouseHeld: false,
+                dispatchingMouseEvent: false,
+                textEditingOwnsFocus: false
+            ) == false
+        )
+    }
+
+    /// The wiring, not the function. Gut the live property's
+    /// third argument to a literal and every assertion above
+    /// stays green while the defect returns whole — the class of
+    /// no-op fix this repo has shipped twice (`tests.md`).
+    @Test("the refusal is wired to the live text-editing read")
+    func refusalIsWiredToTheLiveRead() throws {
+        let file = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent(
+                "Sources/KiwiDesk/Settings/Components/Common/"
+                    + "ClickBornFocus.swift"
+            )
+        let source = SourceScan.stripComments(
+            try String(contentsOf: file, encoding: .utf8)
+        )
+        .split(whereSeparator: \.isWhitespace)
+        .joined()
+        #expect(
+            source.contains(
+                "textEditingOwnsFocus:textEditingOwnsFocus"
+            ),
+            Comment(
+                rawValue:
+                    "`isClickBorn` no longer hands `refuses` the "
+                    + "live editable-responder read, so the "
+                    + "#1309 arm cannot fire however the pure "
+                    + "function is written. Pass the property, "
+                    + "never a literal."
+            )
+        )
+    }
+}

--- a/Tests/KiwiDeskGuiTests/ClickBornFocusTests.swift
+++ b/Tests/KiwiDeskGuiTests/ClickBornFocusTests.swift
@@ -3,27 +3,25 @@ import Testing
 
 @testable import KiwiDesk
 
-/// The #1309 arm on `ClickBornFocus`, held at both its answers.
+/// The #1309 arm on `ClickBornFocus`, held at both its answers
+/// and at both values of the choice that reaches it.
 ///
-/// The defect it closes is not a stray ring but the opposite: a
-/// refusal firing on a click the user aimed at a text field. A
-/// container's `.focused($x)` reads "focus is within me", so the
-/// Settings detail pane's binding turns true when a hex field
-/// takes the caret — and the refusal answered by the button
-/// state alone then cleared that field. Every failing click on
-/// the device logged the same three lines in the same order:
-/// the swatch focused, the pane refused, the swatch unfocused
-/// (2026-09-07). Disabling only the refusal made every field
-/// clickable on the same build, which is the causal half.
+/// The claim: a container's `.focused($x)` reads "focus is
+/// WITHIN me", so the refusal cannot tell its own ring from the
+/// caret a click just put in a field inside it — and only the
+/// caller knows which of the two it is. The argument, its device
+/// log and its negative control are on #1309.
 ///
-/// These pin the DECISION rather than the live read: the live
-/// property needs an `NSApplication` and a key window, neither
-/// of which a test host has. What holds the wiring between the
-/// two is `refusalIsWiredToTheLiveRead` below — the function
-/// being right buys nothing if the caller stops passing it.
+/// These pin the DECISION, never the live read: that needs an
+/// `NSApplication` and a key window, which no test host has.
+/// Measured residue (`guard-prover`, 2026-09-07, under a full
+/// 4855-test run): gutting `textEditingOwnsFocus` to `false`
+/// reds NOTHING here or anywhere in the suite, so the green
+/// below covers the decision and its wiring and not whether the
+/// live read identifies a field editor.
 @Suite("A click that starts text editing is not a stray ring")
 struct ClickBornFocusTests {
-    @Test("text editing withholds the refusal, however clicked")
+    @Test("a container withholds the refusal, however clicked")
     func editingNeverRefused() {
         for held in [true, false] {
             for dispatching in [true, false] {
@@ -31,6 +29,7 @@ struct ClickBornFocusTests {
                     ClickBornFocus.refuses(
                         mouseHeld: held,
                         dispatchingMouseEvent: dispatching,
+                        focusMayBeADescendant: true,
                         textEditingOwnsFocus: true
                     ) == false
                 )
@@ -38,14 +37,41 @@ struct ClickBornFocusTests {
         }
     }
 
-    /// The other value of the same argument, or the arm above
-    /// would pass on a function that refuses nothing at all.
+    /// The other value of the choice, and the reason it is the
+    /// caller's: a leaf control cannot be confused by a
+    /// descendant, so the arm must be unreachable for it rather
+    /// than merely unlikely — #991's ring survives even while
+    /// something else in the key window is being typed into.
+    @Test("a leaf control still refuses while text is edited")
+    func leafRefusesDespiteEditing() {
+        #expect(
+            ClickBornFocus.refuses(
+                mouseHeld: true,
+                dispatchingMouseEvent: false,
+                focusMayBeADescendant: false,
+                textEditingOwnsFocus: true
+            )
+        )
+        #expect(
+            ClickBornFocus.refuses(
+                mouseHeld: false,
+                dispatchingMouseEvent: true,
+                focusMayBeADescendant: false,
+                textEditingOwnsFocus: true
+            )
+        )
+    }
+
+    /// Or the arms above would pass on a function that refuses
+    /// nothing at all — the symmetric deletion `guard-prover`
+    /// measured this suite against.
     @Test("either mouse reading alone still refuses")
     func mouseStillRefused() {
         #expect(
             ClickBornFocus.refuses(
                 mouseHeld: true,
                 dispatchingMouseEvent: false,
+                focusMayBeADescendant: true,
                 textEditingOwnsFocus: false
             )
         )
@@ -53,31 +79,114 @@ struct ClickBornFocusTests {
             ClickBornFocus.refuses(
                 mouseHeld: false,
                 dispatchingMouseEvent: true,
+                focusMayBeADescendant: true,
                 textEditingOwnsFocus: false
             )
         )
     }
 
-    /// #991 allows programmatic focus, and the arrival ring
-    /// (#996) is exactly that — the first line of the device log
-    /// is `clickBorn=false pressed=0`, an allowed focus.
+    /// #991 allows programmatic focus, and #996's arrival ring
+    /// is exactly that.
     @Test("a focus change with no mouse behind it stands")
     func programmaticFocusStands() {
         #expect(
             ClickBornFocus.refuses(
                 mouseHeld: false,
                 dispatchingMouseEvent: false,
+                focusMayBeADescendant: true,
                 textEditingOwnsFocus: false
             ) == false
         )
     }
 
     /// The wiring, not the function. Gut the live property's
-    /// third argument to a literal and every assertion above
-    /// stays green while the defect returns whole — the class of
-    /// no-op fix this repo has shipped twice (`tests.md`).
+    /// argument to a literal and every assertion above stays
+    /// green while the defect returns whole.
+    ///
+    /// Read against `isClickBorn`'s own brace-balanced body, not
+    /// the file: `guard-prover` (2026-09-07) satisfied a
+    /// file-wide needle twice with the defect fully live — once
+    /// by shadowing the property with a local `false`, once by
+    /// adding an uncalled neighbour that did pass the read. That
+    /// is the class `tests.md` names against `WorkflowSource`
+    /// ▸ #968.
     @Test("the refusal is wired to the live text-editing read")
     func refusalIsWiredToTheLiveRead() throws {
+        let body = try Self.isClickBornBody()
+        for argument in [
+            "focusMayBeADescendant:focusMayBeADescendant",
+            "textEditingOwnsFocus:textEditingOwnsFocus",
+        ] {
+            #expect(
+                body.contains(argument),
+                Comment(
+                    rawValue:
+                        "`isClickBorn` no longer hands `refuses` "
+                        + "`\(argument)`, so the #1309 arm cannot "
+                        + "fire however the pure function is "
+                        + "written. Pass it, never a literal."
+                )
+            )
+        }
+    }
+
+    /// Every focusable Settings control STATES which of the two
+    /// it is, and the population is derived rather than listed —
+    /// `ArrivalRingTests.clickRefusalCensus`' idiom, which holds
+    /// the same files to consulting this predicate at all. A new
+    /// `.focusable()` control reds here until someone rules its
+    /// value, which is the whole point of moving the choice onto
+    /// the call.
+    @Test("each focusable control rules its own container-ness")
+    func everyConsumerStatesTheChoice() throws {
+        let ruled = [
+            "SettingsView+Detail.swift": "true",
+            "SpaceAssignmentChip.swift": "false",
+            "SettingsSlider.swift": "false",
+            "SegmentedPicker.swift": "false",
+        ]
+        let root = SourceScan.repoRoot(from: #filePath)
+            .appendingPathComponent("Sources/KiwiDesk/Settings")
+        let files = try SourceScan.swiftSources(under: root)
+        #expect(files.count > 50)
+        var seen: [String] = []
+        for file in files {
+            let name = file.lastPathComponent
+            let source = SourceScan.stripComments(
+                try String(contentsOf: file, encoding: .utf8)
+            )
+            .split(whereSeparator: \.isWhitespace).joined()
+            guard source.contains("ClickBornFocus.isClickBorn")
+            else { continue }
+            seen.append(name)
+            let value = try #require(
+                ruled[name],
+                Comment(
+                    rawValue:
+                        "\(name) consults `ClickBornFocus` and "
+                        + "is not ruled here. Say whether its "
+                        + "focus can land on a DESCENDANT — a "
+                        + "container passes true, a leaf false."
+                )
+            )
+            #expect(
+                source.contains(
+                    "focusMayBeADescendant:\(value)"
+                ),
+                Comment(
+                    rawValue:
+                        "\(name) no longer passes "
+                        + "`focusMayBeADescendant: \(value)`."
+                )
+            )
+        }
+        #expect(seen.sorted() == ruled.keys.sorted())
+    }
+
+    /// `isClickBorn`'s body, brace-balanced from its own
+    /// declaration so a neighbour can neither satisfy nor break
+    /// the clause above.
+    private static func isClickBornBody() throws -> String {
         let file = SourceScan.repoRoot(from: #filePath)
             .appendingPathComponent(
                 "Sources/KiwiDesk/Settings/Components/Common/"
@@ -86,19 +195,42 @@ struct ClickBornFocusTests {
         let source = SourceScan.stripComments(
             try String(contentsOf: file, encoding: .utf8)
         )
-        .split(whereSeparator: \.isWhitespace)
-        .joined()
-        #expect(
-            source.contains(
-                "textEditingOwnsFocus:textEditingOwnsFocus"
+        .split(whereSeparator: \.isWhitespace).joined()
+        let marker = "staticfuncisClickBorn("
+        let start = try #require(
+            source.range(of: marker),
+            Comment(
+                rawValue:
+                    "`isClickBorn` is no longer declared as a "
+                    + "function taking the container choice."
+            )
+        )
+        var cursor = Array(source[start.upperBound...])
+        var index = 0
+        _ = SourceScan.balanced(
+            cursor,
+            from: &index,
+            open: "(",
+            close: ")"
+        )
+        cursor = Array(cursor[index...])
+        var bodyCursor = 0
+        // Skip the return type between `)` and the body brace.
+        while bodyCursor < cursor.count,
+            cursor[bodyCursor] != "{"
+        {
+            bodyCursor += 1
+        }
+        return try #require(
+            SourceScan.balanced(
+                cursor,
+                from: &bodyCursor,
+                open: "{",
+                close: "}"
             ),
             Comment(
                 rawValue:
-                    "`isClickBorn` no longer hands `refuses` the "
-                    + "live editable-responder read, so the "
-                    + "#1309 arm cannot fire however the pure "
-                    + "function is written. Pass the property, "
-                    + "never a literal."
+                    "`isClickBorn` has no brace-balanced body."
             )
         )
     }

--- a/Tests/KiwiDeskGuiTests/SettingsInputSourceSeamTests.swift
+++ b/Tests/KiwiDeskGuiTests/SettingsInputSourceSeamTests.swift
@@ -25,10 +25,14 @@ struct SettingsInputSourceSeamTests {
     ///
     /// - `SettingsInputSource` — would the platform have moved
     ///   focus for this NAVIGATION? Refuses a mouse event.
-    /// - `ClickBornFocus` — did the mouse cause this FOCUS
-    ///   CHANGE on a `.focusable()` control? Also weighs the
+    /// - `ClickBornFocus` — should this FOCUS CHANGE on a
+    ///   `.focusable()` control be refused? Also weighs the
     ///   button state, which the first must not, because a
-    ///   navigation may be programmatic while a button is down.
+    ///   navigation may be programmatic while a button is down,
+    ///   and — for a CONTAINER that says so — whether the click
+    ///   put the caret in an editable responder, which its
+    ///   `FocusState` cannot distinguish from its own ring
+    ///   (#1309, `ClickBornFocusTests`).
     ///
     /// Merging them would refuse programmatic focus, which the
     /// second must allow. A THIRD entry is the thing to refuse:


### PR DESCRIPTION
Advanced Colors' hex field took Tab focus but not a mouse click. It is a
recurrence — the same symptom hit App Rules' `Custom…` field, and #1279
deleted that field rather than repairing the cause.

## What it was

The detail pane's #991 click-born focus refusal, which the issue thread
had struck out. It was struck out on a confounded observation: the search
field is outside the pane, and the Spaces field "worked" because it was
tested as a FIRST click — which always works, since the pane already holds
its #996 arrival focus and there is therefore no transition to refuse.

The mechanism nothing had spotted: **a container's `.focused($x)` reads
"focus is WITHIN me"**. A click into a `TextField` inside the pane turns
the pane's binding true exactly as the pane's own ring would, and the
refusal — answered by the button state alone — then cleared the field the
click had just focused.

Instrumented build, device log, every failing click, in this order:

```
swatch[Füllfarbe].focused=true              <- the click focuses the field
pane.onChange now=true  clickBorn=true      <- the pane's binding goes true too
pane.REFUSE                                 <- contentFocused = false
swatch[Füllfarbe].focused=false             <- the field is cleared
```

The `LazyVGrid` lead and the left/right-column split are both dead: a
working and a dead click were recorded in BOTH containers and BOTH columns.
Clipping is dead too — at the reported width the cell content is 260 pt in
a 363 pt column, and an AX hit test at the field's centre returns the field.

## The fix

`ClickBornFocus.isClickBorn(focusMayBeADescendant:)` — no default, so every
consultant states which it is. The pane passes `true`; the three leaf
controls pass `false`, which makes the new arm UNREACHABLE for them rather
than merely unlikely. The arm itself: a click that has put the caret in an
editable text responder is the focus the user asked for, never a stray ring.

The choice is on the value deliberately. The first cut answered it from
window-global state, which let an editable responder anywhere in the key
window withhold a leaf control's refusal — and `NSColorPanel` carries hex
fields of its own.

## Verification

No synthesised click was used as proof; the issue records that a posted
`CGEvent` focused a field that refuses a real press, and passed on the
unfixed build.

- **Negative control, recorded twice** on the unfixed build — the owner's
  own clicks, and a second instrumented run of the shipped refusal on the
  same binary. Both bounce in 1-6 ms.
- **Causal isolation:** a build differing only in whether the refusal runs
  made every field clickable.
- **The fix, owner's hands, signed build:** nine consecutive field clicks
  across both containers and both columns, from the pane-focused state that
  previously killed every click. Every one held 861-3746 ms.
- **A regression caught and closed by review + device.** The first cut left
  the pane holding focus 907 ms / 3 s / 13 s after a background click,
  drawing the #991 ring — `main` drops it. With the choice on the value the
  pane's episodes are 0-1 ms, matching `main`.

Gate: build clean, **4878 tests in 935 suites**, lint OK. Release build
skipped (no concurrency or `Sendable` surface); CI's required job covers it.

`guard-prover`, isolated worktree: **4/4 red-proofed**. It also proved two
fail-open holes in the first cut's wiring needle — a local shadow and an
uncalled neighbour each kept it green with the defect whole — both closed by
brace-scoping the clause to `isClickBorn`'s own body. Measured residue, now
stated in the suite: gutting the live read reds nothing, under a full
4855-test run. No test host has an `NSApplication` or key window.

Review: `code-reviewer` and `architect-reviewer` (2 major + 4 major, all
addressed or stated), plus the device regression above.

## Also here

- A second census derives its population the way
  `ArrivalRingTests.clickRefusalCensus` does, so a focusable control ruling
  neither value reds rather than inheriting one silently.
- `SettingsInputSourceSeamTests`' register said the seam weighs only the
  mouse; this falsifies it, so it is rewritten.
- `gui.md` gains the obligation — a guardrail living only in a Swift
  docstring is not one.

## Stated residue

The read asks the KEY window, not the window the binding lives in, which no
`FocusState` reading can reach from there. A click into a background window
makes it key before the focus change is observed, so the two agree on the
measured path; an editable responder in a panel ABOVE (the colour panel) is
the case that owes a device sitting rather than an argument. Written where
it can be acted on rather than claimed away.

Not armed for auto-merge — owner eyeball owed on a GUI change.

fixes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)
