### PR TITLE
fix(localization): the shortcuts panel has one name (#1316)

### DIFF
--- a/.claude/rules/config-vocabulary.md
+++ b/.claude/rules/config-vocabulary.md
@@ -237,9 +237,13 @@ synonym:
   own accessibility name said "Shortcuts reference", so a
   sighted user read one noun and a VoiceOver user heard another
   for one surface, and all ten catalogs faithfully mirrored it
-  (#1316). Nothing scans for this class: it is two words for one
-  thing, which `DestinationNameCollisionTests`' exact-collision
-  predicate cannot see, so it is caught by review or not at all.
+  (#1316). The general class is two words for one thing, which
+  `DestinationNameCollisionTests`' exact-collision predicate
+  cannot see — but THIS surface is held:
+  `ShortcutsPanelNounTests` asks, per catalog, that the panel's
+  own accessibility name is the noun the shortcut opening it
+  already uses. A second surface naming itself twice is still
+  review's until someone gives it the same pairing.
 
 See `docs/design-decisions.md` for each ruling's rationale, and
 `docs/ui-patterns.md` ("Labels & wire names") for when a rename

--- a/.claude/rules/config-vocabulary.md
+++ b/.claude/rules/config-vocabulary.md
@@ -230,6 +230,16 @@ synonym:
   section is where the two collide), and not "tier" either:
   *tier* is already spoken for twice over by `SettingTier` /
   row tiers (`docs/ui-patterns.md`) and the bars' dim tiers.
+- **shortcuts panel** — the read-only surface ⌃⌥K opens (#326).
+  Retired as names for it: *shortcuts reference*, *reference
+  panel*. The split was not a coining but a drift — everything
+  POINTING at the panel said "shortcuts panel" while the panel's
+  own accessibility name said "Shortcuts reference", so a
+  sighted user read one noun and a VoiceOver user heard another
+  for one surface, and all ten catalogs faithfully mirrored it
+  (#1316). Nothing scans for this class: it is two words for one
+  thing, which `DestinationNameCollisionTests`' exact-collision
+  predicate cannot see, so it is caught by review or not at all.
 
 See `docs/design-decisions.md` for each ruling's rationale, and
 `docs/ui-patterns.md` ("Labels & wire names") for when a rename

--- a/.claude/rules/config-vocabulary.md
+++ b/.claude/rules/config-vocabulary.md
@@ -232,7 +232,12 @@ synonym:
   row tiers (`docs/ui-patterns.md`) and the bars' dim tiers.
 - **shortcuts panel** — the read-only surface ⌃⌥K opens (#326).
   Retired as names for it: *shortcuts reference*, *reference
-  panel*. The split was not a coining but a drift — everything
+  panel*. Binds **copy** — a label, a catalog value, CLI help
+  text, `docs/` prose — and not identifiers, so
+  `ShortcutsReferenceBuilder` and `ShortcutsReferenceTests` stay
+  as they are; the doc comments that still spell the retired
+  name describe those types and are the sweep a rename of them
+  would carry. The split was not a coining but a drift — everything
   POINTING at the panel said "shortcuts panel" while the panel's
   own accessibility name said "Shortcuts reference", so a
   sighted user read one noun and a VoiceOver user heard another

--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -1254,7 +1254,7 @@ Obligations:
   two toolkits agree, and a tint neither lightens a plate nor
   colours it — only a `GlassTint`-style backdrop carries hue, and
   one opaque enough to read stops the wallpaper coming through.
-  `docs/design-decisions.md` ▸ the reference panel carries the
+  `docs/design-decisions.md` ▸ the shortcuts panel carries the
   ruling; its second reason needs no platform fact at all, since
   a SwiftUI surface's `.primary` / `.secondary` are vibrant
   against the composite backdrop and so need no fill the way a

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -413,6 +413,12 @@ why they are here rather than beside the views:
   catalog ships and reds when a destination's name is some other
   feature's string, which is ladder rule 1 and the shape that
   shipped `zh-Hans`'s Profile as "configuration file".
+  `ShortcutsPanelNounTests` holds a second such sub-class the
+  same way — a surface that names ITSELF on one channel and is
+  named on another, paired within one catalog (#1316) — so a
+  further pairing is buildable rather than ruled out; what the
+  page forecloses is the vocabulary register, not a comparison
+  the catalog already contains.
 
 ## Registering a new locale
 

--- a/Sources/KiwiDesk/Settings/Components/Common/GlassChrome.swift
+++ b/Sources/KiwiDesk/Settings/Components/Common/GlassChrome.swift
@@ -14,7 +14,7 @@ extension View {
     /// NOT a default, and not the bars' `.clear`. Untinted by
     /// ruling rather than by capability. Both arguments, and the
     /// Reduce Transparency gap this does not answer, are in
-    /// `docs/design-decisions.md` ▸ the reference panel (#1295).
+    /// `docs/design-decisions.md` ▸ the shortcuts panel (#1295).
     /// `enabled` is the #1307 switch's third leaf. Off takes the
     /// SAME `.regularMaterial` the pre-26 branch already draws,
     /// which `docs/design-decisions.md` rules to be today's

--- a/Sources/KiwiDesk/Shortcuts/ShortcutsPanelView.swift
+++ b/Sources/KiwiDesk/Shortcuts/ShortcutsPanelView.swift
@@ -79,7 +79,7 @@ struct ShortcutsPanelView: View {
             // "scroll area" before interacting into it
             // (`SettingsDetailPanel`, #812).
             .accessibilityLabel(
-                L("shortcuts.panel.ax_label", "Shortcuts reference")
+                L("shortcuts.panel.ax_label", "Shortcuts panel")
             )
         } else {
             placeholder(unavailable: reference == nil)

--- a/Sources/KiwiDeskCore/Commands/Reference/APIRecords+LuaOnly.swift
+++ b/Sources/KiwiDeskCore/Commands/Reference/APIRecords+LuaOnly.swift
@@ -39,8 +39,8 @@ extension APIReference {
             .text("name")
         ),
         "show_shortcuts": APIRecord(
-            "Opens the read-only shortcuts reference panel, or "
-                + "closes it if it is open."
+            "Opens the read-only shortcuts panel, or closes "
+                + "it if it is open."
         ),
         "open_settings": APIRecord(
             "Opens the Settings window and brings it to the "

--- a/Sources/KiwiDeskCore/Resources/Locales/en.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/en.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "Editing “%1$@” — shortcuts re-apply as soon as you save.",
   "shortcuts.override.title": "Profile shortcuts",
   "shortcuts.panel.apps": "Apps",
-  "shortcuts.panel.ax_label": "Shortcuts reference",
+  "shortcuts.panel.ax_label": "Shortcuts panel",
   "shortcuts.panel.controls": "Controls",
   "shortcuts.panel.custom": "Custom",
   "shortcuts.panel.dismiss_hint": "Esc or click away to close",

--- a/Sources/KiwiDeskCore/Resources/Locales/es.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/es.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "Editando «%1$@» — los atajos se aplican tan pronto como guardes.",
   "shortcuts.override.title": "Atajos del perfil",
   "shortcuts.panel.apps": "Aplicaciones",
-  "shortcuts.panel.ax_label": "Referencia de atajos",
+  "shortcuts.panel.ax_label": "Panel de atajos",
   "shortcuts.panel.controls": "Controles",
   "shortcuts.panel.custom": "Personalizado",
   "shortcuts.panel.dismiss_hint": "Escape o clic fuera para cerrar",

--- a/Sources/KiwiDeskCore/Resources/Locales/fr.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/fr.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "Modification de « %1$@ » — les raccourcis s'appliquent dès l'enregistrement.",
   "shortcuts.override.title": "Raccourcis du profil",
   "shortcuts.panel.apps": "Applications",
-  "shortcuts.panel.ax_label": "Référence des raccourcis",
+  "shortcuts.panel.ax_label": "Panneau des raccourcis",
   "shortcuts.panel.controls": "Contrôles",
   "shortcuts.panel.custom": "Personnalisé",
   "shortcuts.panel.dismiss_hint": "Échap ou cliquez à côté pour fermer",

--- a/Sources/KiwiDeskCore/Resources/Locales/it.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/it.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "Modifica di «%1$@»: le scorciatoie si riapplicano appena salvi.",
   "shortcuts.override.title": "Scorciatoie profilo",
   "shortcuts.panel.apps": "App",
-  "shortcuts.panel.ax_label": "Riferimento delle scorciatoie",
+  "shortcuts.panel.ax_label": "Pannello delle scorciatoie",
   "shortcuts.panel.controls": "Controlli",
   "shortcuts.panel.custom": "Personalizzate",
   "shortcuts.panel.dismiss_hint": "Esc o un clic fuori per chiudere",

--- a/Sources/KiwiDeskCore/Resources/Locales/ja.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/ja.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "「%1$@」を編集しています。ショートカットは保存するとすぐに再適用されます。",
   "shortcuts.override.title": "プロファイルのショートカット",
   "shortcuts.panel.apps": "アプリ",
-  "shortcuts.panel.ax_label": "ショートカット一覧",
+  "shortcuts.panel.ax_label": "ショートカットパネル",
   "shortcuts.panel.controls": "コントロール",
   "shortcuts.panel.custom": "カスタム",
   "shortcuts.panel.dismiss_hint": "Escキーまたは外側をクリックで閉じる",

--- a/Sources/KiwiDeskCore/Resources/Locales/ko.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/ko.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "‘%1$@’을(를) 편집하는 중입니다. 저장하는 즉시 단축키가 다시 적용됩니다.",
   "shortcuts.override.title": "프로필 단축키",
   "shortcuts.panel.apps": "앱",
-  "shortcuts.panel.ax_label": "단축키 목록",
+  "shortcuts.panel.ax_label": "단축키 패널",
   "shortcuts.panel.controls": "제어",
   "shortcuts.panel.custom": "사용자화",
   "shortcuts.panel.dismiss_hint": "Esc 또는 바깥쪽 클릭으로 닫기",

--- a/Sources/KiwiDeskCore/Resources/Locales/pt-BR.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/pt-BR.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "Editando “%1$@” — os atalhos são reaplicados assim que você salvar.",
   "shortcuts.override.title": "Atalhos do perfil",
   "shortcuts.panel.apps": "Apps",
-  "shortcuts.panel.ax_label": "Referência de atalhos",
+  "shortcuts.panel.ax_label": "Painel de atalhos",
   "shortcuts.panel.controls": "Controles",
   "shortcuts.panel.custom": "Personalizados",
   "shortcuts.panel.dismiss_hint": "Esc ou um clique fora para fechar",

--- a/Sources/KiwiDeskCore/Resources/Locales/ru.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/ru.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "Идёт правка «%1$@» — сочетания клавиш применятся заново, как только ты сохранишь.",
   "shortcuts.override.title": "Сочетания клавиш профиля",
   "shortcuts.panel.apps": "Приложения",
-  "shortcuts.panel.ax_label": "Справочник сочетаний клавиш",
+  "shortcuts.panel.ax_label": "Панель сочетаний клавиш",
   "shortcuts.panel.controls": "Элементы управления",
   "shortcuts.panel.custom": "Свои",
   "shortcuts.panel.dismiss_hint": "Esc или нажатие вне окна закрывает панель",

--- a/Sources/KiwiDeskCore/Resources/Locales/zh-Hans.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/zh-Hans.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "正在编辑“%1$@” — 存储后快捷键会立即重新应用。",
   "shortcuts.override.title": "描述文件快捷键",
   "shortcuts.panel.apps": "App",
-  "shortcuts.panel.ax_label": "快捷键参考",
+  "shortcuts.panel.ax_label": "快捷键面板",
   "shortcuts.panel.controls": "控制",
   "shortcuts.panel.custom": "自定义",
   "shortcuts.panel.dismiss_hint": "按 Esc 或点按别处关闭",

--- a/Sources/KiwiDeskCore/Resources/Locales/zh-Hant.json
+++ b/Sources/KiwiDeskCore/Resources/Locales/zh-Hant.json
@@ -1028,7 +1028,7 @@
   "shortcuts.override.staged_loaded": "正在編輯「%1$@」 — 快速鍵會在你儲存後立即重新套用。",
   "shortcuts.override.title": "描述檔快速鍵",
   "shortcuts.panel.apps": "App",
-  "shortcuts.panel.ax_label": "快速鍵參考",
+  "shortcuts.panel.ax_label": "快速鍵面板",
   "shortcuts.panel.controls": "控制項",
   "shortcuts.panel.custom": "自訂",
   "shortcuts.panel.dismiss_hint": "按 Esc 或點按其他地方即可關閉",

--- a/Tests/KiwiDeskGuiTests/ShortcutsPanelNounTests.swift
+++ b/Tests/KiwiDeskGuiTests/ShortcutsPanelNounTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+
+/// The ⌃⌥K surface has ONE name per catalog: whatever a locale
+/// calls the panel when it points AT it, the panel's own
+/// accessibility name uses (#1316,
+/// `.claude/rules/config-vocabulary.md` ▸ shortcuts panel).
+///
+/// The defect this reds on is not inconsistency in the abstract.
+/// `shortcuts.panel.ax_label` shipped as "Shortcuts reference"
+/// while `keybinding.show_shortcuts` said "Show shortcuts panel",
+/// so a sighted user read one noun and a VoiceOver user heard
+/// another for one surface — and all ten catalogs faithfully
+/// mirrored it, because a correct translation of a wrong source
+/// looks exactly like this.
+///
+/// **Family C says no guard is possible; that is about a
+/// content-guard predicate, and this is not one** — the argument
+/// is `DestinationNameCollisionTests`', which holds the
+/// exact-collision sub-class the same way, and is not repeated
+/// here. This suite reads no vocabulary: it asks only whether
+/// ONE catalog's two strings for one surface share a noun, by
+/// containment.
+///
+/// What it does NOT cover, so a green run is not read as more:
+/// containment is the whole predicate, so a locale that
+/// INFLECTS the noun inside the verb phrase — a case-marking
+/// language whose accusative differs from the citation form —
+/// reds here correctly rather than falsely, and takes an
+/// `allowed` entry stating the two forms. Every shipped catalog
+/// today keeps the citation form, which is why the map is empty.
+@Suite("The shortcuts panel has one name per catalog")
+struct ShortcutsPanelNounTests {
+    /// The panel's own accessibility name.
+    static let panelName = "shortcuts.panel.ax_label"
+    /// The verb that opens it, which names it in passing.
+    static let opener = "keybinding.show_shortcuts"
+
+    /// Locales whose grammar inflects the noun inside the verb
+    /// phrase, each naming the two forms — **the one copy of who
+    /// may**. EMPTY: nothing shipped inflects it today.
+    static let allowed: [String: String] = [:]
+
+    @Test("the panel's own name is the noun its opener uses")
+    func oneNounPerCatalog() throws {
+        for locale in try Self.catalogNames() {
+            let catalog = try Self.catalog(locale)
+            guard let name = catalog[Self.panelName],
+                let opens = catalog[Self.opener]
+            else { continue }
+            guard Self.allowed[locale] == nil else { continue }
+            #expect(
+                opens.lowercased().contains(name.lowercased()),
+                """
+                \(locale): the panel announces itself as \
+                "\(name)" while the shortcut that opens it says \
+                "\(opens)" — two names for one surface (#1316). \
+                Give the panel the noun the opener already uses, \
+                or add \(locale) to `allowed` naming the two \
+                grammatical forms.
+                """
+            )
+        }
+    }
+
+    /// English lives at the call sites and is regenerated into
+    /// `en.json`, so it is checked here beside the translations
+    /// — it is the source the split came from.
+    private static func catalogNames() throws -> [String] {
+        let names = try FileManager.default
+            .contentsOfDirectory(atPath: localesDirectory.path)
+            .filter { $0.hasSuffix(".json") }
+            .sorted()
+        for name in names where name.hasPrefix("missing_") {
+            Issue.record(
+                """
+                \(name) is a translator worksheet sitting in the \
+                catalog directory. It belongs under \
+                locale-worksheets/ — every reader of this \
+                directory globs *.json and will try to decode it.
+                """
+            )
+        }
+        let shipped =
+            names
+            .filter { !$0.hasPrefix("missing_") }
+            .map { String($0.dropLast(".json".count)) }
+        #expect(
+            shipped.count > 1,
+            "the catalog directory yielded nothing to compare"
+        )
+        return shipped
+    }
+
+    private static var localesDirectory: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // KiwiDeskGuiTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+            .appendingPathComponent(
+                "Sources/KiwiDeskCore/Resources/Locales"
+            )
+    }
+
+    private static func catalog(_ name: String) throws
+        -> [String: String]
+    {
+        try JSONDecoder().decode(
+            [String: String].self,
+            from: Data(
+                contentsOf:
+                    localesDirectory
+                    .appendingPathComponent("\(name).json")
+            )
+        )
+    }
+}

--- a/Tests/KiwiDeskGuiTests/ShortcutsPanelNounTests.swift
+++ b/Tests/KiwiDeskGuiTests/ShortcutsPanelNounTests.swift
@@ -22,13 +22,34 @@ import Testing
 /// ONE catalog's two strings for one surface share a noun, by
 /// containment.
 ///
-/// What it does NOT cover, so a green run is not read as more:
-/// containment is the whole predicate, so a locale that
-/// INFLECTS the noun inside the verb phrase — a case-marking
-/// language whose accusative differs from the citation form —
-/// reds here correctly rather than falsely, and takes an
-/// `allowed` entry stating the two forms. Every shipped catalog
-/// today keeps the citation form, which is why the map is empty.
+/// **What it holds is containment, one-directional**, and the
+/// docstring says so rather than claiming the whole invariant:
+/// the panel's name must be SOME substring of the opener. Two
+/// shapes therefore pass, both measured (`guard-prover`, #1316)
+/// rather than reasoned about:
+///
+/// - a panel name SHORTENED to a bare head noun — `fr`
+///   announcing `Raccourcis` against "Afficher le panneau des
+///   raccourcis" is two names for one surface and stays green,
+///   as does any substring down to one character;
+/// - a second noun regrowing on the OPENER — "Show shortcuts
+///   panel reference" contains the panel's name and passes.
+///
+/// Both need per-language vocabulary to tell from a legitimate
+/// rewording, which is the register Family C rules a guard may
+/// not carry. They stay with review. What is bought is the
+/// shape that actually shipped: the two keys naming the surface
+/// with DIFFERENT nouns.
+///
+/// A locale that INFLECTS the noun inside the verb phrase — a
+/// case-marking language whose accusative differs from the
+/// citation form — reds correctly rather than falsely, and takes
+/// an `allowed` entry naming the form the opener carries, which
+/// is then checked in the citation form's place. Every shipped
+/// catalog today keeps the citation form, so the map is empty.
+///
+/// An empty value does NOT pass vacuously: `contains("")` is
+/// false in Swift, so an untranslated-empty merge reds.
 @Suite("The shortcuts panel has one name per catalog")
 struct ShortcutsPanelNounTests {
     /// The panel's own accessibility name.
@@ -37,30 +58,65 @@ struct ShortcutsPanelNounTests {
     static let opener = "keybinding.show_shortcuts"
 
     /// Locales whose grammar inflects the noun inside the verb
-    /// phrase, each naming the two forms — **the one copy of who
-    /// may**. EMPTY: nothing shipped inflects it today.
+    /// phrase, valued by the form the OPENER carries — **the one
+    /// copy of who may**.
+    ///
+    /// The value is checked, not decoration: an entry narrows
+    /// the comparison to that form rather than dropping the
+    /// locale out of it, so an exemption still holds the pairing
+    /// it was granted for. EMPTY: nothing shipped inflects it.
     static let allowed: [String: String] = [:]
 
     @Test("the panel's own name is the noun its opener uses")
     func oneNounPerCatalog() throws {
+        var compared = 0
         for locale in try Self.catalogNames() {
             let catalog = try Self.catalog(locale)
-            guard let name = catalog[Self.panelName],
-                let opens = catalog[Self.opener]
-            else { continue }
-            guard Self.allowed[locale] == nil else { continue }
+            let name = catalog[Self.panelName]
+            let opens = catalog[Self.opener]
+            // ONE of the two present is the defect wearing the
+            // English fallback: `drop-key --locale` retires a bad
+            // translation, after which that locale announces the
+            // English noun against its own translated opener.
+            // Skipping it is how the guard would go quiet on the
+            // exact repair path (`guard-prover`, #1316).
+            if (name == nil) != (opens == nil) {
+                Issue.record(
+                    """
+                    \(locale) carries one of \(Self.panelName) / \
+                    \(Self.opener) and not the other, so the \
+                    surface is named by a translation on one \
+                    channel and by the English fallback on the \
+                    other — the #1316 split, wearing a fallback.
+                    """
+                )
+                continue
+            }
+            guard let name, let opens else { continue }
+            compared += 1
+            let expected = Self.allowed[locale] ?? name
             #expect(
-                opens.lowercased().contains(name.lowercased()),
+                opens.lowercased().contains(expected.lowercased()),
                 """
                 \(locale): the panel announces itself as \
                 "\(name)" while the shortcut that opens it says \
                 "\(opens)" — two names for one surface (#1316). \
                 Give the panel the noun the opener already uses, \
-                or add \(locale) to `allowed` naming the two \
-                grammatical forms.
+                or add \(locale) to `allowed` naming the form \
+                the opener carries.
                 """
             )
         }
+        // The floor counts COMPARISONS, never files: every
+        // catalog losing the key passes a file count and
+        // compares nothing (`guard-prover`, #1316).
+        #expect(
+            compared > 1,
+            """
+            \(compared) catalog(s) actually compared — this \
+            suite passed for having looked at nothing.
+            """
+        )
     }
 
     /// English lives at the call sites and is regenerated into

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -6813,7 +6813,7 @@ deleting it would lose config across a routine monitor swap.
 The rows stay live at runtime by design; only their
 *visibility* was broken. (#92)
 
-**The reference panel scrolls, and says so — in words, in the
+**The shortcuts panel scrolls, and says so — in words, in the
 footer.** The panel is a glance surface but not a small one: the
 seeded keymap grows three rows per Space, so a stock setup runs
 to more rows than fit under the height ceiling
@@ -6891,7 +6891,7 @@ permanent, not a stopgap. The asymmetry that issue would
 exploit — the panel's height derives from the screen while its
 width is a literal 760 — is its own ruling if taken.
 
-**The reference panel takes UNTINTED Liquid Glass, and the
+**The shortcuts panel takes UNTINTED Liquid Glass, and the
 untinted half is a ruling rather than a limit.** (#1295/#1293,
 2026-09-07.) A large translucent panel summoned over the desktop
 is the exact shape the platform now renders in glass, and the
@@ -7020,7 +7020,7 @@ app. The panel's `Shortcuts/` tree was outside `ChromeScanRoots`
 and therefore not partly covered but *silently exempt*, which is
 why it did.
 
-**The reference panel never lists its own opener.** The
+**The shortcuts panel never lists its own opener.** The
 `show_shortcuts` binding (⌃⌥K, seeded per layer since #602) is
 dropped from the panel builder's working set and renders in no
 band — the one deliberate exception to the panel's "no bound

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -3272,7 +3272,7 @@ window verbs. Its float rules work the same way yours do, so a
 KiwiDesk's *other* windows are not managed: the setup tour and
 the Config Issues window are tracked but always floating (each
 one ends, so neither takes a slot), and its panels — the ⌃⌥K
-shortcuts reference, drag/drop overlays, App Bar overlays and
+shortcuts panel, drag/drop overlays, App Bar overlays and
 focus borders — remain fully ignored, which is why they appear
 in no bar and no window list KiwiDesk publishes.
 
@@ -3792,10 +3792,10 @@ applications shortcut carries a per-row **Launch behavior** menu —
 
 **Expects:** nothing.
 
-**Does:** opens the read-only **shortcuts reference** panel — a
+**Does:** opens the read-only **shortcuts panel** — a
 live glance at the active layer's bindings — or closes it if it is
 already open (the verb toggles). Bind it to a hotkey to summon the
-reference from anywhere. This is the same panel reached from the
+panel from anywhere. This is the same panel reached from the
 menu bar's *View Shortcuts…* row; the bound combo also shows beside
 the menu row and in the panel's own close hint. It is seeded to
 **⌃⌥K** by default, in the base layer and in every layer you

--- a/docs/ui-patterns.md
+++ b/docs/ui-patterns.md
@@ -889,7 +889,7 @@ counted has lost its clear button and its menu.
 
 **"+N" governs a bounded container that cannot scroll; content
 past the fold of a SCROLLING container is cued in words
-instead** (#1292). The ⌃⌥K reference panel is the worked case,
+instead** (#1292). The ⌃⌥K shortcuts panel is the worked case,
 and the reason is that N is not reachable there: its bands are
 non-uniform (headers, a caption, two-column layouts), the fold
 cuts *through* a row rather than between rows, and the

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -37,7 +37,7 @@ App Bar, and answers the window shortcuts — float it with
 `toggle_floating`, move it between spaces, resize it. KiwiDesk's
 other windows are not managed that way: the setup tour and the
 Config Issues window always float, because each one ends, and
-the shortcuts reference panel is not a managed window at all,
+the shortcuts panel is not a managed window at all,
 which is why it appears in no bar.
 
 The window opens on **Home** — a grid of cards, one per
@@ -418,7 +418,7 @@ the KiwiDesk icon opens the quick menu where you can:
   answers are unusually slow is finished off just after boot, so
   its windows are tiled a beat later than everything else.
 
-### The Shortcuts Reference
+### The Shortcuts Panel
 
 **View Shortcuts…** opens a floating, read-only panel that mirrors the
 shortcuts bound in the currently active layer — a fast "what can I press


### PR DESCRIPTION
## Description

The ⌃⌥K surface had two names in English. Everything pointing AT
it said **shortcuts panel** — `keybinding.show_shortcuts`, the
three keys #1307 added, the user guide, the Lua reference — while
the panel's own accessibility name said **Shortcuts reference**.
A sighted user read one noun and a VoiceOver user heard another
for one surface, and all ten catalogs faithfully mirrored the
split, which is what a correct translation of a wrong source
looks like.

"shortcuts panel" wins, being the noun every other site already
uses. `shortcuts.panel.ax_label`'s English moves onto it and the
key goes through `drop-key` → `extract-keys` → `merge-keys` for
all ten locales — no catalog hand-edited. Each new value is the
panel noun that locale's own `keybinding.show_shortcuts` and
`colors.glass.caption` already settled on, so `de` — consistent
from the start — round-trips unchanged.

The prose carried a **third** name. `docs/design-decisions.md`'s
three "reference panel" rulings, the user guide's "The Shortcuts
Reference" heading, the Lua reference's "shortcuts reference" and
`show_shortcuts`' CLI help summary all take the settled noun. The
ruling is recorded in `config-vocabulary.md`'s glossary, scoped
to copy rather than identifiers, so none of the three is
re-proposed.

## Related Issue(s)

Closes #1316

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] PR is focused; refactors separated from features

## How I verified

Full gate green: `swift build`, **4894 tests in 938 suites**,
`scripts/lint.sh` OK (`extract-keys --check` included, so the
content guards ran).

The issue said no test was possible. That is true of the general
class — two words for one thing, which
`DestinationNameCollisionTests`' exact-collision predicate cannot
see — and false of this surface, which has a pairing to compare.
`ShortcutsPanelNounTests` asks, per catalog, that the panel's own
name is contained in the string of the shortcut that opens it. It
reads no vocabulary, so it carries none of what Family C says a
guard may not.

`guard-prover` red-proofed it three ways and found two fail-opens,
both now closed and both re-proved: a catalog missing one of the
two keys was SKIPPED rather than reported — which is exactly the
state `drop-key --locale` leaves behind, the split wearing an
English fallback — and the floor counted FILES, so every catalog
losing the key passed having compared nothing. It also showed the
predicate is weaker than the first docstring claimed (containment
is one-directional and substring-based), so the two shapes it
cannot see are now named rather than implied.

## Notes for Reviewer

`localization-auditor` judged all ten drafts. Two it flagged as
worth knowing rather than wrong, both recorded here because
near-equality is what no guard sees: `de`'s `Tastenkürzel-
Übersicht` shares its head noun with `home.back` (`Übersicht`),
and `ru`'s `Панель` is also `ru`'s word for a bar
(`destination.bars` is `Панели`). Both are qualified in context
and were kept; either moving is a catalog-wide sweep of the
opener and the three glass strings, never this key alone.

It also found a pre-existing English defect outside this change:
`discard.*_profile.message` calls the Home surface "dashboard"
while everything else calls it "Home", which is why five catalogs
render the panel noun for it too. Not touched here — the fix
belongs in the English.
