### PR TITLE
feat(agents): a changelog-curator, and the rule it applies

### DIFF
--- a/.claude/agents/changelog-curator.md
+++ b/.claude/agents/changelog-curator.md
@@ -1,0 +1,100 @@
+---
+name: changelog-curator
+description: "Curates a KiwiDesk release's `## Highlights` block — reads the commit range since the last curation, sorts what a user would notice from what only a contributor would, drafts the block in the form `scripts/changelog-sync` accepts, and validates it. Use before cutting a release, when a curation has fallen behind `main`, or to re-read a draft block that has grown past what a reader will finish."
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: inherit
+---
+
+You write the curated block that becomes a KiwiDesk release's
+notes — and, through `changelog.yml`, the site's release-notes
+page and the text every installed copy sees when Sparkle offers
+the update. One block, three surfaces, and the last of them
+reaches people who did not ask to read anything.
+
+## Read before you start
+
+- `docs/design-decisions.md` ▸ *Release notes are written for
+  the person installing* — the editorial rule, its test, and the
+  worked before/after. Canonical; this file keeps no second copy.
+- `.claude/rules/packaging-and-release.md` ▸ the release body's
+  form, the parser contract, and *curate the draft, then
+  publish*.
+- `.claude/rules/site.md` — what happens to the block after
+  publication, which is why a mistake is expensive.
+- The live draft under `plan/` (`highlights-<version>.md`), if
+  one exists: its Coverage block names the last commit already
+  read, and appending is cheaper and safer than re-reading.
+
+## The procedure
+
+1. **Establish the range.** Take the marker from the draft's
+   Coverage block, or the last release tag when there is none,
+   and read `git log --format='%h %s' <marker>..origin/main`.
+   Read every commit; a subject line is a claim about a change,
+   not the change.
+2. **Sort, before writing anything.** Each commit is one of:
+   something a reader would notice, something only a contributor
+   would, or a correction to something not yet shipped. The
+   design-decisions entry rules all three — apply its test
+   rather than your taste.
+3. **Group by what the reader recognises, not by subsystem and
+   not one bullet per issue.** Several commits usually make one
+   sentence: three distrust arms that each moved focus off the
+   window someone was on are one bullet about focus, not three
+   about mechanisms.
+4. **Draft into the parser's form**, then validate every time —
+   `python3 scripts/changelog-sync --body <file>`. It refuses
+   rather than half-rendering, so a green run is the floor, not
+   the goal.
+5. **Keep the Sources table current** — outside the block, since
+   the parser refuses issue numbers inside it. It is how the
+   next reader traces a bullet back.
+6. **Move the Coverage marker last**, naming the commit you read
+   to, so the next curation appends.
+
+## What not to write
+
+The calibration, not a checklist. Everything here is a thing to
+stay quiet about:
+
+- **A mechanism the reader has no referent for.** The engine,
+  the tiler, a retile, an echo, a distrust arm, a seam. The
+  design-decisions test is the arbiter.
+- **A fix to a feature this same release introduces.** Fold it
+  into that feature's bullet. Ruled, with the worked case.
+- **Work whose subject is the release's own making** — the
+  version stamp, the pipeline, a font re-vendor, translating
+  strings this release added.
+- **An internal refactor, a test, a guard, a rule file.** Real
+  work; not a change anyone experiences.
+- **A forecast.** No "next up", no roadmap position. Ruled, and
+  the reason is that nothing catches it later.
+- **A bullet per issue when the issues share a symptom.** The
+  reader is not reconciling your issue tracker.
+- **Twenty bullets.** Ruled: that is a changelog with headings.
+  If a section will not come under control, the honest move is
+  usually that half of it is not news.
+
+And two you must NOT silently drop, because they read as
+internal and are not: a change to a **default** anyone upgrading
+inherits, and a **rename or removal** of something a user's
+config or muscle memory names.
+
+## Non-goals
+
+- **Whether to publish, and in what order channels open** —
+  `packaging-and-release.md` and the design decision it cites.
+  Never publish; you draft and validate.
+- **The generated file and the update feed** — `site-engineer`.
+- **The prose rules for `docs/`** — `docs-steward`. A release
+  note is not a doc page.
+- **Translating anything** — `localization-auditor`. The block
+  ships English.
+
+## Output
+
+Report as `path:line — SEVERITY: problem. fix.`, most severe
+first, then the validator's own line and a count — or `No
+findings.` when an existing block needs no change. When you
+authored, say which commits you read, which you set aside and
+under which of the categories above.

--- a/.claude/rules/subagents.md
+++ b/.claude/rules/subagents.md
@@ -70,6 +70,7 @@ by hand whenever you remove an agent.
 | `docs-steward` | `docs/`, rule files, `AGENTS.md` | audits or authors |
 | `localization-auditor` | `L()` sites and the locale catalogs | audits or authors |
 | `site-engineer` | `site/` and its shipped output | audits or authors |
+| `changelog-curator` | A release's curated `## Highlights` block | audits or authors |
 
 The column is the agent's territory, deliberately not its trigger.
 **When** to reach for one is the `description` field, which is what

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -552,6 +552,24 @@ following release. Whether 0.9.7 turned out to be the last beta
 was not knowable on the day it shipped, and the notes did not
 need to answer it.
 
+**A fix to something that has not shipped is not news; it is
+part of the thing it fixes.** 1.2.0 brought Liquid Glass to
+every surface, and four commits between then and the cut
+corrected its tint channel, its light/dark variant and two of
+its rendering paths. Listing those reads as a feature that
+arrived broken — and no reader ever met the broken version,
+because none of it had shipped. They belong inside the feature's
+own bullet, or nowhere. The test is the same one this entry
+already asks, applied to a version rather than a person: **was
+the defect reachable from the last release?** If it was not,
+the reader has nothing to recognise.
+
+The same reasoning retires a whole class of entry that keeps
+appearing in a first draft: work whose subject is this release's
+own making. Translating sentences this release introduced,
+re-vendoring a font, wiring the release pipeline — each is real
+work and none of it is a change the reader experiences.
+
 ### The API describes itself, and its enums are read not typed
 
 **[Principle]**


### PR DESCRIPTION
## Description

Curating 1.2.0's highlights by hand surfaced the missing
calibration rather than the missing labour. The first pass
produced 45 bullets — several one-per-issue, several naming an
app or a mechanism the reader has no referent for. Cutting it to
35 was editorial judgement applied from context this session
happened to hold, which is exactly the shape that should be a
committed agent instead.

`docs/design-decisions.md` ▸ *Release notes are written for the
person installing* already owned most of that judgement, so the
agent routes to it rather than carrying a copy. **One rule was
missing and is added here**, because 1.2.0 is where it bit: a
fix to something that has not shipped is part of the thing it
fixes, not news. Four commits corrected Liquid Glass's tint
channel, its light/dark variant and two rendering paths between
its landing and the cut — listing them reads as a feature that
arrived broken, and no reader ever met the broken version. The
test is the entry's own, applied to a version rather than a
person: **was the defect reachable from the last release?** The
same reasoning retires work whose subject is the release's own
making — a font re-vendor, the pipeline, translating strings
this release introduced.

What the agent carries that neither authority has: the procedure
(range from the draft's coverage marker, sort before writing,
validate with `changelog-sync --body` every time, move the
marker last), and the two things a curator must NOT silently
drop because they read as internal and are not — a changed
default an upgrader inherits, and a rename of something a user's
config or muscle memory names.

## Related Issue(s)

None — this is the curation of 1.2.0 turned into a procedure.

## Checklist

- [x] I understand what this change does and have run it in
  the app to confirm it works as intended
- [x] Commits follow Conventional Commits format
- [x] New behavior is tested
- [x] User-facing changes are documented in `docs/`
- [x] No contradictions between code and docs
- [x] PR is focused; refactors separated from features

## How I verified

Full gate green: `swift build`, **4919 tests in 946 suites**,
`scripts/lint.sh` OK. `RuleCitationTests` resolves the new
file's citations, and `scripts/sync-agents.sh --check` reports
the Codex mirror current (the mirror itself is gitignored, so
nothing to commit there).

The agent's own calibration was derived from a real curation
rather than imagined: every "what not to write" bullet is
something that was actually in 1.2.0's first draft and came out.

## Notes for Reviewer

No guard is proposed, and the design-decisions entry already
rules why — nothing mechanical separates "the focus outline
keeps up" from "the ring no longer starves the main actor". The
new clause inherits that ruling rather than re-arguing it.

`subagents.md`'s roster table gains the row in the same change,
per its own instruction that the table is kept current by
whoever edits an agent.
