### PR TITLE
fix(profiles): an away window takes the incoming profile's Space

### DIFF
--- a/.claude/rules/state-and-layout.md
+++ b/.claude/rules/state-and-layout.md
@@ -50,6 +50,21 @@ editing here:
   are [profiles.md](profiles.md) ▸ "Whose arrangement is live",
   which is where they load: this file's `paths:` do not reach
   `Sources/KiwiDeskCore/Profiles/**`, where every toucher lives.
+- **A profile's record beats where a window departed from
+  (#1248).** The remembered Space answers ONCE across every
+  profile, so for a window not in state the two authorities
+  disagree and the ledger wins by default — the same window then
+  landing in a different Space depending on whether it happened
+  to be on another Desktop at switch time, which the user cannot
+  see and did not choose. A profile becoming live therefore
+  re-files an absent window it has a record for, through the one
+  `StateCoordinator.refileAway`; a window the profile has never
+  seen keeps its memory, matching the live half's "stays where
+  the prune put it". **Re-filing to the Space a window is ALREADY
+  remembered in is refused rather than a no-op** — the #1207
+  return rank goes with the move, so a redirect that changes
+  nothing spends the slot and the window comes back last after
+  any switch (`AwayProfileSpaceTests`).
 - It follows that **a new per-`Space` field is keyed by
   `WindowID` or it is SHARED across Desktops** — the Desktop
   partition is emergent from window residence, and a per-window
@@ -355,7 +370,9 @@ editing here:
   new bar derivation that merges the ledger is the bug, not a
   feature. A reader that needs a Space's row as it WILL return
   takes `withAwayMembers(_:of:)` — the fold's own rank insert —
-  never a hand merge; a reader keyed by app takes
+  never a hand merge, and a profile's PARTITIONING record is such
+  a reader, since a record that omits what is away forgets it on
+  every switch (#1248); a reader keyed by app takes
   `awayWindows(bundleID:)`. An entry with NO Space (a boot-found
   window nothing has filed) is UNFILED: every reader carries the
   skip branch — `awayMembers(of:)` omits it, `get_state` lists it

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileSpaces.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileSpaces.swift
@@ -20,7 +20,12 @@ extension KiwiCore {
     /// that has applied nothing, has no partitioning of its own.
     func recordLivePartitioning() {
         state.profilePartitioning.record(
-            state.workspaces.allSpaces,
+            state.workspaces.allSpaces.map {
+                Space(
+                    id: $0.id,
+                    windows: withAwayMembers($0.windows, of: $0.id)
+                )
+            },
             as: profiles.currentName
         )
     }
@@ -101,14 +106,30 @@ extension KiwiCore {
             heldSpaceFocus[space.id] = space.focused
         }
         var moved = 0
+        var redirected = 0
         for space in SpaceID.numericLexicalSorted(
             Array(remembered.keys)
         ) {
             guard declared.contains(space),
                 state.workspaces[space] != nil
             else { continue }
-            for window in remembered[space] ?? []
-            where state.windows[window] != nil {
+            for window in remembered[space] ?? [] {
+                guard state.windows[window] != nil else {
+                    // Away on another Desktop (#1146), so there is
+                    // nothing to move — but its DEPARTURE memory
+                    // is what will place it on return, and that
+                    // memory is per-window with one answer across
+                    // profiles. Re-point it, or the away ledger
+                    // decides alone and the window comes back in
+                    // the outgoing profile's Space (#1248).
+                    if state.redirectDeparture(
+                        of: window,
+                        to: space
+                    ) {
+                        redirected += 1
+                    }
+                    continue
+                }
                 let from = state.workspaces.space(of: window)
                 state.workspaces.add(window, to: space)
                 // A float crossing displays must re-anchor
@@ -127,10 +148,12 @@ extension KiwiCore {
             candidate: heldCandidate,
             spaceFocus: heldSpaceFocus
         )
-        if moved > 0 {
+        if moved > 0 || redirected > 0 {
             onLog(
                 "profile '\(profile.name)': restored \(moved) "
                     + "window(s) to their own Spaces"
+                    + (redirected > 0
+                        ? ", \(redirected) away" : "")
             )
         }
     }

--- a/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileSpaces.swift
+++ b/Sources/KiwiDeskCore/Profiles/KiwiCore+ProfileSpaces.swift
@@ -75,11 +75,13 @@ extension KiwiCore {
     /// prune put it, which is the existing setting for exactly
     /// this situation and needs no new concept.
     ///
-    /// Only LIVE windows move: a remembered id can belong to a
+    /// Only LIVE windows MOVE: a remembered id can belong to a
     /// window since closed, or to one sitting on an away Desktop
     /// (#1146), and inserting either would put a phantom in the
-    /// row. The away case comes back through its own memory
-    /// (`rememberedSpaces`), not this one.
+    /// row. Those take the other half — their remembered Space is
+    /// re-filed to this profile's, since it is what places them
+    /// if they come back and it answers once across every profile
+    /// (#1248, `refileAway`).
     ///
     /// A remembered Space the profile no longer declares is
     /// skipped rather than re-created: the prune just dropped it,
@@ -106,7 +108,7 @@ extension KiwiCore {
             heldSpaceFocus[space.id] = space.focused
         }
         var moved = 0
-        var redirected = 0
+        var refiled = 0
         for space in SpaceID.numericLexicalSorted(
             Array(remembered.keys)
         ) {
@@ -115,18 +117,14 @@ extension KiwiCore {
             else { continue }
             for window in remembered[space] ?? [] {
                 guard state.windows[window] != nil else {
-                    // Away on another Desktop (#1146), so there is
-                    // nothing to move — but its DEPARTURE memory
-                    // is what will place it on return, and that
-                    // memory is per-window with one answer across
-                    // profiles. Re-point it, or the away ledger
-                    // decides alone and the window comes back in
-                    // the outgoing profile's Space (#1248).
-                    if state.redirectDeparture(
-                        of: window,
-                        to: space
-                    ) {
-                        redirected += 1
+                    // Not in state: away on another Desktop, or
+                    // closed and still remembered. Its remembered
+                    // Space is what places it if it comes back,
+                    // and that memory answers once across every
+                    // profile — so re-point it, or the profile's
+                    // record loses to it (#1248).
+                    if state.refileAway(of: window, to: space) {
+                        refiled += 1
                     }
                     continue
                 }
@@ -148,12 +146,12 @@ extension KiwiCore {
             candidate: heldCandidate,
             spaceFocus: heldSpaceFocus
         )
-        if moved > 0 || redirected > 0 {
+        if moved > 0 || refiled > 0 {
             onLog(
                 "profile '\(profile.name)': restored \(moved) "
                     + "window(s) to their own Spaces"
-                    + (redirected > 0
-                        ? ", \(redirected) away" : "")
+                    + (refiled > 0
+                        ? ", re-filed \(refiled) absent" : "")
             )
         }
     }

--- a/Sources/KiwiDeskCore/State/StateCoordinator+SpaceMemory.swift
+++ b/Sources/KiwiDeskCore/State/StateCoordinator+SpaceMemory.swift
@@ -53,10 +53,11 @@ extension StateCoordinator {
 
     /// Re-files a departure the destroy fold just recorded under
     /// the Space an explicit Desktop-move target named (#1150).
-    /// The one writer of `rememberedSpaces` OUTSIDE a fold, and
-    /// safe as one because it runs in the same synchronous arm
-    /// as that fold, before any reader: `forgetGoneWindow` reads
-    /// nothing of it, and the away ledger files the NATIVE Space.
+    /// A writer of `rememberedSpaces` OUTSIDE a fold — `refileAway`
+    /// is the other (#1248) — and safe as one because it runs in
+    /// the same synchronous arm as that fold, before any reader:
+    /// `forgetGoneWindow` reads nothing of it, and the away
+    /// ledger files the NATIVE Space.
     /// The `.departed` memory takes the name and the slot rank is
     /// dropped, a rank meaning something only in the Space it was
     /// taken in; rankless, the create fold's spawn placement is
@@ -73,6 +74,39 @@ extension StateCoordinator {
             return false
         }
         rememberedSpaces[id] = .departed(space)
+        departedSlots[id] = nil
+        return true
+    }
+
+    /// Re-points an AWAY window's remembered Space at the one the
+    /// incoming profile records for it (#1248), keeping the kind:
+    /// a watched departure stays `.departed`, a boot-seeded
+    /// `.restored` filing stays restored — the population most
+    /// likely to be away across a switch is the one a restart
+    /// seeded, so it cannot be the case this skips.
+    ///
+    /// A same-space call is REFUSED rather than made a silent
+    /// no-op: the rank goes with the move (it means something
+    /// only in the Space it was taken in), so redirecting a
+    /// window to where it already is would spend its #1207 return
+    /// slot for nothing, on every switch.
+    ///
+    /// `redirectDeparture` is the other writer and stays separate:
+    /// it answers #1150's explicit Desktop-move target, is
+    /// `.departed`-only by ruling, and runs in the destroy fold's
+    /// own arm.
+    @discardableResult
+    mutating func refileAway(
+        of id: WindowID,
+        to space: SpaceID
+    ) -> Bool {
+        guard let current = rememberedSpaces[id],
+            current.space != space
+        else { return false }
+        switch current {
+        case .departed: rememberedSpaces[id] = .departed(space)
+        case .restored: rememberedSpaces[id] = .restored(space)
+        }
         departedSlots[id] = nil
         return true
     }

--- a/Tests/KiwiDeskCoreTests/AwayProfileSpaceTests.swift
+++ b/Tests/KiwiDeskCoreTests/AwayProfileSpaceTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// A window away on another Desktop keeps the wrong Space across
+/// a profile switch (#1248).
+///
+/// The away ledger and the per-profile partitioning (#1230) are
+/// two authorities over one question — which Space a window
+/// belongs to — and for an away window the ledger answers alone:
+/// `restorePartitioning` skips a remembered id whose window is
+/// not in state, correctly, and nothing else re-asserts the
+/// incoming profile's placement.
+@Suite("An away window follows the profile (#1248)", .serialized)
+@MainActor
+struct AwayProfileSpaceTests {
+    private func makeCore() -> KiwiCore {
+        makeTestCore(
+            configDirectory: FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(
+                    "kiwi-awayprofile-\(UUID().uuidString)"
+                )
+        )
+    }
+
+    private func profile(
+        _ name: String,
+        spaces: [SpaceID]
+    ) -> Profile {
+        Profile(
+            name: name,
+            monitorSets: [],
+            spaces: spaces,
+            spaceModes: Dictionary(
+                uniqueKeysWithValues: spaces.map { ($0, .bsp) }
+            ),
+            settings: TilingSettings()
+        )
+    }
+
+    private func live(_ core: KiwiCore, _ ids: [Int]) {
+        for id in ids {
+            core.state.windows.upsert(
+                ManagedWindow(
+                    id: WindowID(UInt32(id)),
+                    pid: 1,
+                    appName: "App\(id)"
+                )
+            )
+        }
+    }
+
+    /// Sends `id` to another Desktop: out of state, into the away
+    /// ledger, with the `.departed` memory the return reads.
+    private func sendAway(
+        _ core: KiwiCore,
+        _ id: WindowID,
+        from space: SpaceID
+    ) {
+        core.state.rememberedSpaces[id] = .departed(space)
+        core.state.awayWindows[id] = AwayWindow(
+            id: id,
+            pid: 1,
+            appName: "App",
+            appBundleID: nil,
+            nativeSpace: SkyLight.SpaceID(9),
+            isUp: true
+        )
+        core.state.workspaces.remove(id)
+        core.state.windows.remove(id)
+    }
+
+    /// Brings it back, as the create fold does on arrival.
+    private func bringBack(_ core: KiwiCore, _ id: WindowID) {
+        var effects = AppliedEffects()
+        core.state.applyWindowCreated(
+            ManagedWindow(id: id, pid: 1, appName: "App"),
+            effects: &effects
+        )
+    }
+
+    private func members(
+        _ core: KiwiCore,
+        _ space: SpaceID
+    ) -> [WindowID] {
+        core.state.workspaces[space]?.windows ?? []
+    }
+
+    /// The measured repro from the issue.
+    @Test("A window away across a switch lands in B's Space")
+    func awayWindowFollowsTheIncomingProfile() {
+        let core = makeCore()
+        let a = profile("A", spaces: ["1", "2"])
+        let b = profile("B", spaces: ["1", "2"])
+        live(core, [1])
+
+        // Under A, w1 sits in Space 1.
+        core.apply(profile: a, forceRetile: false)
+        core.state.workspaces.add(WindowID(1), to: "1")
+        // Under B, the user moves it to Space 2, so B's
+        // partitioning records it there when B goes inactive.
+        core.apply(profile: b, forceRetile: false)
+        core.state.workspaces.add(WindowID(1), to: "2")
+        core.apply(profile: a, forceRetile: false)
+        #expect(members(core, "1") == [WindowID(1)])
+
+        // It goes away to another Desktop, then the profile
+        // switches to B while it is gone.
+        sendAway(core, WindowID(1), from: "1")
+        core.apply(profile: b, forceRetile: false)
+
+        bringBack(core, WindowID(1))
+        // B's own record wants it in Space 2.
+        #expect(members(core, "2") == [WindowID(1)])
+        #expect(members(core, "1").isEmpty)
+    }
+}

--- a/Tests/KiwiDeskCoreTests/AwayProfileSpaceTests.swift
+++ b/Tests/KiwiDeskCoreTests/AwayProfileSpaceTests.swift
@@ -115,6 +115,14 @@ struct AwayProfileSpaceTests {
         sendAway(core, WindowID(1))
         core.apply(profile: b, forceRetile: false)
 
+        // Re-filed to B's Space, and still a WATCHED departure:
+        // the other kind is `.restored`, and promoting or
+        // demoting one is invisible to a placement assertion.
+        #expect(
+            core.state.rememberedSpaces[WindowID(1)]
+                == .departed("2")
+        )
+
         bringBack(core, WindowID(1))
         // B's own record wants it in Space 2.
         #expect(members(core, "2") == [WindowID(1)])
@@ -197,6 +205,120 @@ struct AwayProfileSpaceTests {
         #expect(
             members(core, "1")
                 == [WindowID(1), WindowID(2), WindowID(3)]
+        )
+    }
+
+    /// A boot-seeded away window is filed `.restored`, not
+    /// `.departed` — and a restart is the likeliest way to be
+    /// away across a switch, so the re-file must reach it AND
+    /// leave the kind alone.
+    ///
+    /// The kind is load-bearing elsewhere: `redirectDeparture`
+    /// refuses anything but `.departed`, `rememberDepartedSlot`
+    /// filters on it, and #1010's screen-home answers only for a
+    /// departure the fold WATCHED. Promoting a boot filing into a
+    /// watched departure, or demoting one, both shipped green
+    /// (`guard-prover`, 2026-09-08).
+    @Test("A restored filing is re-filed and stays restored")
+    func aRestoredFilingKeepsItsKind() {
+        let core = makeCore()
+        let a = profile("A", spaces: ["1", "2"])
+        let b = profile("B", spaces: ["1", "2"])
+        live(core, [1])
+
+        // Give B a record placing w1 in Space 2.
+        core.apply(profile: b, forceRetile: false)
+        core.state.workspaces.add(WindowID(1), to: "2")
+        core.apply(profile: a, forceRetile: false)
+
+        // Now the boot-seed shape: away, filed `.restored` in
+        // Space 1, with no watched departure behind it.
+        core.state.windows.remove(WindowID(1))
+        core.state.workspaces.remove(WindowID(1))
+        core.state.remember(WindowID(1), in: "1")
+        core.state.awayWindows[WindowID(1)] = AwayWindow(
+            id: WindowID(1),
+            pid: 1,
+            appName: "App",
+            appBundleID: nil,
+            nativeSpace: SkyLight.SpaceID(9),
+            isUp: true
+        )
+
+        core.apply(profile: b, forceRetile: false)
+        #expect(
+            core.state.rememberedSpaces[WindowID(1)]
+                == .restored("2"),
+            Comment(
+                rawValue:
+                    "B's record must re-file it, and a boot "
+                    + "filing must not become a watched departure"
+            )
+        )
+    }
+
+    /// The mirror of the same-Space refusal: a REAL move drops
+    /// the rank, because a rank means something only in the Space
+    /// it was taken in. Keeping it shipped green — only the
+    /// refusal direction was held (`guard-prover`, 2026-09-08).
+    @Test("A cross-Space re-file drops the return rank")
+    func aCrossSpaceRefileDropsTheRank() {
+        let core = makeCore()
+        let a = profile("A", spaces: ["1", "2"])
+        let b = profile("B", spaces: ["1", "2"])
+        live(core, [1, 2])
+
+        // B remembers w1 in Space 2; A leaves it in Space 1.
+        core.apply(profile: b, forceRetile: false)
+        core.state.workspaces.add(WindowID(1), to: "2")
+        core.apply(profile: a, forceRetile: false)
+        core.state.workspaces.add(WindowID(1), to: "1")
+        core.state.workspaces.add(WindowID(2), to: "1")
+        sendAway(core, WindowID(1))
+        #expect(core.state.departedSlots[WindowID(1)] != nil)
+
+        // B re-files it into Space 2 — a different Space, so the
+        // rank it took in Space 1 no longer means anything.
+        core.apply(profile: b, forceRetile: false)
+        #expect(
+            core.state.rememberedSpace(of: WindowID(1)) == "2"
+        )
+        #expect(core.state.departedSlots[WindowID(1)] == nil)
+    }
+
+    /// A re-file re-points an EXISTING memory; it never mints
+    /// one. A profile record can name a window whose memory has
+    /// already been retired — `forgetAway` nils it on a census
+    /// prune or an app exit — and a switch must not hand that
+    /// window a departure nothing observed (`guard-prover`,
+    /// 2026-09-08).
+    @Test("A re-file mints no memory where none existed")
+    func aRefileMintsNoMemory() {
+        let core = makeCore()
+        let a = profile("A", spaces: ["1", "2"])
+        let b = profile("B", spaces: ["1", "2"])
+        live(core, [1])
+
+        core.apply(profile: a, forceRetile: false)
+        core.state.workspaces.add(WindowID(1), to: "2")
+        // The switch captures A's record while w1 is still LIVE,
+        // so the record names it. Only then does it go away and
+        // have its memory retired outright — a census prune or an
+        // app exit. A's record still names an id nothing has a
+        // remembered Space for, which is the state the guard is
+        // about, and it is unreachable if the memory is retired
+        // before the record is taken (measured 2026-09-08).
+        core.apply(profile: b, forceRetile: false)
+        sendAway(core, WindowID(1))
+        core.state.forgetAway(WindowID(1))
+        #expect(
+            core.state.rememberedSpaces[WindowID(1)] == nil
+        )
+
+        core.apply(profile: a, forceRetile: false)
+        #expect(
+            core.state.rememberedSpaces[WindowID(1)] == nil,
+            "a profile switch minted a departure nothing observed"
         )
     }
 }

--- a/Tests/KiwiDeskCoreTests/AwayProfileSpaceTests.swift
+++ b/Tests/KiwiDeskCoreTests/AwayProfileSpaceTests.swift
@@ -52,14 +52,20 @@ struct AwayProfileSpaceTests {
         }
     }
 
-    /// Sends `id` to another Desktop: out of state, into the away
-    /// ledger, with the `.departed` memory the return reads.
-    private func sendAway(
-        _ core: KiwiCore,
-        _ id: WindowID,
-        from space: SpaceID
-    ) {
-        core.state.rememberedSpaces[id] = .departed(space)
+    /// Sends `id` to another Desktop. The DESTROY FOLD does the
+    /// departure, so the `.departed` memory and the #1207 rank are
+    /// written the way production writes them — hand-filing the
+    /// memory alone leaves `departedSlots` empty, and a fixture
+    /// with no rank cannot see a rank being spent (code review,
+    /// 2026-09-08). The ledger entry is the away half the
+    /// compositor census would file.
+    private func sendAway(_ core: KiwiCore, _ id: WindowID) {
+        var effects = AppliedEffects()
+        core.state.applyWindowDestroyed(
+            id,
+            wasMinimized: false,
+            effects: &effects
+        )
         core.state.awayWindows[id] = AwayWindow(
             id: id,
             pid: 1,
@@ -68,8 +74,6 @@ struct AwayProfileSpaceTests {
             nativeSpace: SkyLight.SpaceID(9),
             isUp: true
         )
-        core.state.workspaces.remove(id)
-        core.state.windows.remove(id)
     }
 
     /// Brings it back, as the create fold does on arrival.
@@ -108,12 +112,91 @@ struct AwayProfileSpaceTests {
 
         // It goes away to another Desktop, then the profile
         // switches to B while it is gone.
-        sendAway(core, WindowID(1), from: "1")
+        sendAway(core, WindowID(1))
         core.apply(profile: b, forceRetile: false)
 
         bringBack(core, WindowID(1))
         // B's own record wants it in Space 2.
         #expect(members(core, "2") == [WindowID(1)])
         #expect(members(core, "1").isEmpty)
+    }
+
+    /// The other half: the outgoing record must not FORGET a
+    /// window that is away. It recorded `workspaces.allSpaces`,
+    /// and an away window is not in state, so every switch
+    /// silently dropped whatever was on another Desktop.
+    ///
+    /// It takes A→B→A with the window away THROUGHOUT and the two
+    /// profiles disagreeing about its Space. Simpler shapes do
+    /// not discriminate: if the window's memory already names the
+    /// Space its profile records, re-filing is a no-op and the
+    /// record carrying it changes nothing (measured 2026-09-08 —
+    /// the first draft of this test passed with the half
+    /// reverted). Here B re-points the memory to Space 1 on the
+    /// way out, so only A's own record can bring it back to 2.
+    @Test("A profile's record keeps a window that is away")
+    func theRecordKeepsAnAwayWindow() {
+        let core = makeCore()
+        let a = profile("A", spaces: ["1", "2"])
+        let b = profile("B", spaces: ["1", "2"])
+        live(core, [1])
+
+        // A puts w1 in Space 2; B puts it in Space 1.
+        core.apply(profile: a, forceRetile: false)
+        core.state.workspaces.add(WindowID(1), to: "2")
+        core.apply(profile: b, forceRetile: false)
+        core.state.workspaces.add(WindowID(1), to: "1")
+        core.apply(profile: a, forceRetile: false)
+        #expect(members(core, "2") == [WindowID(1)])
+
+        // Away it goes, and stays away across both switches.
+        sendAway(core, WindowID(1))
+        core.apply(profile: b, forceRetile: false)
+        #expect(
+            core.state.rememberedSpace(of: WindowID(1)) == "1",
+            "B's record should have re-filed it to Space 1"
+        )
+        core.apply(profile: a, forceRetile: false)
+
+        bringBack(core, WindowID(1))
+        // Only A's record — taken while the window was away —
+        // can carry it back to Space 2.
+        #expect(members(core, "2") == [WindowID(1)])
+        #expect(members(core, "1").isEmpty)
+    }
+
+    /// A redirect spends the #1207 return rank, because a rank
+    /// means something only in the Space it was taken in. So a
+    /// record naming the Space the window is ALREADY remembered
+    /// in must not fire one — otherwise every away window loses
+    /// its slot on every profile switch, and comes back last
+    /// (code review, 2026-09-08).
+    @Test("A same-Space record keeps the return rank")
+    func aSameSpaceRecordKeepsTheRank() {
+        let core = makeCore()
+        let a = profile("A", spaces: ["1", "2"])
+        let b = profile("B", spaces: ["1", "2"])
+        live(core, [1, 2, 3])
+
+        core.apply(profile: a, forceRetile: false)
+        for id in [1, 2, 3] {
+            core.state.workspaces.add(WindowID(UInt32(id)), to: "1")
+        }
+        // The middle window leaves, so its rank is 1.
+        sendAway(core, WindowID(2))
+        let rank = core.state.departedSlots[WindowID(2)]
+        #expect(rank != nil)
+
+        // Both profiles record it in Space 1, so neither switch
+        // has anything to re-point.
+        core.apply(profile: b, forceRetile: false)
+        core.apply(profile: a, forceRetile: false)
+        #expect(core.state.departedSlots[WindowID(2)] == rank)
+
+        bringBack(core, WindowID(2))
+        #expect(
+            members(core, "1")
+                == [WindowID(1), WindowID(2), WindowID(3)]
+        )
     }
 }


### PR DESCRIPTION
## What & why

The away ledger and the per-profile partitioning (#1230) were **two
authorities over one question** — which Space a window belongs to — and for
a window away on another Desktop the ledger answered alone. It came back
where the *outgoing* profile had it.

Reproduced before any fix, from the issue's own probe.

fixes #1248

## The ruling this embeds

> Where the incoming profile has a record for an away window, that record
> beats where the window departed from.

`restorePartitioning` **already** does exactly this for a window that is
*present*. Treating an away one differently means the same window lands in a
different Space depending on whether it happened to be on another Desktop at
switch time — a condition the user cannot see and did not choose. A window
the profile has never seen keeps its memory, matching the live half's "stays
where the prune put it".

It lives in `.claude/rules/state-and-layout.md`, not only here.
`code-reviewer` was asked to rule independently and would rule the same way.

## How

Two halves, both in the #1230 door:

1. `recordLivePartitioning` records through the one `withAwayMembers`, so
   the outgoing record no longer silently drops whatever sat on another
   Desktop. (§5 names that door for "a reader that needs the row as it will
   return"; a partitioning record is bookkeeping, not a bar row, so #1228
   does not bite.)
2. `restorePartitioning` re-files an absent window's remembered Space to the
   one the incoming profile names, through a new
   `StateCoordinator.refileAway`. The two authorities are reconciled at the
   switch rather than racing at the arrival.

`refileAway` stays separate from `redirectDeparture` (#1150), which answers
an explicit Desktop-move target, is `.departed`-only by ruling, and runs in
the destroy fold's own arm.

## What review and the prover caught

A blocker and four silent gaps, none of which reddened anything:

- **The redirect fired unconditionally**, and re-filing clears the #1207
  return rank. A record naming the Space a window was *already* in destroyed
  its slot for nothing — every away window would come back **last** after any
  switch. The fixture hand-wrote the departure memory without the rank the
  destroy fold writes beside it, so it structurally could not see a rank
  being spent. It drives `applyWindowDestroyed` now.
- **`redirectDeparture` is `.departed`-only**, and the boot seed files away
  windows as `.restored` — so the first cut declined exactly the population
  most likely to be away across a switch.
- **The record half had no test that reds when reverted**, and neither did
  its first replacement. It takes A→B→A with the window away *throughout*
  and the profiles disagreeing.
- **Three claims my own docstrings made shipped unguarded** — the memory's
  kind (both directions), dropping the rank on a real move, and never
  minting a memory. Each left all 4950 tests green.

Two of those fixtures did not reach the state they named on the first cut,
and the mutations said so. Every half is now proved by reverting it.

## Verification

Gate green at each commit: `swift build`, 4953 tests in 951 suites,
`scripts/lint.sh`. Release build skipped — no concurrency or `Sendable`
change.

Core-only. The behaviour change is the ruling above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRZ2bk8tiU1GwQbsvjT6dr
