### PR TITLE
fix(site): let the compare table breathe, and label its blocks

### DIFF
--- a/site/node_modules
+++ b/site/node_modules
@@ -1,0 +1,1 @@
+/Users/maikelhajiabadi/Desktop/Second_Brain/3_Ressourcen/Github/KiwiDesk/site/node_modules

--- a/site/src/components/Compare.astro
+++ b/site/src/components/Compare.astro
@@ -965,16 +965,23 @@ const jsonLd = [
   }
   /* MINOR — centring the numeral is right for a one-line heading
      and wrong for two, and every anchor title wraps at 375px. */
+  /* The two labels are a matched PAIR — same size, weight and
+     ink — because each one opens a block and the reader is meant
+     to weigh the halves against each other. Coloured apart (one
+     accent, one dim) the second read as a caption rather than as
+     a heading, and dropped out of the scan (owner, 2026-09-08).
+     Not underlined, for the same reason: the card's own title is
+     a link and its body carries more, so an underlined label
+     reads as a third one. */
   .cmp__label {
     margin: 0 0 0.3rem;
-    font-size: 0.72rem;
-    font-weight: 650;
-    letter-spacing: 0.1em;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--accent);
+    color: var(--text);
   }
   .cmp__label--diff {
-    color: var(--text-dim);
     margin-top: 0;
   }
   .cmp__chips {

--- a/site/src/components/Compare.astro
+++ b/site/src/components/Compare.astro
@@ -565,13 +565,17 @@ const jsonLd = [
      every locale wraps at a different place (German needs roughly
      a third more room than English for the same cell), so a table
      tuned until the English fits on one line is a table that
-     breaks in the other two. Two lines is a fine cell. What makes
+     breaks in the other two. Two lines is a fine cell — the
+     widths above are sized so the LONGEST shipped cell label
+     ("Bedienungshilfen", measured 6.4 pt short before this) has
+     one line to sit on, not so that any given locale never
+     wraps. What makes
      wrapping read as accidental is neighbours that do not wrap
      hugging the top of the row — which `vertical-align` below
      fixes once, for every language. */
   @media (min-width: 76rem) {
     .cmp__scroll {
-      margin-inline: -6rem;
+      margin-inline: -8rem;
     }
   }
   .cmp__table {
@@ -582,7 +586,7 @@ const jsonLd = [
     font-size: 0.9rem;
   }
   .cmp__table th:first-child {
-    width: 22%;
+    width: 20%;
   }
   .cmp__table th,
   .cmp__table td {
@@ -591,6 +595,12 @@ const jsonLd = [
     vertical-align: middle;
     border-bottom: 1px solid var(--border);
     line-height: 1.4;
+    /* `hyphens` first, `overflow-wrap` as the last resort: a
+       German compound is broken at a syllable with a visible
+       hyphen instead of shedding its final letter onto a line of
+       its own, which reads as a bug rather than as a wrap.
+       Needs the page's `lang`, which PageShell sets. */
+    hyphens: auto;
     overflow-wrap: break-word;
   }
   .cmp__table thead th {
@@ -813,20 +823,47 @@ const jsonLd = [
   }
   /* What a tool is genuinely good at is set off as a quote-like
      callout, so conceding reads as deliberate rather than as
-     throat-clearing before the pitch. */
+     throat-clearing before the pitch.
+
+     Its LABEL is inside the callout, not above it: outside, the
+     card read as one run of prose with two small captions in it,
+     and the second heading did not announce a second block
+     (owner, 2026-09-08). The tint and rule are declared once on
+     the card and worn by both, since a band split across two
+     elements has to match exactly or the seam shows. */
+  .cmp__tool {
+    --cmp-good-tint: color-mix(
+      in srgb,
+      var(--accent-deep) 10%,
+      transparent
+    );
+    --cmp-good-rule: color-mix(
+      in srgb,
+      var(--accent) 22%,
+      transparent
+    );
+  }
+  .cmp__tool p.cmp__label:not(.cmp__label--diff) {
+    margin: 0 -1.5rem;
+    padding: 0.8rem 1.5rem 0;
+    background: var(--cmp-good-tint);
+    border-top: 1px solid var(--cmp-good-rule);
+    /* The prose measure caps every other `p` in the card; here
+       it would stop the tint short of the paragraph's own edge
+       and leave a notch in the band. */
+    max-width: none;
+  }
   .cmp__tool p.cmp__good {
     color: var(--text);
-    margin: 0 -1.5rem 0.9rem;
-    padding: 0.85rem 1.5rem;
-    background: color-mix(in srgb, var(--accent-deep) 10%, transparent);
-    border-top: 1px solid
-      color-mix(in srgb, var(--accent) 22%, transparent);
-    border-bottom: 1px solid
-      color-mix(in srgb, var(--accent) 22%, transparent);
+    margin: 0 -1.5rem 1.1rem;
+    padding: 0.35rem 1.5rem 0.85rem;
+    background: var(--cmp-good-tint);
+    border-bottom: 1px solid var(--cmp-good-rule);
     max-width: none;
   }
   @media (max-width: 34rem) {
-    .cmp__tool p.cmp__good {
+    .cmp__tool p.cmp__good,
+    .cmp__tool p.cmp__label:not(.cmp__label--diff) {
       margin-inline: -1.1rem;
       padding-inline: 1.1rem;
     }
@@ -938,10 +975,7 @@ const jsonLd = [
   }
   .cmp__label--diff {
     color: var(--text-dim);
-    margin-top: 0.2rem;
-  }
-  .cmp__tool p.cmp__good {
-    padding-top: 0.5rem;
+    margin-top: 0;
   }
   .cmp__chips {
     display: flex;


### PR DESCRIPTION
Two things you caught on `/compare/` today. Both verified in `site/dist` after a clean build, at four viewport widths, in all three locales.

## 1. "Bedienungshilfen" no longer orphans its last letter

**Measured, not guessed:** the cell needed **114.1 pt** and had **107.7 pt** — 6.4 pt short, in six columns, at *every* viewport ≥ 1216 px (the table is capped at 1038 px by `main.cmp`'s `max-width`, so a bigger screen never helped).

- `.cmp__scroll` bleed `-6rem` → `-8rem` (table 1038 → 1102 px)
- row-label column `22%` → `20%` — affordable: its longest shipped value ("macOS-Schreibtische") needs 152 pt of the 201 it had
- result: **119.7 pt available vs 114.1 needed**, one line, ~5.6 pt of slack

No page overflow at 1216 (the media-query threshold), 1280, 1512 or 1920.

## 2. Long German compounds hyphenate instead of shedding letters

The table's own comment rules that cells **must** be free to wrap, so this does not chase one-line cells. It changes *how* they break: `hyphens: auto` turns "Eingabeüberwa/chung" into "Eingabeüberwa-/chung". Needs the page `lang`, which PageShell sets.

## 3. The two halves of a tool card now read as two

The **"Was es gut macht"** label sat *outside* the tinted callout it introduces, and the **"Wie sich KiwiDesk unterscheidet"** label was a dim caption in the same flow — so the card read as one run of prose with two small captions rather than two labelled blocks.

The label moves **inside** the band. Each half is now `[label + body]`, the band's own bottom rule separates them, and the second heading is a real start.

**Not underlined, deliberately** — the card is full of links (the tool name is one), so an underlined label would read as another.

The tint and rule are declared once as custom properties on `.cmp__tool` and worn by both elements: a band split across two elements has to match exactly or the seam shows. The label also needs `max-width: none` — the prose measure caps every other `p` in the card and left a notch in the band on the first cut (caught in the render, fixed).

## Verification

- `npm run build` → 37 pages; `extract-keys --site --check` OK; `check-site-tokens.py --dist dist` OK (365 `var(--x)` names resolve, up 2 for the new tokens); unreleased-marker checks OK.
- Change is entirely under `site/**`, which is on `.github/ci-ignore.txt`, so the Swift gate cannot be affected and was skipped per the verify-gate skill's own rule.
- No guard owed or added: nothing here is a decision a source scan can hold — the widths are typography, and `check-site-tokens.py` already holds that the custom properties resolve.

Rendered before/after went to you in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDVzXqPpskdH7ABQygvxPo