### PR TITLE
fix(site): untrack site/node_modules, and close the gap that let it in

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,5 +1,8 @@
 # Astro / Node build artifacts
-node_modules/
+# No trailing slash: `node_modules/` matches a DIRECTORY only, and
+# a symlink of that name slips past it into `git add -A` — which
+# is how an absolute, machine-specific link reached main (#1339).
+node_modules
 dist/
 .astro/
 .cache/

--- a/site/node_modules
+++ b/site/node_modules
@@ -1,1 +1,0 @@
-/Users/maikelhajiabadi/Desktop/Second_Brain/3_Ressourcen/Github/KiwiDesk/site/node_modules


### PR DESCRIPTION
**My error, and it is on `main`.** PR #1339 carried a stray `site/node_modules` — a symlink pointing at an absolute path on one machine, and self-referential there. It came from a `git add -A` in a worktree where I had linked `node_modules` to save an `npm ci`.

## Why it is worth a PR rather than a quiet delete

`site/.gitignore` said `node_modules/`. **The trailing slash makes the pattern match a directory only**, so a *symlink* of that name was never ignored and staged happily. Removing the file without dropping the slash leaves the same door open for the next person who does the same thing.

## What it costs while it sits there

In a checkout that has it, `astro build` exits **194 with no output at all**, and `check-site-tokens.py --dist` then reports a missing `dist/404.html` — which reads like the #635 route bug rather than a broken toolchain. It cost me a while to find, from the wrong end.

## Why CI was green

The site job runs `npm ci`, which replaces whatever sits at that path before anything reads it. So the artifact was never wrong — only the tree was.

## Verification

- `git check-ignore -v site/node_modules` → `site/.gitignore:5:node_modules`, so the pattern now catches both shapes.
- No source change; nothing under `site/src`, so the built output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDVzXqPpskdH7ABQygvxPo