### PR TITLE
test(settings): close three escapes in the Desktop help guard

### DIFF
--- a/Tests/KiwiDeskGuiTests/ShortcutsDesktopHelpTests.swift
+++ b/Tests/KiwiDeskGuiTests/ShortcutsDesktopHelpTests.swift
@@ -24,7 +24,16 @@ import Testing
 ///
 /// The scan that remains watches PLACEMENT, which has no runtime
 /// value to compare: whether the `?` is the header's sibling or
-/// a row inside the drawer is a fact about the view tree.
+/// a row inside the drawer is a fact about the view tree — and
+/// what that door is HANDED, since the equality watches a
+/// property while the door renders an argument.
+///
+/// One hole is known and left: the interpolation clause compares
+/// against the label AS THIS HOST RENDERS IT, so a label
+/// hardcoded in the host's own language passes. Pinning a locale
+/// would only move which language is fooled, and it would
+/// mutate process-global state for a clause that is not the
+/// suite's subject (round 3, 2026-09-08).
 ///
 /// Main-actor spend (tests.md): two `makeTestModel` builds and
 /// one `ShortcutsFamilyRows` fixture, as its sibling suite.
@@ -143,9 +152,22 @@ struct ShortcutsDesktopHelpTests {
             )
         )
         #expect(accessory.contains("HelpButton("))
+        // What the door is HANDED, not merely that it exists.
+        // The equality above watches `helpText`; the shipped
+        // sentence is this argument, and the two are only the
+        // same string while nothing sits between them —
+        // `explanation: helpText + doorNote` and a second
+        // property rendered here instead both shipped two
+        // sentences past an earlier cut (guard-prover round 3,
+        // 2026-09-08).
+        #expect(accessory.contains("explanation:helpText,"))
         // Each door names ITSELF: a fixed subject would have
         // both announcing one drawer to VoiceOver.
         #expect(accessory.contains("subject:drawer.control.text"))
+        // …and it is the ONLY door in the file: a second `?`
+        // inside the drawer leaves this run untouched, so
+        // nothing above can see one.
+        #expect(source.occurrences(of: "HelpButton(") == 1)
     }
 
     /// A mount hands the offer its rows and its door, never its


### PR DESCRIPTION
Follow-up to #1342 (#1114). `guard-prover` round 3 red-proofed all three tests of `ShortcutsDesktopHelpTests` and then walked past them three ways, each shipping **two different sentences on the two Desktop doors** with the suite green:

| escape | why it got through |
|---|---|
| `explanation: helpText + doorNote` | the equality watches the **property**; the door renders an **argument**, and nothing said they were the same string |
| a second property (`mountText`) rendered in the accessory instead of `helpText` | same seam — `helpText` stays equal, and unused |
| a second, unanchored `?` inside the drawer, differing per door | the header's own accessory run is untouched, so nothing above could see it |

Two clauses close all three: pin **what the door is handed** (`explanation:helpText,`), and **count the doors** (`HelpButton(` exactly once in the offer). I mutated the last two back in and confirmed each now reds before pushing.

## One hole stays, deliberately, and is written down beside the clause

The #818 interpolation check compares against the profiles-drawer label **as this host renders it**, so a label hardcoded in the host's own language passes — on a German host an English hardcode is caught, on an English CI runner it is not. Pinning a locale would only change which language is fooled, and would mutate process-global state for a clause that is not this suite's subject. Stated in the docstring rather than left for the next prover round to rediscover.

## Verification

`swift build` OK · **4959 tests in 952 suites passed** · `scripts/lint.sh` exit 0. Test-only change; release build skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDVzXqPpskdH7ABQygvxPo