### PR TITLE
fix(commands): a Desktop switch that changes nothing reports itself

### DIFF
--- a/Sources/KiwiDeskCore/Commands/KiwiCore+DesktopSwitch.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+DesktopSwitch.swift
@@ -16,25 +16,26 @@ extension KiwiCore {
         case switched
         case refused(CommandResponse)
 
-        /// The stand-down's one sentence, so the response and the
-        /// log cannot drift into naming different events — a log
-        /// line carrying the verb but another event's wording is
-        /// what a guard on the verb alone cannot see (prover
-        /// round 1, #1336).
+        /// One home for the sentence, so the payload and the log
+        /// cannot name different events (#1336).
         static let alreadyShownNote =
             "that Desktop is already showing"
 
-        /// `.alreadyShown` answers SUCCESS carrying a note, never
-        /// a bare `.ok()` (#1336): the caller asked for a switch
-        /// and got none, and an empty success is indistinguishable
-        /// from one that moved the screen — the CLI prints nothing
-        /// and exits 0. Success rather than a refusal so a caller
-        /// ENSURING a Desktop is shown still succeeds.
+        /// Both arms report `switched` so a caller reads a FIELD
+        /// rather than the payload's presence, and it describes
+        /// the SWITCH alone — a follow's stand-down arm still
+        /// moved the window (#1336).
         var response: CommandResponse {
             switch self {
             case .alreadyShown:
-                .ok(.string(Self.alreadyShownNote))
-            case .switched: .ok()
+                .ok(
+                    .object([
+                        "switched": .bool(false),
+                        "note": .string(Self.alreadyShownNote),
+                    ])
+                )
+            case .switched:
+                .ok(.object(["switched": .bool(true)]))
             case .refused(let response): response
             }
         }

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+DesktopSwitch.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+DesktopSwitch.swift
@@ -16,6 +16,14 @@ extension KiwiCore {
         case switched
         case refused(CommandResponse)
 
+        /// The stand-down's one sentence, so the response and the
+        /// log cannot drift into naming different events — a log
+        /// line carrying the verb but another event's wording is
+        /// what a guard on the verb alone cannot see (prover
+        /// round 1, #1336).
+        static let alreadyShownNote =
+            "that Desktop is already showing"
+
         /// `.alreadyShown` answers SUCCESS carrying a note, never
         /// a bare `.ok()` (#1336): the caller asked for a switch
         /// and got none, and an empty success is indistinguishable
@@ -25,7 +33,7 @@ extension KiwiCore {
         var response: CommandResponse {
             switch self {
             case .alreadyShown:
-                .ok(.string("that Desktop is already showing"))
+                .ok(.string(Self.alreadyShownNote))
             case .switched: .ok()
             case .refused(let response): response
             }
@@ -63,7 +71,7 @@ extension KiwiCore {
         verb: String
     ) -> DesktopSwitchOutcome {
         guard !target.isCurrent else {
-            onLog("\(verb): that Desktop is already showing")
+            onLog("\(verb): \(DesktopSwitchOutcome.alreadyShownNote)")
             return .alreadyShown
         }
         guard

--- a/Sources/KiwiDeskCore/Commands/KiwiCore+DesktopSwitch.swift
+++ b/Sources/KiwiDeskCore/Commands/KiwiCore+DesktopSwitch.swift
@@ -16,9 +16,17 @@ extension KiwiCore {
         case switched
         case refused(CommandResponse)
 
+        /// `.alreadyShown` answers SUCCESS carrying a note, never
+        /// a bare `.ok()` (#1336): the caller asked for a switch
+        /// and got none, and an empty success is indistinguishable
+        /// from one that moved the screen — the CLI prints nothing
+        /// and exits 0. Success rather than a refusal so a caller
+        /// ENSURING a Desktop is shown still succeeds.
         var response: CommandResponse {
             switch self {
-            case .alreadyShown, .switched: .ok()
+            case .alreadyShown:
+                .ok(.string("that Desktop is already showing"))
+            case .switched: .ok()
             case .refused(let response): response
             }
         }
@@ -54,7 +62,10 @@ extension KiwiCore {
         to target: DesktopTarget,
         verb: String
     ) -> DesktopSwitchOutcome {
-        guard !target.isCurrent else { return .alreadyShown }
+        guard !target.isCurrent else {
+            onLog("\(verb): that Desktop is already showing")
+            return .alreadyShown
+        }
         guard
             WMBridge.setCurrentSpace(
                 target.space,

--- a/Tests/KiwiDeskCoreTests/DesktopAlreadyShownTests.swift
+++ b/Tests/KiwiDeskCoreTests/DesktopAlreadyShownTests.swift
@@ -86,15 +86,25 @@ struct DesktopAlreadyShownTests {
         let box = Box()
         core.onLog = { box.lines.append($0) }
 
-        _ = core.switchDesktop(
+        let outcome = core.switchDesktop(
             to: shownTarget(),
             verb: "move_to_desktop_and_follow"
         )
+        // Derived from the response's own payload rather than a
+        // literal: the line must name the same EVENT the caller
+        // was answered with. A line carrying the verb beside
+        // another event's wording — the bridge refusal, say —
+        // read as green while the trace lied (prover round 1).
+        guard case .string(let note)? = outcome.response.data else {
+            Issue.record("the stand-down answered no note")
+            return
+        }
         // The verb, because the trace has to say WHICH caller
         // stood down — the two share this dispatch.
         #expect(
             box.lines.contains {
                 $0.contains("move_to_desktop_and_follow")
+                    && $0.contains(note)
             }
         )
     }

--- a/Tests/KiwiDeskCoreTests/DesktopAlreadyShownTests.swift
+++ b/Tests/KiwiDeskCoreTests/DesktopAlreadyShownTests.swift
@@ -3,20 +3,12 @@ import Testing
 
 @testable import KiwiDeskCore
 
-/// A switch to the Desktop already on screen answers SUCCESS
-/// CARRYING A NOTE (#1336). The silence it replaces was
-/// measured: `move_to_desktop_and_follow <current>` printed
-/// nothing, logged nothing and exited 0, which a caller cannot
-/// tell from a switch that moved the screen.
+/// Both switching arms report `switched` (#1336). The silence it
+/// replaces was measured: `move_to_desktop_and_follow <current>`
+/// printed nothing, logged nothing and exited 0.
 ///
-/// Success rather than a refusal is the ruling (owner,
-/// 2026-09-08): a caller ENSURING a Desktop is shown must still
-/// succeed, so only the note distinguishes the two.
-///
-/// No bridge fakes here on purpose — the stand-down returns
-/// before `switchDesktop` reaches the bridge, so this suite
-/// reaches nothing the machine owns beyond the topology
-/// override the fixture already installs.
+/// No bridge fakes on purpose — the stand-down returns before
+/// `switchDesktop` reaches the bridge.
 @Suite("A shown Desktop says so (#1336)", .serialized)
 @MainActor
 struct DesktopAlreadyShownTests {
@@ -34,13 +26,35 @@ struct DesktopAlreadyShownTests {
         )
     }
 
-    @Test("The stand-down answers success carrying a note")
-    func standDownCarriesANote() {
+    private func pinTopology() {
         NativeSpaces.spacesOverride = authorityTopology(
             mainCurrent: 10,
             secondaryCurrent: 20
         )
         pinTwoDisplays()
+    }
+
+    /// The fields a caller reads, so each assertion names one.
+    private func fields(
+        _ response: CommandResponse
+    ) -> (switched: Bool?, note: String?) {
+        guard case .object(let payload)? = response.data else {
+            return (nil, nil)
+        }
+        var switched: Bool?
+        if case .bool(let value)? = payload["switched"] {
+            switched = value
+        }
+        var note: String?
+        if case .string(let value)? = payload["note"] {
+            note = value
+        }
+        return (switched, note)
+    }
+
+    @Test("The stand-down reports switched: false, and says why")
+    func standDownReportsNoSwitch() {
+        pinTopology()
         defer { resetAuthorityOverrides() }
         let core = makeTestCore()
 
@@ -56,31 +70,35 @@ struct DesktopAlreadyShownTests {
         // Still a success: an ensure-shown caller keeps working.
         #expect(response.isSuccess)
         #expect(response.error == nil)
-        // And no longer silent — the note is what the CLI prints.
-        #expect(response.data != nil)
+        let read = fields(response)
+        #expect(read.switched == false)
+        // An EMPTY note satisfies "carries a note" while shipping
+        // the silence #1336 removed, so pin that it says something
+        // (code review, round 1).
+        #expect(read.note?.isEmpty == false)
     }
 
-    @Test("A switch that DID move the screen stays quiet")
-    func aRealSwitchCarriesNoNote() {
-        // The note belongs to the stand-down alone: a blanket
-        // note on every success would satisfy the assertion
-        // above while telling a caller nothing, so pin the
-        // other arm too.
+    @Test("A switch that DID move the screen reports switched: true")
+    func aRealSwitchReportsTheSwitch() {
+        // The discriminator is the point: a payload on the
+        // stand-down alone would still leave a caller reading
+        // presence-vs-absence, which on the Lua channel is truthy
+        // exactly when nothing happened.
         let switched = KiwiCore.DesktopSwitchOutcome.switched
         #expect(switched.response.isSuccess)
-        #expect(switched.response.data == nil)
+        #expect(fields(switched.response).switched == true)
+        // The note belongs to the stand-down: a blanket note would
+        // satisfy the assertion above while telling a caller
+        // nothing (prover round 1).
+        #expect(fields(switched.response).note == nil)
     }
 
-    @Test("The stand-down is logged, naming the verb")
+    @Test("The stand-down is logged, naming the verb and the event")
     func standDownIsLogged() {
         final class Box: @unchecked Sendable {
             var lines: [String] = []
         }
-        NativeSpaces.spacesOverride = authorityTopology(
-            mainCurrent: 10,
-            secondaryCurrent: 20
-        )
-        pinTwoDisplays()
+        pinTopology()
         defer { resetAuthorityOverrides() }
         let core = makeTestCore()
         let box = Box()
@@ -90,12 +108,14 @@ struct DesktopAlreadyShownTests {
             to: shownTarget(),
             verb: "move_to_desktop_and_follow"
         )
-        // Derived from the response's own payload rather than a
-        // literal: the line must name the same EVENT the caller
-        // was answered with. A line carrying the verb beside
-        // another event's wording — the bridge refusal, say —
-        // read as green while the trace lied (prover round 1).
-        guard case .string(let note)? = outcome.response.data else {
+        // Derived from the payload rather than a literal: the line
+        // must name the same EVENT the caller was answered with. A
+        // line carrying the verb beside another event's wording —
+        // the bridge refusal, say — read as green while the trace
+        // lied (prover round 1).
+        guard let note = fields(outcome.response).note,
+            !note.isEmpty
+        else {
             Issue.record("the stand-down answered no note")
             return
         }

--- a/Tests/KiwiDeskCoreTests/DesktopAlreadyShownTests.swift
+++ b/Tests/KiwiDeskCoreTests/DesktopAlreadyShownTests.swift
@@ -34,24 +34,6 @@ struct DesktopAlreadyShownTests {
         pinTwoDisplays()
     }
 
-    /// The fields a caller reads, so each assertion names one.
-    private func fields(
-        _ response: CommandResponse
-    ) -> (switched: Bool?, note: String?) {
-        guard case .object(let payload)? = response.data else {
-            return (nil, nil)
-        }
-        var switched: Bool?
-        if case .bool(let value)? = payload["switched"] {
-            switched = value
-        }
-        var note: String?
-        if case .string(let value)? = payload["note"] {
-            note = value
-        }
-        return (switched, note)
-    }
-
     @Test("The stand-down reports switched: false, and says why")
     func standDownReportsNoSwitch() {
         pinTopology()
@@ -70,12 +52,15 @@ struct DesktopAlreadyShownTests {
         // Still a success: an ensure-shown caller keeps working.
         #expect(response.isSuccess)
         #expect(response.error == nil)
-        let read = fields(response)
-        #expect(read.switched == false)
+        #expect(
+            SwitchOutcomeReading.switched(response) == false
+        )
         // An EMPTY note satisfies "carries a note" while shipping
         // the silence #1336 removed, so pin that it says something
         // (code review, round 1).
-        #expect(read.note?.isEmpty == false)
+        #expect(
+            SwitchOutcomeReading.note(response)?.isEmpty == false
+        )
     }
 
     @Test("A switch that DID move the screen reports switched: true")
@@ -86,11 +71,13 @@ struct DesktopAlreadyShownTests {
         // exactly when nothing happened.
         let switched = KiwiCore.DesktopSwitchOutcome.switched
         #expect(switched.response.isSuccess)
-        #expect(fields(switched.response).switched == true)
+        #expect(
+            SwitchOutcomeReading.switched(switched.response) == true
+        )
         // The note belongs to the stand-down: a blanket note would
         // satisfy the assertion above while telling a caller
         // nothing (prover round 1).
-        #expect(fields(switched.response).note == nil)
+        #expect(SwitchOutcomeReading.note(switched.response) == nil)
     }
 
     @Test("The stand-down is logged, naming the verb and the event")
@@ -113,7 +100,7 @@ struct DesktopAlreadyShownTests {
         // line carrying the verb beside another event's wording —
         // the bridge refusal, say — read as green while the trace
         // lied (prover round 1).
-        guard let note = fields(outcome.response).note,
+        guard let note = SwitchOutcomeReading.note(outcome.response),
             !note.isEmpty
         else {
             Issue.record("the stand-down answered no note")

--- a/Tests/KiwiDeskCoreTests/DesktopAlreadyShownTests.swift
+++ b/Tests/KiwiDeskCoreTests/DesktopAlreadyShownTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import KiwiDeskCore
+
+/// A switch to the Desktop already on screen answers SUCCESS
+/// CARRYING A NOTE (#1336). The silence it replaces was
+/// measured: `move_to_desktop_and_follow <current>` printed
+/// nothing, logged nothing and exited 0, which a caller cannot
+/// tell from a switch that moved the screen.
+///
+/// Success rather than a refusal is the ruling (owner,
+/// 2026-09-08): a caller ENSURING a Desktop is shown must still
+/// succeed, so only the note distinguishes the two.
+///
+/// No bridge fakes here on purpose — the stand-down returns
+/// before `switchDesktop` reaches the bridge, so this suite
+/// reaches nothing the machine owns beyond the topology
+/// override the fixture already installs.
+@Suite("A shown Desktop says so (#1336)", .serialized)
+@MainActor
+struct DesktopAlreadyShownTests {
+    /// A target whose Desktop is the one its screen shows, so
+    /// `isCurrent` is true by derivation rather than by hand.
+    private func shownTarget() -> KiwiCore.DesktopTarget {
+        KiwiCore.DesktopTarget(
+            space: 10,
+            displayIdentifier: "UUID-A",
+            originSpace: 10,
+            spaces: authorityTopology(
+                mainCurrent: 10,
+                secondaryCurrent: 20
+            )
+        )
+    }
+
+    @Test("The stand-down answers success carrying a note")
+    func standDownCarriesANote() {
+        NativeSpaces.spacesOverride = authorityTopology(
+            mainCurrent: 10,
+            secondaryCurrent: 20
+        )
+        pinTwoDisplays()
+        defer { resetAuthorityOverrides() }
+        let core = makeTestCore()
+
+        let outcome = core.switchDesktop(
+            to: shownTarget(),
+            verb: "focus_desktop"
+        )
+        guard case .alreadyShown = outcome else {
+            Issue.record("expected .alreadyShown, got \(outcome)")
+            return
+        }
+        let response = outcome.response
+        // Still a success: an ensure-shown caller keeps working.
+        #expect(response.isSuccess)
+        #expect(response.error == nil)
+        // And no longer silent — the note is what the CLI prints.
+        #expect(response.data != nil)
+    }
+
+    @Test("A switch that DID move the screen stays quiet")
+    func aRealSwitchCarriesNoNote() {
+        // The note belongs to the stand-down alone: a blanket
+        // note on every success would satisfy the assertion
+        // above while telling a caller nothing, so pin the
+        // other arm too.
+        let switched = KiwiCore.DesktopSwitchOutcome.switched
+        #expect(switched.response.isSuccess)
+        #expect(switched.response.data == nil)
+    }
+
+    @Test("The stand-down is logged, naming the verb")
+    func standDownIsLogged() {
+        final class Box: @unchecked Sendable {
+            var lines: [String] = []
+        }
+        NativeSpaces.spacesOverride = authorityTopology(
+            mainCurrent: 10,
+            secondaryCurrent: 20
+        )
+        pinTwoDisplays()
+        defer { resetAuthorityOverrides() }
+        let core = makeTestCore()
+        let box = Box()
+        core.onLog = { box.lines.append($0) }
+
+        _ = core.switchDesktop(
+            to: shownTarget(),
+            verb: "move_to_desktop_and_follow"
+        )
+        // The verb, because the trace has to say WHICH caller
+        // stood down — the two share this dispatch.
+        #expect(
+            box.lines.contains {
+                $0.contains("move_to_desktop_and_follow")
+            }
+        )
+    }
+}

--- a/Tests/KiwiDeskCoreTests/DesktopCommandTests.swift
+++ b/Tests/KiwiDeskCoreTests/DesktopCommandTests.swift
@@ -189,7 +189,12 @@ struct DesktopCommandTests {
         let core = makeCore()
         defer { teardown() }
         let before = core.lastDesktopSwitch
-        #expect(core.execute("focus_desktop", args: [.number(2)]).isSuccess)
+        let moved = core.execute("focus_desktop", args: [.number(2)])
+        #expect(moved.isSuccess)
+        // The other half of the discriminator, through the same
+        // consumer: presence-vs-absence must never come back as
+        // the way a caller tells the two apart (#1336).
+        #expect(SwitchOutcomeReading.switched(moved) == true)
         #expect(Bridge.switches.map(\.0) == [11])
         #expect(Bridge.switches.map(\.1) == ["UUID-A"])
         #expect(core.lastDesktopSwitch > before)
@@ -210,15 +215,23 @@ struct DesktopCommandTests {
     func currentDesktopSwitchStandsDown() {
         let core = makeCore()
         defer { teardown() }
-        #expect(core.execute("focus_desktop", args: [.number(1)]).isSuccess)
+        let shown = core.execute("focus_desktop", args: [.number(1)])
+        #expect(shown.isSuccess)
+        // Success alone is what a bare `.ok()` also satisfies, so
+        // read the field the Lua and CLI callers read (#1336).
+        #expect(SwitchOutcomeReading.switched(shown) == false)
         #expect(Bridge.switches.isEmpty)
         // The move cannot know the window is there already — it
         // may sit on another display — so it dispatches; only
         // the follow stands down.
-        #expect(
-            core.execute("move_to_desktop_and_follow", args: [.number(1)])
-                .isSuccess
+        let followed = core.execute(
+            "move_to_desktop_and_follow",
+            args: [.number(1)]
         )
+        #expect(followed.isSuccess)
+        // The follow's own consumer, which returns the outcome's
+        // response after doing the most work of any arm.
+        #expect(SwitchOutcomeReading.switched(followed) == false)
         #expect(Bridge.moves.map(\.1) == [10])
         #expect(Bridge.switches.isEmpty)
         // No switch dispatched means nothing to hide either — a

--- a/Tests/KiwiDeskCoreTests/SwitchOutcomeReading.swift
+++ b/Tests/KiwiDeskCoreTests/SwitchOutcomeReading.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@testable import KiwiDeskCore
+
+/// The switch verbs' payload, read the way a CALLER reads it
+/// (#1336) — the CLI over JSON, Lua over the mapped table.
+///
+/// Shared because the reading is the thing under test in two
+/// places at once: the outcome's own suite builds the enum, and
+/// `DesktopCommandTests` drives the verbs that return it. A copy
+/// per suite would let the two disagree about what a caller
+/// sees, which is the divergence this whole change closes.
+enum SwitchOutcomeReading {
+    /// `switched`, or nil where the payload does not carry it —
+    /// which is what a consumer dropping `.response` produces,
+    /// and so must stay distinguishable from `false`.
+    static func switched(_ response: CommandResponse) -> Bool? {
+        guard case .object(let payload)? = response.data,
+            case .bool(let value)? = payload["switched"]
+        else { return nil }
+        return value
+    }
+
+    /// The stand-down's note, nil when absent.
+    static func note(_ response: CommandResponse) -> String? {
+        guard case .object(let payload)? = response.data,
+            case .string(let value)? = payload["note"]
+        else { return nil }
+        return value
+    }
+}

--- a/Tests/KiwiDeskGuiTests/DesktopStandDownNoteSeamTests.swift
+++ b/Tests/KiwiDeskGuiTests/DesktopStandDownNoteSeamTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+/// The stand-down sentence keeps ONE home (#1336).
+///
+/// `DesktopAlreadyShownTests` pins that the payload and the log
+/// AGREE at runtime, which is a weaker property than it reads: a
+/// second, identical copy of the sentence inlined at the log
+/// satisfies it, and nothing notices until someone later edits
+/// one copy and the trace starts naming a different event than
+/// the response (guard-prover round 2 — that mutation went
+/// green).
+///
+/// So this pins the ROUTE rather than the text: each reader
+/// names the constant. Retuning the sentence moves one line and
+/// stays green, which is the calibration tests.md ▸ #1021 asks
+/// for — a value pin here would red on every deliberate reword
+/// and catch no regression.
+@Suite("The stand-down sentence has one home (#1336)")
+struct DesktopStandDownNoteSeamTests {
+    private static let root = SourceScan.repoRoot(
+        from: #filePath
+    )
+    private static let core = root.appendingPathComponent(
+        "Sources/KiwiDeskCore"
+    )
+
+    /// needle → the file that may carry it, exactly once.
+    ///
+    /// Two spellings because the readers sit at different
+    /// depths: the response arm is inside the enum, the log line
+    /// is in the `KiwiCore` extension beside it. Pinned by exact
+    /// count in both directions — zero is an inlined literal
+    /// (the escape above), two is a second reader that owes its
+    /// own entry here.
+    private static let readers: [(String, String)] = [
+        ("Self.alreadyShownNote", "KiwiCore+DesktopSwitch.swift"),
+        (
+            "DesktopSwitchOutcome.alreadyShownNote",
+            "KiwiCore+DesktopSwitch.swift"
+        ),
+    ]
+
+    @Test("both readers name the constant, each exactly once")
+    func bothReadersNameTheConstant() throws {
+        for (needle, file) in Self.readers {
+            let sites = try SourceScan.identifierSites(
+                of: needle,
+                under: Self.core
+            )
+            #expect(
+                sites.count == 1,
+                .init(
+                    rawValue: "\(needle) is expected exactly once, "
+                        + "in \(file) — found "
+                        + (sites.isEmpty
+                            ? "none (an inlined literal?)"
+                            : sites.map(\.site)
+                                .joined(separator: ", "))
+                )
+            )
+            #expect(
+                sites.allSatisfy {
+                    $0.file.lastPathComponent == file
+                },
+                .init(
+                    rawValue: "\(needle) belongs in \(file) — found "
+                        + sites.map(\.site).joined(separator: ", ")
+                )
+            )
+        }
+    }
+}

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -3721,6 +3721,54 @@ Space it was taken in, so a window filed into a different Space
 returns by the arrival's ordinary placement rather than at its
 old index (#1207).
 
+### A Desktop switch that changes nothing still reports itself (#1336)
+
+**[Principle]**
+
+A command that acts on nothing answers **success carrying the
+fact**, never a bare `.ok()` and never a refusal. `focus_desktop`
+and `move_to_desktop_and_follow` both answer
+`{"switched": true|false}`, with a `note` on the stand-down.
+
+The measurement: on the device, `move_to_desktop_and_follow 1`
+while Desktop 1 was already showing printed nothing, logged
+nothing and exited 0. A caller cannot tell that from a switch
+that moved the screen, and the user has no signal the verb
+declined — which is the half of #1336 the reporter called the
+worse one.
+
+**Success rather than a refusal**, because these verbs are
+routinely called to ENSURE a state: "make sure Desktop 3 is
+showing" must not fail merely because it already was. That is
+what separates this class from the sibling ruling above — a
+keyboard reorder that cannot apply refuses with the home-space
+pill, because there the user asked for a CHANGE and the
+arrangement cannot give it. Asking for a state you are already
+in is not a failed change.
+
+**Structure rather than prose**, because the payload is read by
+scripts on three channels. It also decides the shape of the
+other arm: were only the stand-down to carry data, the Lua
+return would be truthy exactly when nothing happened and nil
+when the screen moved. Both arms report `switched`, so the
+discriminator is a field rather than the payload's presence.
+
+**`switched` describes the SWITCH, not the command.** A follow's
+stand-down arm is the one that does the most work — it is the
+only path on which the cross-screen re-home fires — so
+`switched: false` there must not be read as "nothing happened".
+The window moved; only the screen did not.
+
+Two residues, deliberately left. The plain `move_to_desktop` is
+NOT covered: whether the window was already on that Desktop is
+not knowable from a target current on its own screen (the
+`moveToDesktop` docstring rules this), so there is no detectable
+no-op to report — its silence is about the WINDOW where this
+ruling is about the SCREEN. And the hotkey path discards command
+responses entirely, so a keyboard user still sees nothing; a
+screen that did not move is its own evidence there, and giving
+it a cue is a separate question from this one.
+
 ### A ∞ window entering a floating Space on another screen is moved, not left (#1217)
 
 **[Rationale]**

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -233,12 +233,14 @@ KiwiDesk Space — exactly as a swipe would: the screen that
 Desktop belongs to switches, and the bound profile, the
 remembered Space and the `desktop_change` event all follow as
 they do for a swipe (macOS reports the switch to KiwiDesk the
-same way either way — device-checked 2026-08-25). A Desktop its
-screen already shows switches nothing, and says so: the command
-succeeds — so a script that only wants the Desktop shown still
-works — and reports that it was already showing rather than
-answering an empty success a caller cannot tell from a real
-switch.
+same way either way — device-checked 2026-08-25).
+
+**Returns** a table with `switched` — `true` when the screen
+moved, `false` when that Desktop was already the one it showed,
+with a `note` saying so. Either way the command SUCCEEDS, so a
+script that only wants the Desktop shown still works; read
+`switched` rather than the return's presence to tell the two
+apart.
 
 Needs macOS's own window-management bridge, which KiwiDesk looks
 up at runtime: present on macOS 26.6.1 (observed 2026-08-18); no
@@ -356,9 +358,10 @@ there is nothing to hand over.
 
 With more than one screen, "there" is that Desktop's own screen,
 and a Desktop that screen already shows switches nothing — the
-window still moves, and focus still goes with it. The command
-reports that the Desktop was already showing, so a silent
-success never stands for a switch that did not happen.
+window still moves, and focus still goes with it. The return
+table's `switched` is `false` there, and it describes the
+SWITCH alone: the move happened regardless, so `false` is not
+"nothing happened".
 
 The window itself is placed by the cross-screen rule above — on
 another screen it joins the Space that screen shows — unless you

--- a/docs/lua-reference.md
+++ b/docs/lua-reference.md
@@ -234,7 +234,11 @@ Desktop belongs to switches, and the bound profile, the
 remembered Space and the `desktop_change` event all follow as
 they do for a swipe (macOS reports the switch to KiwiDesk the
 same way either way — device-checked 2026-08-25). A Desktop its
-screen already shows is a no-op.
+screen already shows switches nothing, and says so: the command
+succeeds — so a script that only wants the Desktop shown still
+works — and reports that it was already showing rather than
+answering an empty success a caller cannot tell from a real
+switch.
 
 Needs macOS's own window-management bridge, which KiwiDesk looks
 up at runtime: present on macOS 26.6.1 (observed 2026-08-18); no
@@ -352,7 +356,9 @@ there is nothing to hand over.
 
 With more than one screen, "there" is that Desktop's own screen,
 and a Desktop that screen already shows switches nothing — the
-window still moves, and focus still goes with it.
+window still moves, and focus still goes with it. The command
+reports that the Desktop was already showing, so a silent
+success never stands for a switch that did not happen.
 
 The window itself is placed by the cross-screen rule above — on
 another screen it joins the Space that screen shows — unless you


### PR DESCRIPTION
## What

`focus_desktop <current>` and `move_to_desktop_and_follow
<current>` answered a bare `.ok()`: the CLI printed nothing,
logged nothing and exited 0 — which a caller cannot tell from a
switch that moved the screen. Measured on device 2026-09-08.

Both switching arms now report `switched` structurally:

```
$ kiwidesk focus_desktop 1          # already on Desktop 1
{"note":"that Desktop is already showing","switched":false}
```

`switched` describes the **switch alone**. A follow's stand-down
arm is the one that does the most work — it is the only path on
which the cross-screen re-home fires — so `false` there is not
"nothing happened": the window moved, only the screen did not.

Both arms carry the field so a caller reads a **value** rather
than the payload's presence. On the Lua channel a payload on the
stand-down alone would have made the return truthy exactly when
nothing happened.

## Why success rather than a refusal

Owner ruling 2026-09-08. These verbs are routinely called to
ENSURE a state — "make sure Desktop 3 is showing" must not fail
because it already was. That is what separates this class from
the sibling ruling in `docs/design-decisions.md`, where a
keyboard reorder that cannot apply refuses with a pill: there
the user asked for a CHANGE the arrangement cannot give.

## Scope, deliberately

Plain `move_to_desktop <current>` is **not** covered and stays
silent. `moveToDesktop`'s own docstring rules that whether the
window is already on that Desktop is not knowable from a target
current on ITS screen, so there is no detectable no-op to
report — its silence is about the WINDOW where this is about the
SCREEN. The window's host IS readable, but `os-private-apis.md`
disciplines that census seam, so reaching it from a command path
is its own ruling rather than a rider here.

The hotkey path still shows nothing: it discards command
responses entirely (the `#483 _and_follow does nothing` trap).
Both deferrals are recorded on the issue and in the ruling.

## Review and proving

`code-reviewer` + `architect-reviewer`, then three
`guard-prover` rounds. What they changed:

- **The architect caught the shared sentence being wrong for the
  verb that does the most work** — the first draft answered a
  cross-screen move with "that Desktop is already showing",
  reading as a decline. That is why `switched` describes the
  switch rather than the command.
- **Round 1**: a log line naming the verb beside *another
  event's wording* stayed green. The sentence now has one home
  and the assertion derives from the payload.
- **Round 2**: re-inlining the identical literal at the log line
  passed — runtime agreement is weaker than one home. Closed by
  `DesktopStandDownNoteSeamTests`, a source scan pinning the
  route rather than the text, so retuning the sentence stays
  green (tests.md #1021).
- **Round 3**: both verbs could stop returning `.response`
  entirely with every guard green — the outcome's suite builds
  the enum itself. `DesktopCommandTests` now reads the field
  where the caller reads it; I mutated both consumers by hand to
  confirm each reds.
- **Code review**: an empty note satisfied every assertion, and
  the Lua return was undocumented on both verbs.

## Docs

`docs/design-decisions.md` gains the ruling; both verbs' Lua
sections document the return.

Refs #1336
