### PR TITLE
chore(release): stamp version 1.2.1

### DIFF
--- a/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
+++ b/Sources/KiwiDeskCore/App/KiwiDeskVersion.swift
@@ -2,7 +2,7 @@
 /// `ScriptStampTests`, #32).
 public enum KiwiDeskVersion {
     /// Semantic version, bumped per release.
-    public static let semantic = "1.2.0"
+    public static let semantic = "1.2.1"
 
     /// Short commit SHA of the build, stamped during release (#32).
     public static let commit = "unknown"


### PR DESCRIPTION
Version stamp for 1.2.1, produced by
scripts/release.sh.

main is protected (#487), so the stamp reaches it through this
PR. The v1.2.1 tag is pushed by re-running the script once this
has merged, which takes its tag phase and creates no second
commit.