### PR TITLE
docs(agents): a highlight bullet is short, and a site fix is not news

### DIFF
--- a/.claude/agents/changelog-curator.md
+++ b/.claude/agents/changelog-curator.md
@@ -73,9 +73,10 @@ stay quiet about:
   reader is not reconciling your issue tracker.
 - **Twenty bullets, or a nine-line bullet.** Ruled: the first
   is a changelog with headings, the second a PR description. A
-  bullet is one to three sentences — the symptom, then what
-  changed — and the diagnosis between them stays in the PR. The
-  lead paragraph is one or two sentences. If a section will not
+  bullet is ONE line — the symptom, and that it is fixed — and a
+  second sentence is earned only when one line cannot say it,
+  never by the diagnosis, which stays in the PR. The lead
+  paragraph is one or two sentences. If a section will not
   come under control, the honest move is usually that half of
   it is not news.
 - **A site fix.** A corrected heading, a term, a translation, a

--- a/.claude/agents/changelog-curator.md
+++ b/.claude/agents/changelog-curator.md
@@ -71,9 +71,18 @@ stay quiet about:
   the reason is that nothing catches it later.
 - **A bullet per issue when the issues share a symptom.** The
   reader is not reconciling your issue tracker.
-- **Twenty bullets.** Ruled: that is a changelog with headings.
-  If a section will not come under control, the honest move is
-  usually that half of it is not news.
+- **Twenty bullets, or a nine-line bullet.** Ruled: the first
+  is a changelog with headings, the second a PR description. A
+  bullet is one to three sentences — the symptom, then what
+  changed — and the diagnosis between them stays in the PR. The
+  lead paragraph is one or two sentences. If a section will not
+  come under control, the honest move is usually that half of
+  it is not news.
+- **A site fix.** A corrected heading, a term, a translation, a
+  layout nudge — none of it is news to someone installing an
+  update, not even as one closing line. Ruled. A site change
+  earns a bullet only when a visitor would come for it: a new
+  page, a new language, a changed download.
 
 And two you must NOT silently drop, because they read as
 internal and are not: a change to a **default** anyone upgrading

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -564,9 +564,20 @@ Two consequences fall out, both structural rather than stylistic:
   as well makes the reader's eye redo work the section below
   already did, and turns news into a bug list.
 - **Highlights are highlights.** Twenty bullets is a changelog
-  with headings. Site fixes, a font bump and release plumbing
-  collapse into one closing line; the generated list still
-  carries each of them for whoever wants that.
+  with headings, and a nine-line bullet is a PR description. A
+  bullet is one to three sentences: the thing you would notice,
+  then what changed — never the diagnosis in between, which is
+  the PR's. The whole block should read in one screen of the
+  update sheet Sparkle shows.
+- **A site change is news only when a visitor would come for
+  it.** A new page, a new language, a changed download earns a
+  line. A heading that now fits its column, a corrected term, a
+  font bump and release plumbing earn none — not even a closing
+  "on the site" line, which 1.2.1's first draft carried and the
+  owner struck (ruling 2026-09-08): a reader installing an
+  update has no reason to care that the website was tidied. The
+  generated list still carries each of them for whoever wants
+  that.
 
 This binds whichever surface carries the notes, not the surface
 it happens to be today. That surface is currently the GitHub

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -565,9 +565,11 @@ Two consequences fall out, both structural rather than stylistic:
   already did, and turns news into a bug list.
 - **Highlights are highlights.** Twenty bullets is a changelog
   with headings, and a nine-line bullet is a PR description. A
-  bullet is one to three sentences: the thing you would notice,
-  then what changed — never the diagnosis in between, which is
-  the PR's. The whole block should read in one screen of the
+  bullet is ONE line: the thing you would notice, and that it
+  is fixed. A second sentence is earned only when one line
+  cannot say it — a default that changed, a control to go and
+  find — and never by the diagnosis, which is the PR's (ruling
+  2026-09-08). The whole block should read in one screen of the
   update sheet Sparkle shows.
 - **A site change is news only when a visitor would come for
   it.** A new page, a new language, a changed download earns a


### PR DESCRIPTION
## Summary

Follow-up from curating 1.2.1's highlights: the first draft ran seven bullets of up to nine lines and a closing "on the site" line about a heading that now fits its column. Owner ruling 2026-09-08: bullets are one to three sentences, and a site fix is not news to someone installing an update.

- `docs/design-decisions.md` ▸ *Release notes are written for the person installing*: the "Highlights are highlights" consequence now carries the length calibration, and a new consequence rules when a site change earns a line (a new page, a language, a changed download) and when it earns none.
- `.claude/agents/changelog-curator.md` ▸ *What not to write*: two entries routing to that ruling. Codex mirror regenerated (`scripts/sync-agents.sh --check` is current).

No code, no user-visible behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
