### PR TITLE
chore(site): sync release notes and feed for v1.2.1

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -417,14 +417,12 @@ the KiwiDesk icon opens the quick menu where you can:
   answers are unusually slow is finished off just after boot, so
   its windows are tiled a beat later than everything else.
 
-:::unreleased
 When the background check finds an update, the menu-bar icon
 shows a small dot and the **Check for Updates…** row reads
 **Update Available…** until you act on it — nothing pops up over
 your work. Choosing the row brings the update forward, and
 *Remind Me Later* there clears the dot until the next background
 check finds the update again.
-:::
 
 ### The Shortcuts Panel
 
@@ -2910,7 +2908,6 @@ part of your setup it is not an offer any more. (They stay
 rows you can collapse — opening is a starting point, not a
 setting.)
 
-:::unreleased
 Each drawer's header carries a **?** saying what the rows are
 for: Desktops are macOS's own Spaces, not KiwiDesk's. KiwiDesk
 arranges windows inside its own Spaces, so most setups never
@@ -2918,7 +2915,6 @@ need these — switching a Desktop moves your whole environment,
 not a window, and each Desktop keeps its own Spaces. If you do
 work across Desktops, bind a profile per Desktop in Profiles ▸
 **Profiles per macOS Desktop**.
-:::
 
 If your Mac cannot drive Desktops at all, the offer does not
 appear — see

--- a/site/public/appcast.xml
+++ b/site/public/appcast.xml
@@ -13,6 +13,19 @@
     <description>Updates for KiwiDesk, a tiling window manager for macOS.</description>
     <language>en</language>
     <item>
+      <title>1.2.1</title>
+      <pubDate>Tue, 08 Sep 2026 15:21:20 +0000</pubDate>
+      <sparkle:version>1.2.1</sparkle:version>
+      <sparkle:shortVersionString>1.2.1</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <description><![CDATA[<style>:root{color-scheme:light dark;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5;}body{margin:0;padding:2px 4px 16px 4px;}h3{font-size:13px;font-weight:600;margin:12px 0 6px 0;}p{margin:0 0 8px 0;}ul{margin:0 0 10px 0;padding-left:18px;}li{margin-bottom:5px;}code{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,monospace;font-size:11.5px;padding:1px 4px;border-radius:4px;background:rgba(128,128,128,0.15);}::-webkit-scrollbar{width:6px;height:6px;}::-webkit-scrollbar-thumb{background:rgba(128,128,128,0.35);border-radius:3px;}::-webkit-scrollbar-thumb:hover{background:rgba(128,128,128,0.65);}</style><p>A small release: Desktop switches that stay put, profiles that keep their arrangements, and an update you can actually see.</p><h3>Desktops</h3><ul><li><strong>A swipe to another Desktop stays there</strong> instead of bouncing you back a moment later, and the swipe back keeps the window macOS refocused.</li><li><strong>Switching Desktops no longer reads or rewrites your profile files.</strong> A hand-edited profile takes effect at the next reload or apply.</li></ul><h3>Profiles</h3><ul><li><strong>A profile keeps the arrangement you left it with</strong> through a Settings save, a preset, a discard, Reset All Settings and a backup restore — a window parked on another Desktop included.</li></ul><h3>Updates</h3><ul><li><strong>You are told when an update is waiting:</strong> an orange dot on the menu-bar icon and an Update Available… row, instead of a window opened behind everything else.</li></ul><h3>Settings and the command line</h3><ul><li><strong>The Desktop shortcut drawers explain themselves</strong> with a ? that says what a macOS Desktop is next to a KiwiDesk Space.</li><li><strong><code>focus_desktop</code> and <code>move_to_desktop_and_follow</code> return <code>switched</code></strong>, <code>false</code> when the Desktop was already showing.</li></ul>]]></description>
+      <enclosure
+        url="https://github.com/KiwiCanopy/KiwiDesk/releases/download/v1.2.1/KiwiDesk-1.2.1.zip"
+        length="8696765"
+        type="application/octet-stream"
+        sparkle:edSignature="1Sd0N+25vxwJvmvBJdadQUfBya+BD/iyMSQxFWU9ytPr/N1lYTqZ65HIvQUDDahaZ6nLtf6AJ6uoKGHMJrmkDQ==" />
+    </item>
+    <item>
       <title>1.2.0</title>
       <pubDate>Mon, 07 Sep 2026 17:42:16 +0000</pubDate>
       <sparkle:version>1.2.0</sparkle:version>

--- a/site/src/data/changelog.json
+++ b/site/src/data/changelog.json
@@ -2,6 +2,43 @@
   "generated_by": "scripts/changelog-sync",
   "releases": [
     {
+      "version": "1.2.1",
+      "tag": "v1.2.1",
+      "date": "2026-09-08",
+      "prerelease": false,
+      "url": "https://github.com/KiwiCanopy/KiwiDesk/releases/tag/v1.2.1",
+      "download": "https://github.com/KiwiCanopy/KiwiDesk/releases/download/v1.2.1/KiwiDesk-1.2.1.dmg",
+      "summary": "A small release: Desktop switches that stay put, profiles that keep their arrangements, and an update you can actually see.",
+      "sections": [
+        {
+          "title": "Desktops",
+          "items": [
+            "**A swipe to another Desktop stays there** instead of bouncing you back a moment later, and the swipe back keeps the window macOS refocused.",
+            "**Switching Desktops no longer reads or rewrites your profile files.** A hand-edited profile takes effect at the next reload or apply."
+          ]
+        },
+        {
+          "title": "Profiles",
+          "items": [
+            "**A profile keeps the arrangement you left it with** through a Settings save, a preset, a discard, Reset All Settings and a backup restore — a window parked on another Desktop included."
+          ]
+        },
+        {
+          "title": "Updates",
+          "items": [
+            "**You are told when an update is waiting:** an orange dot on the menu-bar icon and an Update Available… row, instead of a window opened behind everything else."
+          ]
+        },
+        {
+          "title": "Settings and the command line",
+          "items": [
+            "**The Desktop shortcut drawers explain themselves** with a ? that says what a macOS Desktop is next to a KiwiDesk Space.",
+            "**`focus_desktop` and `move_to_desktop_and_follow` return `switched`**, `false` when the Desktop was already showing."
+          ]
+        }
+      ]
+    },
+    {
       "version": "1.2.0",
       "tag": "v1.2.0",
       "date": "2026-09-07",


### PR DESCRIPTION
chore(site): sync release notes and feed for v1.2.1

Generated by scripts/changelog-sync and
scripts/appcast-sync from the published releases.
Neither file is hand-edited — the next publish
overwrites both.

Merging this rebuilds the release-notes page AND puts
the new version in front of every installed copy — the
appcast is live the moment Cloudflare redeploys.

These docs blocks no longer say `Unreleased`:

unreleased-strip: retired 2 marker(s)
  - user-guide.md: When the background check finds an update, the menu-bar icon
  - user-guide.md: Each drawer's header carries a **?** saying what the rows are

If one of them describes something that did NOT ship in
this release, put its `:::unreleased` marker back on
this branch before merging.