### PR TITLE
chore(site): sync release notes and feed for v1.2.2

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -957,11 +957,9 @@ Pick a layout mode for each space:
   remembers where each floating window sits when you switch
   spaces.
 
-:::unreleased
 Should that memory ever be lost — it survives a relaunch and a
 Desktop switch — a floating window comes back centred on its
 screen rather than at the corner hidden spaces park in.
-:::
 
 Gaps are carved out of the layout — windows never overlap them —
 and the app bar, if shown, carves its space the same way. The

--- a/site/public/appcast.xml
+++ b/site/public/appcast.xml
@@ -13,6 +13,19 @@
     <description>Updates for KiwiDesk, a tiling window manager for macOS.</description>
     <language>en</language>
     <item>
+      <title>1.2.2</title>
+      <pubDate>Wed, 09 Sep 2026 23:41:56 +0000</pubDate>
+      <sparkle:version>1.2.2</sparkle:version>
+      <sparkle:shortVersionString>1.2.2</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <description><![CDATA[<style>:root{color-scheme:light dark;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5;}body{margin:0;padding:2px 4px 16px 4px;}h3{font-size:13px;font-weight:600;margin:12px 0 6px 0;}p{margin:0 0 8px 0;}ul{margin:0 0 10px 0;padding-left:18px;}li{margin-bottom:5px;}code{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,monospace;font-size:11.5px;padding:1px 4px;border-radius:4px;background:rgba(128,128,128,0.15);}::-webkit-scrollbar{width:6px;height:6px;}::-webkit-scrollbar-thumb{background:rgba(128,128,128,0.35);border-radius:3px;}::-webkit-scrollbar-thumb:hover{background:rgba(128,128,128,0.65);}</style><p>A one-fix release: floating windows that come back where you left them.</p><h3>Floating windows</h3><ul><li><strong>A floating window no longer gets stuck in the screen corner.</strong> Switching spaces could lose where a floating window belonged — after a Desktop switch, a relaunch, or simply a slow app — and from then on it came back tucked into the bottom corner where hidden windows park. Its place now survives all three, and a window whose place is genuinely lost comes back centred on its screen instead of in the corner.</li></ul>]]></description>
+      <enclosure
+        url="https://github.com/KiwiCanopy/KiwiDesk/releases/download/v1.2.2/KiwiDesk-1.2.2.zip"
+        length="8700456"
+        type="application/octet-stream"
+        sparkle:edSignature="zqJvUl9/ie0mFfFG2U/sTHELqSUwbMpiIHJLPJZSwk/T6Onpp47pPZsJRDJBWB5f2I5jVbAVKFPMED/SFXCSBg==" />
+    </item>
+    <item>
       <title>1.2.1</title>
       <pubDate>Tue, 08 Sep 2026 15:21:20 +0000</pubDate>
       <sparkle:version>1.2.1</sparkle:version>

--- a/site/src/data/changelog.json
+++ b/site/src/data/changelog.json
@@ -2,6 +2,23 @@
   "generated_by": "scripts/changelog-sync",
   "releases": [
     {
+      "version": "1.2.2",
+      "tag": "v1.2.2",
+      "date": "2026-09-09",
+      "prerelease": false,
+      "url": "https://github.com/KiwiCanopy/KiwiDesk/releases/tag/v1.2.2",
+      "download": "https://github.com/KiwiCanopy/KiwiDesk/releases/download/v1.2.2/KiwiDesk-1.2.2.dmg",
+      "summary": "A one-fix release: floating windows that come back where you left them.",
+      "sections": [
+        {
+          "title": "Floating windows",
+          "items": [
+            "**A floating window no longer gets stuck in the screen corner.** Switching spaces could lose where a floating window belonged — after a Desktop switch, a relaunch, or simply a slow app — and from then on it came back tucked into the bottom corner where hidden windows park. Its place now survives all three, and a window whose place is genuinely lost comes back centred on its screen instead of in the corner."
+          ]
+        }
+      ]
+    },
+    {
       "version": "1.2.1",
       "tag": "v1.2.1",
       "date": "2026-09-08",


### PR DESCRIPTION
chore(site): sync release notes and feed for v1.2.2

Generated by scripts/changelog-sync and
scripts/appcast-sync from the published releases.
Neither file is hand-edited — the next publish
overwrites both.

Merging this rebuilds the release-notes page AND puts
the new version in front of every installed copy — the
appcast is live the moment Cloudflare redeploys.

These docs blocks no longer say `Unreleased`:

unreleased-strip: retired 1 marker(s)
  - user-guide.md: Should that memory ever be lost — it survives a relaunch and a

If one of them describes something that did NOT ship in
this release, put its `:::unreleased` marker back on
this branch before merging.